### PR TITLE
[fix] Attempt to fix missing perm for metronome in weird cases

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -562,7 +562,9 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
     _set_permissions(new_cert_folder, "root", "root", 0655)
 
     # Move the private key
-    shutil.move(domain_key_file, os.path.join(new_cert_folder, "key.pem"))
+    domain_key_file_finaldest = os.path.join(new_cert_folder, "key.pem")
+    shutil.move(domain_key_file, domain_key_file_finaldest)
+    _set_permissions(domain_key_file_finaldest, "root", "metronome", 0640)
 
     # Write the cert
     domain_cert_file = os.path.join(new_cert_folder, "crt.pem")


### PR DESCRIPTION
Attempt to address https://dev.yunohost.org/issues/695, though I don't quite understand so far why the `shutil.move()` would not keep the permissions of the original file :/