### PR TITLE
[fix] Disable removal of main domain and clarify tools_maindomain

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1266,7 +1266,7 @@ tools:
 
         ### tools_maindomain()
         maindomain:
-            action_help: Main domain change tool
+            action_help: Check the current main domain, or change it
             api:
                 - GET /domains/main
                 - PUT /domains/main
@@ -1274,12 +1274,9 @@ tools:
                 authenticate: all
                 lock: false
             arguments:
-                -o:
-                    full: --old-domain
-                    extra:
-                        pattern: *pattern_domain
                 -n:
                     full: --new-domain
+                    help: Change the current main domain
                     extra:
                         pattern: *pattern_domain
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -258,5 +258,6 @@
     "certmanager_hit_rate_limit" :"Too many certificates already issued for exact set of domains {domain:s} recently. Please try again later. See https://letsencrypt.org/docs/rate-limits/ for more details.",
     "certmanager_cert_signing_failed" : "Signing the new certificate failed.",
     "certmanager_no_cert_file" : "Unable to read certificate file for domain {domain:s} (file : {file:s})",
-    "certmanager_conflicting_nginx_file": "Unable to prepare domain for ACME challenge : the nginx configuration file {filepath:s} is conflicting and should be removed first."
+    "certmanager_conflicting_nginx_file": "Unable to prepare domain for ACME challenge : the nginx configuration file {filepath:s} is conflicting and should be removed first.",
+    "domain_cannot_remove_main": "Cannot remove main domain. Set a new main domain first"
 }

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -160,7 +160,7 @@ def domain_remove(auth, domain, force=False):
         raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
 
     # Check domain is not the main domain
-    if (domain == _get_maindomain()) :
+    if domain == _get_maindomain():
         raise MoulinetteError(errno.EINVAL, m18n.n('domain_cannot_remove_main'))
 
     # Check if apps are installed on the domain
@@ -289,6 +289,7 @@ def get_public_ip(protocol=4):
         logger.debug('cannot retrieve public IPv%d' % protocol, exc_info=1)
         raise MoulinetteError(errno.ENETUNREACH,
                               m18n.n('no_internet_connection'))
+
 
 def _get_maindomain():
     with open('/etc/yunohost/current_host', 'r') as f:

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -113,6 +113,7 @@ def domain_add(auth, domain, dyndns=False):
                 raise MoulinetteError(errno.EINVAL,
                                       m18n.n('domain_dyndns_root_unknown'))
 
+
     try:
         yunohost.certificate._certificate_install_selfsigned([domain], False)
 
@@ -157,6 +158,10 @@ def domain_remove(auth, domain, force=False):
 
     if not force and domain not in domain_list(auth)['domains']:
         raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
+
+    # Check domain is not the main domain
+    if (domain == _get_maindomain()) :
+        raise MoulinetteError(errno.EINVAL, m18n.n('domain_cannot_remove_main'))
 
     # Check if apps are installed on the domain
     for app in os.listdir('/etc/yunohost/apps/'):
@@ -284,3 +289,12 @@ def get_public_ip(protocol=4):
         logger.debug('cannot retrieve public IPv%d' % protocol, exc_info=1)
         raise MoulinetteError(errno.ENETUNREACH,
                               m18n.n('no_internet_connection'))
+
+def _get_maindomain():
+    with open('/etc/yunohost/current_host', 'r') as f:
+        maindomain = f.readline().rstrip()
+    return maindomain
+
+def _set_maindomain(domain):
+    with open('/etc/yunohost/current_host', 'w') as f:
+        f.write(domain)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -39,7 +39,7 @@ import apt.progress
 from moulinette.core import MoulinetteError, init_authenticator
 from moulinette.utils.log import getActionLogger
 from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, app_list
-from yunohost.domain import domain_add, domain_list, get_public_ip
+from yunohost.domain import domain_add, domain_list, get_public_ip, _get_maindomain, _set_maindomain
 from yunohost.dyndns import dyndns_subscribe
 from yunohost.firewall import firewall_upnp
 from yunohost.service import service_status, service_regen_conf, service_log
@@ -127,50 +127,43 @@ def tools_adminpw(auth, new_password):
 
 def tools_maindomain(auth, old_domain=None, new_domain=None, dyndns=False):
     """
-    Main domain change tool
+    Main domain consultaton or change tool
 
     Keyword argument:
-        new_domain
-        old_domain
+        new_domain -- The new domain to be set as the main domain
 
     """
-    if not old_domain:
-        with open('/etc/yunohost/current_host', 'r') as f:
-            old_domain = f.readline().rstrip()
 
-        if not new_domain:
-            return { 'current_main_domain': old_domain }
-
+    # If no new domain specified, we return the current main domain
     if not new_domain:
-        raise MoulinetteError(errno.EINVAL, m18n.n('new_domain_required'))
+        return { 'current_main_domain': _get_maindomain() }
+
+    # Check domain exists
     if new_domain not in domain_list(auth)['domains']:
-        domain_add(auth, new_domain)
+        raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
 
-    os.system('rm /etc/ssl/private/yunohost_key.pem')
-    os.system('rm /etc/ssl/certs/yunohost_crt.pem')
+    # Apply changes to ssl certs
+    ssl_key = "/etc/ssl/private/yunohost_key.pem"
+    ssl_crt = "/etc/ssl/private/yunohost_crt.pem"
+    new_ssl_key = "/etc/yunohost/certs/%s/key.pem" % new_domain
+    new_ssl_crt = "/etc/yunohost/certs/%s/crt.pem" % new_domain
 
-    command_list = [
-        'ln -s /etc/yunohost/certs/%s/key.pem /etc/ssl/private/yunohost_key.pem' % new_domain,
-        'ln -s /etc/yunohost/certs/%s/crt.pem /etc/ssl/certs/yunohost_crt.pem'   % new_domain,
-        'echo %s > /etc/yunohost/current_host' % new_domain,
-    ]
+    try:
 
-    for command in command_list:
-        if os.system(command) != 0:
-            raise MoulinetteError(errno.EPERM,
-                                  m18n.n('maindomain_change_failed'))
+        if os.path.exists(ssl_key) or os.path.lexists(ssl_key) :
+            os.remove(ssl_key)
+        if os.path.exists(ssl_crt) or os.path.lexists(ssl_crt) :
+            os.remove(ssl_crt)
 
-    if dyndns and len(new_domain.split('.')) >= 3:
-        try:
-            r = requests.get('https://dyndns.yunohost.org/domains')
-        except requests.ConnectionError:
-            pass
-        else:
-            dyndomains = json.loads(r.text)
-            dyndomain  = '.'.join(new_domain.split('.')[1:])
-            if dyndomain in dyndomains:
-                dyndns_subscribe(domain=new_domain)
+        os.symlink(new_ssl_key, ssl_key)
+        os.symlink(new_ssl_crt, ssl_crt)
 
+        _set_maindomain(new_domain)
+    except Exception as e:
+        print e
+        raise MoulinetteError(errno.EPERM, m18n.n('maindomain_change_failed'))
+
+    # Regen configurations
     try:
         with open('/etc/yunohost/installed', 'r') as f:
             service_regen_conf()
@@ -285,7 +278,8 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
                                   m18n.n('yunohost_ca_creation_failed'))
 
     # New domain config
-    tools_maindomain(auth, old_domain='yunohost.org', new_domain=domain, dyndns=dyndns)
+    domain_add(auth, new_domain, dyndns)
+    tools_maindomain(auth, old_domain='yunohost.org', new_domain=domain)
 
     # Generate SSOwat configuration file
     app_ssowatconf(auth)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -159,7 +159,7 @@ def tools_maindomain(auth, new_domain=None):
 
         _set_maindomain(new_domain)
     except Exception as e:
-        print e
+        logger.warning("%s" % e, exc_info=1)
         raise MoulinetteError(errno.EPERM, m18n.n('maindomain_change_failed'))
 
     # Regen configurations

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -136,7 +136,7 @@ def tools_maindomain(auth, new_domain=None):
 
     # If no new domain specified, we return the current main domain
     if not new_domain:
-        return { 'current_main_domain': _get_maindomain() }
+        return {'current_main_domain': _get_maindomain()}
 
     # Check domain exists
     if new_domain not in domain_list(auth)['domains']:
@@ -149,7 +149,6 @@ def tools_maindomain(auth, new_domain=None):
     new_ssl_crt = "/etc/yunohost/certs/%s/crt.pem" % new_domain
 
     try:
-
         if os.path.exists(ssl_key) or os.path.lexists(ssl_key) :
             os.remove(ssl_key)
         if os.path.exists(ssl_crt) or os.path.lexists(ssl_crt) :

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -127,7 +127,7 @@ def tools_adminpw(auth, new_password):
 
 def tools_maindomain(auth, new_domain=None):
     """
-    Main domain consultaton or change tool
+    Check the current main domain, or change it
 
     Keyword argument:
         new_domain -- The new domain to be set as the main domain

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -125,7 +125,7 @@ def tools_adminpw(auth, new_password):
         logger.success(m18n.n('admin_password_changed'))
 
 
-def tools_maindomain(auth, old_domain=None, new_domain=None, dyndns=False):
+def tools_maindomain(auth, new_domain=None):
     """
     Main domain consultaton or change tool
 
@@ -278,8 +278,8 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
                                   m18n.n('yunohost_ca_creation_failed'))
 
     # New domain config
-    domain_add(auth, new_domain, dyndns)
-    tools_maindomain(auth, old_domain='yunohost.org', new_domain=domain)
+    domain_add(auth, domain, dyndns)
+    tools_maindomain(auth, domain)
 
     # Generate SSOwat configuration file
     app_ssowatconf(auth)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -149,9 +149,9 @@ def tools_maindomain(auth, new_domain=None):
     new_ssl_crt = "/etc/yunohost/certs/%s/crt.pem" % new_domain
 
     try:
-        if os.path.exists(ssl_key) or os.path.lexists(ssl_key) :
+        if os.path.exists(ssl_key) or os.path.lexists(ssl_key):
             os.remove(ssl_key)
-        if os.path.exists(ssl_crt) or os.path.lexists(ssl_crt) :
+        if os.path.exists(ssl_crt) or os.path.lexists(ssl_crt):
             os.remove(ssl_crt)
 
         os.symlink(new_ssl_key, ssl_key)


### PR DESCRIPTION
Attempt to fix [issue 639](https://dev.yunohost.org/issues/639).

I refactorized `tools_maindomain()` in the same time, which had a lot of weird stuff (old_domain option not actually used ? dyndns option not documented, only used in postinstall ? duplicated and outdated code with domain_add ? automatically create the new main domain if it does not exist ?)

I still need to check that this doesn't break postinstall.