### PR TITLE
[fix] Depreciation warning in backup for --hooks was always shown

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2093,7 +2093,7 @@ def backup_restore(auth, name,
         logger.warning("--ignore-hooks is deprecated and will be removed in the"
                        "future. Please use --ignore-system instead.")
         ignore_system = ignore_hooks
-    if hooks != []:
+    if hooks != [] and hooks is not None:
         logger.warning("--hooks is deprecated and will be removed in the"
                        "future. Please use --system instead.")
         system = hooks


### PR DESCRIPTION
### Problem

Minor issue where running `yunohost backup restore <archivename>` shows the depreciation warning about `--hooks` despite it not being used

### Solution

Copied what was done in `backup create`

### How to test

Create a backup archive, then try to restore it with an without this patch while not using `--hooks`.

### Reviews

- [ ] Agree in principle (0/2)
- [ ] Simple tests (0/1)
- [ ] Quick review (0/1)
- [ ] Deep tests (0/0)
- [ ] Deep reviews (0/0)