### PR TITLE
[enh] Add a script to reset ladp admin password

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,4 +1,5 @@
 bin/* /usr/bin/
+sbin/* /usr/sbin/
 data/bash-completion.d/yunohost /etc/bash_completion.d/
 data/actionsmap/* /usr/share/moulinette/actionsmap/
 data/hooks/* /usr/share/yunohost/hooks/

--- a/sbin/yunohost-reset-ldap-password
+++ b/sbin/yunohost-reset-ldap-password
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+################################
+#   Set a temporary password   #
+################################
+
+# Generate a random temporary password (won't be valid after this script ends !)
+# and hash it
+TMP_LDAPROOT_PASSWORD=`slappasswd -g`
+TMP_LDAPROOT_PASSWORD_HASH=`slappasswd -h {SSHA} -s ${TMP_LDAPROOT_PASSWORD}`
+
+# Stop slapd service...
+service slapd stop
+
+# Backup slapd.conf (to be restored at the end of script)
+cp /etc/ldap/slapd.conf /root/slapd.conf.bkp
+
+# Append lines to slapd.conf to manually define root password hash
+echo 'rootdn "cn=admin,dc=yunohost,dc=org"' >> /etc/ldap/slapd.conf
+echo "rootpw $TMP_LDAPROOT_PASSWORD_HASH" >> /etc/ldap/slapd.conf
+
+# Test conf (might not be entirely necessary though :P)
+slaptest -Q -u -f /etc/ldap/slapd.conf
+
+# Regenerate slapd.d directory
+rm -Rf /etc/ldap/slapd.d
+mkdir /etc/ldap/slapd.d
+slaptest -f /etc/ldap/slapd.conf -F /etc/ldap/slapd.d/ 2>&1
+
+# Set permissions to slapd.d
+chown -R openldap:openldap /etc/ldap/slapd.d/
+
+# Restore slapd.conf
+mv /root/slapd.conf.bkp /etc/ldap/slapd.conf
+
+# Restart slapd service
+service slapd start
+
+#######################################
+#   Properly set new admin password   #
+#######################################
+
+# Display tmp password to user
+# NB : we do NOT pass it as a command line argument for "yunohost tools adminpw"
+# as a malicious user could run a script in background waiting for this command
+# to pop in ps -ef and automatically do nasty stuff in the ldap database
+# meanwhile.
+echo "Use this temporary password when asked for the administration password : $TMP_LDAPROOT_PASSWORD"
+
+# Call yunohost tools adminpw for user to set new password
+yunohost tools adminpw
+
+###########################
+#   Forget tmp password   #
+###########################
+
+# Stop slapd service
+service slapd stop
+
+# Regenerate slapd.d directory
+rm -Rf /etc/ldap/slapd.d
+mkdir /etc/ldap/slapd.d
+slaptest -f /etc/ldap/slapd.conf -F /etc/ldap/slapd.d/ 2>&1
+
+# Set permissions to slapd.d
+chown -R openldap:openldap /etc/ldap/slapd.d/
+
+# Restart slapd service
+service slapd start


### PR DESCRIPTION
Hello,

I'm opening this PR both to start the work and both to start the discussion.

* do we want an utility to reset ldap admin password?
* if so, how do we want to do it?

This is a common request but making it super available doesn't necessary seems like the best idea in the world.

If we do it I would recommend that we have a separate script only executable by root (which I think that you still need to be root to do all the operations).