### PR TITLE
[fix] app_checkport was broken.

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1072,8 +1072,7 @@ def app_checkport(port):
     # This import cannot be moved on top of file because it create a recursive
     # import...
     from yunohost.tools import tools_port_available
-    availability = tools_port_available(port)
-    if availability["available"]:
+    if tools_port_available(port):
         logger.success(m18n.n('port_available', port=int(port)))
     else:
         raise MoulinetteError(errno.EINVAL,


### PR DESCRIPTION
Before:
```bash
yunohost app checkport 8999
Warnung: 'yunohost app checkport' ist veraltet und wird bald entfernt werden
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 217, in <module>
    timeout=opts.timeout,
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 139, in cli
    moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 358, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 484, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/app.py", line 1076, in app_checkport
    if availability["available"]:
TypeError: 'bool' object has no attribute '__getitem__'
```

After:
```bash
yunohost app checkport 8999 --no-cache
Warnung: 'yunohost app checkport' ist veraltet und wird bald entfernt werden
Erfolg! Der Port 8999 ist verfügbar
```