### PR TITLE
Don't emit Nginx version

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -24,6 +24,7 @@ cd /usr/share/yunohost/templates/nginx
 
 # Copy plain single configuration files
 files="ssowat.conf
+global.conf
 yunohost_admin.conf
 yunohost_admin.conf.inc
 yunohost_api.conf.inc

--- a/data/templates/nginx/global.conf
+++ b/data/templates/nginx/global.conf
@@ -1,0 +1,1 @@
+server_tokens off;

--- a/data/templates/nginx/server.conf.sed
+++ b/data/templates/nginx/server.conf.sed
@@ -2,7 +2,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name {{ domain }};
-    
+
     access_by_lua_file /usr/share/ssowat/access.lua;
 
     include conf.d/{{ domain }}.d/*.conf;
@@ -19,23 +19,23 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
     server_name {{ domain }};
-    ssl_certificate        /etc/yunohost/certs/{{ domain }}/crt.pem;
-    ssl_certificate_key    /etc/yunohost/certs/{{ domain }}/key.pem;
 
+    ssl_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
+    ssl_certificate_key /etc/yunohost/certs/{{ domain }}/key.pem;
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
+
     add_header Strict-Transport-Security "max-age=31536000;";
-    
+
     # Uncomment the following directive after DH generation
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
-
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     access_by_lua_file /usr/share/ssowat/access.lua;
-    
+
     include conf.d/{{ domain }}.d/*.conf;
 
     include conf.d/yunohost_admin.conf.inc;

--- a/data/templates/nginx/yunohost_admin.conf
+++ b/data/templates/nginx/yunohost_admin.conf
@@ -1,25 +1,30 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+
     location / {
         rewrite ^ https://$http_host/yunohost/admin permanent;
     }
+
     location /yunohost/admin {
         rewrite ^ https://$http_host$request_uri? permanent;
     }
 }
+
 server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
-    ssl_certificate     /etc/yunohost/certs/yunohost.org/crt.pem;
+
+    ssl_certificate /etc/yunohost/certs/yunohost.org/crt.pem;
     ssl_certificate_key /etc/yunohost/certs/yunohost.org/key.pem;
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
+
     add_header Strict-Transport-Security "max-age=31536000;";
-    
+
     location / {
         rewrite ^ https://$http_host/yunohost/admin permanent;
     }
@@ -30,6 +35,7 @@ server {
            return 403;
        }
     }
+
     include conf.d/yunohost_admin.conf.inc;
     include conf.d/yunohost_api.conf.inc;
 }


### PR DESCRIPTION
This hides the Nginx version in error pages to make it harder for script kiddies to target vulnerabilities specific to a version.

Before:

```html
<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.6.2</center>
</body>
</html>
```

After:

```html
<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

I also did some whitespace cleanup.

This is my first PR to get to know the _yunohost_ codebase. I used https://yunohost.org/#/docker to test my changes and it worked relatively well but I'm wondering if you have any kind of automated testsuite or build system? Thank you for this great project!