### PR TITLE
[enh] Add a script to test m18n keys usage

### DIFF
--- a/tests/_test_m18nkeys.py
+++ b/tests/_test_m18nkeys.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+import re
+import glob
+import json
+import yaml
+
+###############################################################################
+#   Find used keys in python code                                             #
+###############################################################################
+
+# This regex matches « foo » in patterns like « m18n.n(  "foo" »
+p = re.compile(r'm18n\.n\(\s*[\"\']([a-zA-Z1-9_]+)[\"\']')
+
+python_files = glob.glob("/vagrant/yunohost/src/yunohost/*.py")
+python_files.extend(glob.glob("/vagrant/yunohost/src/yunohost/utils/*.py"))
+python_files.append("/vagrant/yunohost/bin/yunohost")
+
+python_keys = set()
+for python_file in python_files:
+    with open(python_file) as f:
+        keys_in_file = p.findall(f.read())
+        for key in keys_in_file:
+            python_keys.add(key)
+
+###############################################################################
+#   Find keys used in actionmap                                               #
+###############################################################################
+
+actionmap_keys = set()
+actionmap = yaml.load(open("../data/actionsmap/yunohost.yml"))
+for _, category in actionmap.items():
+    if "actions" not in category.keys():
+        continue
+    for _, action in category["actions"].items():
+        if "arguments" not in action.keys():
+            continue
+        for _, argument in action["arguments"].items():
+            if "extra" not in argument.keys():
+                continue
+            if "password" in argument["extra"]:
+                actionmap_keys.add(argument["extra"]["password"])
+            if "ask" in argument["extra"]:
+                actionmap_keys.add(argument["extra"]["ask"])
+            if "pattern" in argument["extra"]:
+                actionmap_keys.add(argument["extra"]["pattern"][1])
+            if "help" in argument["extra"]:
+                print argument["extra"]["help"]
+
+# These keys are used but difficult to parse
+actionmap_keys.add("admin_password")
+
+###############################################################################
+#   Load en locale json keys                                                  #
+###############################################################################
+
+en_locale_file = "/vagrant/yunohost/locales/en.json"
+with open(en_locale_file) as f:
+    en_locale_json = json.loads(f.read())
+
+en_locale_keys = set(en_locale_json.keys())
+
+###############################################################################
+#   Compare keys used and keys defined                                        #
+###############################################################################
+
+used_keys = python_keys.union(actionmap_keys)
+
+keys_used_but_not_defined = used_keys.difference(en_locale_keys)
+keys_defined_but_not_used = en_locale_keys.difference(used_keys)
+
+if len(keys_used_but_not_defined) != 0:
+    print "> Error ! Those keys are used in some files but not defined :"
+    for key in sorted(keys_used_but_not_defined):
+        print "   - %s" % key
+
+if len(keys_defined_but_not_used) != 0:
+    print "> Warning ! Those keys are defined but seems unused :"
+    for key in sorted(keys_defined_but_not_used):
+        print "   - %s" % key
+
+


### PR DESCRIPTION
### Problem

Remembering which i18n/m18n keys are defined and their names is a pain in the ass. Also it's easy to forget about testing or defining some keys while focusing on writing actual code.

### Solution

I wrote a draft of script to analyze the code to look for m18n keys which are used. This is not perfect though, as sometimes m18n calls are not simply `m18n.n("foo")`, sometimes the key is computed on the fly (using concatenation, or conditions). Also it doesn't test that the arguments like `{bar:s}` are correctly passed and with the right format (string, integer, ...). But it's a start.

Right now it returns the following : 

```
> Error ! Those keys are used in some files but not defined :
   - ask_path
   - backup_archive_writing_error
> Warning ! Those keys are defined but seems unused :
   - app_change_url_no_script
   - ask_current_admin_password
   - diagnostic_monitor_network_error
   - dnsmasq_isnt_installed
   - domain_zone_exists
   - domain_zone_not_found
   - invalid_url_format
   - new_domain_required
   - no_appslist_found
   - no_restore_script
   - package_not_installed
   - package_unexpected_error
   - path_removal_failed
   - service_conf_would_be_updated
   - service_regenconf_dry_pending_applying
```