### PR TITLE
New helper ynh_secure_remove

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -80,3 +80,31 @@ properly with chmod/chown." >&2
     chmod 755 $TMP_DIR
     echo $TMP_DIR
 }
+
+# Remove a file or a directory securely
+#
+# usage: ynh_secure_remove path_to_remove
+# | arg: path_to_remove - File or directory to remove
+ynh_secure_remove () {
+	path_to_remove=$1
+	forbidden_path=" \
+	/var/www \
+	/home/yunohost.app"
+
+	if [[ "$forbidden_path" =~ "$path_to_remove" \
+		# Match all path or subpath in $forbidden_path
+		|| "$path_to_remove" =~ ^/[[:alnum:]]+$ \
+		# Match all first level path from / (Like /var, /root, etc...)
+		|| "${path_to_remove:${#path_to_remove}-1}" = "/" ]]
+		# Match if the path finish by /. Because it's seems there is an empty variable
+	then
+		echo "Avoid deleting of $path_to_remove." >&2
+	else
+		if [ -e "$path_to_remove" ]
+		then
+			sudo rm -R "$path_to_remove"
+		else
+			echo "$path_to_remove doesn't deleted because it's not exist." >&2
+		fi
+	fi
+}

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -92,19 +92,19 @@ ynh_secure_remove () {
 	/home/yunohost.app"
 
 	if [[ "$forbidden_path" =~ "$path_to_remove" \
-		# Match all path or subpath in $forbidden_path
+		# Match all paths or subpaths in $forbidden_path
 		|| "$path_to_remove" =~ ^/[[:alnum:]]+$ \
-		# Match all first level path from / (Like /var, /root, etc...)
+		# Match all first level paths from / (Like /var, /root, etc...)
 		|| "${path_to_remove:${#path_to_remove}-1}" = "/" ]]
-		# Match if the path finish by /. Because it's seems there is an empty variable
+		# Match if the path finishes by /. Because it seems there is an empty variable
 	then
-		echo "Avoid deleting of $path_to_remove." >&2
+		echo "Avoid deleting $path_to_remove." >&2
 	else
 		if [ -e "$path_to_remove" ]
 		then
 			sudo rm -R "$path_to_remove"
 		else
-			echo "$path_to_remove doesn't deleted because it's not exist." >&2
+			echo "$path_to_remove wasn't deleted because it doesn't exist." >&2
 		fi
 	fi
 }


### PR DESCRIPTION
A secure way to remove a file or directory.
Prevent to knew issues.

Tested with this paths:
- / -> Not removed
- /var -> Not removed
- /var/www -> Not removed
- /var/www/file -> Removed
- /opt -> Not removed
- /opt/file -> Removed
- /home/yunohost.app -> Not removed
- /home -> Not removed
- /home/ -> Not removed
- // -> Not removed
- /etc/cron.d/ -> Not removed
- /etc -> Not removed
- /etc/ -> Not removed
- /etc/X11 -> Removed
- /etc/X11/$var -> Removed (if $var is not empty)