### PR TITLE
[fix] dnsmasq conf: remove 'resolv-file' line.

### DIFF
--- a/data/templates/dnsmasq/domain.tpl
+++ b/data/templates/dnsmasq/domain.tpl
@@ -1,4 +1,3 @@
-resolv-file=
 address=/{{ domain }}/{{ ip }}
 txt-record={{ domain }},"v=spf1 mx a -all"
 mx-host={{ domain }},{{ domain }},5


### PR DESCRIPTION
With [dnsmasq configured as a local dns resolver](https://yunohost.org/#/dns_resolver_en).

This file which is automatically configured for domain names on `/etc/dnsmasq.d/domain.tld` are used by DNS resolver dnsmasq.

There is no file specified for this line, and on some case dns resolution like for metronome could not works caused by this line:
- [Forum post 1](https://forum.yunohost.org/t/xmpp-cant-connect-to-conference-yunohost-org/2142)
- [Forum post 2](https://forum.yunohost.org/t/metronome-narrive-pas-a-communiquer-avec-lexterieur/1327)