### PR TITLE
[fix] Can't restore app on a root domain

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -909,10 +909,6 @@ def app_checkurl(auth, url, app=None):
         raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
 
     if domain in apps_map:
-        # Domain already has apps on sub path
-        if path == '/':
-            raise MoulinetteError(errno.EPERM,
-                                  m18n.n('app_location_install_failed'))
         # Loop through apps
         for p, a in apps_map[domain].items():
             # Skip requested app checking
@@ -922,7 +918,7 @@ def app_checkurl(auth, url, app=None):
             if path == p:
                 raise MoulinetteError(errno.EINVAL,
                                       m18n.n('app_location_already_used'))
-            elif path.startswith(p):
+            elif path.startswith(p) or p.startswith(path):
                 raise MoulinetteError(errno.EPERM,
                                       m18n.n('app_location_install_failed'))
 


### PR DESCRIPTION
Fix this issue https://dev.yunohost.org/issues/593

It fix an unlisted other bug. Before the fix it was possible to install an app on /a/b and next install an other app on /a .