### PR TITLE
[mod] dnsmasq conf: remove deprecated XMPP DNS record line.

### DIFF
--- a/data/templates/dnsmasq/domain.tpl
+++ b/data/templates/dnsmasq/domain.tpl
@@ -4,4 +4,3 @@ txt-record={{ domain }},"v=spf1 mx a -all"
 mx-host={{ domain }},{{ domain }},5
 srv-host=_xmpp-client._tcp.{{ domain }},{{ domain }},5222,0,5
 srv-host=_xmpp-server._tcp.{{ domain }},{{ domain }},5269,0,5
-srv-host=_jabber._tcp.{{ domain }},{{ domain }},5269,0,5


### PR DESCRIPTION
With [dnsmasq configured as a local dns resolver](https://yunohost.org/#/dns_resolver_en).

This file which is automatically configured for domain names on `/etc/dnsmasq.d/domain.tld` are used by DNS resolver dnsmasq.

You could check that locally, the dns record is resolved with one of following commands:
```bash
host -t SRV _jabber._tcp.${domain.tld}
dig _jabber._tcp.${domain.tld} SRV
nslookup -querytype=SRV _jabber._tcp.${domain.tld}
```

In the future, if we want to use dnsmasq as an authoritative DNS server, it's better to remove [jabber._tcp SRV record which is deprecated](https://serverfault.com/questions/582106/should-i-specify-the-srv-record-jabber-tcp).