### PR TITLE
[enh] Add a yunopaste script to paste data to YunoHost Haste server

### DIFF
--- a/bin/yunopaste
+++ b/bin/yunopaste
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -e
+set -u
+
+PASTE_URL="https://paste.yunohost.org"
+
+_die() {
+  printf "Error: %s\n" "$*"
+  exit 1
+}
+
+check_dependencies() {
+  curl -V > /dev/null 2>&1 || _die "This script requires curl."
+}
+
+paste_data() {
+  json=$(curl -X POST -s -d "$1" "${PASTE_URL}/documents")
+  [[ -z "$json" ]] && _die "Unable to post the data to the server."
+
+  key=$(echo "$json" \
+    | python -c 'import json,sys;o=json.load(sys.stdin);print o["key"]' \
+        2>/dev/null)
+  [[ -z "$key" ]] && _die "Unable to parse the server response."
+
+  echo "${PASTE_URL}/${key}"
+}
+
+usage() {
+  printf "Usage: ${0} [OPTION]...
+
+Read from input stream and paste the data to the YunoHost
+Haste server.
+
+For example, to paste the output of the YunoHost diagnosis, you
+can simply execute the following:
+  yunohost tools diagnosis | ${0}
+
+It will return the URL where you can access the pasted data.
+
+Options:
+  -h, --help   show this help message and exit
+"
+}
+
+main() {
+  # parse options
+  while (( ${#} )); do
+    case "${1}" in
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown parameter detected: ${1}" >&2
+        echo >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+
+    shift 1
+  done
+
+  # check input stream
+  read -t 0 || {
+    echo -e "Invalid usage: No input is provided.\n" >&2
+    usage
+    exit 1
+  }
+
+  paste_data "$(cat)"
+}
+
+check_dependencies
+
+main "${@}"


### PR DESCRIPTION
Thanks to @opi, we now have our Haste server back. As also suggested by @opi, we could easily provide a script for users to paste commands output - and especially YunoHost ones - to it. This script attempts to do that.