### PR TITLE
[fix] Properly manage resolv.conf, dns resolvers and dnsmasq

### DIFF
--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -13,6 +13,15 @@ do_pre_regen() {
   # create directory for pending conf
   dnsmasq_dir="${pending_dir}/etc/dnsmasq.d"
   mkdir -p "$dnsmasq_dir"
+  etcdefault_dir="${pending_dir}/etc/default"
+  mkdir -p "$etcdefault_dir"
+
+  # add general conf files
+  cp plain/etcdefault ${pending_dir}/etc/default/dnsmasq
+  cp plain/dnsmasq.conf ${pending_dir}/etc/dnsmasq.conf
+
+  # add resolver file
+  cat plain/resolv.dnsmasq.conf | grep nameserver | shuf > ${pending_dir}/etc/resolv.dnsmasq.conf
 
   # retrieve variables
   ipv4=$(curl -s -4 https://ip.yunohost.org 2>/dev/null || true)
@@ -20,12 +29,6 @@ do_pre_regen() {
   ipv6=$(curl -s -6 https://ip6.yunohost.org 2>/dev/null || true)
   ynh_validate_ip6 "$ipv6" || ipv6=''
   domain_list=$(sudo yunohost domain list --output-as plain --quiet)
-
-  # add general conf file
-  cp plain/dnsmasq.conf ${pending_dir}/etc/dnsmasq.conf
-
-  # add resolver file
-  cp plain/resolv.dnsmasq.conf ${pending_dir}/etc/resolv.dnsmasq.conf
 
   # add domain conf files
   for domain in $domain_list; do

--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -21,6 +21,12 @@ do_pre_regen() {
   ynh_validate_ip6 "$ipv6" || ipv6=''
   domain_list=$(sudo yunohost domain list --output-as plain --quiet)
 
+  # add general conf file
+  cp plain/dnsmasq.conf ${pending_dir}/etc/dnsmasq.conf
+
+  # add resolver file
+  cp plain/resolv.dnsmasq.conf ${pending_dir}/etc/resolv.dnsmasq.conf
+
   # add domain conf files
   for domain in $domain_list; do
     cat domain.tpl \

--- a/data/templates/dnsmasq/plain/dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/dnsmasq.conf
@@ -1,0 +1,6 @@
+domain-needed
+expand-hosts
+
+listen-address=127.0.0.1
+resolv-file=/etc/resolv.dnsmasq.conf
+cache-size=256

--- a/data/templates/dnsmasq/plain/etcdefault
+++ b/data/templates/dnsmasq/plain/etcdefault
@@ -1,0 +1,33 @@
+# This file has five functions: 
+# 1) to completely disable starting dnsmasq, 
+# 2) to set DOMAIN_SUFFIX by running `dnsdomainname` 
+# 3) to select an alternative config file
+#    by setting DNSMASQ_OPTS to --conf-file=<file>
+# 4) to tell dnsmasq to read the files in /etc/dnsmasq.d for
+#    more configuration variables.
+# 5) to stop the resolvconf package from controlling dnsmasq's
+#    idea of which upstream nameservers to use.
+# For upgraders from very old versions, all the shell variables set 
+# here in previous versions are still honored by the init script
+# so if you just keep your old version of this file nothing will break.
+
+#DOMAIN_SUFFIX=`dnsdomainname`
+#DNSMASQ_OPTS="--conf-file=/etc/dnsmasq.alt"
+
+# Whether or not to run the dnsmasq daemon; set to 0 to disable.
+ENABLED=1
+
+# By default search this drop directory for configuration options.
+# Libvirt leaves a file here to make the system dnsmasq play nice.
+# Comment out this line if you don't want this. The dpkg-* are file
+# endings which cause dnsmasq to skip that file. This avoids pulling
+# in backups made by dpkg.
+CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+
+# If the resolvconf package is installed, dnsmasq will use its output 
+# rather than the contents of /etc/resolv.conf to find upstream 
+# nameservers. Uncommenting this line inhibits this behaviour.
+# Note that including a "resolv-file=<filename>" line in 
+# /etc/dnsmasq.conf is not enough to override resolvconf if it is
+# installed: the line below must be uncommented.
+IGNORE_RESOLVCONF=yes

--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -6,21 +6,21 @@
 # http://diyisp.org/dokuwiki/doku.php?id=technical:dnsresolver
 
 # (FR) FDN
-80.67.169.12
-80.67.169.40
+nameserver 80.67.169.12
+nameserver 80.67.169.40
 # (FR) LDN
-80.67.188.188
+nameserver 80.67.188.188
 # (FR) ARN
-89.234.141.66
+nameserver 89.234.141.66
 # (FR) gozmail / grifon
-89.234.186.18
+nameserver 89.234.186.18
 # (DE) FoeBud / Digital Courage
-85.214.20.141
+nameserver 85.214.20.141
 # (DE) CCC Berlin
-213.73.91.35
+nameserver 213.73.91.35
 # (DE) Ideal-Hosting
-84.200.69.80
-84.200.70.40
+nameserver 84.200.69.80
+nameserver 84.200.70.40
 # (DK) censurfridns
-91.239.100.100
-89.233.43.71
+nameserver 91.239.100.100
+nameserver 89.233.43.71

--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -5,9 +5,7 @@
 # List taken from
 # http://diyisp.org/dokuwiki/doku.php?id=technical:dnsresolver
 
-# (FR) FDN
-nameserver 80.67.169.12
-nameserver 80.67.169.40
+
 # (FR) LDN
 nameserver 80.67.188.188
 # (FR) ARN
@@ -24,3 +22,6 @@ nameserver 84.200.70.40
 # (DK) censurfridns
 nameserver 91.239.100.100
 nameserver 89.233.43.71
+# (FR) FDN
+nameserver 80.67.169.12
+nameserver 80.67.169.40

--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -1,0 +1,26 @@
+# According to dnsmasq's doc, dnsmasq will automatically 
+# choose the fastest-to-answer resolver as primary 
+# (if strict-order is disabled)
+
+# List taken from
+# http://diyisp.org/dokuwiki/doku.php?id=technical:dnsresolver
+
+# (FR) FDN
+80.67.169.12
+80.67.169.40
+# (FR) LDN
+80.67.188.188
+# (FR) ARN
+89.234.141.66
+# (FR) gozmail / grifon
+89.234.186.18
+# (DE) FoeBud / Digital Courage
+85.214.20.141
+# (DE) CCC Berlin
+213.73.91.35
+# (DE) Ideal-Hosting
+84.200.69.80
+84.200.70.40
+# (DK) censurfridns
+91.239.100.100
+89.233.43.71

--- a/data/templates/nsswitch/nsswitch.conf
+++ b/data/templates/nsswitch/nsswitch.conf
@@ -9,7 +9,7 @@ group:          compat ldap
 shadow:         compat ldap
 gshadow:        files
 
-hosts:          files mdns4_minimal [NOTFOUND=return] dns
+hosts:          files myhostname mdns4_minimal [NOTFOUND=return] dns
 networks:       files
 
 protocols:      db files

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban
  , nginx-extras (>=1.6.2), php5-fpm, php5-ldap, php5-intl
- , dnsmasq, openssl, avahi-daemon, libnss-mdns
+ , dnsmasq, openssl, avahi-daemon, libnss-mdns, resolvconf
  , ssowat, metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
  , haveged

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban
  , nginx-extras (>=1.6.2), php5-fpm, php5-ldap, php5-intl
- , dnsmasq, openssl, avahi-daemon, libnss-mdns, resolvconf
+ , dnsmasq, openssl, avahi-daemon, libnss-mdns, resolvconf, libnss-myhostname
  , ssowat, metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
  , haveged

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -163,7 +163,8 @@ def tools_maindomain(auth, new_domain=None):
         logger.warning("%s" % e, exc_info=1)
         raise MoulinetteError(errno.EPERM, m18n.n('maindomain_change_failed'))
 
-    # Clear nsswitch cache for hosts...
+    # Clear nsswitch cache for hosts to make sure hostname is resolved ...
+    service_regen_conf(['nsswitch'], force=True)
     subprocess.call(['nscd', '-i', 'hosts'])
 
     # Set hostname

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -163,6 +163,9 @@ def tools_maindomain(auth, new_domain=None):
         logger.warning("%s" % e, exc_info=1)
         raise MoulinetteError(errno.EPERM, m18n.n('maindomain_change_failed'))
 
+    # Clear nsswitch cache for hosts...
+    subprocess.call(['nscd', '-i', 'hosts'])
+
     # Set hostname
     pretty_hostname = "(YunoHost/%s)" % new_domain
     commands = [

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -164,7 +164,6 @@ def tools_maindomain(auth, new_domain=None):
         raise MoulinetteError(errno.EPERM, m18n.n('maindomain_change_failed'))
 
     # Clear nsswitch cache for hosts to make sure hostname is resolved ...
-    service_regen_conf(['nsswitch'], force=True)
     subprocess.call(['nscd', '-i', 'hosts'])
 
     # Set hostname
@@ -312,6 +311,7 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
                                   m18n.n('yunohost_ca_creation_failed'))
 
     # New domain config
+    service_regen_conf(['nsswitch'], force=True)
     domain_add(auth, domain, dyndns)
     tools_maindomain(auth, domain)
 


### PR DESCRIPTION
### Status

Ready for review and tests (Feel free also to discuss the strategy adopted)

### Problem

(Imho this is a serious bug and should be treated as a release blocker for 2.6.x)

This is an attempt to fix https://dev.yunohost.org/issues/822 and other related issues. Right now, on some setups (such as ynh-dev / vagrant), resolvconf is not present and therefore `/etc/resolv.conf` does not point to 127.0.0.1 / dnsmasq. This leads to several issues since [the main domain is now the hostname](https://github.com/YunoHost/yunohost/pull/219), such as `Warning: sudo: unable to resolve host the.main.domain`. 

As long as at least `/etc/resolv.conf` or `/etc/hosts` is not managed properly, we will also always have people who will get messages such as "Cannot resolve some.domain.tld locally" (when installing Let's Encrypt certificate) and will have to tweak `/etc/hosts` manually.

### Solution

- Add resolvconf as dependency. This automatically (apparently ??) make `/etc/resolv.conf` point to 127.0.0.1 = dnsmasq ;
- This leads to the question of which 'external' DNS are used. Right now my understanding is that by default dnsmasq use google's DNS and caching is disabled ? Therefore I propose tweaking dnsmasq config to use [friendly DNS resolvers](http://diyisp.org/dokuwiki/doku.php?id=technical:dnsresolver) and enable caching.

### References

Got some inspiration from these pages : 
- http://www.drazzib.com/docs/admin/dnsmasq.html
- https://wiki.archlinux.org/index.php/dnsmasq
- https://wiki.archlinux.org/index.php/Resolv.conf
