### PR TITLE
[fix] Remove version from api

### DIFF
--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -192,12 +192,10 @@ if __name__ == '__main__':
     _init_moulinette(opts.use_websocket, opts.debug, opts.verbose)
 
     # Run the server
-    from yunohost.utils.packages import ynh_packages_version
     ret = moulinette.api(
         _retrieve_namespaces(),
         host=opts.host, port=opts.port, routes={
             ('GET', '/installed'): is_installed,
-            ('GET', '/version'): ynh_packages_version,
         }, use_cache=opts.use_cache, use_websocket=opts.use_websocket
     )
     sys.exit(ret)


### PR DESCRIPTION
Related to: https://dev.yunohost.org/issues/703

It's for security.