### PR TITLE
[fix] Don't verify SSL during changeurl tests :/

### DIFF
--- a/src/yunohost/tests/test_changeurl.py
+++ b/src/yunohost/tests/test_changeurl.py
@@ -38,7 +38,7 @@ def check_changeurl_app(path):
 
     assert appmap[maindomain][path + "/"]["id"] == "change_url_app"
 
-    r = requests.get("https://%s%s/" % (maindomain, path))
+    r = requests.get("https://%s%s/" % (maindomain, path), verify=False)
     assert r.status_code == 200
 
 


### PR DESCRIPTION
### Problem

See https://github.com/YunoHost/test_apps/pull/1 : for some reason, when running unit tests for changeurl, python-requests doesnt want to validate the request because of SSL error. Not sure what this is coming from... I think it was working before. Maybe some update in the python-requests version (I've seen some similar weird stuff on tartare where python-requests don't want to validate a requests to dev.yunohost.org because of SSL)

### Proposed solution

Disable the SSL verification for the request 😕 