### PR TITLE
First version of "journals" for YunoHost

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1392,7 +1392,7 @@ journals:
     category_help: Manage debug journals
     actions:
 
-        ### domain_list()
+        ### journals_list()
         list:
             action_help: List journals
             api: GET /journals

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1401,3 +1401,11 @@ journals:
                     full: --limit
                     help: Maximum number of journals per categories
                     type: int
+
+        ### journals_display()
+        display:
+            action_help: List journals
+            api: GET /journals/<file_name>
+            arguments:
+                file_name:
+                    help: Journal file name

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1384,3 +1384,15 @@ hook:
                 -d:
                     full: --chdir
                     help: The directory from where the script will be executed
+
+#############################
+#          Journals         #
+#############################
+journals:
+    category_help: Manage debug journals
+    actions:
+
+        ### domain_list()
+        list:
+            action_help: List journals
+            api: GET /journals

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1396,3 +1396,8 @@ journals:
         list:
             action_help: List journals
             api: GET /journals
+            arguments:
+               -l:
+                    full: --limit
+                    help: Maximum number of journals per categories
+                    type: int

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -334,6 +334,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
 
     """
     from yunohost.hook import hook_add, hook_remove, hook_exec
+    from yunohost.journals import Journal
 
     try:
         app_list()
@@ -401,7 +402,8 @@ def app_upgrade(auth, app=[], url=None, file=None):
 
         # Execute App upgrade script
         os.system('chown -hR admin: %s' % install_tmp)
-        if hook_exec(app_tmp_folder +'/scripts/upgrade', args=args_list, env=env_dict) != 0:
+        journal = Journal(["upgrade", app_instance_name], "app", args=args_list, env=env_dict)
+        if hook_exec(app_tmp_folder +'/scripts/upgrade', args=args_list, env=env_dict, journa=journal) != 0:
             logger.error(m18n.n('app_upgrade_failed', app=app_instance_name))
         else:
             now = int(time.time())

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -600,6 +600,7 @@ def app_remove(auth, app):
 
     """
     from yunohost.hook import hook_exec, hook_remove
+    from yunohost.journals import Journal
 
     if not _is_installed(app):
         raise MoulinetteError(errno.EINVAL,
@@ -624,7 +625,9 @@ def app_remove(auth, app):
     env_dict["YNH_APP_INSTANCE_NAME"] = app
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
 
-    if hook_exec('/tmp/yunohost_remove/scripts/remove', args=args_list, env=env_dict) == 0:
+    journal = Journal(["remove", app], "app", args=args_list, env=env_dict)
+
+    if hook_exec('/tmp/yunohost_remove/scripts/remove', args=args_list, env=env_dict, journal=journal) == 0:
         logger.success(m18n.n('app_removed', app=app))
 
     if os.path.exists(app_setting_path): shutil.rmtree(app_setting_path)

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -446,6 +446,7 @@ def app_install(auth, app, label=None, args=None):
 
     """
     from yunohost.hook import hook_add, hook_remove, hook_exec
+    from yunohost.journals import Journal
 
     # Fetch or extract sources
     try: os.listdir(install_tmp)
@@ -529,7 +530,12 @@ def app_install(auth, app, label=None, args=None):
     try:
         install_retcode = hook_exec(
             os.path.join(app_tmp_folder, 'scripts/install'),
-            args=args_list, env=env_dict)
+            args=args_list, env=env_dict,
+            journal = Journal(
+                ["install", app_instance_name],
+                "app", args=args_list, env=env_dict
+            ),
+        )
     except (KeyboardInterrupt, EOFError):
         install_retcode = -1
     except:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -551,7 +551,12 @@ def app_install(auth, app, label=None, args=None):
             # Execute remove script
             remove_retcode = hook_exec(
                 os.path.join(app_tmp_folder, 'scripts/remove'),
-                args=[app_instance_name], env=env_dict_remove)
+                args=[app_instance_name], env=env_dict_remove,
+                journal = Journal(
+                    ["remove", app_instance_name, "failed install"],
+                    "app", args=[app_instance_name], env=env_dict_remove,
+                ),
+            )
             if remove_retcode != 0:
                 logger.warning(m18n.n('app_not_properly_removed',
                                       app=app_instance_name))

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -295,7 +295,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
 
 
 def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
-              chdir=None, env=None):
+              chdir=None, env=None, journal=None):
     """
     Execute hook from a file with arguments
 
@@ -348,11 +348,18 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     else:
         logger.info(m18n.n('executing_script', script=path))
 
-    # Define output callbacks and call command
-    callbacks = (
-        lambda l: logger.info(l.rstrip()),
-        lambda l: logger.warning(l.rstrip()),
-    )
+    if journal is None:
+        # Define output callbacks and call command
+        callbacks = (
+            lambda l: logger.info(l.rstrip()),
+            lambda l: logger.warning(l.rstrip()),
+        )
+    else:
+        callbacks = journal.as_callbacks_tuple(
+            stdout=lambda l: logger.info(l.rstrip()),
+            stderr=lambda l: logger.warning(l.rstrip()),
+        )
+
     returncode = call_async_output(
         command, callbacks, shell=False, cwd=chdir
     )

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+""" License
+
+    Copyright (C) 2016 YunoHost
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program; if not, see http://www.gnu.org/licenses
+
+"""
+
+""" yunohost_journals.py
+
+    Manage debug journals
+"""
+
+import os
+
+from moulinette.utils.log import getActionLogger
+
+JOURNALS_PATH = '/var/log/journals/'
+
+logger = getActionLogger('yunohost.journals')
+
+
+def journals_list():
+    """
+    List domains
+
+    Keyword argument:
+        filter -- LDAP filter used to search
+        offset -- Starting number for domain fetching
+        limit -- Maximum number of domain fetched
+
+    """
+    return {}

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -48,3 +48,41 @@ def journals_list():
         return {}
 
     return {}
+
+
+class Journal(object):
+    def __init__(self, name, category, on_stdout=None, on_stderr=None, on_write=None, **kwargs):
+        self.name = name
+        self.category = category
+        self.first_write = False
+        self.started_at = None
+
+        self.on_stdout = [] if on_stdout is None else on_stdout
+        self.on_stderr = [] if on_stderr is None else on_stderr
+        self.on_write = [] if on_write is None else on_write
+
+        self.additional_information = kwargs
+
+    def write(self, line):
+        print "[journal]", line.rstrip()
+
+    def stdout(self, line):
+        for i in self.on_stdout:
+            i(line)
+
+        self.write(line)
+
+    def stderr(self, line):
+        for i in self.on_stderr:
+            i(line)
+
+        self.write(line)
+
+    def as_callbacks_tuple(self, stdout=None, stderr=None):
+        if stdout:
+            self.on_stdout.append(stdout)
+
+        if stderr:
+            self.on_stderr.append(stderr)
+
+        return (self.stdout, self.stderr)

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -95,7 +95,7 @@ def journals_display(file_name):
 
                 infos, logs = content.split("\n---\n", 1)
                 infos = yaml.safe_load(infos)
-                logs = [x.split(": ", 1) for x in logs.split("\n") if x]
+                logs = [{"datetime": x.split(": ", 1)[0].replace("_", " "), "line": x.split(": ", 1)[1]}  for x in logs.split("\n") if x]
 
                 return {
                     "started_at": journal_datetime,

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -76,6 +76,40 @@ def journals_list(limit=None):
     return result
 
 
+def journals_display(file_name):
+    if not os.path.exists(JOURNALS_PATH):
+        # TODO raise exception
+        return {}
+
+    for category in os.listdir(JOURNALS_PATH):
+        for journal in filter(lambda x: x.endswith(".journal"), os.listdir(os.path.join(JOURNALS_PATH, category))):
+            if journal != file_name:
+                continue
+
+            with open(os.path.join(JOURNALS_PATH, category, file_name), "r") as content:
+                content = content.read()
+
+                journal = journal[:-len(".journal")]
+                journal = journal.split("_")
+                journal_datetime = datetime.strptime(" ".join(journal[-2:]), "%Y-%m-%d %H-%M-%S")
+
+                infos, logs = content.split("\n---\n", 1)
+                infos = yaml.safe_load(infos)
+                logs = [x.split(": ", 1) for x in logs.split("\n") if x]
+
+                return {
+                    "started_at": journal_datetime,
+                    "name": " ".join(journal[:-2]),
+                    "file_name": file_name,
+                    "path": os.path.join(JOURNALS_PATH, category, file_name),
+                    "metadata": infos,
+                    "logs": logs,
+                }
+
+    # TODO raise exception
+    return {}
+
+
 class Journal(object):
     def __init__(self, name, category, on_stdout=None, on_stderr=None, on_write=None, **kwargs):
         self.name = name

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -74,7 +74,9 @@ class Journal(object):
         self.name = name
         self.category = category
         self.first_write = True
-        self.started_at = None
+
+        # this help uniformise file name and avoir threads concurrency errors
+        self.started_at = datetime.now()
 
         self.path = os.path.join(JOURNALS_PATH, category)
 
@@ -101,8 +103,6 @@ class Journal(object):
         self.fd.flush()
 
     def _do_first_write(self):
-        self.started_at = datetime.now()
-
         if not os.path.exists(self.path):
             os.makedirs(self.path)
 

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -104,7 +104,7 @@ class Journal(object):
             self._do_first_write()
             self.first_write = False
 
-        self.fd.write("%s: " % datetime.now().strftime("%F_%X").replace(":", "-"))
+        self.fd.write("%s: " % datetime.now().strftime("%F %X"))
         self.fd.write(line.rstrip())
         self.fd.write("\n")
         self.fd.flush()

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -47,13 +47,13 @@ def journals_list(limit=None):
 
     """
 
+    result = {"categories": []}
+
     if not os.path.exists(JOURNALS_PATH):
-        return {}
+        return result
 
-    result = {}
-
-    for category in os.listdir(JOURNALS_PATH):
-        result[category] = []
+    for category in sorted(os.listdir(JOURNALS_PATH)):
+        result["categories"].append({"name": category, "journals": []})
         for journal in filter(lambda x: x.endswith(".journal"), os.listdir(os.path.join(JOURNALS_PATH, category))):
 
             file_name = journal
@@ -61,17 +61,17 @@ def journals_list(limit=None):
             journal = journal[:-len(".journal")]
             journal = journal.split("_")
             journal_datetime = datetime.strptime(" ".join(journal[-2:]), "%Y-%m-%d %H-%M-%S")
-            result[category].append({
+            result["categories"][-1]["journals"].append({
                 "started_at": journal_datetime,
                 "name": " ".join(journal[:-2]),
                 "file_name": file_name,
                 "path": os.path.join(JOURNALS_PATH, category, file_name),
             })
 
-        result[category] = list(reversed(sorted(result[category], key=lambda x: x["started_at"])))
+        result["categories"][-1]["journals"] = list(reversed(sorted(result["categories"][-1]["journals"], key=lambda x: x["started_at"])))
 
         if limit is not None:
-            result[category] = result[category][:limit]
+            result["categories"][-1]["journals"] = result["categories"][-1]["journals"][:limit]
 
     return result
 

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -56,12 +56,16 @@ def journals_list(limit=None):
         result[category] = []
         for journal in filter(lambda x: x.endswith(".journal"), os.listdir(os.path.join(JOURNALS_PATH, category))):
 
+            file_name = journal
+
             journal = journal[:-len(".journal")]
             journal = journal.split("_")
             journal_datetime = datetime.strptime(" ".join(journal[-2:]), "%Y-%m-%d %H-%M-%S")
             result[category].append({
                 "started_at": journal_datetime,
                 "name": " ".join(journal[:-2]),
+                "file_name": file_name,
+                "path": os.path.join(JOURNALS_PATH, category, file_name),
             })
 
         result[category] = list(reversed(sorted(result[category], key=lambda x: x["started_at"])))

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -36,7 +36,7 @@ JOURNALS_PATH = '/var/log/journals/'
 logger = getActionLogger('yunohost.journals')
 
 
-def journals_list():
+def journals_list(limit=None):
     """
     List domains
 
@@ -65,6 +65,9 @@ def journals_list():
             })
 
         result[category] = list(reversed(sorted(result[category], key=lambda x: x["started_at"])))
+
+        if limit is not None:
+            result[category] = result[category][:limit]
 
     return result
 

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -50,7 +50,23 @@ def journals_list():
     if not os.path.exists(JOURNALS_PATH):
         return {}
 
-    return {}
+    result = {}
+
+    for category in os.listdir(JOURNALS_PATH):
+        result[category] = []
+        for journal in filter(lambda x: x.endswith(".journal"), os.listdir(os.path.join(JOURNALS_PATH, category))):
+
+            journal = journal[:-len(".journal")]
+            journal = journal.split("_")
+            journal_datetime = datetime.strptime(" ".join(journal[-2:]), "%Y-%m-%d %H-%M-%S")
+            result[category].append({
+                "started_at": journal_datetime,
+                "name": " ".join(journal[:-2]),
+            })
+
+        result[category] = list(reversed(sorted(result[category], key=lambda x: x["started_at"])))
+
+    return result
 
 
 class Journal(object):

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -31,7 +31,7 @@ from datetime import datetime
 
 from moulinette.utils.log import getActionLogger
 
-JOURNALS_PATH = '/var/log/journals/'
+JOURNALS_PATH = '/var/log/yunohost/journals/'
 
 logger = getActionLogger('yunohost.journals')
 

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -112,6 +112,7 @@ def journals_display(file_name):
 
 class Journal(object):
     def __init__(self, name, category, on_stdout=None, on_stderr=None, on_write=None, **kwargs):
+        # TODO add a way to not save password on app installation
         self.name = name
         self.category = category
         self.first_write = True

--- a/src/yunohost/journals.py
+++ b/src/yunohost/journals.py
@@ -43,4 +43,8 @@ def journals_list():
         limit -- Maximum number of domain fetched
 
     """
+
+    if not os.path.exists(JOURNALS_PATH):
+        return {}
+
     return {}


### PR DESCRIPTION
Hello,

A feature I've been talking about in the past: store in an individual "journals" files some operations like "installing an app" "remove an app" etc...

The idea is to ease debug (it's easy to find what has happen after) but also to empower web users who can't get access to those logs once they have close the tab or other similar behavior.

For now I'm only generating journals for app installation/remove/remove when installation failed/upgrade. We should probably introduce new journals like domain create (openssl stuff), apt related operations and other I can't thnink about right now.

This PR needs a bit of finishing work but it fully functional but I'm still opening it to get feedback,

Here is the result of both commands:

![2016-06-28-061340_925x335_scrot](https://cloud.githubusercontent.com/assets/41827/16403644/9acdff80-3cf7-11e6-8301-bd2dd2aa69d3.png)

![2016-06-28-061414_923x270_scrot](https://cloud.githubusercontent.com/assets/41827/16403646/a07e3594-3cf7-11e6-91d5-1c58041d9c18.png)
End of previous command:
![2016-06-28-061529_744x339_scrot](https://cloud.githubusercontent.com/assets/41827/16403655/c5128b26-3cf7-11e6-92c2-14654c61b919.png)


Weird format is due to mustache limitations.

Kinds regards,