### PR TITLE
[enh] Add haveged as Debian dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dnsmasq, openssl, avahi-daemon
  , ssowat, metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
+ , haveged
 Recommends: yunohost-admin
  , openssh-server, ntp, inetutils-ping | iputils-ping
  , bash-completion, rsyslog, etckeeper


### PR DESCRIPTION
Increase entropy on virtual servers. Speed up key generation by openssl and dnssec
See https://github.com/YunoHost/yunohost/pull/201 & https://bugs.launchpad.net/ubuntu/+source/bind9/+bug/963368