### PR TITLE
[fix] Set /var/mail folder owners and permissions

### DIFF
--- a/data/hooks/conf_regen/25-dovecot
+++ b/data/hooks/conf_regen/25-dovecot
@@ -38,6 +38,8 @@ do_post_regen() {
   # fix permissions
   sudo chown -R vmail:mail /etc/dovecot/global_script
   sudo chmod 770 /etc/dovecot/global_script
+  sudo chown root:mail /var/mail
+  sudo chmod 1775 /var/mail
 
   [ -z "$regen_conf_files" ] && exit 0
 


### PR DESCRIPTION
This is needed by Dovecot - and especially by Sieve. If the permission is incorrectly set - as it was on my server: `drwxrwsr-x root:man`, *managesieve* will not be able to create any folder inside. Here is the error when trying to manage Sieve filters with Roundcube:

    dovecot[1150]: managesieve(camille): Error: sieve-storage: mkdir_parents_chgrp(/var/mail/sievescript/camille/scripts//tmp) failed: Permission denied (euid=500(vmail) egid=8(mail) missing +w perm: /var/mail, we're not in group 12(man), dir owned by 0:12 mode=0775)
    dovecot[1150]: managesieve(camille): Fatal: Failed to open Sieve storage.