### PR TITLE
[mod] rename all global variables to uppercase

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1158,7 +1158,7 @@ def _get_app_status(app_id, format_date=False):
 
 def _extract_app_from_file(path, remove=False):
     """
-    Unzip or untar application tarball in app_tmp_folder, or copy it from a directory
+    Unzip or untar application tarball in APP_TMP_FOLDER, or copy it from a directory
 
     Keyword arguments:
         path -- Path of the tarball or directory
@@ -1231,7 +1231,7 @@ def _get_git_last_commit_hash(repository, reference='HEAD'):
 
 def _fetch_app_from_git(app):
     """
-    Unzip or untar application tarball in app_tmp_folder
+    Unzip or untar application tarball in APP_TMP_FOLDER
 
     Keyword arguments:
         app -- App_id or git repo URL

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -44,11 +44,11 @@ from yunohost.utils import packages
 
 logger = getActionLogger('yunohost.app')
 
-repo_path        = '/var/cache/yunohost/repo'
-apps_path        = '/usr/share/yunohost/apps'
-apps_setting_path= '/etc/yunohost/apps/'
-install_tmp      = '/var/cache/yunohost'
-app_tmp_folder   = install_tmp + '/from_file'
+REPO_PATH        = '/var/cache/yunohost/repo'
+APPS_PATH        = '/usr/share/yunohost/apps'
+APPS_SETTING_PATH= '/etc/yunohost/apps/'
+INSTALL_TMP      = '/var/cache/yunohost'
+APP_TMP_FOLDER   = INSTALL_TMP + '/from_file'
 
 re_github_repo = re.compile(
     r'^(http[s]?://|git@)github.com[/:]'
@@ -69,7 +69,7 @@ def app_listlists():
     """
     list_list = []
     try:
-        for filename in os.listdir(repo_path):
+        for filename in os.listdir(REPO_PATH):
             if '.json' in filename:
                 list_list.append(filename[:len(filename)-5])
     except OSError:
@@ -88,8 +88,8 @@ def app_fetchlist(url=None, name=None):
 
     """
     # Create app path if not exists
-    if not os.path.exists(repo_path):
-        os.makedirs(repo_path)
+    if not os.path.exists(REPO_PATH):
+        os.makedirs(REPO_PATH)
 
     if url is None:
         url = 'https://app.yunohost.org/official.json'
@@ -117,7 +117,7 @@ def app_fetchlist(url=None, name=None):
         raise MoulinetteError(errno.EBADR, m18n.n('appslist_retrieve_bad_format'))
 
     # Write app list to file
-    list_file = '%s/%s.json' % (repo_path, name)
+    list_file = '%s/%s.json' % (REPO_PATH, name)
     with open(list_file, "w") as f:
         f.write(applist)
 
@@ -136,7 +136,7 @@ def app_removelist(name):
 
     """
     try:
-        os.remove('%s/%s.json' % (repo_path, name))
+        os.remove('%s/%s.json' % (REPO_PATH, name))
         os.remove("/etc/cron.d/yunohost-applist-%s" % name)
     except OSError:
         raise MoulinetteError(errno.ENOENT, m18n.n('appslist_unknown'))
@@ -177,13 +177,13 @@ def app_list(offset=None, limit=None, filter=None, raw=False, installed=False, w
         applists = app_listlists()['lists']
 
     for applist in applists:
-        with open(os.path.join(repo_path, applist + '.json')) as json_list:
+        with open(os.path.join(REPO_PATH, applist + '.json')) as json_list:
             for app, info in json.loads(str(json_list.read())).items():
                 if app not in app_dict:
                     info['repository'] = applist
                     app_dict[app] = info
 
-    for app in os.listdir(apps_setting_path):
+    for app in os.listdir(APPS_SETTING_PATH):
         if app not in app_dict:
             # Look for forks
             if '__' in app:
@@ -191,7 +191,7 @@ def app_list(offset=None, limit=None, filter=None, raw=False, installed=False, w
                 if original_app in app_dict:
                     app_dict[app] = app_dict[original_app]
                     continue
-            with open( apps_setting_path + app +'/manifest.json') as json_manifest:
+            with open( APPS_SETTING_PATH + app +'/manifest.json') as json_manifest:
                 app_dict[app] = {"manifest":json.loads(str(json_manifest.read()))}
             app_dict[app]['repository'] = None
 
@@ -212,8 +212,8 @@ def app_list(offset=None, limit=None, filter=None, raw=False, installed=False, w
 
                     # Filter only apps with backup and restore scripts
                     if with_backup and (
-                        not os.path.isfile(apps_setting_path + app_id + '/scripts/backup') or
-                        not os.path.isfile(apps_setting_path + app_id + '/scripts/restore')
+                        not os.path.isfile(APPS_SETTING_PATH + app_id + '/scripts/backup') or
+                        not os.path.isfile(APPS_SETTING_PATH + app_id + '/scripts/restore')
                     ):
                         continue
 
@@ -269,7 +269,7 @@ def app_info(app, show_status=False, raw=False):
         ret['settings'] = _get_app_settings(app)
         return ret
 
-    app_setting_path = apps_setting_path + app
+    app_setting_path = APPS_SETTING_PATH + app
 
     # Retrieve manifest and status
     with open(app_setting_path + '/manifest.json') as f:
@@ -309,7 +309,7 @@ def app_map(app=None, raw=False, user=None):
                                   m18n.n('app_not_installed', app=app))
         apps = [app,]
     else:
-        apps = os.listdir(apps_setting_path)
+        apps = os.listdir(APPS_SETTING_PATH)
 
     for app_id in apps:
         app_settings = _get_app_settings(app_id)
@@ -363,7 +363,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
     # If no app is specified, upgrade all apps
     if not app:
         if (not url and not file):
-            app = os.listdir(apps_setting_path)
+            app = os.listdir(APPS_SETTING_PATH)
     elif not isinstance(app, list):
         app = [ app ]
 
@@ -398,7 +398,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
         # Check requirements
         _check_manifest_requirements(manifest)
 
-        app_setting_path = apps_setting_path +'/'+ app_instance_name
+        app_setting_path = APPS_SETTING_PATH +'/'+ app_instance_name
 
         # Retrieve current app status
         status = _get_app_status(app_instance_name)
@@ -418,7 +418,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
         env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
 
         # Execute App upgrade script
-        os.system('chown -hR admin: %s' % install_tmp)
+        os.system('chown -hR admin: %s' % INSTALL_TMP)
         if hook_exec(extracted_app_folder +'/scripts/upgrade', args=args_list, env=env_dict) != 0:
             logger.error(m18n.n('app_upgrade_failed', app=app_instance_name))
         else:
@@ -467,8 +467,8 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     from yunohost.hook import hook_add, hook_remove, hook_exec
 
     # Fetch or extract sources
-    try: os.listdir(install_tmp)
-    except OSError: os.makedirs(install_tmp)
+    try: os.listdir(INSTALL_TMP)
+    except OSError: os.makedirs(INSTALL_TMP)
 
     status = {
         'installed_at': int(time.time()),
@@ -521,7 +521,7 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(instance_number)
 
     # Create app directory
-    app_setting_path = os.path.join(apps_setting_path, app_instance_name)
+    app_setting_path = os.path.join(APPS_SETTING_PATH, app_instance_name)
     if os.path.exists(app_setting_path):
         shutil.rmtree(app_setting_path)
     os.makedirs(app_setting_path)
@@ -538,7 +538,7 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     os.system('chown -R admin: '+ extracted_app_folder)
 
     # Execute App install script
-    os.system('chown -hR admin: %s' % install_tmp)
+    os.system('chown -hR admin: %s' % INSTALL_TMP)
     # Move scripts and manifest to the right place
     os.system('cp %s/manifest.json %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
@@ -614,7 +614,7 @@ def app_remove(auth, app):
         raise MoulinetteError(errno.EINVAL,
                               m18n.n('app_not_installed', app=app))
 
-    app_setting_path = apps_setting_path + app
+    app_setting_path = APPS_SETTING_PATH + app
 
     #TODO: display fail messages from script
     try:
@@ -783,7 +783,7 @@ def app_debug(app):
     Keyword argument:
         app
     """
-    with open(apps_setting_path + app + '/manifest.json') as f:
+    with open(APPS_SETTING_PATH + app + '/manifest.json') as f:
         manifest = json.loads(f.read())
 
     return {
@@ -1021,7 +1021,7 @@ def app_ssowatconf(auth):
 
     for app in apps_list:
         if _is_installed(app['id']):
-            with open(apps_setting_path + app['id'] +'/settings.yml') as f:
+            with open(APPS_SETTING_PATH + app['id'] +'/settings.yml') as f:
                 app_settings = yaml.load(f)
                 for item in _get_setting(app_settings, 'skipped_uris'):
                     if item[-1:] == '/':
@@ -1092,7 +1092,7 @@ def _get_app_settings(app_id):
                               m18n.n('app_not_installed', app=app_id))
     try:
         with open(os.path.join(
-                apps_setting_path, app_id, 'settings.yml')) as f:
+                APPS_SETTING_PATH, app_id, 'settings.yml')) as f:
             settings = yaml.load(f)
         if app_id == settings['id']:
             return settings
@@ -1112,7 +1112,7 @@ def _set_app_settings(app_id, settings):
 
     """
     with open(os.path.join(
-            apps_setting_path, app_id, 'settings.yml'), 'w') as f:
+            APPS_SETTING_PATH, app_id, 'settings.yml'), 'w') as f:
         yaml.safe_dump(settings, f, default_flow_style=False)
 
 
@@ -1125,7 +1125,7 @@ def _get_app_status(app_id, format_date=False):
         format_date -- Format date fields
 
     """
-    app_setting_path = apps_setting_path + app_id
+    app_setting_path = APPS_SETTING_PATH + app_id
     if not os.path.isdir(app_setting_path):
         raise MoulinetteError(errno.EINVAL, m18n.n('app_unknown'))
     status = {}
@@ -1170,22 +1170,22 @@ def _extract_app_from_file(path, remove=False):
     """
     logger.info(m18n.n('extracting'))
 
-    if os.path.exists(app_tmp_folder): shutil.rmtree(app_tmp_folder)
-    os.makedirs(app_tmp_folder)
+    if os.path.exists(APP_TMP_FOLDER): shutil.rmtree(APP_TMP_FOLDER)
+    os.makedirs(APP_TMP_FOLDER)
 
     path = os.path.abspath(path)
 
     if ".zip" in path:
-        extract_result = os.system('unzip %s -d %s > /dev/null 2>&1' % (path, app_tmp_folder))
+        extract_result = os.system('unzip %s -d %s > /dev/null 2>&1' % (path, APP_TMP_FOLDER))
         if remove: os.remove(path)
     elif ".tar" in path:
-        extract_result = os.system('tar -xf %s -C %s > /dev/null 2>&1' % (path, app_tmp_folder))
+        extract_result = os.system('tar -xf %s -C %s > /dev/null 2>&1' % (path, APP_TMP_FOLDER))
         if remove: os.remove(path)
     elif os.path.isdir(path):
-        shutil.rmtree(app_tmp_folder)
+        shutil.rmtree(APP_TMP_FOLDER)
         if path[len(path)-1:] != '/':
             path = path + '/'
-        extract_result = os.system('cp -a "%s" %s' % (path, app_tmp_folder))
+        extract_result = os.system('cp -a "%s" %s' % (path, APP_TMP_FOLDER))
     else:
         extract_result = 1
 
@@ -1193,7 +1193,7 @@ def _extract_app_from_file(path, remove=False):
         raise MoulinetteError(errno.EINVAL, m18n.n('app_extraction_failed'))
 
     try:
-        extracted_app_folder = app_tmp_folder
+        extracted_app_folder = APP_TMP_FOLDER
         if len(os.listdir(extracted_app_folder)) == 1:
             for folder in os.listdir(extracted_app_folder):
                 extracted_app_folder = extracted_app_folder +'/'+ folder
@@ -1240,7 +1240,7 @@ def _fetch_app_from_git(app):
         Dict manifest
 
     """
-    extracted_app_folder = app_tmp_folder
+    extracted_app_folder = APP_TMP_FOLDER
 
     app_tmp_archive = '{0}.zip'.format(extracted_app_folder)
     if os.path.exists(extracted_app_folder):
@@ -1383,9 +1383,9 @@ def _installed_instance_number(app, last=False):
     if last:
         number = 0
         try:
-            installed_apps = os.listdir(apps_setting_path)
+            installed_apps = os.listdir(APPS_SETTING_PATH)
         except OSError:
-            os.makedirs(apps_setting_path)
+            os.makedirs(APPS_SETTING_PATH)
             return 0
 
         for installed_app in installed_apps:
@@ -1419,7 +1419,7 @@ def _is_installed(app):
         Boolean
 
     """
-    return os.path.isdir(apps_setting_path + app)
+    return os.path.isdir(APPS_SETTING_PATH + app)
 
 
 def _value_for_locale(values):

--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -38,8 +38,8 @@ from moulinette.utils import process
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.text import prependlines
 
-firewall_file = '/etc/yunohost/firewall.yml'
-upnp_cron_job = '/etc/cron.d/yunohost-firewall-upnp'
+FIREWALL_FILE = '/etc/yunohost/firewall.yml'
+UPNP_CRON_JOB = '/etc/cron.d/yunohost-firewall-upnp'
 
 logger = getActionLogger('yunohost.firewall')
 
@@ -161,7 +161,7 @@ def firewall_list(raw=False, by_ip_version=False, list_forwarded=False):
         list_forwarded -- List forwarded ports with UPnP
 
     """
-    with open(firewall_file) as f:
+    with open(FIREWALL_FILE) as f:
         firewall = yaml.load(f)
     if raw:
         return firewall
@@ -318,7 +318,7 @@ def firewall_upnp(action='status', no_refresh=False):
         return {'enabled': enabled}
     elif action == 'enable' or (enabled and action == 'status'):
         # Add cron job
-        with open(upnp_cron_job, 'w+') as f:
+        with open(UPNP_CRON_JOB, 'w+') as f:
             f.write('*/50 * * * * root '
                     '/usr/bin/yunohost firewall upnp status >>/dev/null\n')
         # Open port 1900 to receive discovery message
@@ -330,7 +330,7 @@ def firewall_upnp(action='status', no_refresh=False):
     elif action == 'disable' or (not enabled and action == 'status'):
         try:
             # Remove cron job
-            os.remove(upnp_cron_job)
+            os.remove(UPNP_CRON_JOB)
         except:
             pass
         enabled = False
@@ -384,8 +384,8 @@ def firewall_upnp(action='status', no_refresh=False):
         firewall['uPnP']['enabled'] = enabled
 
         # Make a backup and update firewall file
-        os.system("cp {0} {0}.old".format(firewall_file))
-        with open(firewall_file, 'w') as f:
+        os.system("cp {0} {0}.old".format(FIREWALL_FILE))
+        with open(FIREWALL_FILE, 'w') as f:
             yaml.safe_dump(firewall, f, default_flow_style=False)
 
         if not no_refresh:
@@ -427,7 +427,7 @@ def firewall_stop():
         os.system("ip6tables -F")
         os.system("ip6tables -X")
 
-    if os.path.exists(upnp_cron_job):
+    if os.path.exists(UPNP_CRON_JOB):
         firewall_upnp('disable')
 
 
@@ -450,8 +450,8 @@ def _get_ssh_port(default=22):
 
 def _update_firewall_file(rules):
     """Make a backup and write new rules to firewall file"""
-    os.system("cp {0} {0}.old".format(firewall_file))
-    with open(firewall_file, 'w') as f:
+    os.system("cp {0} {0}.old".format(FIREWALL_FILE))
+    with open(FIREWALL_FILE, 'w') as f:
         yaml.safe_dump(rules, f, default_flow_style=False)
 
 

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -31,8 +31,8 @@ from glob import iglob
 from moulinette.core import MoulinetteError
 from moulinette.utils import log
 
-hook_folder = '/usr/share/yunohost/hooks/'
-custom_hook_folder = '/etc/yunohost/hooks.d/'
+HOOK_FOLDER = '/usr/share/yunohost/hooks/'
+CUSTOM_HOOK_FOLDER = '/etc/yunohost/hooks.d/'
 
 logger = log.getActionLogger('yunohost.hook')
 
@@ -49,12 +49,12 @@ def hook_add(app, file):
     path, filename = os.path.split(file)
     priority, action = _extract_filename_parts(filename)
 
-    try: os.listdir(custom_hook_folder + action)
-    except OSError: os.makedirs(custom_hook_folder + action)
+    try: os.listdir(CUSTOM_HOOK_FOLDER + action)
+    except OSError: os.makedirs(CUSTOM_HOOK_FOLDER + action)
 
-    finalpath = custom_hook_folder + action +'/'+ priority +'-'+ app
+    finalpath = CUSTOM_HOOK_FOLDER + action +'/'+ priority +'-'+ app
     os.system('cp %s %s' % (file, finalpath))
-    os.system('chown -hR admin: %s' % hook_folder)
+    os.system('chown -hR admin: %s' % HOOK_FOLDER)
 
     return { 'hook': finalpath }
 
@@ -68,10 +68,10 @@ def hook_remove(app):
 
     """
     try:
-        for action in os.listdir(custom_hook_folder):
-            for script in os.listdir(custom_hook_folder + action):
+        for action in os.listdir(CUSTOM_HOOK_FOLDER):
+            for script in os.listdir(CUSTOM_HOOK_FOLDER + action):
                 if script.endswith(app):
-                    os.remove(custom_hook_folder + action +'/'+ script)
+                    os.remove(CUSTOM_HOOK_FOLDER + action +'/'+ script)
     except OSError: pass
 
 
@@ -89,7 +89,7 @@ def hook_info(action, name):
 
     # Search in custom folder first
     for h in iglob('{:s}{:s}/*-{:s}'.format(
-            custom_hook_folder, action, name)):
+            CUSTOM_HOOK_FOLDER, action, name)):
         priority, _ = _extract_filename_parts(os.path.basename(h))
         priorities.add(priority)
         hooks.append({
@@ -98,7 +98,7 @@ def hook_info(action, name):
         })
     # Append non-overwritten system hooks
     for h in iglob('{:s}{:s}/*-{:s}'.format(
-            hook_folder, action, name)):
+            HOOK_FOLDER, action, name)):
         priority, _ = _extract_filename_parts(os.path.basename(h))
         if priority not in priorities:
             hooks.append({
@@ -183,23 +183,23 @@ def hook_list(action, list_by='name', show_info=False):
         # Append system hooks first
         if list_by == 'folder':
             result['system'] = dict() if show_info else set()
-            _append_folder(result['system'], hook_folder)
+            _append_folder(result['system'], HOOK_FOLDER)
         else:
-            _append_folder(result, hook_folder)
+            _append_folder(result, HOOK_FOLDER)
     except OSError:
         logger.debug("system hook folder not found for action '%s' in %s",
-                     action, hook_folder)
+                     action, HOOK_FOLDER)
 
     try:
         # Append custom hooks
         if list_by == 'folder':
             result['custom'] = dict() if show_info else set()
-            _append_folder(result['custom'], custom_hook_folder)
+            _append_folder(result['custom'], CUSTOM_HOOK_FOLDER)
         else:
-            _append_folder(result, custom_hook_folder)
+            _append_folder(result, CUSTOM_HOOK_FOLDER)
     except OSError:
         logger.debug("custom hook folder not found for action '%s' in %s",
-                     action, custom_hook_folder)
+                     action, CUSTOM_HOOK_FOLDER)
 
     return { 'hooks': result }
 

--- a/src/yunohost/monitor.py
+++ b/src/yunohost/monitor.py
@@ -44,9 +44,9 @@ from yunohost.domain import get_public_ip
 
 logger = getActionLogger('yunohost.monitor')
 
-glances_uri = 'http://127.0.0.1:61209'
-stats_path = '/var/lib/yunohost/stats'
-crontab_path = '/etc/cron.d/yunohost-monitor'
+GLANCES_URI = 'http://127.0.0.1:61209'
+STATS_PATH = '/var/lib/yunohost/stats'
+CRONTAB_PATH = '/etc/cron.d/yunohost-monitor'
 
 
 def monitor_disk(units=None, mountpoint=None, human_readable=False):
@@ -422,7 +422,7 @@ def monitor_enable(with_stats=False):
                  '3 * * * * root {cmd} week >> /dev/null\n'
                  '6 */4 * * * root {cmd} month >> /dev/null').format(
             cmd='/usr/bin/yunohost --quiet monitor update-stats')
-        with open(crontab_path, 'w') as f:
+        with open(CRONTAB_PATH, 'w') as f:
             f.write(rules)
 
     logger.success(m18n.n('monitor_enabled'))
@@ -447,7 +447,7 @@ def monitor_disable():
 
     # Remove crontab
     try:
-        os.remove(crontab_path)
+        os.remove(CRONTAB_PATH)
     except:
         pass
 
@@ -460,7 +460,7 @@ def _get_glances_api():
 
     """
     try:
-        p = xmlrpclib.ServerProxy(glances_uri)
+        p = xmlrpclib.ServerProxy(GLANCES_URI)
         p.system.methodHelp('getAll')
     except (xmlrpclib.ProtocolError, IOError):
         pass
@@ -552,9 +552,9 @@ def _retrieve_stats(period, date=None):
     # Retrieve pickle file
     if date is not None:
         timestamp = calendar.timegm(date)
-        pkl_file = '%s/%d_%s.pkl' % (stats_path, timestamp, period)
+        pkl_file = '%s/%d_%s.pkl' % (STATS_PATH, timestamp, period)
     else:
-        pkl_file = '%s/%s.pkl' % (stats_path, period)
+        pkl_file = '%s/%s.pkl' % (STATS_PATH, period)
     if not os.path.isfile(pkl_file):
         return False
 
@@ -581,11 +581,11 @@ def _save_stats(stats, period, date=None):
     # Set pickle file name
     if date is not None:
         timestamp = calendar.timegm(date)
-        pkl_file = '%s/%d_%s.pkl' % (stats_path, timestamp, period)
+        pkl_file = '%s/%d_%s.pkl' % (STATS_PATH, timestamp, period)
     else:
-        pkl_file = '%s/%s.pkl' % (stats_path, period)
-    if not os.path.isdir(stats_path):
-        os.makedirs(stats_path)
+        pkl_file = '%s/%s.pkl' % (STATS_PATH, period)
+    if not os.path.isdir(STATS_PATH):
+        os.makedirs(STATS_PATH)
 
     # Limit stats
     if date is None:

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -39,9 +39,9 @@ from moulinette.utils import log, filesystem
 from yunohost.hook import hook_callback
 
 
-base_conf_path = '/home/yunohost.conf'
-backup_conf_dir = os.path.join(base_conf_path, 'backup')
-pending_conf_dir = os.path.join(base_conf_path, 'pending')
+BASE_CONF_PATH = '/home/yunohost.conf'
+BACKUP_CONF_DIR = os.path.join(BASE_CONF_PATH, 'backup')
+PENDING_CONF_DIR = os.path.join(BASE_CONF_PATH, 'pending')
 
 logger = log.getActionLogger('yunohost.service')
 
@@ -300,15 +300,15 @@ def service_regen_conf(names=[], with_diff=False, force=False, dry_run=False,
         return pending_conf
 
     # Clean pending conf directory
-    if os.path.isdir(pending_conf_dir):
+    if os.path.isdir(PENDING_CONF_DIR):
         if not names:
-            shutil.rmtree(pending_conf_dir, ignore_errors=True)
+            shutil.rmtree(PENDING_CONF_DIR, ignore_errors=True)
         else:
             for name in names:
-                shutil.rmtree(os.path.join(pending_conf_dir, name),
+                shutil.rmtree(os.path.join(PENDING_CONF_DIR, name),
                               ignore_errors=True)
     else:
-        filesystem.mkdir(pending_conf_dir, 0755, True)
+        filesystem.mkdir(PENDING_CONF_DIR, 0755, True)
 
     # Format common hooks arguments
     common_args = [1 if force else 0, 1 if dry_run else 0]
@@ -318,7 +318,7 @@ def service_regen_conf(names=[], with_diff=False, force=False, dry_run=False,
 
     def _pre_call(name, priority, path, args):
         # create the pending conf directory for the service
-        service_pending_path = os.path.join(pending_conf_dir, name)
+        service_pending_path = os.path.join(PENDING_CONF_DIR, name)
         filesystem.mkdir(service_pending_path, 0755, True, uid='admin')
         # return the arguments to pass to the script
         return pre_args + [service_pending_path, ]
@@ -615,12 +615,12 @@ def _get_pending_conf(services=[]):
 
     """
     result = {}
-    if not os.path.isdir(pending_conf_dir):
+    if not os.path.isdir(PENDING_CONF_DIR):
         return result
     if not services:
-        services = os.listdir(pending_conf_dir)
+        services = os.listdir(PENDING_CONF_DIR)
     for name in services:
-        service_pending_path = os.path.join(pending_conf_dir, name)
+        service_pending_path = os.path.join(PENDING_CONF_DIR, name)
         if not os.path.isdir(service_pending_path):
             continue
         path_index = len(service_pending_path)
@@ -672,7 +672,7 @@ def _process_regen_conf(system_conf, new_conf=None, save=True):
 
     """
     if save:
-        backup_path = os.path.join(backup_conf_dir, '{0}-{1}'.format(
+        backup_path = os.path.join(BACKUP_CONF_DIR, '{0}-{1}'.format(
             system_conf.lstrip('/'), time.strftime("%Y%m%d.%H%M%S")))
         backup_dir = os.path.dirname(backup_path)
         if not os.path.isdir(backup_dir):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -46,7 +46,8 @@ from yunohost.service import service_status, service_regen_conf, service_log
 from yunohost.monitor import monitor_disk, monitor_system
 from yunohost.utils.packages import ynh_packages_version
 
-apps_setting_path= '/etc/yunohost/apps/'
+# FIXME this is a duplicate from apps.py
+APPS_SETTING_PATH= '/etc/yunohost/apps/'
 
 logger = getActionLogger('yunohost.tools')
 
@@ -341,7 +342,7 @@ def tools_update(ignore_apps=False, ignore_packages=False):
             app_fetchlist()
         except MoulinetteError:
             pass
-        app_list = os.listdir(apps_setting_path)
+        app_list = os.listdir(APPS_SETTING_PATH)
         if len(app_list) > 0:
             for app_id in app_list:
                 if '__' in app_id:


### PR DESCRIPTION
We wanted to do some code cleaning for this release therefor I've started doing this. My plan is to do a small series of easy to review PR that only does one thing so we can move forward without having a huge PR that no one will never read.

This one is for adopting a python convention: global variables should always be uppercase so you can directly see their nature when reading them.

I've tested the code (not all commands, but at least one per module like `domain list`) and this doesn't seems to break anything. I've also took the time to grep every variable to see if they weren't imported anywhere.

I'm labeling this as a small decision but that could be a micro one.

Next, I'll run autopep8 on app.py.