### PR TITLE
[fix] Backup daily cron (Redmine 933)

### DIFF
--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -10,6 +10,6 @@ source /usr/share/yunohost/helpers.d/filesystem
 backup_dir="${1}/conf/cron"
 
 # Backup the configuration
-for f in $(ls -1B /etc/cron.d/yunohost*); do
-  ynh_backup "$f" "${backup_dir}/${f##*/}"
+for f in $(ls -1B /etc/cron.*/yunohost*); do
+  ynh_backup "$f" "${backup_dir}${f}"
 done

--- a/data/hooks/restore/32-conf_cron
+++ b/data/hooks/restore/32-conf_cron
@@ -1,6 +1,12 @@
 backup_dir="$1/conf/cron"
 
-sudo cp -a $backup_dir/. /etc/cron.d
+# Old backup format
+if [ ! -d $backup_dir/etc ]; then
+    sudo cp -a $backup_dir/. /etc/cron.d
+# New backup format (2017-07-19 commit:902f331)
+else
+    sudo cp -a $backup_dir/etc/cron.* /etc/
+fi
 
 # Restart just in case
 sudo service cron restart


### PR DESCRIPTION
## Problem
Currently yunohost cron in cron.daily are not backup, only cron.d

## Solution
Backup all cron in cron.* and begining by yunohost

## How to test
```bash
yunohost backup create --ignore-apps --hooks conf_cron -n cronbkp --debug --verbose
rm /etc/cron.*/yunohost*
yunohost backup restore cronbkp --debug --verbose
ls -1B -l /etc/cron.*/yunohost*
```
Check permissions and owner

## PR Status
Untested. 

## Validation

- [ ] **Principle agreement** 1/2 : Bram
- [x] **Quick review** 1/1 : Bram
- [ ] **Simple test** 0/1 : 
- [ ] **Deep review** 0/1: 
- [ ] **Complex test** 0/0 
