### PR TITLE
[fix] Attempt to fix Sender Rewriting Scheme with postsrsd

### DIFF
--- a/data/hooks/conf_regen/19-postfix
+++ b/data/hooks/conf_regen/19-postfix
@@ -10,14 +10,24 @@ do_pre_regen() {
   postfix_dir="${pending_dir}/etc/postfix"
   mkdir -p "$postfix_dir"
 
+  default_dir="${pending_dir}/etc/default/"
+  mkdir -p "$default_dir"
+
   # install plain conf files
   cp plain/* "$postfix_dir"
 
   # prepare main.cf conf file
   main_domain=$(cat /etc/yunohost/current_host)
+  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+
   cat main.cf \
     | sed "s/{{ main_domain }}/${main_domain}/g" \
     > "${postfix_dir}/main.cf"
+
+  cat postsrsd \
+    | sed "s/{{ main_domain }}/${main_domain}/g" \
+    | sed "s/{{ domain_list }}/${domain_list}/g" \
+    > "${default_dir}/postsrsd"
 
   # adapt it for IPv4-only hosts
   if [ ! -f /proc/net/if_inet6 ]; then
@@ -34,7 +44,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service postfix restart
+    || { sudo service postfix restart && sudo service postsrsd restart }
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/19-postfix
+++ b/data/hooks/conf_regen/19-postfix
@@ -18,7 +18,7 @@ do_pre_regen() {
 
   # prepare main.cf conf file
   main_domain=$(cat /etc/yunohost/current_host)
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(sudo yunohost domain list --output-as plain --quiet | tr '\n' ' ')
 
   cat main.cf \
     | sed "s/{{ main_domain }}/${main_domain}/g" \
@@ -44,7 +44,8 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || { sudo service postfix restart && sudo service postsrsd restart }
+    || { sudo service postfix restart && sudo service postsrsd restart; }
+
 }
 
 FORCE=${2:-0}

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -130,8 +130,10 @@ smtpd_recipient_restrictions =
     permit
 
 # SRS
-sender_canonical_maps = regexp:/etc/postfix/sender_canonical
+sender_canonical_maps = tcp:localhost:10001
 sender_canonical_classes = envelope_sender
+recipient_canonical_maps = tcp:localhost:10002
+recipient_canonical_classes= envelope_recipient,header_recipient
 
 # Ignore some headers
 smtp_header_checks = regexp:/etc/postfix/header_checks

--- a/data/templates/postfix/postsrsd
+++ b/data/templates/postfix/postsrsd
@@ -1,0 +1,43 @@
+# Default settings for postsrsd
+
+# Local domain name.
+# Addresses are rewritten to originate from this domain. The default value
+# is taken from `postconf -h mydomain` and probably okay.
+#
+SRS_DOMAIN={{ main_domain }}
+
+# Exclude additional domains.
+# You may list domains which shall not be subjected to address rewriting.
+# If a domain name starts with a dot, it matches all subdomains, but not
+# the domain itself. Separate multiple domains by space or comma.
+# We have to put some "dummy" stuff at start and end... see this comment :
+# https://github.com/roehling/postsrsd/issues/64#issuecomment-284003762
+SRS_EXCLUDE_DOMAINS=dummy {{ domain_list }} dummy
+
+# First separator character after SRS0 or SRS1.
+# Can be one of: -+=
+SRS_SEPARATOR==
+
+# Secret key to sign rewritten addresses.
+# When postsrsd is installed for the first time, a random secret is generated
+# and stored in /etc/postsrsd.secret. For most installations, that's just fine.
+#
+SRS_SECRET=/etc/postsrsd.secret
+
+# Local ports for TCP list.
+# These ports are used to bind the TCP list for postfix. If you change
+# these, you have to modify the postfix settings accordingly. The ports
+# are bound to the loopback interface, and should never be exposed on
+# the internet.
+#
+SRS_FORWARD_PORT=10001
+SRS_REVERSE_PORT=10002
+
+# Drop root privileges and run as another user after initialization.
+# This is highly recommended as postsrsd handles untrusted input.
+#
+RUN_AS=postsrsd
+
+# Jail daemon in chroot environment
+CHROOT=/var/lib/postsrsd
+

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , ca-certificates, netcat-openbsd, iproute
  , mariadb-server | mysql-server, php5-mysql | php5-mysqlnd
  , slapd, ldap-utils, sudo-ldap, libnss-ldapd, nscd
- , postfix-ldap, postfix-policyd-spf-perl, postfix-pcre, procmail
+ , postfix-ldap, postfix-policyd-spf-perl, postfix-pcre, procmail, postsrsd
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban
  , nginx-extras (>=1.6.2), php5-fpm, php5-ldap, php5-intl


### PR DESCRIPTION
### Problem

Right now, the Sender Rewriting Scheme implementation is a bit weird (see the old regex) and reportedly leaks metadata because the Return Path header is set to sender@main.domain (see https://dev.yunohost.org/issues/626). 

After investigating with fr0g, we realized that even though SRS is usually used to satisfy the SPF when forwarding emails (see 'Crash course' in [this readme](https://github.com/roehling/postsrsd/blob/master/README.md)), the current implementation in postfix does not seem to do what's recommended though (see the same paragraph in README).

### Solution

Several tutorial are poiting to postsrsd to do the job. It also allow to not apply SRS for some domains. So excluding the local domains avoid changing the Return Path to sender@main.domain (e.g. keep the original domain even if it's not the main domain).

So far, I have not been able to actually check how it affects the spaminess of mails though ... (this requires complicated setups because the whole SPF issue arrives in the context of forwards or mailing lists for instance)

### How to test

Pull the branch in. Make sure you have two domains A and B on your instance with (ideally) correct mail DNS records. A is the main domain. Send a mail from B to some external email (e.g. yahoo, gmail, whatever) and check the source. Without the patch, if you inspect the source, you should see `Return-Path: user@domain.A` (i.e. leaking existence of domain A to the recipient) whereas with the patch it's just 'Return-Path: user@domain.B' (i.e. not leaking stuff).

In more complicated setups though (i.e. sending a mail to user@domain.B which is then refowarded to user@gmail.com for instance) you might see something like : `Return-Path: SRS0=RQUm=6T=gmail.com=johndoe@domain.A`. This leaks the existence of 'domain A' to user (of domain B). Which is kinda less dramatic than the previous case imho.

### Reviews

- [ ] Agree in principle (0/2)
- [ ] Simple tests (0/1)
- [ ] Quick review (0/1)
- [ ] Deep tests (0/0)
- [ ] Deep reviews (0/0)