### PR TITLE
[Fix] Add check and remove function for domain default app

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -606,7 +606,7 @@ app:
         ### app_makedefault()
         makedefault:
             action_help: Redirect domain root to an app
-            api: PUT /apps/<app>/default
+            api: PUT /apps/<app>/makedefault
             configuration:
                 authenticate: all
                 authenticator: ldap-anonymous
@@ -616,6 +616,34 @@ app:
                 -d:
                     full: --domain
                     help: Specific domain to put app on (the app domain by default)
+        
+        ### app_removedefault()
+        removedefault:
+            action_help: Remove the default redirection to an app on a domain
+            api: PUT /apps/<app>/removedefault
+            configuration:
+                authenticate: all
+                authenticator: ldap-anonymous
+            arguments:
+                app:
+                    help: App to remove the redirection
+                -d:
+                    full: --domain
+                    help: Specific domain to remove the redirection (the app domain by default)
+
+        ### app_checkdefault()
+        checkdefault:
+            action_help: Check if app is the default domain redirection
+            api: GET /apps/<app>/checkdefault
+            configuration:
+                authenticate: all
+                authenticator: ldap-anonymous
+            arguments:
+                app:
+                    help: App name to check
+                -d:
+                    full: --domain
+                    help: Specific domain to check the app on (the app domain by default)
 
         ### app_ssowatconf()
         ssowatconf:

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,6 +17,7 @@
     "app_no_upgrade": "No app to upgrade",
     "app_not_correctly_installed": "{app:s} seems to be incorrectly installed",
     "app_not_installed": "{app:s} is not installed",
+   	"app_not_domain_default": "{app:s} is not the domain default",
     "app_not_properly_removed": "{app:s} has not been properly removed",
     "app_package_need_update": "The app package needs to be updated to follow YunoHost changes",
     "app_removed": "{app:s} has been removed",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -17,6 +17,7 @@
     "app_manifest_invalid": "Manifeste d'application incorrect",
     "app_no_upgrade": "Aucune application à mettre à jour",
     "app_not_correctly_installed": "{app:s} semble être mal installé",
+	"app_not_domain_default": "{app:s} n'est pas l'application par défault du domaine",
     "app_not_installed": "{app:s} n'est pas installé",
     "app_not_properly_removed": "{app:s} n'a pas été supprimé correctement",
     "app_package_need_update": "Le paquet de l'application doit être mis à jour pour suivre les changements de YunoHost",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -797,7 +797,7 @@ def app_makedefault(auth, app, domain=None):
 
     app_settings = _get_app_settings(app)
     app_domain = app_settings['domain']
-    app_path   = app_settings['path']
+    app_path = app_settings['path']
 
     if domain is None:
         domain = app_domain
@@ -820,7 +820,7 @@ def app_makedefault(auth, app, domain=None):
     if 'redirected_urls' not in ssowat_conf:
         ssowat_conf['redirected_urls'] = {}
 
-    ssowat_conf['redirected_urls'][domain +'/'] = app_domain + app_path
+    ssowat_conf['redirected_urls'][domain + '/'] = app_domain + app_path
 
     try:
         with open('/etc/ssowat/conf.json.persistent', 'w+') as f:
@@ -829,10 +829,108 @@ def app_makedefault(auth, app, domain=None):
         raise MoulinetteError(errno.EPERM,
                               m18n.n('ssowat_persistent_conf_write_error', error=e.strerror))
 
+    os.system('chmod 644 /etc/ssowat/conf.json.persistent')
+
+    logger.success(m18n.n('ssowat_conf_updated'))
+
+
+def app_removedefault(auth, app, domain=None):
+    """
+    Remove the default redirection to an app on a domain
+
+    Keyword argument:
+        app
+        domain
+
+    """
+    from yunohost.domain import domain_list
+
+    app_settings = _get_app_settings(app)
+    app_domain = app_settings['domain']
+    app_path = app_settings['path']
+
+    if domain is None:
+        domain = app_domain
+    elif domain not in domain_list(auth)['domains']:
+        raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
+
+    if '/' in app_map(raw=True)[domain]:
+        raise MoulinetteError(errno.EEXIST,
+                              m18n.n('app_location_already_used'))
+
+    try:
+        with open('/etc/ssowat/conf.json.persistent') as json_conf:
+            ssowat_conf = json.loads(str(json_conf.read()))
+    except ValueError as e:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('ssowat_persistent_conf_read_error', error=e.strerror))
+    except IOError:
+        ssowat_conf = {}
+
+    if 'redirected_urls' not in ssowat_conf:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('app_not_default', error=e.strerror))
+
+    try:
+        ssowat_conf['redirected_urls'].pop(domain + '/')
+    except IOError as e:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('app_not_domain_default', error=e.strerror))
+
+    try:
+        with open('/etc/ssowat/conf.json.persistent', 'w+') as f:
+            json.dump(ssowat_conf, f, sort_keys=True, indent=4)
+    except IOError as e:
+        raise MoulinetteError(errno.EPERM,
+                              m18n.n('ssowat_persistent_conf_write_error', error=e.strerror))
 
     os.system('chmod 644 /etc/ssowat/conf.json.persistent')
 
     logger.success(m18n.n('ssowat_conf_updated'))
+
+
+def app_checkdefault(auth, app, domain=None):
+    """
+    Check if an app is the default redirecton of a domain
+
+    Keyword argument:
+        app
+        domain
+
+    """
+    from yunohost.domain import domain_list
+
+    app_settings = _get_app_settings(app)
+    app_domain = app_settings['domain']
+    app_path = app_settings['path']
+
+    if domain is None:
+        domain = app_domain
+    elif domain not in domain_list(auth)['domains']:
+        raise MoulinetteError(errno.EINVAL, m18n.n('domain_unknown'))
+
+    if '/' in app_map(raw=True)[domain]:
+        raise MoulinetteError(errno.EEXIST,
+                                m18n.n('app_location_already_used'))
+
+    try:
+        with open('/etc/ssowat/conf.json.persistent') as json_conf:
+            ssowat_conf = json.loads(str(json_conf.read()))
+    except ValueError as e:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('ssowat_persistent_conf_read_error', error=e.strerror))
+    except IOError:
+        ssowat_conf = {}
+
+    if 'redirected_urls' not in ssowat_conf:
+        return False
+    elif app_domain + '/' in ssowat_conf['redirected_urls']:
+        if app_domain + app_path in ssowat_conf['redirected_urls'][app_domain + '/']:
+            return True
+        else:
+            return False
+    else:
+        return False
 
 
 def app_setting(app, key, value=None, delete=False):


### PR DESCRIPTION
This fixes [125](https://dev.yunohost.org/issues/125) and [40](https://dev.yunohost.org/issues/125). I renamed the api call to make an app the default one for the domain "default" to "makedefault".

If I understand correctly we have to stick with conf.json.persistent rather than the generated conf, as it only contains info for paths after the app path itself, and not the domain