### PR TITLE
Fix ynh_local_curl

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -161,7 +161,7 @@ ynh_local_curl () {
 	if [ -n "$POST_data" ]
 	then
 		# Add --data arg and remove the last character, which is an unecessary '&'
-		POST_data="--data \"${POST_data::-1}\""
+		POST_data="--data ${POST_data::-1}"
 	fi
 
 	# Curl the URL


### PR DESCRIPTION
Weirdly, POST arguments aren't given to the request if quotes are used...
I'm puzzled as @maniackcrudelis has certainly tested this helper.
Also @scith wasn't able to make it work, but I don't know if this can be the cause.
