### PR TITLE
[enh] add example to use '-a' option with 'yunohost app install' comm…

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -436,7 +436,7 @@ app:
                     help: Custom name for the app
                 -a:
                     full: --args
-                    help: Serialize arguments for app installation
+                    help: Serialized arguments for app script (i.e. "domain=domain.tld&url_path=/path")
 
         ### app_remove() TODO: Write help
         remove:


### PR DESCRIPTION
…and.

I can't use a dot to split in two sentences.