### PR TITLE
[enh] Add libnss-mdns as Debian dependency.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban
  , nginx-extras (>=1.6.2), php5-fpm, php5-ldap, php5-intl
- , dnsmasq, openssl, avahi-daemon
+ , dnsmasq, openssl, avahi-daemon, libnss-mdns
  , ssowat, metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
  , haveged


### PR DESCRIPTION
See https://dev.yunohost.org/issues/760 ; It'll help discovering Yunohost boxes through `yunohost.local` domain, on local networks.