### PR TITLE
[enh] Prevent wget from appearing in the post install

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -99,7 +99,7 @@ def app_fetchlist(url=None, name=None):
                                   m18n.n('custom_appslist_name_required'))
 
     list_file = '%s/%s.json' % (repo_path, name)
-    if os.system('wget --timeout=30 "%s" -O "%s.tmp"' % (url, list_file)) != 0:
+    if os.system('wget -q --timeout=30 "%s" -O "%s.tmp"' % (url, list_file)) != 0:
         os.remove('%s.tmp' % list_file)
         raise MoulinetteError(errno.EBADR, m18n.n('appslist_retrieve_error'))
 


### PR DESCRIPTION
Right now there is a random wget that shows up during the postinstall : 

```
Success! The domain has been created
Success! The main domain has been changed
--2017-01-18 07:08:28--  https://app.yunohost.org/official.json
Resolving app.yunohost.org (app.yunohost.org)... 37.187.18.36
Connecting to app.yunohost.org (app.yunohost.org)|37.187.18.36|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 26105 (25K) [application/json]
Saving to: ‘/var/cache/yunohost/repo/yunohost.json.tmp’

/var/cache/yunohost/repo/yunohost.json.tm 100%[=======================================================================================>]  25.49K  --.-KB/s   in 0.04s

2017-01-18 07:08:29 (666 KB/s) - ‘/var/cache/yunohost/repo/yunohost.json.tmp’ saved [26105/26105]

Success! The app list has been fetched
Success! The SSOwat configuration has been generated
```
This gets rid of it.
