### PR TITLE
[enh] display file path on file_not_exist error

### DIFF
--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -315,7 +315,7 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     if path[0] != '/':
         path = os.path.realpath(path)
     if not os.path.isfile(path):
-        raise MoulinetteError(errno.EIO, m18n.g('file_not_exist'))
+        raise MoulinetteError(errno.EIO, m18n.g('file_not_exist', path=path))
 
     # Construct command variables
     cmd_args = ''


### PR DESCRIPTION
Move from displaying

```
"ERROR File does not exist"
```

To:

```
"ERROR File does not exist: '/path/to/file'"
```

Requires https://github.com/YunoHost/moulinette/pull/123 (and thus a release of both moulinette and yunohost)
