### PR TITLE
[fix] Backup without info.json

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2292,21 +2292,21 @@ def backup_delete(name):
         name -- Name of the local backup archive
 
     """
+    if name not in backup_list()["archives"]:
+        raise MoulinetteError(errno.EIO, m18n.n('backup_archive_name_unknown',
+                                                name=name))
+
     hook_callback('pre_backup_delete', args=[name])
 
     archive_file = '%s/%s.tar.gz' % (ARCHIVES_PATH, name)
-
     info_file = "%s/%s.info.json" % (ARCHIVES_PATH, name)
+
     for backup_file in [archive_file, info_file]:
-        if not os.path.isfile(backup_file) and not os.path.islink(backup_file):
-            raise MoulinetteError(errno.EIO,
-                m18n.n('backup_archive_name_unknown', name=backup_file))
         try:
             os.remove(backup_file)
         except:
             logger.debug("unable to delete '%s'", backup_file, exc_info=1)
-            raise MoulinetteError(errno.EIO,
-                m18n.n('backup_delete_error', path=backup_file))
+            logger.warning(m18n.n('backup_delete_error', path=backup_file))
 
     hook_callback('post_backup_delete', args=[name])
 

--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -634,5 +634,21 @@ def _test_backup_and_restore_app(app):
 
     assert app_is_installed(app)
 
+###############################################################################
+#  Some edge cases                                                            #
+###############################################################################
 
+def test_restore_archive_with_no_json(mocker):
+
+    # Create a backup with no info.json associated
+    os.system("touch /tmp/afile")
+    os.system("tar -czvf /home/yunohost.backup/archives/badbackup.tar.gz /tmp/afile")
+
+    assert "badbackup" in backup_list()["archives"]
+
+    mocker.spy(m18n, "n")
+    with pytest.raises(MoulinetteError):
+        backup_restore(auth, name="badbackup", force=True,
+                       ignore_system=False, ignore_apps=False)
+    m18n.n.assert_any_call('backup_invalid_archive')
 


### PR DESCRIPTION
## Problem
https://dev.yunohost.org/issues/988
yunohost backup info return an error if the backup has no info.json outside or inside the archive.
Note: the backup code written in october 2015 already put the info.json in the archive. I don't know why there is archive without info.json. The bug was reported with an archive of 20GB.

## Solution
Return a MoulinetteError

## How to test
```
$ yunohost backup create --ignore-apps --system conf_ldap -n goodbackup
$ touch afile
$ tar czf  /home/yunohost.backup/archives/badbackup.tar.gz ./afile
$ yunohost backup info badbackup
Error: Invalid backup archive
$ yunohost backup list
archives: 
  - goodbackup
  - badbackup
$ yunohost backup list --with-info
Warning: badbackup: Invalid backup archive
archives: 
  goodbackup: 
    created_at: 08/08/2017 02:41 PM
    description: 
    path: /home/yunohost.backup/archives/goodbackup.tar.gz
    size: 99866

```

## PR Status
Work finished

## Validation
*Minor decision*
- [x] **Simple test** : Aleks
- [x] **Light Code review** : Aleks
- [x] **Approval (LGTM)** : Aleks
- [x] **Approval (LGTM)** : opi
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.
