### PR TITLE
Get rid of Sender Rewriting Scheme

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -129,10 +129,6 @@ smtpd_recipient_restrictions =
     reject_unauth_destination,
     permit
 
-# SRS
-sender_canonical_maps = regexp:/etc/postfix/sender_canonical
-sender_canonical_classes = envelope_sender
-
 # Ignore some headers
 smtp_header_checks = regexp:/etc/postfix/header_checks
 


### PR DESCRIPTION
As implemented today, SRS through sender_canonical_maps gives a strange behavior, rewriting Return-Path to something along senderlocalpart@mydomain which doesn't seem to make much sense.
I'd suggest to remove these two lines from the configuration, getting rid of the unwanted behavior and simplifying postfix configuration.