### PR TITLE
[fix] Move archivemount to suggested dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends: ${python:Depends}, ${misc:Depends}
  , ssowat, metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
  , haveged
- , archivemount
 Recommends: yunohost-admin
  , openssh-server, ntp, inetutils-ping | iputils-ping
  , bash-completion, rsyslog, etckeeper
@@ -34,7 +33,7 @@ Recommends: yunohost-admin
  , python-pip
  , unattended-upgrades
  , libdbd-ldap-perl, libnet-dns-perl
-Suggests: htop, vim, rsync, acpi-support-base, udisks2
+Suggests: htop, vim, rsync, acpi-support-base, udisks2, archivemount
 Conflicts: iptables-persistent
  , moulinette-yunohost, yunohost-config
  , yunohost-config-others, yunohost-config-postfix


### PR DESCRIPTION
### Problem

Archivemount depends on fuse, which cannot be installed on some specific machines likes OpenVZ containers (see https://dev.yunohost.org/issues/942). This make `apt-get install yunohost` crash because fuse can't be configured (and also the update to 2.6 / current testing).

### Proposed solution

- *[This PR]* Move archivemount as a suggested dependency. Therefore it won't be installed automatically.
- *[To be done in another PR]* In the install script, attempt to install fuse (or check fuse can be installed) and install archivemount if this works
- *[To be done later]* For the migration 2.5 -> 2.6, tell people to install archivemount manually if they want to have an optimized 'restore'. (Ideally this could be added as a migration once the migration framework is there)