### PR TITLE
[fix] Fix 693 invalid domain dyndns postinstall

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -178,7 +178,8 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
 
     Keyword argument:
         domain -- YunoHost main domain
-        ignore_dyndns -- Do not subscribe domain to a DynDNS service
+        ignore_dyndns -- Do not subscribe domain to a DynDNS service (only
+        needed for nohost.me, noho.st domains)
         password -- YunoHost admin password
 
     """
@@ -203,6 +204,10 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
                 else:
                     raise MoulinetteError(errno.EEXIST,
                                           m18n.n('dyndns_unavailable'))
+            else:
+                dyndns = False
+    else:
+        dyndns = False
 
     logger.info(m18n.n('yunohost_installing'))
 
@@ -296,7 +301,6 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
     os.system('service yunohost-firewall start')
 
     service_regen_conf(force=True)
-
     logger.success(m18n.n('yunohost_configured'))
 
 


### PR DESCRIPTION
This morning I have got 2 issues on unstable branches when I have tried to postinstall.
### First issue : moulinette error about logging.SUCCESS
One was due to a non built commit on moulinette (it should be done this night).

The 2 others are fixed by this PR.
### Second issue : postinstall on domain (with just one . ) fails due to --ignore-dyndns option

> yunohost tools postinstall test.local --verbose --debug
fails due to the missing option --ignore-dyndns. But it shouldn't fail because it's a short domain so it's not a dyndns one...

Note: I am not sure about the good behaviour to have with 3 parts domain ( eg: toto.example.org ). We don't support for the moment dyndns on it but in future it could be the case...
