### PR TITLE
[enh] upgrade ciphers suit to more secure ones

### DIFF
--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -19,9 +19,12 @@ server {
     ssl_certificate_key /etc/yunohost/certs/yunohost.org/key.pem;
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
+
+    # Ciphers with modern configuration
+    # Source : https://mozilla.github.io/server-side-tls/ssl-config-generator/
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
     ssl_prefer_server_ciphers on;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
 
     add_header Strict-Transport-Security "max-age=31536000;";
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -24,15 +24,14 @@ server {
     ssl_certificate_key /etc/yunohost/certs/{{ domain }}/key.pem;
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
+
+    # Ciphers with modern configuration
+    # Source : https://mozilla.github.io/server-side-tls/ssl-config-generator/
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
     ssl_prefer_server_ciphers on;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
 
     add_header Strict-Transport-Security "max-age=31536000;";
-
-    # Uncomment the following directive after DH generation
-    # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
-    #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -26,7 +26,7 @@ server {
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers ALL:!aNULL:!eNULL:!LOW:!EXP:!RC4:!3DES:+HIGH:+MEDIUM;
+    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
 
     add_header Strict-Transport-Security "max-age=31536000;";
 


### PR DESCRIPTION
Following this topic https://forum.yunohost.org/t/ssl-security-disable-diffie-hellman-key-exchange-per-default/2540 I'm opening this PR following his instruction for further discussion.

*Please not that I haven't tested this PR.*

This PR, if good, should be backported to stable.

*Edit by Alex:*
### Status / summary

So right now the proposal is to follow the Modern Compat' recommendation from Mozilla (cf. [this](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility) and this [this](https://mozilla.github.io/server-side-tls/ssl-config-generator/)). 

Pros : 
- Mozilla are good guys and we can trust their recommendations ;
- With modern compat, we don't need DH params anymore (we used non-custom 1024 bit DH params so far, which was bad) ;
- We probably get A+ on SSLLabs by default ;
- Modern compat' is compatible with all ~relatively recent browsers (cf [this](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility))

Cons:
- People with ~old computers/setup/browsers/smartphones (e.g. Safari < 9, Android ~ 2.x) might not have access to yunohost instances, and we have no mechanic yet to allow admin to set "softer" ciphers nginx conf (same discussion as [here](https://github.com/YunoHost/yunohost/pull/161#issuecomment-226692995)). We need to discuss to which extend this is an issue or not.

### Todo

- Propagate the changes to [yunohost_admin.conf](https://github.com/YunoHost/yunohost/blob/unstable/data/templates/nginx/plain/yunohost_admin.conf)
- Test on several different browsers ?


 