### PR TITLE
[fix] Regenerate SSOwat conf during main_domain operation. #672

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -185,6 +185,9 @@ def tools_maindomain(auth, new_domain=None):
         else:
             logger.info(out)
 
+    # Generate SSOwat configuration file
+    app_ssowatconf(auth)
+
     # Regen configurations
     try:
         with open('/etc/yunohost/installed', 'r') as f:
@@ -307,9 +310,6 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
     # New domain config
     domain_add(auth, domain, dyndns)
     tools_maindomain(auth, domain)
-
-    # Generate SSOwat configuration file
-    app_ssowatconf(auth)
 
     # Change LDAP admin password
     tools_adminpw(auth, password)


### PR DESCRIPTION
After this change, `/etc/ssowat/conf.json` is updated every time the main domain is changed.

Fixes https://dev.yunohost.org/issues/672