### PR TITLE
Clean services.yml

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -65,7 +65,7 @@ with open('/etc/yunohost/services.yml') as f:
 updated = False
 for service, conf in new_services.items():
     # remove service with empty conf
-    if not conf:
+    if conf is None:
         if service in services:
             print("removing '{0}' from services".format(service))
             del services[service]

--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -50,7 +50,7 @@ yunohost-firewall:
 nslcd:
    status: service
    log: /var/log/syslog
-nsswitch: null
+nsswitch: {}
 bind9: null
 tahoe-lafs: null
 memcached: null

--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -50,10 +50,8 @@ yunohost-firewall:
 nslcd:
    status: service
    log: /var/log/syslog
-nsswitch:
-   status: service
-udisks2:
-   status: service
+nsswitch: null
+udisks2: null
 amavis: null
 postgrey: null
 spamassassin: null

--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -52,7 +52,10 @@ nslcd:
    log: /var/log/syslog
 nsswitch: null
 bind9: null
+tahoe-lafs: null
+memcached: null
 udisks2: null
+udisk-glue: null
 amavis: null
 postgrey: null
 spamassassin: null

--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -51,6 +51,7 @@ nslcd:
    status: service
    log: /var/log/syslog
 nsswitch: null
+bind9: null
 udisks2: null
 amavis: null
 postgrey: null

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -201,11 +201,12 @@ def service_status(names=[]):
                                   m18n.n('service_unknown', service=name))
 
         status = None
-        if 'status' not in services[name] or \
-                services[name]['status'] == 'service':
+        if services[name].get('status') == 'service':
             status = 'service %s status' % name
-        else:
+        elif "status" in services[name]:
             status = str(services[name]['status'])
+        else:
+            continue
 
         runlevel = 5
         if 'runlevel' in services[name].keys():


### PR DESCRIPTION
Hello,

This is an attempt to clean `/etc/yunohost/services.yml` from outdated services.

Right we have a series of old/not used anymore/doesn't make sens services and this confused users (can be confirmed from several feedback with this internet cube, this was a very frequent request like "is it normal that those services doesn't run?").

`services.yml` is used for 2 things: saying which services are tracked with which logs files AND keeping track of the regen-conf. This collide sometime because it happens that we handle the regen-conf of stuff that *aren't services* but they end up being listed as inactive services.

This PR attempt to do 3 things to fix that:

* don't list as a service an entry that doesn't have a `status` key, by default the "service %(service name)s" was used when no `status` key was present, we ended up with services like `ssl` which didn't make any sens
* set as null the services `nsswitch` and `udisks2` because I THINK (not sure) that they aren't used anymore (I couldn't find any trace of them and they were always inactives)
* add `bind9` as a null service entry, this will remove bind9 from old YunoHost `services.yml` where it was still present before the dnsmasq migration (this concern quite a lot of Internet Cube actually)