### PR TITLE
Reboot function in the admin/tools menu

### DIFF
--- a/lib/yunohost/tools.py
+++ b/lib/yunohost/tools.py
@@ -469,3 +469,11 @@ def tools_upgrade(auth, ignore_apps=False, ignore_packages=False):
     if is_api:
         from yunohost.service import service_log
         return { "log": service_log('yunohost-api', number="100").values()[0] }
+
+
+def tools_reboot_server():
+    """
+    Simple function to reboot the server. 
+    Interesting to use via the web interface.
+    """
+    os.system('reboot')


### PR DESCRIPTION
Reboot function (to be done properly !), to add the possibility of remotely rebooting the yunohost system.  
The function added is JUST AN EXAMPLE and needs to be done properly.

The insterest is to have a dedicated entry in the web interface.
