### PR TITLE
[enh] Cleaner postinstall logs during CA creation

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -240,6 +240,7 @@
     "user_updated": "The user has been updated",
     "yunohost_already_installed": "YunoHost is already installed",
     "yunohost_ca_creation_failed": "Unable to create certificate authority",
+    "yunohost_ca_creation_success": "The local certification authority has been created.",
     "yunohost_configured": "YunoHost has been configured",
     "yunohost_installing": "Installing YunoHost...",
     "yunohost_not_installed": "YunoHost is not or not correctly installed. Please execute 'yunohost tools postinstall'",


### PR DESCRIPTION
Right now the post-install still displays some ugly logs such as : 

```
Generating a 2048 bit RSA private key
.+++
.......+++
writing new private key to '/usr/share/yunohost/yunohost-config/ssl/yunoCA/ca/cakey.pem'
---
Updating certificates in /etc/ssl/certs... 0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d....done.
```
which pollutes the screen. With this PR and #159 (which removes the ugly wget verbose logs), we can achieve much cleaner postinstall logs.

Edit : the purpose of this PR is not to simply remove information, it is to replace it with more meaningful one.