### PR TITLE
[mod] Cleaner _get_conf_hashes logs

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -640,16 +640,16 @@ def _get_pending_conf(services=[]):
 def _get_conf_hashes(service):
     """Get the registered conf hashes for a service"""
 
-    d = _get_services()
+    services = _get_services()
 
-    if service not in d.keys():
+    if service not in services:
         logger.debug("Service %s is not in services.yml yet.", service)
         return {}
-    elif 'conffiles' not in d[service].keys():
+    elif 'conffiles' not in services[service]:
         logger.debug("No configuration files for service %s.", service)
         return {}
     else:
-        return d[service]['conffiles']
+        return services[service]['conffiles']
 
 
 def _update_conf_hashes(service, hashes):

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -639,12 +639,17 @@ def _get_pending_conf(services=[]):
 
 def _get_conf_hashes(service):
     """Get the registered conf hashes for a service"""
-    try:
-        return _get_services()[service]['conffiles']
-    except:
-        logger.debug("unable to retrieve conf hashes for %s",
-                     service, exc_info=1)
+
+    d = _get_services()
+
+    if (service not in d.keys()):
+        logger.debug("Service %s is not in services.yml yet.", service)
         return {}
+    elif ('conffiles' not in d[service].keys()):
+        logger.debug("No configuration files for service %s.", service)
+        return {}
+    else:
+        return d[service]['conffiles']
 
 
 def _update_conf_hashes(service, hashes):

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -642,10 +642,10 @@ def _get_conf_hashes(service):
 
     d = _get_services()
 
-    if (service not in d.keys()):
+    if service not in d.keys():
         logger.debug("Service %s is not in services.yml yet.", service)
         return {}
-    elif ('conffiles' not in d[service].keys()):
+    elif 'conffiles' not in d[service].keys():
         logger.debug("No configuration files for service %s.", service)
         return {}
     else:


### PR DESCRIPTION
This is intended to clean some post-installation logs when runned with `--debug`. Currently, since there's no "conffiles" entries in services.yml during post-install, we get some messages lilke :
```
45152 unable to retrieve conf hashes for glances
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/service.py", line 640, in _get_conf_hashes
    return _get_services()[service]['conffiles']
KeyError: 'conffiles'
```
This is a problem for my continous integration stuff which alwats report these errors (see post-installations logs [here](http://bicyclette.netlib.re/))