### PR TITLE
[enh] Do not change the db_pwd

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -122,6 +122,7 @@ ynh_mysql_setup_db () {
 	local db_user="$1"
 	local db_name="$2"
 	local new_db_pwd=$(ynh_string_random)	# Generate a random password
+	# If $3 is not given, use new_db_pwd instead for db_pwd.
 	db_pwd="${3:-$new_db_pwd}"
 	ynh_mysql_create_db "$db_name" "$db_user" "$db_pwd"	# Create the database
 	ynh_app_setting_set $app mysqlpwd $db_pwd	# Store the password in the app's config

--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -114,13 +114,15 @@ ynh_mysql_drop_user() {
 # After executing this helper, the password of the created database will be available in $db_pwd
 # It will also be stored as "mysqlpwd" into the app settings.
 #
-# usage: ynh_mysql_setup_db user name
+# usage: ynh_mysql_setup_db user name [pwd]
 # | arg: user - Owner of the database
 # | arg: name - Name of the database
+# | arg: pwd - Password of the database. If not given, a password will be generated
 ynh_mysql_setup_db () {
 	local db_user="$1"
 	local db_name="$2"
-	db_pwd=$(ynh_string_random)	# Generate a random password
+	local new_db_pwd=$(ynh_string_random)	# Generate a random password
+	db_pwd="${3:-$new_db_pwd}"
 	ynh_mysql_create_db "$db_name" "$db_user" "$db_pwd"	# Create the database
 	ynh_app_setting_set $app mysqlpwd $db_pwd	# Store the password in the app's config
 }


### PR DESCRIPTION
For restore script, do not change the password.
Keep the primary password and recreate a new database with it.