### PR TITLE
[fix] Don't attempt to change hostname in LXC

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -223,13 +223,14 @@ def _is_inside_container():
     Returns True or False
     """
 
-    p = subprocess.Popen("sudo grep -qa container=lxc /proc/1/environ".split(),
+    # See https://stackoverflow.com/a/37016302
+    p = subprocess.Popen("sudo cat /proc/1/sched".split(),
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
 
     out, _ = p.communicate()
 
-    return p.returncode == 0
+    return out.split()[1] != "(1,"
 
 
 def tools_postinstall(domain, password, ignore_dyndns=False):


### PR DESCRIPTION
### Problem

For some reason, `hostnamectl` can't be used to change hostname inside LXC's. This is troublesome for bicyclette because [the postinstall crashes because of this](http://bicyclette.netlib.re) and therefore is quite useless.

### Solution

Use some [black magic](https://stackoverflow.com/questions/20010199/determining-if-a-process-runs-inside-lxc-docker) to check if we're running inside a LXC. I wrapped this in a small  `_is_inside_container()` helper