### PR TITLE
[fix] Rspamd & Rmilter are no more sockets

### DIFF
--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -14,10 +14,10 @@ postfix:
    status: service
    log: [/var/log/mail.log,/var/log/mail.err]
 rmilter:
-   status: systemctl status rmilter.socket
+   status: systemctl status rmilter.service
    log: /var/log/mail.log
 rspamd:
-   status: systemctl status rspamd.socket
+   status: systemctl status rspamd.service
    log: /var/log/mail.log
 redis-server:
    status: service


### PR DESCRIPTION
Changes introduced by https://github.com/YunoHost/yunohost/commit/b419c8c5641f29284befc29b059ee37db0b74a59