### PR TITLE
Remove helper ynh_mkdir_tmp

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -62,15 +62,3 @@ ynh_bind_or_cp() {
     echo "This helper is deprecated, you should use ynh_backup instead" >&2
     ynh_backup "$1" "$2" 1 "$NO_ROOT"
 }
-
-# Create a directory under /tmp
-#
-# usage: ynh_mkdir_tmp
-# | ret: the created directory path
-ynh_mkdir_tmp() {
-    TMPDIR="/tmp/$(ynh_string_random 6)"
-    while [ -d $TMPDIR ]; do
-        TMPDIR="/tmp/$(ynh_string_random 6)"
-    done
-    mkdir -p "$TMPDIR" && echo "$TMPDIR"
-}

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -70,5 +70,6 @@ ynh_bind_or_cp() {
 # usage: ynh_mkdir_tmp
 # | ret: the created directory path
 ynh_mkdir_tmp() {
+    echo "This helper is deprecated, you should use 'mktemp -d' instead." >&2
     mktemp -d
 }

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -62,3 +62,13 @@ ynh_bind_or_cp() {
     echo "This helper is deprecated, you should use ynh_backup instead" >&2
     ynh_backup "$1" "$2" 1 "$NO_ROOT"
 }
+
+# Create a directory under /tmp
+#
+# Deprecated helper
+#
+# usage: ynh_mkdir_tmp
+# | ret: the created directory path
+ynh_mkdir_tmp() {
+    mktemp -d
+}


### PR DESCRIPTION
Le helper `ynh_mkdir_tmp` est inutile. Il existe la commande `mktemp -d` pour créer des dossiers temporaires.