### PR TITLE
[fix] Fix #681/ typo in hook.py

### DIFF
--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -26,6 +26,7 @@
 import os
 import re
 import errno
+import logging
 from glob import iglob
 
 from moulinette.core import MoulinetteError
@@ -340,7 +341,7 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
                     for k, v in env.items()]), cmd)
     command.append(cmd.format(script=cmd_script, args=cmd_args))
 
-    if logger.isEnabledFor(log.DEBUG):
+    if logger.isEnabledFor(logging.DEBUG):
         logger.info(m18n.n('executing_command', command=' '.join(command)))
     else:
         logger.info(m18n.n('executing_script', script=path))


### PR DESCRIPTION
Reading package lists...
Building dependency tree...
Reading state information...
moulinette is already the newest version.
yunohost is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
1 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Setting up yunohost (2016.12.22+0100) ...
Regenerating configuration, this might take a while...
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 217, in <module>
    timeout=opts.timeout,
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 139, in cli
    moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 358, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 484, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/service.py", line 325, in service_regen_conf
    pre_result = hook_callback('conf_regen', names, pre_callback=_pre_call)
  File "/usr/lib/moulinette/yunohost/hook.py", line 278, in hook_callback
    no_trace=no_trace, raise_on_error=True)
  File "/usr/lib/moulinette/yunohost/hook.py", line 343, in hook_exec
    if logger.isEnabledFor(log.DEBUG):
AttributeError: 'module' object has no attribute 'DEBUG'
dpkg: error processing package yunohost (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 yunohost
E: Sub-process /usr/bin/dpkg returned an error code (1)