### PR TITLE
[fix] Missing change from metronome to ssl-cert

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -595,7 +595,7 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
     # Move the private key
     domain_key_file_finaldest = os.path.join(new_cert_folder, "key.pem")
     shutil.move(domain_key_file, domain_key_file_finaldest)
-    _set_permissions(domain_key_file_finaldest, "root", "metronome", 0640)
+    _set_permissions(domain_key_file_finaldest, "root", "ssl-cert", 0640)
 
     # Write the cert
     domain_cert_file = os.path.join(new_cert_folder, "crt.pem")


### PR DESCRIPTION
Follow-up of https://github.com/YunoHost/yunohost/pull/222#issuecomment-303127134, I found that there was a patch between the beginning of #222 and the current unstable where permissions were explicitly changed for the key at the end. But since the PR wasn't rebased it wasn't apparent when looking at the file in the branch.

Anyway, this fixes it.