### PR TITLE
Harden backup hooks to handle errors

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -22,7 +22,7 @@ ynh_backup() {
     }
 
     # prepend the backup directory
-    [[ -n "${YNH_APP_BACKUP_DIR}" && "${DESTPATH:0:1}" != "/" ]] \
+    [[ -n "${YNH_APP_BACKUP_DIR:-}" && "${DESTPATH:0:1}" != "/" ]] \
         && DESTPATH="${YNH_APP_BACKUP_DIR}/${DESTPATH}"
     [[ ! -e "${DESTPATH}" ]] || {
         echo "Destination path '${DESTPATH}' already exist" >&2

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -35,8 +35,7 @@ ynh_backup() {
 
         if sudo mount --rbind "${SRCPATH}" "${DESTPATH}"; then
             # try to remount destination directory as read-only
-            sudo mount -o remount,ro "${DESTPATH}" >/dev/null 2>&1 \
-              || sudo mount -o remount,ro,bind "${SRCPATH}" "${DESTPATH}" \
+            sudo mount -o remount,ro,bind "${SRCPATH}" "${DESTPATH}" \
               || true
             return 0
         else

--- a/data/hooks/backup/05-conf_ldap
+++ b/data/hooks/backup/05-conf_ldap
@@ -1,14 +1,17 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ldap"
 
-# Back up the configuration
+# Backup the configuration
 ynh_backup "/etc/ldap/slapd.conf" "${backup_dir}/slapd.conf"
 sudo slapcat -b cn=config -l "${backup_dir}/cn=config.master.ldif"
 
-# Back up the database
+# Backup the database
 sudo slapcat -b dc=yunohost,dc=org -l "${backup_dir}/dc=yunohost-dc=org.ldif"

--- a/data/hooks/backup/05-conf_ldap
+++ b/data/hooks/backup/05-conf_ldap
@@ -1,13 +1,13 @@
-backup_dir="${1}/conf/ldap"
-sudo mkdir -p "$backup_dir"
+#!/bin/bash
 
-# Fix for first jessie yunohost where slapd.conf is called slapd-yuno.conf
-# without slapcat doesn't work
-[[ ! -f /etc/ldap/slapd.conf ]] \
-  && sudo mv /etc/ldap/slapd-yuno.conf /etc/ldap/slapd.conf
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ldap"
 
 # Back up the configuration
-sudo cp -a /etc/ldap/slapd.conf "${backup_dir}/slapd.conf"
+ynh_backup "/etc/ldap/slapd.conf" "${backup_dir}/slapd.conf"
 sudo slapcat -b cn=config -l "${backup_dir}/cn=config.master.ldif"
 
 # Back up the database

--- a/data/hooks/backup/05-conf_ldap
+++ b/data/hooks/backup/05-conf_ldap
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ldap"

--- a/data/hooks/backup/08-conf_ssh
+++ b/data/hooks/backup/08-conf_ssh
@@ -1,8 +1,13 @@
-backup_dir="$1/conf/ssh"
-sudo mkdir -p $backup_dir
+#!/bin/bash
+
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ssh"
 
 if [ -d /etc/ssh/ ]; then
-    sudo cp -a /etc/ssh/. $backup_dir
+    ynh_backup "/etc/ssh" "$backup_dir"
 else
     echo "SSH is not installed"
 fi

--- a/data/hooks/backup/08-conf_ssh
+++ b/data/hooks/backup/08-conf_ssh
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ssh"

--- a/data/hooks/backup/08-conf_ssh
+++ b/data/hooks/backup/08-conf_ssh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ssh"
 
+# Backup the configuration
 if [ -d /etc/ssh/ ]; then
     ynh_backup "/etc/ssh" "$backup_dir"
 else

--- a/data/hooks/backup/11-conf_ynh_mysql
+++ b/data/hooks/backup/11-conf_ynh_mysql
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ynh/mysql"

--- a/data/hooks/backup/11-conf_ynh_mysql
+++ b/data/hooks/backup/11-conf_ynh_mysql
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ynh/mysql"
 
 # Save MySQL root password

--- a/data/hooks/backup/11-conf_ynh_mysql
+++ b/data/hooks/backup/11-conf_ynh_mysql
@@ -1,4 +1,10 @@
-backup_dir="$1/conf/ynh/mysql"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/yunohost/mysql "${backup_dir}/root_pwd"
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ynh/mysql"
+
+# Save MySQL root password
+ynh_backup "/etc/yunohost/mysql" "${backup_dir}/root_pwd"

--- a/data/hooks/backup/14-conf_ssowat
+++ b/data/hooks/backup/14-conf_ssowat
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ssowat"
 
+# Backup the configuration
 ynh_backup "/etc/ssowat" "$backup_dir"

--- a/data/hooks/backup/14-conf_ssowat
+++ b/data/hooks/backup/14-conf_ssowat
@@ -1,4 +1,9 @@
-backup_dir="$1/conf/ssowat"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/ssowat/. $backup_dir
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ssowat"
+
+ynh_backup "/etc/ssowat" "$backup_dir"

--- a/data/hooks/backup/14-conf_ssowat
+++ b/data/hooks/backup/14-conf_ssowat
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ssowat"

--- a/data/hooks/backup/17-data_home
+++ b/data/hooks/backup/17-data_home
@@ -1,4 +1,8 @@
-. /usr/share/yunohost/helpers
+#!/bin/bash
+
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
 
 for f in $(find /home/* -type d -prune | awk -F/ '{print $NF}'); do
     if [[ ! "$f" =~ ^yunohost|lost\+found ]]; then

--- a/data/hooks/backup/17-data_home
+++ b/data/hooks/backup/17-data_home
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
+backup_dir="${1}/data/home"
+
+# Backup user home
 for f in $(find /home/* -type d -prune | awk -F/ '{print $NF}'); do
     if [[ ! "$f" =~ ^yunohost|lost\+found ]]; then
-        ynh_backup "/home/$f" "${1}/data/home/$f" 1
+        ynh_backup "/home/$f" "${backup_dir}/$f" 1
     fi
 done

--- a/data/hooks/backup/17-data_home
+++ b/data/hooks/backup/17-data_home
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/data/home"

--- a/data/hooks/backup/20-conf_ynh_firewall
+++ b/data/hooks/backup/20-conf_ynh_firewall
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ynh/firewall"

--- a/data/hooks/backup/20-conf_ynh_firewall
+++ b/data/hooks/backup/20-conf_ynh_firewall
@@ -1,4 +1,9 @@
-backup_dir="$1/conf/ynh/firewall"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/yunohost/firewall* $backup_dir
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ynh/firewall"
+
+ynh_backup "/etc/yunohost/firewall.yml" "${backup_dir}/firewall.yml"

--- a/data/hooks/backup/20-conf_ynh_firewall
+++ b/data/hooks/backup/20-conf_ynh_firewall
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ynh/firewall"
 
+# Backup the configuration
 ynh_backup "/etc/yunohost/firewall.yml" "${backup_dir}/firewall.yml"

--- a/data/hooks/backup/21-conf_ynh_certs
+++ b/data/hooks/backup/21-conf_ynh_certs
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ynh/certs"
 
+# Backup certificates
 ynh_backup "/etc/yunohost/certs" "$backup_dir"

--- a/data/hooks/backup/21-conf_ynh_certs
+++ b/data/hooks/backup/21-conf_ynh_certs
@@ -1,4 +1,9 @@
-backup_dir="$1/conf/ynh/certs"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/yunohost/certs/. $backup_dir
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ynh/certs"
+
+ynh_backup "/etc/yunohost/certs" "$backup_dir"

--- a/data/hooks/backup/21-conf_ynh_certs
+++ b/data/hooks/backup/21-conf_ynh_certs
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ynh/certs"

--- a/data/hooks/backup/23-data_mail
+++ b/data/hooks/backup/23-data_mail
@@ -1,3 +1,7 @@
-. /usr/share/yunohost/helpers
+#!/bin/bash
+
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
 
 ynh_backup /var/mail "${1}/data/mail" 1

--- a/data/hooks/backup/23-data_mail
+++ b/data/hooks/backup/23-data_mail
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
-ynh_backup /var/mail "${1}/data/mail" 1
+# Backup destination
+backup_dir="${1}/data/mail"
+
+# Backup mails
+ynh_backup /var/mail "$backup_dir" 1

--- a/data/hooks/backup/23-data_mail
+++ b/data/hooks/backup/23-data_mail
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/data/mail"

--- a/data/hooks/backup/26-conf_xmpp
+++ b/data/hooks/backup/26-conf_xmpp
@@ -1,5 +1,10 @@
-backup_dir="$1/conf/xmpp"
-sudo mkdir -p $backup_dir/{etc,var}
+#!/bin/bash
 
-sudo cp -a /etc/metronome/. $backup_dir/etc
-sudo cp -a /var/lib/metronome/. $backup_dir/var
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/xmpp"
+
+ynh_backup /etc/metronome "${backup_dir}/etc"
+ynh_backup /var/lib/metronome "${backup_dir}/var"

--- a/data/hooks/backup/26-conf_xmpp
+++ b/data/hooks/backup/26-conf_xmpp
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/xmpp"

--- a/data/hooks/backup/26-conf_xmpp
+++ b/data/hooks/backup/26-conf_xmpp
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/xmpp"
 
+# Backup the configuration
 ynh_backup /etc/metronome "${backup_dir}/etc"
 ynh_backup /var/lib/metronome "${backup_dir}/var"

--- a/data/hooks/backup/29-conf_nginx
+++ b/data/hooks/backup/29-conf_nginx
@@ -1,4 +1,9 @@
-backup_dir="$1/conf/nginx"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/nginx/conf.d/. $backup_dir
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/nginx"
+
+ynh_backup "/etc/nginx/conf.d" "$backup_dir"

--- a/data/hooks/backup/29-conf_nginx
+++ b/data/hooks/backup/29-conf_nginx
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/nginx"
 
+# Backup the configuration
 ynh_backup "/etc/nginx/conf.d" "$backup_dir"

--- a/data/hooks/backup/29-conf_nginx
+++ b/data/hooks/backup/29-conf_nginx
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/nginx"

--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/cron"

--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -1,4 +1,11 @@
-backup_dir="$1/conf/cron"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/cron.d/yunohost* $backup_dir/
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/cron"
+
+for f in $(ls -1B /etc/cron.d/yunohost*); do
+  ynh_backup "$f" "${backup_dir}/${f##*/}"
+done

--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/cron"
 
+# Backup the configuration
 for f in $(ls -1B /etc/cron.d/yunohost*); do
   ynh_backup "$f" "${backup_dir}/${f##*/}"
 done

--- a/data/hooks/backup/40-conf_ynh_currenthost
+++ b/data/hooks/backup/40-conf_ynh_currenthost
@@ -1,4 +1,9 @@
-backup_dir="$1/conf/ynh"
-sudo mkdir -p $backup_dir
+#!/bin/bash
 
-sudo cp -a /etc/yunohost/current_host "${backup_dir}/current_host"
+set -eu
+
+. /usr/share/yunohost/helpers.d/filesystem
+
+backup_dir="${1}/conf/ynh"
+
+ynh_backup "/etc/yunohost/current_host" "${backup_dir}/current_host"

--- a/data/hooks/backup/40-conf_ynh_currenthost
+++ b/data/hooks/backup/40-conf_ynh_currenthost
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-. /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers.d/filesystem
 
 # Backup destination
 backup_dir="${1}/conf/ynh"

--- a/data/hooks/backup/40-conf_ynh_currenthost
+++ b/data/hooks/backup/40-conf_ynh_currenthost
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# Exit hook on subcommand error or unset variable
 set -eu
 
+# Source YNH helpers
 . /usr/share/yunohost/helpers.d/filesystem
 
+# Backup destination
 backup_dir="${1}/conf/ynh"
 
+# Backup the configuration
 ynh_backup "/etc/yunohost/current_host" "${backup_dir}/current_host"

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -360,12 +360,14 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     # Check and return process' return code
     if returncode is None:
         if raise_on_error:
-            raise MoulinetteError(m18n.n('hook_exec_not_terminated', path=path))
+            raise MoulinetteError(
+                errno.EIO, m18n.n('hook_exec_not_terminated', path=path))
         else:
             logger.error(m18n.n('hook_exec_not_terminated', path=path))
             return 1
     elif raise_on_error and returncode != 0:
-        raise MoulinetteError(m18n.n('hook_exec_failed', path=path))
+        raise MoulinetteError(
+            errno.EIO, m18n.n('hook_exec_failed', path=path))
     return returncode
 
 


### PR DESCRIPTION
It adds `set -eu` to each backup hook to ensure that it will fail on command error and/or unset variable. The goal is to prevent [this situation](https://forum.yunohost.org/t/yunohost-in-read-only-mode/) where a system hook is considered as successful even if it failed. It will by the way also prevent to let the user think that he/she has a system backup - even if it's an empty one!
It also makes use of `ynh_backup` for each file/directory backup.