### PR TITLE
[enh] List available domains when installing an app by CLI.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -84,6 +84,7 @@
     "domain_zone_exists": "DNS zone file already exists",
     "domain_zone_not_found": "DNS zone file not found for domain {:s}",
     "done": "Done",
+    "domains_available": "Available domains:",
     "downloading": "Downloading...",
     "dyndns_cron_installed": "The DynDNS cron job has been installed",
     "dyndns_cron_remove_failed": "Unable to remove the DynDNS cron job",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1497,7 +1497,7 @@ def _parse_args_from_manifest(manifest, action, args={}, auth=None):
         args -- A dictionnary of arguments to parse
 
     """
-    from yunohost.domain import domain_list
+    from yunohost.domain import domain_list, _get_maindomain
     from yunohost.user import user_info
 
     args_dict = OrderedDict()
@@ -1536,6 +1536,13 @@ def _parse_args_from_manifest(manifest, action, args={}, auth=None):
 
                     # Check for a password argument
                     is_password = True if arg_type == 'password' else False
+
+                    if arg_type == 'domain':
+                        arg_default = _get_maindomain()
+                        ask_string += ' (default: {0})'.format(arg_default)
+                        msignals.display(m18n.n('domains_available'))
+                        for domain in domain_list(auth)['domains']:
+                            msignals.display("- {}".format(domain))
 
                     try:
                         input_string = msignals.prompt(ask_string, is_password)


### PR DESCRIPTION
Rework of https://github.com/YunoHost/yunohost/issues/210.

----

Fix [#218](https://dev.yunohost.org/issues/218).
List available domains when installing an app by CLI, and set main domain as the default value.

Features:
- main domain is set as default value
- all domain names are displayed

```bash
yunohost app install my_webapp
Available domains:
- ynh.local
- duniter.ynh.local
Choose a domain for your Webapp (default: ynh.local):
```