### PR TITLE
[enh] Refactorize some parts of dyndns

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -100,6 +100,7 @@
     "dyndns_registered": "The DynDNS domain has been registered",
     "dyndns_registration_failed": "Unable to register DynDNS domain: {error:s}",
     "dyndns_unavailable": "Unavailable DynDNS subdomain",
+    "dyndns_provider_unreachable": "Unreachable dyndns provider {provider:s}",
     "executing_command": "Executing command '{command:s}'...",
     "executing_script": "Executing script '{script:s}'...",
     "extracting": "Extracting...",

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -40,7 +40,7 @@ from moulinette.core import MoulinetteError, init_authenticator
 from moulinette.utils.log import getActionLogger
 from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, app_list
 from yunohost.domain import domain_add, domain_list, get_public_ip, _get_maindomain, _set_maindomain
-from yunohost.dyndns import dyndns_subscribe
+from yunohost.dyndns import _dyndns_available, _dyndns_provides
 from yunohost.firewall import firewall_upnp
 from yunohost.service import service_status, service_regen_conf, service_log
 from yunohost.monitor import monitor_disk, monitor_system
@@ -206,32 +206,38 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
         password -- YunoHost admin password
 
     """
-    dyndns = not ignore_dyndns
 
     # Do some checks at first
     if os.path.isfile('/etc/yunohost/installed'):
         raise MoulinetteError(errno.EPERM,
                               m18n.n('yunohost_already_installed'))
-    if len(domain.split('.')) >= 3 and not ignore_dyndns:
-        try:
-            r = requests.get('https://dyndns.yunohost.org/domains')
-        except requests.ConnectionError:
-            pass
-        else:
-            dyndomains = json.loads(r.text)
-            dyndomain  = '.'.join(domain.split('.')[1:])
 
-            if dyndomain in dyndomains:
-                if requests.get('https://dyndns.yunohost.org/test/%s' % domain).status_code == 200:
-                    dyndns = True
-                else:
-                    raise MoulinetteError(errno.EEXIST,
-                                          m18n.n('dyndns_unavailable'))
-            else:
-                dyndns = False
-    else:
+    # Check if yunohost dyndns can handle the given domain
+    # (i.e. is it a .nohost.me ? a .noho.st ?)
+    dyndns_provider = "dyndns.yunohost.org"
+    try:
+        domain_handled_by_yunohost_dyndns = _dyndns_provides(dyndns_provider, domain)
+    # Ignore exceptions... (most likely we don't have internet connectivity)
+    except:
+        logger.warning(m18n.n('dyndns_provider_unreachable', provider=dyndns_provider))
+        domain_handled_by_yunohost_dyndns = False
+
+    # If it's not a .nohost.me / .noho.st, we don't care about dyndns
+    if not domain_handled_by_yunohost_dyndns:
         dyndns = False
+    # Otherwise, we check if it's available...
+    else:
+        if _dyndns_available(dyndns_provider, domain):
+            dyndns = True
+        else:
+            # Well, it's not available but maybe user says he don't care (--ignore-dyndns)
+            if ignore_dyndns:
+                dyndns = False
+            # Otherwise, abort and tell the user domain is not available.
+            else:
+                raise MoulinetteError(errno.EEXIST, m18n.n('dyndns_unavailable'))
 
+    # Start install
     logger.info(m18n.n('yunohost_installing'))
 
     # Initialize LDAP for YunoHost


### PR DESCRIPTION
Follow up of https://github.com/YunoHost/yunohost/pull/224, to be merged in 2.6.x

TODO : Implement comments from Bram [here](https://github.com/YunoHost/yunohost/commit/2c5d55a7f87f7a7eb5b6e3e59ef7559d8b5f9ebf)

Original description : 

---

- adds `_dyndns_provides` to check if a provider (e.g. dyndns.yunohost.org) can provide/handle a given domain (e.g. toto.nohost.me). This is meant to replace the current check about `len(domain.split('.')) >= 3`, and makes us able to differentiate between `toto.nohost.me` and `toto.someother.tld`. For the first one, we (apriori) implicitly want to have dyndns for it. For the second one, we don't want dyndns stuff (or at least not supported atm)
- adds `_dyndns_available` to check if a given domain is available. This avoid current duplicated code doing requests to https://dyndns.yunohost.org/test/<thedomain> and interpreting the results their own ways.

With this, I refactorized the begining of the postinstall : if the user asks of a domain ending in `.nohost.me`, the postinstall understands that we want dyndns for it. If the user asks for `ynh.local.stuff` or `toto.netlib.re`, the postinstall understands that we don't want dyndns for it.

And the new meaning of `--ignore-dyndns` is « I want toto.nohost.me, but I know it's not available, so don't try to configure the dyndns » 

