### PR TITLE
[enh] readme: add translation badge status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This repository is the core of YunoHost code.
 
+<a href="https://translate.yunohost.org/engage/yunohost/?utm_source=widget">
+<img src="https://translate.yunohost.org/widgets/yunohost/-/287x66-white.png" alt="Translation status" />
+</a>
+
 ## Issues
 - [Please report issues on YunoHost bugtracker](https://dev.yunohost.org/projects/yunohost/issues) (no registration needed).
 


### PR DESCRIPTION
I choosed to add this badge [among the others](https://translate.yunohost.org/widgets/yunohost/?lang=).
If you are agreed with this PR, I will push directly to add badges for `yunohost-admin`, `moulinette` and `ssowat` repositories.