### PR TITLE
[fix] Use ps to check if MySQL is running in conf_regen hook (fix #232)

### DIFF
--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -17,7 +17,7 @@ do_post_regen() {
       . /usr/share/yunohost/helpers.d/string
 
       # ensure that mysql is running
-      service mysql status >/dev/null 2>&1 \
+      ps -C mysqld >/dev/null 2>&1 \
         || service mysql start
 
       # generate and set new root password


### PR DESCRIPTION
`service mysql status` seems to fail on some systems, even if the service is running. This makes use of `ps` to check if MySQL is running instead, which is more reliable.