### PR TITLE
[fix] Correctly handle custom backup directory

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -43,6 +43,7 @@
     "backup_action_required": "You must specify something to save",
     "backup_app_failed": "Unable to back up the app '{app:s}'",
     "backup_archive_app_not_found": "App '{app:s}' not found in the backup archive",
+    "backup_archive_broken_link": "Unable to access backup archive (broken link to {path:s})",
     "backup_archive_hook_not_exec": "Hook '{hook:s}' not executed in this backup",
     "backup_archive_name_exists": "The backup's archive name already exists",
     "backup_archive_name_unknown": "Unknown local backup archive named '{name:s}'",

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -120,8 +120,10 @@ def backup_create(name=None, description=None, output_directory=None,
             env_var['CAN_BIND'] = 0
     else:
         output_directory = archives_path
-        if not os.path.isdir(archives_path):
-            os.mkdir(archives_path, 0750)
+
+    # Create archives directory if it does not exists
+    if not os.path.isdir(archives_path):
+        os.mkdir(archives_path, 0750)
 
     def _clean_tmp_dir(retcode=0):
         ret = hook_callback('post_backup_create', args=[tmp_dir, retcode])

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -623,15 +623,16 @@ def backup_info(name, with_details=False, human_readable=False):
             m18n.n('backup_archive_name_unknown', name=name))
 
     # If symlink, retrieve the real path
-    if os.path.islink(archive_file) :
+    if os.path.islink(archive_file):
         archive_file = os.path.realpath(archive_file)
 
         # Raise exception if link is broken (e.g. on unmounted external storage)
-        if (not os.path.exists(archive_file)) :
+        if not os.path.exists(archive_file):
             raise MoulinetteError(errno.EIO,
                 m18n.n('backup_archive_broken_link', path=archive_file))
 
     info_file = "%s/%s.info.json" % (archives_path, name)
+
     try:
         with open(info_file) as f:
             # Retrieve backup info

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -290,7 +290,7 @@ def backup_create(name=None, description=None, output_directory=None,
             raise MoulinetteError(errno.EIO,
                                   m18n.n('backup_archive_open_failed'))
 
-        # Add files to the arvhice
+        # Add files to the archive
         try:
             tar.add(tmp_dir, arcname='')
             tar.close()
@@ -300,9 +300,21 @@ def backup_create(name=None, description=None, output_directory=None,
             raise MoulinetteError(errno.EIO,
                                   m18n.n('backup_creation_failed'))
 
+        # FIXME : it looks weird that the "move info file" is not enabled if
+        # user activated "no_compress" ... or does it really means
+        # "dont_keep_track_of_this_backup_in_history" ?
+
         # Move info file
         shutil.move(tmp_dir + '/info.json',
                   '{:s}/{:s}.info.json'.format(archives_path, name))
+
+        # If backuped to a non-default location, keep a symlink of the archive
+        # to that location
+        if output_directory != archives_path:
+            link = "%s/%s.tar.gz" % (archives_path, name)
+            os.symlink(archive_file, link)
+
+
 
     # Clean temporary directory
     if tmp_dir != output_directory:
@@ -604,9 +616,20 @@ def backup_info(name, with_details=False, human_readable=False):
 
     """
     archive_file = '%s/%s.tar.gz' % (archives_path, name)
-    if not os.path.isfile(archive_file):
+
+    # Check file exist (even if it's a broken symlink)
+    if not os.path.lexists(archive_file):
         raise MoulinetteError(errno.EIO,
             m18n.n('backup_archive_name_unknown', name=name))
+
+    # If symlink, retrieve the real path
+    if os.path.islink(archive_file) :
+        archive_file = os.path.realpath(archive_file)
+
+        # Raise exception if link is broken (e.g. on unmounted external storage)
+        if (not os.path.exists(archive_file)) :
+            raise MoulinetteError(errno.EIO,
+                m18n.n('backup_archive_broken_link', path=archive_file))
 
     info_file = "%s/%s.info.json" % (archives_path, name)
     try:


### PR DESCRIPTION
This fixes https://dev.yunohost.org/issues/618

After fixing the reported bug, I realized that when using -o to set a custom directory, code didn't keep track of the path to the backup. I fixed it by adding a symlink to the archive + an exception handling later in case the link is broken.