### PR TITLE
[enh] Check that user is legitimate to use an email adress when sending mail

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -72,6 +72,7 @@ virtual_alias_domains =
 virtual_minimum_uid = 100 
 virtual_uid_maps = static:vmail 
 virtual_gid_maps = static:mail
+smtpd_sender_login_maps= ldap:/etc/postfix/ldap-accounts.cf
 
 # Dovecot LDA 
 virtual_transport = dovecot 
@@ -113,7 +114,8 @@ smtpd_helo_restrictions =
     permit 
  
 # Requirements for the sender address 
-smtpd_sender_restrictions = 
+smtpd_sender_restrictions =
+    reject_sender_login_mismatch, 
     permit_mynetworks, 
     permit_sasl_authenticated, 
     reject_non_fqdn_sender, 


### PR DESCRIPTION
Mail can only be sent if the sender is owner of the address or have the mail alias linked to his account.

Issue: https://dev.yunohost.org/issues/891#change-3384

