### PR TITLE
[fix] Can't get mailbox used space if dovecot is down

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -118,6 +118,7 @@
     "mail_alias_remove_failed": "Unable to remove mail alias '{mail:s}'",
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",
     "mail_forward_remove_failed": "Unable to remove mail forward '{mail:s}'",
+    "mailbox_used_space_dovecot_down": "Dovecot mailbox service need to be up, if you want to get mailbox used space",
     "maindomain_change_failed": "Unable to change the main domain",
     "maindomain_changed": "The main domain has been changed",
     "monitor_disabled": "The server monitoring has been disabled",

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -408,7 +408,7 @@ def user_info(auth, username):
         is_limited = not re.match('0[bkMGT]?', userquota)
         storage_use = '?'
 
-        if (service_status("dovecot")["status"] != "running"):
+        if service_status("dovecot")["status"] != "running":
             logger.warning(m18n.n('mailbox_used_space_dovecot_down'))
         else:
             cmd = 'doveadm -f flow quota get -u %s' % user['uid'][0]

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -399,30 +399,38 @@ def user_info(auth, username):
 
     if 'mailuserquota' in user:
         userquota = user['mailuserquota'][0]
-        if isinstance( userquota, int ):
+
+        if isinstance(userquota, int):
             userquota = str(userquota)
 
         # Test if userquota is '0' or '0M' ( quota pattern is ^(\d+[bkMGT])|0$ )
         is_limited = not re.match('0[bkMGT]?', userquota)
         storage_use = '?'
+
         cmd = 'doveadm -f flow quota get -u %s' % user['uid'][0]
+
         try:
-            cmd_result = subprocess.check_output(cmd,stderr=subprocess.STDOUT,
+            cmd_result = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
                                                  shell=True)
             # Exemple of return value for cmd:
             # """Quota name=User quota Type=STORAGE Value=0 Limit=- %=0
             # Quota name=User quota Type=MESSAGE Value=0 Limit=- %=0"""
-            has_value=re.search(r'Value=(\d+)', cmd_result)
+            has_value = re.search(r'Value=(\d+)', cmd_result)
+
             if has_value:
                 storage_use = int(has_value.group(1))
                 storage_use = _convertSize(storage_use)
+
                 if is_limited:
-                    has_percent=re.search(r'%=(\d+)', cmd_result)
+                    has_percent = re.search(r'%=(\d+)', cmd_result)
+
                     if has_percent:
                         percentage = int(has_percent.group(1))
-                        storage_use += ' (%s%s)' % (percentage, '%')
+                        storage_use += ' (%s%%)' % percentage
+
         except subprocess.CalledProcessError:
             logger.warning(m18n.n('mailbox_used_space_dovecot_down'))
+
         result_dict['mailbox-quota'] = {
             'limit' : userquota if is_limited else m18n.n('unlimit'),
             'use' : storage_use


### PR DESCRIPTION
See https://dev.yunohost.org/issues/640
To solve it there is a try except and a warning display to the user about dovecot status.

There are small fixes in more: it removes a bad eval and the way to parse `doveadm` result is more reliable (the percentage was sometimes the number of message).

Optionaly: I suggest a linked PR on yunohost-admin with https://github.com/YunoHost/yunohost-admin/pull/137 .

Here are some examples of the new api


**Classic case** 
```
root@yunohost:/vagrant# yunohost user info test
firstname: Jean
fullname: Jean Dupont
lastname: Dupont
mail: test@testle4.nohost.me
mailbox-quota: 
  limit: 500M
  use: 5M (1%)
username: test
```

**No quota case : the percentage in use is not displayed**
```
root@yunohost:/vagrant# yunohost user info test
firstname: Jean
fullname: Jean Dupont
lastname: Dupont
mail: test@testle4.nohost.me
mailbox-quota: 
  limit: No quota
  use: 0.0K
username: test
```

**Dovecot shutdown (or failed) case**
```
root@yunohost:/vagrant# yunohost user info test
firstname: Jean
fullname: Jean Dupont
lastname: Dupont
mail: test@testle4.nohost.me
mailbox-quota: 
  limit: 500M
  use: ?
username: test
```