### PR TITLE
[fix] Support git ynh app with submodules #533

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1259,8 +1259,13 @@ def _fetch_app_from_git(app):
                 url = url[:tree_index]
                 branch = app[tree_index+6:]
             try:
+                # We use currently git 2.1 so we can't use --shallow-submodules
+                # option. When git will be in 2.9 (with the new debian version)
+                # we will be able to use it. Without this option all the history
+                # of the submodules repo is downloaded.
                 subprocess.check_call([
-                    'git', 'clone', '--depth=1', url, extracted_app_folder])
+                    'git', 'clone', '--depth=1', '--recursive', url,
+                    extracted_app_folder])
                 subprocess.check_call([
                         'git', 'reset', '--hard', branch
                     ], cwd=extracted_app_folder)


### PR DESCRIPTION
I tried to use git submodule for assure the iso sources but yunohost doesn't support it with a non github url because the git clone is not recursive.

Since git 2.9 there is an option to force submodule to just download the last commit --shallow-submodules https://git-scm.com/docs/git-clone , but with the current yunohost (debian jessie) git is in version 2.1 so we should wait before adding this option.

This Merge Request is linked to the ticket https://dev.yunohost.org/issues/533
