### PR TITLE
[fix] Bracket in passwd from ynh_string_random

### DIFF
--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -6,6 +6,6 @@
 # | arg: length - the string length to generate (default: 24)
 ynh_string_random() {
     dd if=/dev/urandom bs=1 count=200 2> /dev/null \
-      | tr -c -d '[A-Za-z0-9]' \
+      | tr -c -d 'A-Za-z0-9' \
       | sed -n 's/\(.\{'"${1:-24}"'\}\).*/\1/p'
 }


### PR DESCRIPTION
With bracket we get string like "3KFEc[xm4[udnZ6pDJ8LvP0n"
Without "El0nMO3thacDwrjeRzgKnb30"