### PR TITLE
[mod] explicitely import previously globals magic variables

### DIFF
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -202,6 +202,8 @@ if __name__ == '__main__':
     if not os.path.isfile('/etc/yunohost/installed') and \
        (len(args) < 2 or (args[0] +' '+ args[1] != 'tools postinstall' and \
                           args[0] +' '+ args[1] != 'backup restore')):
+
+        from moulinette import m18n
         # Init i18n
         m18n.load_namespace('yunohost')
         m18n.set_locale(get_locale())

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -38,6 +38,7 @@ import pwd
 import grp
 from collections import OrderedDict
 
+from moulinette import msignals, m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -36,6 +36,7 @@ import tempfile
 from glob import glob
 from collections import OrderedDict
 
+from moulinette import msignals, m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils import filesystem
 from moulinette.utils.log import getActionLogger

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -46,6 +46,7 @@ from moulinette.utils.log import getActionLogger
 
 import yunohost.domain
 
+from moulinette import m18n
 from yunohost.app import app_ssowatconf
 from yunohost.service import _run_service_command
 

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -33,6 +33,7 @@ import requests
 
 from urllib import urlopen
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -32,6 +32,7 @@ import errno
 import requests
 import subprocess
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 

--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -33,6 +33,7 @@ except ImportError:
     sys.stderr.write('Error: Yunohost CLI Require miniupnpc lib\n')
     sys.exit(1)
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils import process
 from moulinette.utils.log import getActionLogger

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -28,6 +28,7 @@ import re
 import errno
 from glob import iglob
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils import log
 

--- a/src/yunohost/monitor.py
+++ b/src/yunohost/monitor.py
@@ -37,6 +37,7 @@ import dns.resolver
 import cPickle as pickle
 from datetime import datetime
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -33,6 +33,7 @@ import shutil
 import hashlib
 from difflib import unified_diff
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils import log, filesystem
 

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -5,6 +5,7 @@ import errno
 from datetime import datetime
 from collections import OrderedDict
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 

--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from mock import ANY
 
+from moulinette import m18n
 from moulinette.core import init_authenticator
 from yunohost.app import app_install, app_remove, app_ssowatconf
 from yunohost.app import _is_installed

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -37,6 +37,7 @@ from collections import OrderedDict
 import apt
 import apt.progress
 
+from moulinette import msettings, m18n
 from moulinette.core import MoulinetteError, init_authenticator
 from moulinette.utils.log import getActionLogger
 from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, app_list, _install_appslist_fetch_cron

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -32,6 +32,7 @@ import errno
 import subprocess
 import re
 
+from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 from yunohost.service import service_status

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -25,6 +25,8 @@ from collections import OrderedDict
 import apt
 from apt_pkg import version_compare
 
+from moulinette import m18n
+
 logger = logging.getLogger('yunohost.utils.packages')
 
 


### PR DESCRIPTION
Matching PR for https://github.com/YunoHost/moulinette/pull/145

In addition to makes things cleaner this will also allows to uses tools like `pyflakes` or `pylint` in travis-ci for static analysis.