### PR TITLE
Add unit testing for global settings

### DIFF
--- a/src/yunohost/tests/conftest.py
+++ b/src/yunohost/tests/conftest.py
@@ -1,0 +1,16 @@
+import sys
+import moulinette
+
+sys.path.append("..")
+
+old_init = moulinette.core.Moulinette18n.__init__
+
+
+def monkey_path_i18n_init(self, package, default_locale="en"):
+    old_init(self, package, default_locale)
+    self.load_namespace("yunohost")
+
+
+moulinette.core.Moulinette18n.__init__ = monkey_path_i18n_init
+
+moulinette.init()


### PR DESCRIPTION
TO BE MERGED AFTER GLOBAL SETTINGS.

After years of frustration, I've finally took the time to write tests for YunoHost \o\ /o/

I had to do an ugly hack to "enter the moulinette world". Sadly, those tests only run on a setup environment (like ynh-dev).

To launch the tests:

    apt-get install python-pytest
    cd /usr/lib/moulinette/yunohost
    py.test tests