### PR TITLE
Fix backup when /home/yunohost.backup/archives is on a different device

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -299,7 +299,7 @@ def backup_create(name=None, description=None, output_directory=None,
                                   m18n.n('backup_creation_failed'))
 
         # Move info file
-        os.rename(tmp_dir + '/info.json',
+        shutil.move(tmp_dir + '/info.json',
                   '{:s}/{:s}.info.json'.format(archives_path, name))
 
     # Clean temporary directory


### PR DESCRIPTION
if /home/yunohost.backup/archives is on a different device (for instance, a NAS), backups fail with the message:
...
 File "/usr/lib/moulinette/yunohost/backup.py", line 303, in backup_create
    '{:s}/{:s}.info.json'.format(archives_path, name))
OSError: [Errno 18] Invalid cross-device link

A simple solution is to use shutil.move because, as stated in the documentation, "If the destination is on the current filesystem, then os.rename() is used. Otherwise, src is copied (using shutil.copy2()) to dst and then removed.", which is the needed behavior.
This PR has been successfully tested.
