### PR TITLE
[fix] Wrong fail2ban regex for yunohost

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -25,7 +25,7 @@ ynh_mysql_execute_as_root() {
 
 # Execute a command from a file as root user
 #
-# usage: ynh_mysql_execute_file_as_root sql [db]
+# usage: ynh_mysql_execute_file_as_root file [db]
 # | arg: file - the file containing SQL commands
 # | arg: db - the database to connect to
 ynh_mysql_execute_file_as_root() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-yunohost (2.4.2) testing; urgency=low
+yunohost (2.4.2) stable; urgency=low
 
   [ Laurent Peuch ]
   * [enh] add empty file for hindie to enable it in weblate

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+yunohost (2.4.2) testing; urgency=low
+
+  [ Laurent Peuch ]
+  * [enh] add empty file for hindie to enable it in weblate
+
+  [ opi ]
+  * [fix] Documentation typo
+
+  [ Laurent Peuch ]
+  * [fix] ensure that multi_instance key value is always a boolean
+
+ -- Laurent Peuch <cortex@worlddomination.be>  Sun, 14 Aug 2016 18:55:10 +0200
+
 yunohost (2.4.1) stable; urgency=low
 
   [ Bugsbane ]


### PR DESCRIPTION
In my nginx_error.log, the authentication errors are "helpers.lua", not "access.lua".