### PR TITLE
[fix] Fix ldap caching on postinstall, which might cause 'Unknown admin user'

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -114,7 +114,7 @@
     "ip6tables_unavailable": "You cannot play with ip6tables here. You are either in a container or your kernel does not support it.",
     "iptables_unavailable": "You cannot play with iptables here. You are either in a container or your kernel does not support it.",
     "ldap_initialized": "LDAP has been initialized",
-    "ldap_init_failed_to_create_admin": "LDAP initialization failed to create admin. Aborting.",
+    "ldap_init_failed_to_create_admin": "LDAP initialization failed to create admin user.",
     "license_undefined": "undefined",
     "mail_alias_remove_failed": "Unable to remove mail alias '{mail:s}'",
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",

--- a/locales/en.json
+++ b/locales/en.json
@@ -114,6 +114,7 @@
     "ip6tables_unavailable": "You cannot play with ip6tables here. You are either in a container or your kernel does not support it.",
     "iptables_unavailable": "You cannot play with iptables here. You are either in a container or your kernel does not support it.",
     "ldap_initialized": "LDAP has been initialized",
+    "ldap_init_failed_to_create_admin": "LDAP initialization failed to create admin. Aborting.",
     "license_undefined": "undefined",
     "mail_alias_remove_failed": "Unable to remove mail alias '{mail:s}'",
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -100,8 +100,8 @@ def tools_ldapinit():
     try:
         pwd.getpwnam("admin")
     except KeyError:
-        raise MoulinetteError(errno.EINVAL,
-                              m18n.n('ldap_init_failed_to_create_admin'))
+        logger.error(m18n.n('ldap_init_failed_to_create_admin'))
+        raise MoulinetteError(errno.EINVAL, m18n.n('installation_failed'))
 
     logger.success(m18n.n('ldap_initialized'))
     return auth

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -33,6 +33,7 @@ import json
 import errno
 import logging
 import subprocess
+import pwd
 from collections import OrderedDict
 
 import apt
@@ -53,12 +54,20 @@ apps_setting_path= '/etc/yunohost/apps/'
 logger = getActionLogger('yunohost.tools')
 
 
-def tools_ldapinit(auth):
+def tools_ldapinit():
     """
     YunoHost LDAP initialization
 
 
     """
+
+    # Instantiate LDAP Authenticator
+    auth = init_authenticator(('ldap', 'default'),
+                              {'uri': "ldap://localhost:389",
+                               'base_dn': "dc=yunohost,dc=org",
+                               'user_rdn': "cn=admin" })
+    auth.authenticate('yunohost')
+
     with open('/usr/share/yunohost/yunohost-config/moulinette/ldap_scheme.yml') as f:
         ldap_map = yaml.load(f)
 
@@ -83,10 +92,19 @@ def tools_ldapinit(auth):
     }
 
     auth.update('cn=admin', admin_dict)
+
+    # Force nscd to refresh cache to take admin creation into account
     subprocess.call(['nscd', '-i', 'passwd'])
 
-    logger.success(m18n.n('ldap_initialized'))
+    # Check admin actually exists now
+    try:
+        pwd.getpwnam("admin")
+    except KeyError:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('ldap_init_failed_to_create_admin'))
 
+    logger.success(m18n.n('ldap_initialized'))
+    return auth
 
 def tools_adminpw(auth, new_password):
     """
@@ -193,16 +211,9 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
 
     logger.info(m18n.n('yunohost_installing'))
 
-    # Instantiate LDAP Authenticator
-    auth = init_authenticator(('ldap', 'default'),
-                              {'uri': "ldap://localhost:389",
-                               'base_dn': "dc=yunohost,dc=org",
-                               'user_rdn': "cn=admin" })
-    auth.authenticate('yunohost')
-
     # Initialize LDAP for YunoHost
     # TODO: Improve this part by integrate ldapinit into conf_regen hook
-    tools_ldapinit(auth)
+    auth = tools_ldapinit()
 
     # Create required folders
     folders_to_create = [

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -32,6 +32,7 @@ import requests
 import json
 import errno
 import logging
+import subprocess
 from collections import OrderedDict
 
 import apt
@@ -82,6 +83,7 @@ def tools_ldapinit(auth):
     }
 
     auth.update('cn=admin', admin_dict)
+    subprocess.call(['nscd', '-i', 'passwd'])
 
     logger.success(m18n.n('ldap_initialized'))
 


### PR DESCRIPTION
Follow-up of #172 after some investigation with @Psycojoker (thanks to him ! Had no idea about that nslcd/nscd thing 😛). Not entirely sure this is the real cause of the issue people reported, but there's a good 95% that it is.

Funnily enough, before this fix, if you attempted to log as admin (or `su admin`) before launching post-install, post-install would fail - because the cache of nscd remembers that user admin doesn't exists for the next minute at least. Maybe something like `su admin` happens somewhere in the procedure for raspberry install and others ? Or maybe the cache config is different ?

@Psycojoker suggested on the chat that if this doesn't solves all issues, we could check that nscd and nslcd (and slapd?) are correctly running.  
