### PR TITLE
[enh] Adding new port availability checker

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1351,6 +1351,16 @@ tools:
                     help: Show private data (domain, IP)
                     action: store_true
 
+        ### tools_portavailable()
+        portavailable:
+            action_help: Check availability of a local port
+            api: GET /tools/portavailable
+            arguments:
+                port:
+                    help: Port to check
+                    extra:
+                        pattern: *pattern_port
+
 
 #############################
 #           Hook            #

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -556,6 +556,7 @@ app:
         checkport:
             action_help: Check availability of a local port
             api: GET /tools/checkport
+            deprecated: true
             arguments:
                 port:
                     help: Port to check

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1352,8 +1352,8 @@ tools:
                     help: Show private data (domain, IP)
                     action: store_true
 
-        ### tools_portavailable()
-        portavailable:
+        ### tools_port_available()
+        port-available:
             action_help: Check availability of a local port
             api: GET /tools/portavailable
             arguments:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -891,7 +891,7 @@ def app_checkport(port):
     # import...
     from yunohost.tools import tools_portavailable
     availability = tools_portavailable(port)
-    if availability["available"] is "Yes":
+    if availability["available"]:
         logger.success(m18n.n('port_available', port=int(port)))
     else:
         raise MoulinetteError(errno.EINVAL,

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -40,6 +40,7 @@ from moulinette.utils.log import getActionLogger
 
 from yunohost.service import service_log
 from yunohost.utils import packages
+from yunohost.tools import tools_portavailable
 
 logger = getActionLogger('yunohost.app')
 
@@ -886,7 +887,6 @@ def app_checkport(port):
         port -- Port to check
 
     """
-    from yunohost.tools import tools_portavailable
     logger.warning("This function is now deprecated. Please use `tools portavailable` instead.")
     availability = tools_portavailable(port)
     if availability["available"] is "Yes":

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -29,7 +29,6 @@ import shutil
 import yaml
 import time
 import re
-import socket
 import urlparse
 import errno
 import subprocess
@@ -887,12 +886,10 @@ def app_checkport(port):
         port -- Port to check
 
     """
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.settimeout(1)
-        s.connect(("localhost", int(port)))
-        s.close()
-    except socket.error:
+    from yunohost.tools import tools_portavailable
+    logger.warning("This function is now deprecated. Please use `tools portavailable` instead.")
+    availability = tools_portavailable(port)
+    if availability["available"] is "Yes":
         logger.success(m18n.n('port_available', port=int(port)))
     else:
         raise MoulinetteError(errno.EINVAL,

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -40,7 +40,6 @@ from moulinette.utils.log import getActionLogger
 
 from yunohost.service import service_log
 from yunohost.utils import packages
-from yunohost.tools import tools_portavailable
 
 logger = getActionLogger('yunohost.app')
 
@@ -887,6 +886,10 @@ def app_checkport(port):
         port -- Port to check
 
     """
+
+    # This import cannot be moved on top of file because it create a recursive
+    # import...
+    from yunohost.tools import tools_portavailable
     logger.warning("This function is now deprecated. Please use `tools portavailable` instead.")
     availability = tools_portavailable(port)
     if availability["available"] is "Yes":

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -890,7 +890,6 @@ def app_checkport(port):
     # This import cannot be moved on top of file because it create a recursive
     # import...
     from yunohost.tools import tools_portavailable
-    logger.warning("This function is now deprecated. Please use `tools portavailable` instead.")
     availability = tools_portavailable(port)
     if availability["available"] is "Yes":
         logger.success(m18n.n('port_available', port=int(port)))

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -572,6 +572,6 @@ def tools_portavailable(port):
         s.connect(("localhost", int(port)))
         s.close()
     except socket.error:
-        return { "available" : "Yes" }
+        return { "available" : True }
     else:
-        return { "available" : "No" }
+        return { "available" : False }

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -572,6 +572,6 @@ def tools_port_available(port):
         s.connect(("localhost", int(port)))
         s.close()
     except socket.error:
-        return { "available" : True }
+        return True
     else:
-        return { "available" : False }
+        return False

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -31,6 +31,7 @@ import errno
 import logging
 import subprocess
 import pwd
+import socket
 from collections import OrderedDict
 
 import apt
@@ -555,3 +556,22 @@ def tools_diagnosis(auth, private=False):
         diagnosis['private']['domains'] = domain_list(auth)['domains']
 
     return diagnosis
+
+
+def tools_portavailable(port):
+    """
+    Check availability of a local port
+
+    Keyword argument:
+        port -- Port to check
+
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(1)
+        s.connect(("localhost", int(port)))
+        s.close()
+    except socket.error:
+        return { "available" : "Yes" }
+    else:
+        return { "available" : "No" }

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -558,7 +558,7 @@ def tools_diagnosis(auth, private=False):
     return diagnosis
 
 
-def tools_portavailable(port):
+def tools_port_available(port):
     """
     Check availability of a local port
 


### PR DESCRIPTION
### Problem / context
- Current `app checkport` is not very semantic : it's not specific to apps and 'check' is really vague
- Current implementation raises an error if port doesn't exists, which led to introducting #230 

### Solution
- introduce a `tools portavailable` in the actionmap, which does the same thing as `app checkport` except it simply returns a dictionnary with the form `{ "available" : "Yes" }` (or No). (Even if that's json, it's pretty easy to build a bash helper around it with a grep.)
- add a deprectation warning for `app checkport`.