### PR TITLE
[fix] "backup restore" crashes when archivemount is not installed

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1776,8 +1776,13 @@ class TarBackupMethod(BackupMethod):
         tar.close()
 
         # Mount the tarball
-        ret = subprocess.call(['archivemount', '-o', 'readonly',
-                               self._archive_file, self.work_dir])
+        try:
+            ret = subprocess.call(['archivemount', '-o', 'readonly',
+                                   self._archive_file, self.work_dir])
+        except:
+            ret = -1
+
+        # If archivemount failed, extract the archive
         if ret != 0:
             logger.warning(m18n.n('backup_archive_mount_failed'))
 


### PR DESCRIPTION
### Problem

As reported in https://dev.yunohost.org/issues/953, `yunohost backup restore` crashes when archivemount is not installed.

### Solution

Simple quick and dirty fix is to wrap the call in a try/except.

### How to test

```bash
yunohost backup create
yunohost backup list
yunohost backup restore backup_archive_name
```