### PR TITLE
add delaycompress to metronome logrotate script

### DIFF
--- a/data/templates/metronome/metronome.logrotate
+++ b/data/templates/metronome/metronome.logrotate
@@ -2,6 +2,7 @@
 	daily
 	rotate 14
 	compress
+	delaycompress
 	create 640 metronome adm
 	postrotate
 		/etc/init.d/metronome reload > /dev/null


### PR DESCRIPTION
this prevents gzip to complain files are still written upon by Metronome
by delaying compression until the logs are actually rotated.
Fix this old issue https://github.com/YunoHost/packages_old/issues/37