### PR TITLE
[fix] Properly catch Invalid manifest json with ValueError.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,7 @@
     "app_location_already_used": "An app is already installed in this location",
     "app_location_install_failed": "Unable to install the app in this location",
     "app_location_unavailable": "This url is not available or conflicts with an already installed app",
-    "app_manifest_invalid": "Invalid app manifest",
+    "app_manifest_invalid": "Invalid app manifest: {error}",
     "app_no_upgrade": "No app to upgrade",
     "app_not_correctly_installed": "{app:s} seems to be incorrectly installed",
     "app_not_installed": "{app:s} is not installed",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1415,6 +1415,9 @@ def _extract_app_from_file(path, remove=False):
             manifest['lastUpdate'] = int(time.time())
     except IOError:
         raise MoulinetteError(errno.EIO, m18n.n('app_install_files_invalid'))
+    except ValueError as e:
+        raise MoulinetteError(errno.EINVAL,
+                              m18n.n('app_manifest_invalid', error=e.strerror))
 
     logger.info(m18n.n('done'))
 
@@ -1508,7 +1511,7 @@ def _fetch_app_from_git(app):
             except subprocess.CalledProcessError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_sources_fetch_failed'))
-            except IOError:
+            except ValueError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_manifest_invalid'))
             else:
@@ -1564,7 +1567,7 @@ def _fetch_app_from_git(app):
             except subprocess.CalledProcessError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_sources_fetch_failed'))
-            except IOError:
+            except ValueError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_manifest_invalid'))
             else:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1511,9 +1511,9 @@ def _fetch_app_from_git(app):
             except subprocess.CalledProcessError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_sources_fetch_failed'))
-            except ValueError:
+            except ValueError as e:
                 raise MoulinetteError(errno.EIO,
-                                      m18n.n('app_manifest_invalid'))
+                                      m18n.n('app_manifest_invalid', error=e.strerror))
             else:
                 logger.info(m18n.n('done'))
 
@@ -1567,9 +1567,9 @@ def _fetch_app_from_git(app):
             except subprocess.CalledProcessError:
                 raise MoulinetteError(errno.EIO,
                                       m18n.n('app_sources_fetch_failed'))
-            except ValueError:
+            except ValueError as e:
                 raise MoulinetteError(errno.EIO,
-                                      m18n.n('app_manifest_invalid'))
+                                      m18n.n('app_manifest_invalid', error=e.strerror))
             else:
                 logger.info(m18n.n('done'))
 


### PR DESCRIPTION
Kanhu on support@ room experienced issue with invalid manifest.json during app packaging development. Yunohost should return a proper error message insead of this kind of python trace : 
```
Downloading...
Extracting...
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 217, in <module>
    timeout=opts.timeout,
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 139, in cli
    moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 358, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 484, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/app.py", line 660, in app_install
    manifest, extracted_app_folder = _fetch_app_from_git(app)
  File "/usr/lib/moulinette/yunohost/app.py", line 1489, in _fetch_app_from_git
    app_tmp_archive, remove=True)
  File "/usr/lib/moulinette/yunohost/app.py", line 1414, in _extract_app_from_file
    manifest = json.loads(str(json_manifest.read()))
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting property name: line 7 column 5 (char 181)
```