### PR TITLE
[fix] Unexpected comment line ending up in /etc/resolv.dnsmasq.conf

### DIFF
--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -21,7 +21,7 @@ do_pre_regen() {
   cp plain/dnsmasq.conf ${pending_dir}/etc/dnsmasq.conf
 
   # add resolver file
-  cat plain/resolv.dnsmasq.conf | grep nameserver | shuf > ${pending_dir}/etc/resolv.dnsmasq.conf
+  cat plain/resolv.dnsmasq.conf | grep "^nameserver" | shuf > ${pending_dir}/etc/resolv.dnsmasq.conf
 
   # retrieve variables
   ipv4=$(curl -s -4 https://ip.yunohost.org 2>/dev/null || true)


### PR DESCRIPTION
Micro-decision

A comment line in the template line contained the string "nameserver" and therefore was showing up in generated file randomly