### PR TITLE
Run change_url scripts as root as a matter of homogeneity

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -487,7 +487,7 @@ def app_change_url(auth, app, domain, path):
     os.system('chmod +x %s' % os.path.join(os.path.join(APP_TMP_FOLDER, "scripts", "change_url")))
 
     # XXX journal
-    if hook_exec(os.path.join(APP_TMP_FOLDER, 'scripts/change_url'), args=args_list, env=env_dict) != 0:
+    if hook_exec(os.path.join(APP_TMP_FOLDER, 'scripts/change_url'), args=args_list, env=env_dict, user="root") != 0:
         logger.error("Failed to change '%s' url." % app)
 
         # restore values modified by app_checkurl


### PR DESCRIPTION
Due to parallel development (I guess) of change-url feature and script execution by root, change_url scripts are not run as root at the moment.
Here is a fix proposal; it can be tested with [this PR](https://github.com/YunoHost/test_apps/pull/1) on the test set.