### PR TITLE
[fix] ensure that multi_instance key value is always a boolean

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -208,6 +208,11 @@ def app_list(offset=None, limit=None, filter=None, raw=False, installed=False, w
                         app_info_dict['installed'] = app_installed
                         if app_installed:
                             app_info_dict['status'] = _get_app_status(app_id)
+
+                        # dirty: we used to have manifest containing multi_instance value in form of a string
+                        # but we've switched to bool, this line ensure retrocompatibility
+                        app_info_dict["manifest"]["multi_instance"] = is_true(app_info_dict["manifest"].get("multi_instance", False))
+
                         list_dict[app_id] = app_info_dict
                     else:
                         label = None


### PR DESCRIPTION
We've chosen to use boolean everywhere for multi_instance apps, but some app still use string, we need to ensure that we have boolean value everywhere in the mean time (and we'll remove that code in the future).

This is done because for now yunohost-admin expect string and that breaks app that uses a boolean (they aren't detected as multi instance apps by yunohost-admin but ones that uses strings are).

I'm going to do a pr for yunohost-admin too.