### PR TITLE
New helpers ynh_add_fpm_config and ynh_remove_fpm_config

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -57,13 +57,13 @@ ynh_remove_logrotate () {
 # usage: ynh_add_fpm_config
 ynh_add_fpm_config () {
 	finalphpconf="/etc/php5/fpm/pool.d/$app.conf"
-	ynh_compare_checksum_config "$finalphpconf" 1
+	ynh_backup_if_checksum_is_different "$finalphpconf" 1
 	sudo cp ../conf/php-fpm.conf "$finalphpconf"
 	ynh_replace_string "__NAMETOCHANGE__" "$app" "$finalphpconf"
 	ynh_replace_string "__FINALPATH__" "$final_path" "$finalphpconf"
 	ynh_replace_string "__USER__" "$app" "$finalphpconf"
 	sudo chown root: "$finalphpconf"
-	ynh_store_checksum_config "$finalphpconf"
+	ynh_store_file_checksum "$finalphpconf"
 
 	if [ -e "../conf/php-fpm.ini" ]
 	then
@@ -82,6 +82,6 @@ ynh_add_fpm_config () {
 # usage: ynh_remove_fpm_config
 ynh_remove_fpm_config () {
 	ynh_secure_remove "/etc/php5/fpm/pool.d/$app.conf"
-	ynh_secure_remove "/etc/php5/fpm/conf.d/20-$app.ini"
+	ynh_secure_remove "/etc/php5/fpm/conf.d/20-$app.ini" 2>&1
 	sudo systemctl reload php5-fpm
 }

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -57,7 +57,7 @@ ynh_remove_logrotate () {
 # usage: ynh_add_fpm_config
 ynh_add_fpm_config () {
 	finalphpconf="/etc/php5/fpm/pool.d/$app.conf"
-	ynh_backup_if_checksum_is_different "$finalphpconf" 1
+	ynh_backup_if_checksum_is_different "$finalphpconf"
 	sudo cp ../conf/php-fpm.conf "$finalphpconf"
 	ynh_replace_string "__NAMETOCHANGE__" "$app" "$finalphpconf"
 	ynh_replace_string "__FINALPATH__" "$final_path" "$finalphpconf"
@@ -68,10 +68,10 @@ ynh_add_fpm_config () {
 	if [ -e "../conf/php-fpm.ini" ]
 	then
 		finalphpini="/etc/php5/fpm/conf.d/20-$app.ini"
-		ynh_compare_checksum_config "$finalphpini" 1
+		ynh_backup_if_checksum_is_different "$finalphpini"
 		sudo cp ../conf/php-fpm.ini "$finalphpini"
 		sudo chown root: "$finalphpini"
-		ynh_store_checksum_config "$finalphpini"
+		ynh_store_file_checksum "$finalphpini"
 	fi
 
 	sudo systemctl reload php5-fpm

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -59,9 +59,9 @@ ynh_add_fpm_config () {
 	finalphpconf="/etc/php5/fpm/pool.d/$app.conf"
 	ynh_compare_checksum_config "$finalphpconf" 1
 	sudo cp ../conf/php-fpm.conf "$finalphpconf"
-	ynh_substitute_char "__NAMETOCHANGE__" "$app" "$finalphpconf"
-	ynh_substitute_char "__FINALPATH__" "$final_path" "$finalphpconf"
-	ynh_substitute_char "__USER__" "$app" "$finalphpconf"
+	ynh_replace_string "__NAMETOCHANGE__" "$app" "$finalphpconf"
+	ynh_replace_string "__FINALPATH__" "$final_path" "$finalphpconf"
+	ynh_replace_string "__USER__" "$app" "$finalphpconf"
 	sudo chown root: "$finalphpconf"
 	ynh_store_checksum_config "$finalphpconf"
 

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -51,3 +51,37 @@ ynh_remove_logrotate () {
 		sudo rm "/etc/logrotate.d/$app"
 	fi
 }
+
+# Create a dedicated php-fpm config
+#
+# usage: ynh_add_fpm_config
+ynh_add_fpm_config () {
+	finalphpconf="/etc/php5/fpm/pool.d/$app.conf"
+	ynh_compare_checksum_config "$finalphpconf" 1
+	sudo cp ../conf/php-fpm.conf "$finalphpconf"
+	ynh_substitute_char "__NAMETOCHANGE__" "$app" "$finalphpconf"
+	ynh_substitute_char "__FINALPATH__" "$final_path" "$finalphpconf"
+	ynh_substitute_char "__USER__" "$app" "$finalphpconf"
+	sudo chown root: "$finalphpconf"
+	ynh_store_checksum_config "$finalphpconf"
+
+	if [ -e "../conf/php-fpm.ini" ]
+	then
+		finalphpini="/etc/php5/fpm/conf.d/20-$app.ini"
+		ynh_compare_checksum_config "$finalphpini" 1
+		sudo cp ../conf/php-fpm.ini "$finalphpini"
+		sudo chown root: "$finalphpini"
+		ynh_store_checksum_config "$finalphpini"
+	fi
+
+	sudo systemctl reload php5-fpm
+}
+
+# Remove the dedicated php-fpm config
+#
+# usage: ynh_remove_fpm_config
+ynh_remove_fpm_config () {
+	ynh_secure_remove "/etc/php5/fpm/pool.d/$app.conf"
+	ynh_secure_remove "/etc/php5/fpm/conf.d/20-$app.ini"
+	sudo systemctl reload php5-fpm
+}


### PR DESCRIPTION
Standard configuration of php-fpm.
Use local files stored in conf/, so it's still possible to use a specific config