### PR TITLE
[fix] new rspamd version replace rspamd.socket with rspamd.service

### DIFF
--- a/data/hooks/conf_regen/28-rmilter
+++ b/data/hooks/conf_regen/28-rmilter
@@ -9,8 +9,6 @@ do_pre_regen() {
 
   install -D -m 644 rmilter.conf \
     "${pending_dir}/etc/rmilter.conf"
-  install -D -m 644 rmilter.socket \
-    "${pending_dir}/etc/systemd/system/rmilter.socket"
 }
 
 do_post_regen() {
@@ -40,14 +38,11 @@ do_post_regen() {
   [ -z "$regen_conf_files" ] && exit 0
 
   # reload systemd daemon
-  [[ "$regen_conf_files" =~ rmilter\.socket ]] && {
-    sudo systemctl -q daemon-reload
-  }
+  sudo systemctl -q daemon-reload
 
-  # ensure that the socket is listening and stop the service - it will be
-  # started again by the socket as needed
-  sudo systemctl -q start rmilter.socket
-  sudo systemctl -q stop rmilter.service 2>&1 || true
+  # Restart rmilter due to the rspamd update
+  # https://rspamd.com/announce/2016/08/01/rspamd-1.3.1.html
+  sudo systemctl -q restart rmilter.service
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/28-rmilter
+++ b/data/hooks/conf_regen/28-rmilter
@@ -39,6 +39,11 @@ do_post_regen() {
   sudo chown _rmilter /etc/dkim/*.mail.key
   sudo chmod 400 /etc/dkim/*.mail.key
 
+  # fix rmilter socket permission (postfix is chrooted in /var/spool/postfix )
+  sudo mkdir -p /var/spool/postfix/run/rmilter
+  sudo chown -R postfix:_rmilter /var/spool/postfix/run/rmilter
+  sudo chmod g+w /var/spool/postfix/run/rmilter
+
   [ -z "$regen_conf_files" ] && exit 0
 
   # reload systemd daemon

--- a/data/hooks/conf_regen/28-rmilter
+++ b/data/hooks/conf_regen/28-rmilter
@@ -9,6 +9,10 @@ do_pre_regen() {
 
   install -D -m 644 rmilter.conf \
     "${pending_dir}/etc/rmilter.conf"
+  # Remove old socket file (we stopped using it, since rspamd 1.3.1)
+  # Regen-conf system need an empty file to delete it
+  install -D -m 644 /dev/null \
+    "${pending_dir}/etc/systemd/system/rmilter.socket"
 }
 
 do_post_regen() {

--- a/data/hooks/conf_regen/31-rspamd
+++ b/data/hooks/conf_regen/31-rspamd
@@ -25,10 +25,9 @@ do_post_regen() {
     sudo systemctl restart dovecot
   }
 
-  # ensure that the socket is listening and stop the service - it will be
-  # started again by the socket as needed
-  sudo systemctl -q start rspamd.socket
-  sudo systemctl -q stop rspamd.service 2>&1 || true
+  # Restart rspamd due to the upgrade
+  # https://rspamd.com/announce/2016/08/01/rspamd-1.3.1.html 
+  sudo systemctl -q restart rspamd.service 
 }
 
 FORCE=${2:-0}

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -141,7 +141,7 @@ smtp_reply_filter = pcre:/etc/postfix/smtp_reply_filter
 # Rmilter
 milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_protocol = 6
-smtpd_milters = inet:localhost:11000
+smtpd_milters = unix:/var/tmp/rmilter.sock
 
 # Skip email without checking if milter has died
 milter_default_action = accept

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -141,7 +141,7 @@ smtp_reply_filter = pcre:/etc/postfix/smtp_reply_filter
 # Rmilter
 milter_mail_macros =  i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_protocol = 6
-smtpd_milters = unix:/var/tmp/rmilter.sock
+smtpd_milters = unix:/run/rmilter/rmilter.sock
 
 # Skip email without checking if milter has died
 milter_default_action = accept

--- a/data/templates/rmilter/rmilter.conf
+++ b/data/templates/rmilter/rmilter.conf
@@ -5,7 +5,7 @@
 # pidfile - path to pid file
 pidfile = /run/rmilter/rmilter.pid;
 
-bind_socket = unix:/var/tmp/rmilter.sock;
+bind_socket = unix:/var/spool/postfix/run/rmilter/rmilter.sock;
 
 # DKIM signing
 dkim {

--- a/data/templates/rmilter/rmilter.conf
+++ b/data/templates/rmilter/rmilter.conf
@@ -5,8 +5,7 @@
 # pidfile - path to pid file
 pidfile = /run/rmilter/rmilter.pid;
 
-# rmilter is socket-activated under systemd
-bind_socket = fd:3;
+bind_socket = unix:/var/tmp/rmilter.sock;
 
 # DKIM signing
 dkim {

--- a/data/templates/rmilter/rmilter.socket
+++ b/data/templates/rmilter/rmilter.socket
@@ -1,5 +1,0 @@
-.include /lib/systemd/system/rmilter.socket
-
-[Socket]
-ListenStream=
-ListenStream=127.0.0.1:11000


### PR DESCRIPTION
https://dev.yunohost.org/issues/645

cf https://rspamd.com/announce/2016/08/01/rspamd-1.3.1.html

>Systemd activation has been removed from Rspamd and Rmilter
>
>Over the recent years, we have experienced constant issues reported by users about Systemd socket activation. This feature seems to be completely broken in systems with both IPv4/IPv6 enabled. Moreover, it seems to be harmful as Rspamd setup time is quite significant whilst socket activation is mostly intended for interactive on-demand daemons. Socket activation has been added under the pressure of Debian packaging rules, though Rspamd is completely rotten in Debian official repos and we strongly discourage Debian users from using the official Debian packages. While we are still looking for a new Debian maintainer for Rspamd, I can declare that there will be no sockets activation enabled by default in Rspamd nor Rmilter.
>
> The switch to standalone mode should be transparent for users. The only significant difference is use of rspamd.service instead of rspamd.socket in service management commands. In some cases you might need to restart Rmilter after upgrade (for example, in Debian Jessie):
>
>systemctl restart rmilter.service



So I think we should consider to give the socket activation idea up, for exemple all internetcube with a FFDN vpn have an ipv4 and ipv6.

So I suggest to simply do a restart. The service should be up after the boot.

May be there will ben an increase in memory ?

(Edit from Alex : using quote markdown instead of code block for better readability)


