### PR TITLE
[fix] add timeout to fetchlist's wget

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -99,7 +99,7 @@ def app_fetchlist(url=None, name=None):
                                   m18n.n('custom_appslist_name_required'))
 
     list_file = '%s/%s.json' % (repo_path, name)
-    if os.system('wget "%s" -O "%s.tmp"' % (url, list_file)) != 0:
+    if os.system('wget --timeout=30 "%s" -O "%s.tmp"' % (url, list_file)) != 0:
         os.remove('%s.tmp' % list_file)
         raise MoulinetteError(errno.EBADR, m18n.n('appslist_retrieve_error'))
 


### PR DESCRIPTION
Hello,

It as been observed at least twice by 2 different people that fetchlist could indefinitely idle because of weird networking issues, due to the locking mecanism of moulette this can freeze YunoHost entirely which sound critical to me.

For reference here is wget man section regarding timeout:

```
       -T seconds
       --timeout=seconds
           Set the network timeout to seconds seconds.  This is equivalent to specifying --dns-timeout, --connect-timeout, and --read-timeout, all at the same time.

           When interacting with the network, Wget can check for timeout and abort the operation if it takes too long.  This prevents anomalies like hanging reads and
           infinite connects.  The only timeout enabled by default is a 900-second read timeout.  Setting a timeout to 0 disables it altogether.  Unless you know what
           you are doing, it is best not to change the default timeout settings.

           All timeout-related options accept decimal values, as well as subsecond values.  For example, 0.1 seconds is a legal (though unwise) choice of timeout.
           Subsecond timeouts are useful for checking server response times or for testing network latency.
```