### PR TITLE
[fix] Improve dnssec key generation on low entropy devices

### DIFF
--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -95,7 +95,7 @@ def dyndns_subscribe(subscribe_host="dyndns.yunohost.org", domain=None, key=None
             logger.info(m18n.n('dyndns_key_generating'))
 
             os.system('cd /etc/yunohost/dyndns && ' \
-                      'dnssec-keygen -a hmac-md5 -b 128 -n USER %s' % domain)
+                      'dnssec-keygen -a hmac-md5 -b 128 -r /dev/urandom -n USER %s' % domain)
             os.system('chmod 600 /etc/yunohost/dyndns/*.key /etc/yunohost/dyndns/*.private')
 
         key_file = glob.glob('/etc/yunohost/dyndns/*.key')[0]


### PR DESCRIPTION
See https://bugs.launchpad.net/ubuntu/+source/bind9/+bug/963368

Using /dev/urandom is not a perfect solution, as it is only a pseudo random generator. Do we care here ? (serious question)

Another solution is to had 'haveged' Debian package as dependency, which could be a great improvment for entropy related stuff. But users have to `dist-upgrade` their system

( Note that I encounter this bug only on a ARM Scaleway server )