### PR TITLE
Fix for missing YunoHost tiles

### DIFF
--- a/data/templates/nginx/plain/yunohost_panel.conf.inc
+++ b/data/templates/nginx/plain/yunohost_panel.conf.inc
@@ -1,2 +1,8 @@
+# Insert YunoHost panel
 sub_filter </head> '<script type="text/javascript" src="/ynhpanel.js"></script></head>';
 sub_filter_once on;
+# Apply to other mime types than text/html
+sub_filter_types application/xhtml+xml;
+# Prevent YunoHost panel files from being blocked by specific app rules
+location ~ ynhpanel\.(js|json|css) {
+}


### PR DESCRIPTION
This PR:
- brings back [this PR](https://github.com/YunoHost/yunohost-config-nginx/pull/3/files) which seems to have stayed behind when migrating from `yunohost-config-nginx`. It fixes the missing tile for Jirafeau app (and maybe others).
- adds a fix to serve `ynhpanel.*` files whatever the app ningx rules are (some apps nginx conf files block them, like duniter or nextcloud).

This work is linked to [this issue](https://dev.yunohost.org/issues/285), as well as [this PR](https://github.com/YunoHost/SSOwat/pull/71) on SSOwat.