### PR TITLE
[fix] Errors in backup custom methods

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -748,6 +748,9 @@ backup:
                     full: --no-compress
                     help: Do not create an archive file
                     action: store_true
+                --methods:
+                    help: List of backup methods to apply (copy or tar by default)
+                    nargs: "*"
                 --system:
                     help: List of system parts to backup (all by default)
                     nargs: "*"


### PR DESCRIPTION
## Problem
The backup refacto has been stopped at a state where all old features was ok but some new one, has been disable. It's the case for the --method feature.

## Solution
This PR fix some errors on the --methods and allow you to create custom backup hooks.

## How to test
You can test by folowing this tuto https://forum.yunohost.org/t/the-backup-roadmap/2643/4?u=ljf . You can also adapt it and create your own backup connector.

## Status
This PR works, (i used it) but I am not sure all bugs are fixed in this part. I think you can start to review it.

## Validation

- [x] **Principle agreement** 1/2 : @alexAubin, @psycojoker
- [X] **Quick review** 1/1 : @alexAubin
- [X] **Simple test** 1/1 : @alexAubin
- [X] **Deep review** 1/1: @alexAubin
- [x] **Complex test** 0/0