### PR TITLE
[enh] Use _get_maindomain helper.

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -988,12 +988,10 @@ def app_ssowatconf(auth):
 
 
     """
-    from yunohost.domain import domain_list
+    from yunohost.domain import domain_list, _get_maindomain
     from yunohost.user import user_list
 
-    with open('/etc/yunohost/current_host', 'r') as f:
-        main_domain = f.readline().rstrip()
-
+    main_domain = _get_maindomain()
     domains = domain_list(auth)['domains']
 
     users = {}

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -35,7 +35,7 @@ import subprocess
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
-from yunohost.domain import get_public_ip
+from yunohost.domain import get_public_ip, _get_maindomain
 
 logger = getActionLogger('yunohost.dyndns')
 
@@ -78,8 +78,7 @@ def dyndns_subscribe(subscribe_host="dyndns.yunohost.org", domain=None, key=None
 
     """
     if domain is None:
-        with open('/etc/yunohost/current_host', 'r') as f:
-            domain = f.readline().rstrip()
+        domain = _get_maindomain()
 
     # Verify if domain is available
     try:

--- a/src/yunohost/monitor.py
+++ b/src/yunohost/monitor.py
@@ -40,7 +40,7 @@ from datetime import datetime
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
-from yunohost.domain import get_public_ip
+from yunohost.domain import get_public_ip, _get_maindomain
 
 logger = getActionLogger('yunohost.monitor')
 
@@ -174,8 +174,7 @@ def monitor_network(units=None, human_readable=False):
     for u in units:
         if u == 'check':
             result[u] = {}
-            with open('/etc/yunohost/current_host', 'r') as f:
-                domain = f.readline().rstrip()
+            domain = _get_maindomain()
             cmd_check_smtp = os.system('/bin/nc -z -w1 yunohost.org 25')
             if cmd_check_smtp == 0:
                 smtp_check = m18n.n('network_check_smtp_ok')

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -106,7 +106,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
 
     """
     import pwd
-    from yunohost.domain import domain_list
+    from yunohost.domain import domain_list, _get_maindomain
     from yunohost.hook import hook_callback
     from yunohost.app import app_ssowatconf
 
@@ -163,8 +163,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
 
     # If it is the first user, add some aliases
     if not auth.search(base='ou=users,dc=yunohost,dc=org', filter='uid=*'):
-        with open('/etc/yunohost/current_host') as f:
-            main_domain = f.readline().rstrip()
+        main_domain = _get_maindomain()
         aliases = [
             'root@' + main_domain,
             'admin@' + main_domain,


### PR DESCRIPTION
https://github.com/YunoHost/yunohost/pull/187 introduced a new helper command `_get_maindomain` that should be used whenever we need to get this information. 