### PR TITLE
Display a more useful error message to a user with how to perform the recommanded action.

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -18,7 +18,7 @@ do_configure() {
       service yunohost-firewall status > /dev/null \
         && service yunohost-firewall restart \
         || echo "Service yunohost-firewall is not running, you should " \
-            "consider to start it."
+            "consider to start it by doing 'service yunohost-firewall start'."
   fi
 
   # update PAM configs


### PR DESCRIPTION
In this kind of situation where things are obvious for us by maybe not for the
user we should always display how to the things we recommand to do or even put
a link to the documentation if needed. Those simple actions will **greatlly**
increase the ease of usage of YunoHost and make a lot of users more happy and
reduce support workload.