### PR TITLE
Attemp to fix broken installation on slow hardware / VPS

### DIFF
--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -102,6 +102,23 @@ do_post_regen() {
   fi
 
   sudo service slapd force-reload
+
+  # on slow hardware/vm this regen conf would exit before the admin user that
+  # is stored in ldap is available because ldap seems to slow to restart
+  # so we'll wait either until we are able to log as admin or until a timeout
+  # is reached
+  # we need to do this because the next hooks executed after this one during
+  # postinstall requires to run as admin thus breaking postinstall on slow
+  # hardware which mean yunohost can't be correctly installed on those hardware
+  # and this sucks
+  # wait a maximum time of 5 minutes
+  # yes, force-reload behave like a restart
+  number_of_wait=0
+  while ! sudo su admin -c '' && ((number_of_wait < 60))
+  do
+      sleep 5
+      ((number_of_wait += 1))
+  done
 }
 
 FORCE=${2:-0}


### PR DESCRIPTION
Hello,

As reported [here](https://dev.yunohost.org/issues/447) or
[here](https://dev.yunohost.org/issues/463), YunoHost post install fails on
slow hardware/vps because slapd is to slow to restart itself after its
regen-conf.

This patch is an attempt to fix this but I don't have a good testing
environment (my vagrant is too fast for that). Maybe testing that it's possible
to run something using the admin user could be a better test but I don't see
how to do it easily.

A workarround would be to use my patch to runs this kind of operation using
root instead of admin but this is a workaround, not a real fix (and this bug
could still generate other problems).

Cheers,
