### PR TITLE
[fix] Check ACME challenge conf exists in nginx when renewing a certificate

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -264,5 +264,6 @@
     "certmanager_conflicting_nginx_file": "Unable to prepare domain for ACME challenge: the nginx configuration file {filepath:s} is conflicting and should be removed first",
     "domain_cannot_remove_main": "Cannot remove main domain. Set a new main domain first",
     "certmanager_self_ca_conf_file_not_found": "Configuration file not found for self-signing authority (file: {file:s})",
+    "certmanager_acme_not_configured_for_domain": "Certificate for domain {domain:s} does not appear to be correctly installed. Please run cert-install for this domain first.",
     "certmanager_unable_to_parse_self_CA_name": "Unable to parse name of self-signing authority (file: {file:s})"
 }

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -349,7 +349,7 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
             status = _get_status(domain)
 
             # Does it expire soon?
-            if not force or status["validity"] <= VALIDITY_LIMIT:
+            if status["validity"] > VALIDITY_LIMIT and not force:
                 raise MoulinetteError(errno.EINVAL, m18n.n(
                     'certmanager_attempt_to_renew_valid_cert', domain=domain))
 


### PR DESCRIPTION
This fixes https://dev.yunohost.org/issues/670