### PR TITLE
Allow underscore in backup name

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -678,7 +678,7 @@ backup:
                     help: Name of the backup archive
                     extra:
                         pattern: &pattern_backup_archive_name
-                            - !!str ^[\w\-\.]{1,30}(?<!\.)$
+                            - !!str ^[\w\-\._]{1,30}(?<!\.)$
                             - "pattern_backup_archive_name"
                 -d:
                     full: --description

--- a/locales/en.json
+++ b/locales/en.json
@@ -153,7 +153,7 @@
     "packages_upgrade_critical_later": "Critical packages ({packages:s}) will be upgraded later",
     "packages_upgrade_failed": "Unable to upgrade all of the packages",
     "path_removal_failed": "Unable to remove path {:s}",
-    "pattern_backup_archive_name": "Must be a valid filename with alphanumeric and -_. characters only",
+    "pattern_backup_archive_name": "Must be a valid filename with max 30 characters, and alphanumeric and -_. characters only",
     "pattern_domain": "Must be a valid domain name (e.g. my-domain.org)",
     "pattern_email": "Must be a valid email address (e.g. someone@domain.org)",
     "pattern_firstname": "Must be a valid first name",


### PR DESCRIPTION
Allow underscore in backup name, to allow backup with the name of multi-instance apps.

If there are no reason to avoid this character.

The error message allow this character, so there are a error in one of them.
https://github.com/YunoHost/yunohost/blob/unstable/locales/en.json#L156