### PR TITLE
[fix] timeout on request to avoid blocking process

### DIFF
--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -183,15 +183,15 @@ def dyndns_update(dyn_host="dyndns.yunohost.org", domain=None, key=None,
 
             try:
                 # Check if domain is registered
-                if requests.get('https://{0}/test/{1}'.format(
-                        dyn_host, _domain), timeout=30).status_code == 200:
+                request_url = 'https://{0}/test/{1}'.format(dyn_host, _domain)
+                if requests.get(request_url, timeout=30).status_code == 200:
                     continue
             except requests.ConnectionError:
                 raise MoulinetteError(errno.ENETUNREACH,
                                       m18n.n('no_internet_connection'))
             except requests.exceptions.Timeout:
                 logger.warning("Correction timed out on {}, skip it".format(
-                                   'https://{0}/test/{1}'.format(dyn_host, _domain)))
+                                   request_url))
             domain = _domain
             key = path
             break

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -184,11 +184,14 @@ def dyndns_update(dyn_host="dyndns.yunohost.org", domain=None, key=None,
             try:
                 # Check if domain is registered
                 if requests.get('https://{0}/test/{1}'.format(
-                        dyn_host, _domain)).status_code == 200:
+                        dyn_host, _domain), timeout=30).status_code == 200:
                     continue
             except requests.ConnectionError:
                 raise MoulinetteError(errno.ENETUNREACH,
                                       m18n.n('no_internet_connection'))
+            except requests.exceptions.Timeout:
+                logger.warning("Correction timed out on {}, skip it".format(
+                                   'https://{0}/test/{1}'.format(dyn_host, _domain)))
             domain = _domain
             key = path
             break


### PR DESCRIPTION
Right now the dyndns process can block because we miss a timeout, this is a bad because this will block the whole moulinette due to the locking mechanism and the fact that we put  dyndns-update in a cron tab.

This is a hot fix for that and it's quite important that we release this fast.

This has been tested and seems okay.