### PR TITLE
Use the root user for app installation

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -418,7 +418,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
 
         # Execute App upgrade script
         os.system('chown -hR admin: %s' % INSTALL_TMP)
-        if hook_exec(extracted_app_folder +'/scripts/upgrade', args=args_list, env=env_dict) != 0:
+        if hook_exec(extracted_app_folder + '/scripts/upgrade', args=args_list, env=env_dict, user="root") != 0:
             logger.error(m18n.n('app_upgrade_failed', app=app_instance_name))
         else:
             now = int(time.time())
@@ -547,7 +547,7 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     try:
         install_retcode = hook_exec(
             os.path.join(extracted_app_folder, 'scripts/install'),
-            args=args_list, env=env_dict)
+            args=args_list, env=env_dict, user="root")
     except (KeyboardInterrupt, EOFError):
         install_retcode = -1
     except:
@@ -564,7 +564,7 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
                 # Execute remove script
                 remove_retcode = hook_exec(
                     os.path.join(extracted_app_folder, 'scripts/remove'),
-                    args=[app_instance_name], env=env_dict_remove)
+                    args=[app_instance_name], env=env_dict_remove, user="root")
                 if remove_retcode != 0:
                     logger.warning(m18n.n('app_not_properly_removed',
                                           app=app_instance_name))
@@ -632,7 +632,7 @@ def app_remove(auth, app):
     env_dict["YNH_APP_INSTANCE_NAME"] = app
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
 
-    if hook_exec('/tmp/yunohost_remove/scripts/remove', args=args_list, env=env_dict) == 0:
+    if hook_exec('/tmp/yunohost_remove/scripts/remove', args=args_list, env=env_dict, user="root") == 0:
         logger.success(m18n.n('app_removed', app=app))
 
     if os.path.exists(app_setting_path): shutil.rmtree(app_setting_path)

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -234,7 +234,7 @@ def backup_create(name=None, description=None, output_directory=None,
                 env_dict["YNH_APP_BACKUP_DIR"] = tmp_app_bkp_dir
 
                 hook_exec(tmp_script, args=[tmp_app_bkp_dir, app_instance_name],
-                          raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict)
+                          raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict, user="root")
             except:
                 logger.exception(m18n.n('backup_app_failed', app=app_instance_name))
                 # Cleaning app backup directory
@@ -525,7 +525,7 @@ def backup_restore(auth, name, hooks=[], ignore_hooks=False,
 
                 # Execute app restore script
                 hook_exec(app_script, args=[tmp_app_bkp_dir, app_instance_name],
-                          raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict)
+                          raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict, user="root")
             except:
                 logger.exception(m18n.n('restore_app_failed', app=app_instance_name))
 
@@ -540,7 +540,7 @@ def backup_restore(auth, name, hooks=[], ignore_hooks=False,
                 # Execute remove script
                 # TODO: call app_remove instead
                 if hook_exec(app_script, args=[app_instance_name],
-                             env=env_dict_remove) != 0:
+                             env=env_dict_remove, user="root") != 0:
                     logger.warning(m18n.n('app_not_properly_removed',
                                           app=app_instance_name))
 

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -292,7 +292,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
 
 
 def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
-              chdir=None, env=None):
+              chdir=None, env=None, user=None):
     """
     Execute hook from a file with arguments
 
@@ -303,6 +303,7 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
         no_trace -- Do not print each command that will be executed
         chdir -- The directory from where the script will be executed
         env -- Dictionnary of environment variables to export
+        user -- User with which to run the command
 
     """
     from moulinette.utils.process import call_async_output
@@ -327,7 +328,11 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
         cmd_script = path
 
     # Construct command to execute
-    command = ['sudo', '-n', '-u', 'admin', '-H', 'sh', '-c']
+    if user is not None:
+        command = ['sudo', '-n', '-u', user, '-H', 'sh', '-c']
+    else:
+        command = ['sh', '-c']
+
     if no_trace:
         cmd = '/bin/bash "{script}" {args}'
     else:

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -307,7 +307,6 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
 
     """
     from moulinette.utils.process import call_async_output
-    from yunohost.app import _value_for_locale
 
     # Validate hook path
     if path[0] != '/':

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -292,7 +292,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
 
 
 def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
-              chdir=None, env=None, user=None):
+              chdir=None, env=None, user="admin"):
     """
     Execute hook from a file with arguments
 
@@ -328,10 +328,10 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
         cmd_script = path
 
     # Construct command to execute
-    if user is not None:
-        command = ['sudo', '-n', '-u', user, '-H', 'sh', '-c']
-    else:
+    if user == "root":
         command = ['sh', '-c']
+    else:
+        command = ['sudo', '-n', '-u', user, '-H', 'sh', '-c']
 
     if no_trace:
         cmd = '/bin/bash "{script}" {args}'

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -275,7 +275,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
                 hook_args = pre_callback(name=name, priority=priority,
                                          path=path, args=args)
                 hook_exec(path, args=hook_args, chdir=chdir, env=env,
-                          no_trace=no_trace, raise_on_error=True)
+                          no_trace=no_trace, raise_on_error=True, user="root")
             except MoulinetteError as e:
                 state = 'failed'
                 logger.error(e.strerror, exc_info=1)


### PR DESCRIPTION
Hello,

I'm opening this PR to avoid forgetting it but I'm not calling for a decision yet.

It's the implementation of "don't use admin user for installing apps because it doesn't brings anything and that forgetting sudo is the first bug ever while developping apps", also will greatly reduce broken situation du to missing admin user (well ... hide them).

We'll probably need to talk again about this choice.