### PR TITLE
[fix] Logrotate append

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -2,15 +2,15 @@
 #
 # usage: ynh_use_logrotate [logfile] [--non-append]
 # | arg: logfile - absolute path of logfile
-# | option: --non-append - Replace the config file instead of append this new config.
+# | option: --non-append - Replace the config file instead of appending this new config.
 #
 # If no argument provided, a standard directory will be use. /var/log/${app}
 # You can provide a path with the directory only or with the logfile.
 # /parentdir/logdir/
 # /parentdir/logdir/logfile.log
 #
-# It's possible to use this helper several times, each config will added to same logrotate config file.
-# Unless if you use the option --non-append
+# It's possible to use this helper several times, each config will be added to the same logrotate config file.
+# Unless you use the option --non-append
 ynh_use_logrotate () {
 	local customtee="tee -a"
 	if [ $# -gt 0 ] && [ "$1" == "--non-append" ]; then
@@ -50,7 +50,7 @@ $logfile {
 }
 EOF
 	sudo mkdir -p $(dirname "$logfile")	# Create the log directory, if not exist
-	cat ${app}-logrotate | sudo $customtee /etc/logrotate.d/$app > /dev/null	# Append this config to the others for this app. If a config file already exist
+	cat ${app}-logrotate | sudo $customtee /etc/logrotate.d/$app > /dev/null	# Append this config to the existing config file, or replace the whole config file (depending on $customtee)
 }
 
 # Remove the app's logrotate config.

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -1,7 +1,8 @@
 # Use logrotate to manage the logfile
 #
-# usage: ynh_use_logrotate [logfile]
+# usage: ynh_use_logrotate [logfile] [--non-append]
 # | arg: logfile - absolute path of logfile
+# | option: --non-append - Replace the config file instead of append this new config.
 #
 # If no argument provided, a standard directory will be use. /var/log/${app}
 # You can provide a path with the directory only or with the logfile.
@@ -9,8 +10,17 @@
 # /parentdir/logdir/logfile.log
 #
 # It's possible to use this helper several times, each config will added to same logrotate config file.
+# Unless if you use the option --non-append
 ynh_use_logrotate () {
-	if [ "$#" -gt 0 ]; then
+	local customtee="tee -a"
+	if [ $# -gt 0 ] && [ "$1" == "--non-append" ]; then
+		customtee="tee"
+		# Destroy this argument for the next command.
+		shift
+	elif [ $# -gt 1 ] && [ "$2" == "--non-append" ]; then
+		customtee="tee"
+	fi
+	if [ $# -gt 0 ]; then
 		if [ "$(echo ${1##*.})" == "log" ]; then	# Keep only the extension to check if it's a logfile
 			logfile=$1	# In this case, focus logrotate on the logfile
 		else
@@ -40,7 +50,7 @@ $logfile {
 }
 EOF
 	sudo mkdir -p $(dirname "$logfile")	# Create the log directory, if not exist
-	cat ${app}-logrotate | sudo tee -a /etc/logrotate.d/$app > /dev/null	# Append this config to the others for this app. If a config file already exist
+	cat ${app}-logrotate | sudo $customtee /etc/logrotate.d/$app > /dev/null	# Append this config to the others for this app. If a config file already exist
 }
 
 # Remove the app's logrotate config.


### PR DESCRIPTION
Add a --non-append option to avoid to add the new config at the end of the existing config file.
In case of upgrade, it's a real problem because it will duplicates the same entry.
https://forum.yunohost.org/t/installation-etherpad-mypads/2890/48

- [ ] Complete test
- [ ] Simple test
- [ ] Code review
- [ ] Approval (LGTM)
- [ ] Approval (LGTM)

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization.md#minor-decision), close on 20 of june, or 16 of june.

I've made a complete test, with or without the arguments. And with the new argument at the first and the second place.