### PR TITLE
[enh] Dovecot extensible configuration

### DIFF
--- a/data/hooks/conf_regen/25-dovecot
+++ b/data/hooks/conf_regen/25-dovecot
@@ -26,10 +26,17 @@ do_pre_regen() {
       's/^\(listen =\).*/\1 */' \
       "${dovecot_dir}/dovecot.conf"
   fi
+
+  mkdir -p "${dovecot_dir}/yunohost.d"
+  cp pre-ext.conf "${dovecot_dir}/yunohost.d"
+  cp post-ext.conf "${dovecot_dir}/yunohost.d"
 }
 
 do_post_regen() {
   regen_conf_files=$1
+
+  sudo mkdir -p "/etc/dovecot/yunohost.d/pre-ext.d"
+  sudo mkdir -p "/etc/dovecot/yunohost.d/post-ext.d"
 
   # create vmail user
   id vmail > /dev/null 2>&1 \

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -1,15 +1,44 @@
 listen = *, ::
 auth_mechanisms = plain login
+
 mail_gid = 8
 mail_home = /var/mail/%n
 mail_location = maildir:/var/mail/%n
 mail_uid = 500
+
+protocols = imap sieve
+
+mail_plugins = $mail_plugins quota
+
+ssl = yes
+ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem
+ssl_key = </etc/yunohost/certs/{{ main_domain }}/key.pem
+ssl_protocols = !SSLv2 !SSLv3
+
 passdb {
   args = /etc/dovecot/dovecot-ldap.conf
   driver = ldap
 }
-protocols = imap sieve
-mail_plugins = $mail_plugins quota
+
+userdb {
+  args = /etc/dovecot/dovecot-ldap.conf
+  driver = ldap
+}
+
+protocol imap {
+  imap_client_workarounds =
+  mail_plugins = $mail_plugins imap_quota antispam
+}
+
+protocol lda {
+  auth_socket_path = /var/run/dovecot/auth-master
+  mail_plugins = quota sieve
+  postmaster_address = postmaster@{{ main_domain }}
+}
+
+protocol sieve {
+}
+
 service auth {
   unix_listener /var/spool/postfix/private/auth {
     group = postfix
@@ -23,26 +52,11 @@ service auth {
   }
 }
 
-protocol sieve {
-}
-
-ssl = yes
-ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem
-ssl_key = </etc/yunohost/certs/{{ main_domain }}/key.pem
-ssl_protocols = !SSLv2 !SSLv3
-
-userdb {
-  args = /etc/dovecot/dovecot-ldap.conf
-  driver = ldap
-}
-protocol imap {
-  imap_client_workarounds =
-  mail_plugins = $mail_plugins imap_quota antispam
-}
-protocol lda {
-  auth_socket_path = /var/run/dovecot/auth-master
-  mail_plugins = quota sieve
-  postmaster_address = postmaster@{{ main_domain }}
+service quota-warning {
+  executable = script /usr/bin/quota-warning.sh
+  user = vmail
+  unix_listener quota-warning {
+  }
 }
 
 plugin {
@@ -80,9 +94,3 @@ plugin {
   quota_warning3 = -storage=100%% quota-warning below %u # user is no longer over quota
 }
 
-service quota-warning {
-  executable = script /usr/bin/quota-warning.sh
-  user = vmail
-  unix_listener quota-warning {
-  }
-}

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -78,11 +78,6 @@ plugin {
 }
 
 plugin {
-  autosubscribe = Trash
-  autosubscribe2 = Junk
-}
-
-plugin {
   quota = maildir:User quota
   quota_rule2 = SPAM:ignore
   quota_rule3 = Trash:ignore

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -1,3 +1,5 @@
+!include yunohost.d/pre-ext.conf
+
 listen = *, ::
 auth_mechanisms = plain login
 
@@ -9,6 +11,7 @@ mail_uid = 500
 protocols = imap sieve
 
 mail_plugins = $mail_plugins quota
+
 
 ssl = yes
 ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem
@@ -29,6 +32,7 @@ protocol imap {
   imap_client_workarounds =
   mail_plugins = $mail_plugins imap_quota antispam
 }
+
 
 protocol lda {
   auth_socket_path = /var/run/dovecot/auth-master
@@ -89,3 +93,4 @@ plugin {
   quota_warning3 = -storage=100%% quota-warning below %u # user is no longer over quota
 }
 
+!include yunohost.d/post-ext.conf

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -1,5 +1,3 @@
-# 2.1.7: /etc/dovecot/dovecot.conf
-# OS: Linux 3.2.0-3-686-pae i686 Debian wheezy/sid ext4
 listen = *, ::
 auth_mechanisms = plain login
 login_greeting = Dovecot ready!!

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -1,6 +1,5 @@
 listen = *, ::
 auth_mechanisms = plain login
-login_greeting = Dovecot ready!!
 mail_gid = 8
 mail_home = /var/mail/%n
 mail_location = maildir:/var/mail/%n

--- a/data/templates/dovecot/post-ext.conf
+++ b/data/templates/dovecot/post-ext.conf
@@ -1,0 +1,1 @@
+!include_try post-ext.d/*.conf

--- a/data/templates/dovecot/pre-ext.conf
+++ b/data/templates/dovecot/pre-ext.conf
@@ -1,0 +1,1 @@
+!include_try pre-ext.d/*.conf


### PR DESCRIPTION
This set of commits allow anyone (apps typically) to extend dovecot configuration.
The intendend use is to enable specific plugins not included in the base yunohost conf.

One use case experiment is : https://github.com/YunoHost-Apps/ftssolr_ynh to enable Solr based Full Text Search. (which I currently run successfully in production on my ynh box)
