### PR TITLE
Common ssh keys operations support

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1418,6 +1418,9 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -n:
+                            full: --name
+                            help: Key name
                         -a:
                             full: --algo
                             help: Algorithm to generate the ssh key
@@ -1427,6 +1430,7 @@ ssh:
                                 - ed25519
                                 - rsa
                                 - rsa1
+                            default: rsa
 
                 ### ssh_rootlogin_enable()
                 import:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1448,6 +1448,9 @@ ssh:
                             help: Key as a string
                             extra:
                                 required: True
+                        -c:
+                            full: --comment
+                            help: Key comment
 
                 ### ssh_rootlogin_disable()
                 remove:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1506,6 +1506,8 @@ ssh:
                         -n:
                             full: --name
                             help: Key name
+                            extra:
+                                required: True
 
                 ### ssh_rootlogin_disable()
                 remove:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1418,6 +1418,15 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -a:
+                            full: --algo
+                            help: Algorithm to generate the ssh key
+                            choices:
+                                - dsa
+                                - ecdsa
+                                - ed25519
+                                - rsa
+                                - rsa1
 
                 ### ssh_rootlogin_enable()
                 import:
@@ -1430,6 +1439,11 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -k:
+                            full: --key
+                            help: Key as a string
+                            extra:
+                                required: True
 
                 ### ssh_rootlogin_disable()
                 remove:
@@ -1442,6 +1456,11 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -k:
+                            full: --key
+                            help: Key file name (without the ".pub")
+                            extra:
+                                required: True
 
         authorized-keys:
             subcategory_help: Manage user's authorized ssh keys
@@ -1470,6 +1489,19 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -u:
+                            full: --public
+                            help: Public key
+                            extra:
+                                required: True
+                        -i:
+                            full: --private
+                            help: Private key
+                            extra:
+                                required: True
+                        -n:
+                            full: --name
+                            help: Key name
 
                 ### ssh_rootlogin_disable()
                 remove:
@@ -1482,6 +1514,11 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                        -k:
+                            full: --key
+                            help: Key as a string
+                            extra:
+                                required: True
 
 
 #############################

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1341,14 +1341,24 @@ ssh:
                     api: GET /ssh/user
 
                 ### ssh_user_enable_ssh()
-                enable-ssh:
+                allow-ssh:
                     action_help: Allow the user to uses ssh
                     api: POST /ssh/user/enable-ssh
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_user_disable_ssh()
-                disable-ssh:
+                disallow-ssh:
                     action_help: Disallow the user to uses ssh
                     api: POST /ssh/user/disable-ssh
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
         root-login:
             subcategory_help: Manage if it's possible to log in as root in ssh
@@ -1377,21 +1387,41 @@ ssh:
                 list:
                     action_help: Show user's ssh keys
                     api: GET /ssh/key
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_rootlogin_enable()
                 add:
                     action_help: Add a new ssh key for this user
                     api: POST /ssh/key/add
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_rootlogin_enable()
                 import:
                     action_help: Import a ssh key for this user
                     api: POST /ssh/key/import
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_rootlogin_disable()
                 remove:
                     action_help: Remove a ssh key for this user
                     api: DELETE /ssh/key
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
         authorized-keys:
             subcategory_help: Manage user's authorized ssh keys
@@ -1401,16 +1431,31 @@ ssh:
                 list:
                     action_help: Show user's authorized ssh keys
                     api: GET /ssh/authorized-keys
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_rootlogin_enable()
                 add:
                     action_help: Add a new authorized ssh key for this user
                     api: POST /ssh/authorized-keys
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
                 ### ssh_rootlogin_disable()
                 remove:
                     action_help: Remove an authorized ssh key for this user
                     api: DELETE /ssh/authorized-keys
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
 
 
 #############################

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1395,7 +1395,7 @@ ssh:
             subcategory_help: Manage user's ssh keys
 
             actions:
-                ### ssh_rootlogin_status()
+                ### ssh_key_list()
                 list:
                     action_help: Show user's ssh keys
                     api: GET /ssh/key
@@ -1407,7 +1407,7 @@ ssh:
                             extra:
                                 pattern: *pattern_username
 
-                ### ssh_rootlogin_enable()
+                ### ssh_key_add()
                 add:
                     action_help: Add a new ssh key for this user
                     api: POST /ssh/key/add
@@ -1432,7 +1432,7 @@ ssh:
                                 - rsa1
                             default: rsa
 
-                ### ssh_rootlogin_enable()
+                ### ssh_key_import()
                 import:
                     action_help: Import a ssh key for this user
                     api: POST /ssh/key/import
@@ -1452,7 +1452,7 @@ ssh:
                             full: --comment
                             help: Key comment
 
-                ### ssh_rootlogin_disable()
+                ### ssh_key_remove()
                 remove:
                     action_help: Remove a ssh key for this user
                     api: DELETE /ssh/key
@@ -1473,7 +1473,7 @@ ssh:
             subcategory_help: Manage user's authorized ssh keys
 
             actions:
-                ### ssh_rootlogin_status()
+                ### ssh_authorized_keys_list()
                 list:
                     action_help: Show user's authorized ssh keys
                     api: GET /ssh/authorized-keys
@@ -1485,7 +1485,7 @@ ssh:
                             extra:
                                 pattern: *pattern_username
 
-                ### ssh_rootlogin_enable()
+                ### ssh_authorized_keys_add()
                 add:
                     action_help: Add a new authorized ssh key for this user
                     api: POST /ssh/authorized-keys
@@ -1512,7 +1512,7 @@ ssh:
                             extra:
                                 required: True
 
-                ### ssh_rootlogin_disable()
+                ### ssh_authorized_keys_remove()
                 remove:
                     action_help: Remove an authorized ssh key for this user
                     api: DELETE /ssh/authorized-keys

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1460,8 +1460,8 @@ ssh:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
-                        -k:
-                            full: --key
+                        -n:
+                            full: --name
                             help: Key file name (without the ".pub")
                             extra:
                                 required: True

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1325,6 +1325,95 @@ dyndns:
 
 
 #############################
+#            SSH            #
+#############################
+ssh:
+    category_help: Manage ssh keys and access
+    actions: {}
+    subcategories:
+        user:
+            subcategory_help: Manage users ssh access
+
+            actions:
+                ### ssh_user_list()
+                list:
+                    action_help: List all users and admin and root with ssh related informations
+                    api: GET /ssh/user
+
+                ### ssh_user_enable_ssh()
+                enable-ssh:
+                    action_help: Allow the user to uses ssh
+                    api: POST /ssh/user/enable-ssh
+
+                ### ssh_user_disable_ssh()
+                disable-ssh:
+                    action_help: Disallow the user to uses ssh
+                    api: POST /ssh/user/disable-ssh
+
+        root-login:
+            subcategory_help: Manage if it's possible to log in as root in ssh
+
+            actions:
+                ### ssh_rootlogin_status()
+                status:
+                    action_help: Show if rootlogin is enabled or disabled
+                    api: GET /ssh/rootlogin
+
+                ### ssh_rootlogin_enable()
+                enable:
+                    action_help: Enable ssh root login
+                    api: POST /ssh/rootlogin/enable
+
+                ### ssh_rootlogin_disable()
+                disable:
+                    action_help: Enable ssh root login
+                    api: POST /ssh/rootlogin/disable
+
+        key:
+            subcategory_help: Manage user's ssh keys
+
+            actions:
+                ### ssh_rootlogin_status()
+                list:
+                    action_help: Show user's ssh keys
+                    api: GET /ssh/key
+
+                ### ssh_rootlogin_enable()
+                add:
+                    action_help: Add a new ssh key for this user
+                    api: POST /ssh/key/add
+
+                ### ssh_rootlogin_enable()
+                import:
+                    action_help: Import a ssh key for this user
+                    api: POST /ssh/key/import
+
+                ### ssh_rootlogin_disable()
+                remove:
+                    action_help: Remove a ssh key for this user
+                    api: DELETE /ssh/key
+
+        authorized-keys:
+            subcategory_help: Manage user's authorized ssh keys
+
+            actions:
+                ### ssh_rootlogin_status()
+                list:
+                    action_help: Show user's authorized ssh keys
+                    api: GET /ssh/authorized-keys
+
+                ### ssh_rootlogin_enable()
+                add:
+                    action_help: Add a new authorized ssh key for this user
+                    api: POST /ssh/authorized-keys
+
+                ### ssh_rootlogin_disable()
+                remove:
+                    action_help: Remove an authorized ssh key for this user
+                    api: DELETE /ssh/authorized-keys
+
+
+#############################
 #           Tools           #
 #############################
 tools:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1339,11 +1339,15 @@ ssh:
                 list:
                     action_help: List all users and admin and root with ssh related informations
                     api: GET /ssh/user
+                    configuration:
+                        authenticate: all
 
                 ### ssh_user_enable_ssh()
                 allow-ssh:
                     action_help: Allow the user to uses ssh
                     api: POST /ssh/user/enable-ssh
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1354,6 +1358,8 @@ ssh:
                 disallow-ssh:
                     action_help: Disallow the user to uses ssh
                     api: POST /ssh/user/disable-ssh
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1368,16 +1374,22 @@ ssh:
                 status:
                     action_help: Show if rootlogin is enabled or disabled
                     api: GET /ssh/rootlogin
+                    configuration:
+                        authenticate: all
 
                 ### ssh_rootlogin_enable()
                 enable:
                     action_help: Enable ssh root login
                     api: POST /ssh/rootlogin/enable
+                    configuration:
+                        authenticate: all
 
                 ### ssh_rootlogin_disable()
                 disable:
                     action_help: Enable ssh root login
                     api: POST /ssh/rootlogin/disable
+                    configuration:
+                        authenticate: all
 
         key:
             subcategory_help: Manage user's ssh keys
@@ -1387,6 +1399,8 @@ ssh:
                 list:
                     action_help: Show user's ssh keys
                     api: GET /ssh/key
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1397,6 +1411,8 @@ ssh:
                 add:
                     action_help: Add a new ssh key for this user
                     api: POST /ssh/key/add
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1407,6 +1423,8 @@ ssh:
                 import:
                     action_help: Import a ssh key for this user
                     api: POST /ssh/key/import
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1417,6 +1435,8 @@ ssh:
                 remove:
                     action_help: Remove a ssh key for this user
                     api: DELETE /ssh/key
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1431,6 +1451,8 @@ ssh:
                 list:
                     action_help: Show user's authorized ssh keys
                     api: GET /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1441,6 +1463,8 @@ ssh:
                 add:
                     action_help: Add a new authorized ssh key for this user
                     api: POST /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user
@@ -1451,6 +1475,8 @@ ssh:
                 remove:
                     action_help: Remove an authorized ssh key for this user
                     api: DELETE /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
                     arguments:
                         username:
                             help: Username of the user

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -25,10 +25,18 @@ def ssh_user_list(auth):
         'home_path': root_unix.pw_dir,
     }
 
-    query = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
-    users = {
-        'root': root,
+    admin_unix = pwd.getpwnam("root")
+    admin = {
+        'username': 'admin',
+        'fullname': '',
+        'mail': '',
+        'ssh_allowed': admin_unix.pw_shell.strip() != "/bin/false",
+        'shell': admin_unix.pw_shell,
+        'home_path': admin_unix.pw_dir,
     }
+
+    query = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
+    users = {}
 
     ldap_result = auth.search('ou=users,dc=yunohost,dc=org', query, user_attrs.keys())
 
@@ -47,7 +55,11 @@ def ssh_user_list(auth):
         uid = entry[user_attrs['uid']]
         users[uid] = entry
 
-    return {'users': users}
+    return {
+        'root': root,
+        'admin': admin,
+        'users': users,
+    }
 
 
 def ssh_user_allow_ssh(auth, username):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,7 +1,12 @@
 # encoding: utf-8
 
+import re
 import pwd
 
+from moulinette.utils.filesystem import read_file
+
+
+SSHD_CONFIG_PATH = "/etc/ssh/sshd_config"
 
 # user list + root + admin
 def ssh_user_list(auth):
@@ -87,7 +92,18 @@ def ssh_user_disallow_ssh(auth, username):
 
 
 def ssh_root_login_status(auth):
-    pass
+    # this is the content of "man sshd_config"
+    # PermitRootLogin
+    #     Specifies whether root can log in using ssh(1).  The argument must be
+    #     “yes”, “without-password”, “forced-commands-only”, or “no”.  The
+    #     default is “yes”.
+    sshd_config_content = read_file(SSHD_CONFIG_PATH)
+
+    if re.search("^ *PermitRootLogin +(no|forced-commands-only) *$",
+                 sshd_config_content, re.MULTILINE):
+        return {"PermitRootLogin": False}
+
+    return {"PermitRootLogin": True}
 
 
 def ssh_root_login_enable(auth):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -159,15 +159,16 @@ def ssh_key_list(auth, username):
     ssh_dir = os.path.join(user_home_directory, ".ssh")
 
     if not os.path.exists(ssh_dir):
-        return {"keys": []}
+        return {"keys": {}}
 
-    keys = []
+    keys = {}
 
     for i in os.listdir(ssh_dir):
         if i.endswith(".pub"):
-            keys.append({
-                ".".join(i.split(".")[:-1]): read_file(os.path.join(ssh_dir, i))
-            })
+            # remove ".pub" from name
+            keys[".".join(i.split(".")[:-1])] = {
+                "pub": read_file(os.path.join(ssh_dir, i))
+            }
 
     return {
         "keys": keys,

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -181,8 +181,37 @@ def ssh_key_list(auth, username):
 # and is still very strong
 #
 # QUESTION: should we forbid certains algos known to be BAD?
-def ssh_key_add(auth, username, algo="default"):
-    pass
+def ssh_key_add(auth, username, algo, name=None):
+    all_keys_name = ssh_key_list(auth, username)["keys"].keys()
+
+    user = _get_user(auth, username, ["homeDirectory"])
+
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    if name is None:
+        # TODO
+        print "todo"
+        return
+
+    if not name.startswith("id_"):
+        name = "id_" + name
+
+    if name.endswith(".pub"):
+        name = name[:-len(".pub")]
+
+    if name in all_keys_name:
+        raise Exception("a key with this name already exists")
+
+    if not os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")):
+        os.makedirs(os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")))
+
+    key_path = os.path.join(user["homeDirectory"][0], ".ssh", name)
+
+    # -t --> algo
+    # -f --> output file
+    # -N --> passphrase, here make it empty
+    subprocess.check_call("ssh-keygen -t {} -f {} -N ''".format(algo, key_path), shell=True)
 
 
 def ssh_key_import(auth, username, public, private, name=None):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,4 +1,4 @@
-# (auth, username list) + root + admin
+# user list + root + admin
 def ssh_user_list(auth):
     pass
 
@@ -27,11 +27,17 @@ def ssh_key_list(auth, username):
     pass
 
 
+# dsa | ecdsa | ed25519 | rsa | rsa1
+# this is the list of valid algo according to the man page
+# according to internet ™ rsa seems the one to use for maximum compatibility
+# and is still very strong
+#
+# QUESTION: should we forbid certains algos known to be BAD?
 def ssh_key_add(auth, username, algo="default"):
     pass
 
 
-def ssh_key_import(auth, username, public, private):
+def ssh_key_import(auth, username, public, private, name=None):
     pass
 
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -190,9 +190,20 @@ def ssh_key_add(auth, username, algo, name=None):
         raise Exception("User with username '%s' doesn't exists" % username)
 
     if name is None:
-        # TODO
-        print "todo"
-        return
+        name = "id_{}".format(algo)
+
+        if name in all_keys_name:
+            # caping to 100 to void infinite loop and because people that won't
+            # be satisfied by this solution will be the super absolute edge
+            # case and will probably never happen
+            for i in range(1, 100):
+                if name + str(i) not in all_keys_name:
+                    name += str(i)
+                    break
+            # this else will be executed if the for loop is never "break"
+            else:
+                raise Exception("No available name for you new ssh key, please provide one using the -n command line option")
+
 
     if not name.startswith("id_"):
         name = "id_" + name

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,8 +1,11 @@
 # encoding: utf-8
 
+import pwd
+
+
 # user list + root + admin
 def ssh_user_list(auth):
-    # XXX couldn't resued user_list because it's not customisable enough :(
+    # couldn't resued user_list because it's not customisable enough :(
     user_attrs = {
         'uid': 'username',
         'cn': 'fullname',
@@ -11,8 +14,21 @@ def ssh_user_list(auth):
         'homeDirectory': 'home_path',
     }
 
+    root_unix = pwd.getpwnam("root")
+    root = {
+        'username': 'root',
+        'fullname': '',
+        'mail': '',
+        # TODO ssh-allow using ssh_root_login_status
+        'ssh_allowed': True,
+        'shell': root_unix.pw_shell,
+        'home_path': root_unix.pw_dir,
+    }
+
     query = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
-    users = {}
+    users = {
+        'root': root,
+    }
 
     ldap_result = auth.search('ou=users,dc=yunohost,dc=org', query, user_attrs.keys())
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,6 +1,37 @@
+# encoding: utf-8
+
 # user list + root + admin
 def ssh_user_list(auth):
-    pass
+    # XXX couldn't resued user_list because it's not customisable enough :(
+    user_attrs = {
+        'uid': 'username',
+        'cn': 'fullname',
+        'mail': 'mail',
+        'loginShell': 'shell',
+        'homeDirectory': 'home_path',
+    }
+
+    query = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
+    users = {}
+
+    ldap_result = auth.search('ou=users,dc=yunohost,dc=org', query, user_attrs.keys())
+
+    for user in ldap_result:
+        entry = {}
+
+        for key, value in user.items():
+            if key == "loginShell":
+                if value[0].strip() == "/bin/false":
+                    entry["ssh_allowed"] = False
+                else:
+                    entry["ssh_allowed"] = True
+
+            entry[user_attrs[key]] = value[0]
+
+        uid = entry[user_attrs['uid']]
+        users[uid] = entry
+
+    return {'users': users}
 
 
 def ssh_user_allow_ssh(auth, username):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -184,7 +184,7 @@ def ssh_key_list(auth, username):
 def ssh_key_add(auth, username, algo, name=None):
     all_keys_name = ssh_key_list(auth, username)["keys"].keys()
 
-    user = _get_user(auth, username, ["homeDirectory"])
+    user = _get_user(auth, username, ["homeDirectory", "uid"])
     if not user:
         raise Exception("User with username '%s' doesn't exists" % username)
 
@@ -214,7 +214,8 @@ def ssh_key_add(auth, username, algo, name=None):
         raise Exception("a key with this name already exists")
 
     if not os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")):
-        os.makedirs(os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")))
+        mkdir(os.path.join(user["homeDirectory"][0], ".ssh"),
+              force=True, parents=True, uid=user["uid"][0])
 
     key_path = os.path.join(user["homeDirectory"][0], ".ssh", name)
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,56 +1,55 @@
-# (username list) + root + admin
-def ssh_user_list():
+# (auth, username list) + root + admin
+def ssh_user_list(auth):
     pass
 
 
-def ssh_user_allow_ssh(username):
+def ssh_user_allow_ssh(auth, username):
     pass
 
 
-def ssh_user_disallow_ssh(username):
+def ssh_user_disallow_ssh(auth, username):
     pass
 
 
-def ssh_root_login_status():
+def ssh_root_login_status(auth):
     pass
 
 
-def ssh_root_login_enable():
+def ssh_root_login_enable(auth):
     pass
 
 
-def ssh_root_login_disable():
+def ssh_root_login_disable(auth):
     pass
 
 
-def ssh_key_list(username):
+def ssh_key_list(auth, username):
     pass
 
 
-def ssh_key_add(username, algo="default"):
+def ssh_key_add(auth, username, algo="default"):
     pass
 
 
-def ssh_key_import(username, public, private):
+def ssh_key_import(auth, username, public, private):
     pass
 
 
-def ssh_key_remove(username, key):
+def ssh_key_remove(auth, username, key):
     pass
 
 
-def ssh_authorized_keys_list(username):
+def ssh_authorized_keys_list(auth, username):
     pass
 
 
-def ssh_authorized_keys_add(username, key):
+def ssh_authorized_keys_add(auth, username, key):
     pass
 
 
-def ssh_authorized_keys_remove(username, key):
+def ssh_authorized_keys_remove(auth, username, key):
     pass
 
 
 # TODO
-# auth on critical commands
 # arguments in actionmap

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -342,7 +342,31 @@ def ssh_authorized_keys_add(auth, username, key, comment):
 
 
 def ssh_authorized_keys_remove(auth, username, key):
-    pass
+    user = _get_user(auth, username, ["homeDirectory", "uid"])
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    authorized_keys_file = os.path.join(user["homeDirectory"][0], ".ssh", "authorized_keys")
+
+    if not os.path.exists(authorized_keys_file):
+        raise Exception("this key doesn't exists ({} dosesn't exists)".format(authorized_keys_file))
+
+    authorized_keys_content = read_file(authorized_keys_file)
+
+    if key not in authorized_keys_content:
+        raise Exception("Key '{}' is not present in authorized_keys".format(key))
+
+    # don't delete the previous comment because we can't verify if it's legit
+
+    # this regex approach failed for some reasons and I don't know why :(
+    # authorized_keys_content = re.sub("{} *\n?".format(key),
+    #                                  "",
+    #                                  authorized_keys_content,
+    #                                  flags=re.MULTILINE)
+
+    authorized_keys_content = authorized_keys_content.replace(key, "")
+
+    write_to_file(authorized_keys_file, authorized_keys_content)
 
 
 def _get_user(auth, username, attrs=None):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -356,8 +356,7 @@ def _get_user(auth, username, attrs=None):
             'username': 'root',
             'fullname': '',
             'mail': '',
-            # TODO ssh-allow using ssh_root_login_status
-            'ssh_allowed': True,
+            'ssh_allowed': ssh_root_login_status(auth)["PermitRootLogin"],
             'shell': root_unix.pw_shell,
             'home_path': root_unix.pw_dir,
         }

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -21,26 +21,8 @@ def ssh_user_list(auth):
         'homeDirectory': 'home_path',
     }
 
-    root_unix = pwd.getpwnam("root")
-    root = {
-        'username': 'root',
-        'fullname': '',
-        'mail': '',
-        # TODO ssh-allow using ssh_root_login_status
-        'ssh_allowed': True,
-        'shell': root_unix.pw_shell,
-        'home_path': root_unix.pw_dir,
-    }
-
-    admin_unix = pwd.getpwnam("root")
-    admin = {
-        'username': 'admin',
-        'fullname': '',
-        'mail': '',
-        'ssh_allowed': admin_unix.pw_shell.strip() != "/bin/false",
-        'shell': admin_unix.pw_shell,
-        'home_path': admin_unix.pw_dir,
-    }
+    root = _get_user("root")
+    admin = _get_user("admin")
 
     query = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
     users = {}
@@ -370,7 +352,29 @@ def ssh_authorized_keys_remove(auth, username, key):
 
 
 def _get_user(auth, username, attrs=None):
-    # FIXME handle root and admin
+    if username == "root":
+        root_unix = pwd.getpwnam("root")
+        return {
+            'username': 'root',
+            'fullname': '',
+            'mail': '',
+            # TODO ssh-allow using ssh_root_login_status
+            'ssh_allowed': True,
+            'shell': root_unix.pw_shell,
+            'home_path': root_unix.pw_dir,
+        }
+
+    if username == "admin":
+        admin_unix = pwd.getpwnam("root")
+        return {
+            'username': 'admin',
+            'fullname': '',
+            'mail': '',
+            'ssh_allowed': admin_unix.pw_shell.strip() != "/bin/false",
+            'shell': admin_unix.pw_shell,
+            'home_path': admin_unix.pw_dir,
+        }
+
     user = auth.search('ou=users,dc=yunohost,dc=org',
                        '(&(objectclass=person)(uid=%s))' % username,
                        attrs)

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -75,7 +75,15 @@ def ssh_user_allow_ssh(auth, username):
 
 
 def ssh_user_disallow_ssh(auth, username):
-    pass
+    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
+    # TODO it would be good to support different kind of shells
+
+    query = '(&(objectclass=person)(uid=%s))' % username
+
+    if not auth.search('ou=users,dc=yunohost,dc=org', query):
+        raise Exception("User with username '%s' doesn't exists")
+
+    auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/false'})
 
 
 def ssh_root_login_status(auth):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -3,11 +3,11 @@ def ssh_user_list():
     pass
 
 
-def ssh_user_enable_ssh(username):
+def ssh_user_allow_ssh(username):
     pass
 
 
-def ssh_user_disable_ssh(username):
+def ssh_user_disallow_ssh(username):
     pass
 
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -185,7 +185,6 @@ def ssh_key_add(auth, username, algo, name=None):
     all_keys_name = ssh_key_list(auth, username)["keys"].keys()
 
     user = _get_user(auth, username, ["homeDirectory"])
-
     if not user:
         raise Exception("User with username '%s' doesn't exists" % username)
 
@@ -225,8 +224,30 @@ def ssh_key_add(auth, username, algo, name=None):
     subprocess.check_call("ssh-keygen -t {} -f {} -N ''".format(algo, key_path), shell=True)
 
 
-def ssh_key_import(auth, username, public, private, name=None):
-    pass
+def ssh_key_import(auth, username, public, private, name):
+    all_keys_name = ssh_key_list(auth, username)["keys"].keys()
+
+    user = _get_user(auth, username, ["homeDirectory"])
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    if not name.startswith("id_"):
+        name = "id_" + name
+
+    if name.endswith(".pub"):
+        # remove ".pub"
+        name = ".".join(name.split(".")[:-1])
+
+    if name in all_keys_name:
+        raise Exception("a key with this name already exists")
+
+    if not os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")):
+        os.makedirs(os.path.exists(os.path.join(user["homeDirectory"][0], ".ssh")))
+
+    key_path = os.path.join(user["homeDirectory"][0], ".ssh", name)
+
+    write_to_file(key_path, private)
+    write_to_file(key_path + ".pub", public)
 
 
 def ssh_key_remove(auth, username, key):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -52,7 +52,6 @@ def ssh_user_list(auth):
 
 
 def ssh_user_allow_ssh(auth, username):
-    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
     # TODO it would be good to support different kind of shells
 
     if not _get_user(auth, username):
@@ -62,7 +61,6 @@ def ssh_user_allow_ssh(auth, username):
 
 
 def ssh_user_disallow_ssh(auth, username):
-    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
     # TODO it would be good to support different kind of shells
 
     if not _get_user(auth, username) :
@@ -375,6 +373,7 @@ def _get_user(auth, username, attrs=None):
             'home_path': admin_unix.pw_dir,
         }
 
+    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
     user = auth.search('ou=users,dc=yunohost,dc=org',
                        '(&(objectclass=person)(uid=%s))' % username,
                        attrs)

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -75,6 +75,8 @@ def ssh_user_allow_ssh(auth, username):
 
     query = '(&(objectclass=person)(uid=%s))' % username
 
+    # FIXME handle root and admin
+    # XXX dry
     if not auth.search('ou=users,dc=yunohost,dc=org', query):
         raise Exception("User with username '%s' doesn't exists")
 
@@ -87,6 +89,8 @@ def ssh_user_disallow_ssh(auth, username):
 
     query = '(&(objectclass=person)(uid=%s))' % username
 
+    # FIXME handle root and admin
+    # XXX dry
     if not auth.search('ou=users,dc=yunohost,dc=org', query):
         raise Exception("User with username '%s' doesn't exists")
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -63,7 +63,15 @@ def ssh_user_list(auth):
 
 
 def ssh_user_allow_ssh(auth, username):
-    pass
+    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
+    # TODO it would be good to support different kind of shells
+
+    query = '(&(objectclass=person)(uid=%s))' % username
+
+    if not auth.search('ou=users,dc=yunohost,dc=org', query):
+        raise Exception("User with username '%s' doesn't exists")
+
+    auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/bash'})
 
 
 def ssh_user_disallow_ssh(auth, username):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,0 +1,56 @@
+# (username list) + root + admin
+def ssh_user_list():
+    pass
+
+
+def ssh_user_enable_ssh(username):
+    pass
+
+
+def ssh_user_disable_ssh(username):
+    pass
+
+
+def ssh_root_login_status():
+    pass
+
+
+def ssh_root_login_enable():
+    pass
+
+
+def ssh_root_login_disable():
+    pass
+
+
+def ssh_key_list(username):
+    pass
+
+
+def ssh_key_add(username, algo="default"):
+    pass
+
+
+def ssh_key_import(username, public, private):
+    pass
+
+
+def ssh_key_remove(username, key):
+    pass
+
+
+def ssh_authorized_keys_list(username):
+    pass
+
+
+def ssh_authorized_keys_add(username, key):
+    pass
+
+
+def ssh_authorized_keys_remove(username, key):
+    pass
+
+
+# TODO
+# auth on critical commands
+# arguments in actionmap


### PR DESCRIPTION
Hello,

The idea of this work is to integrate all common ssh keys operation into yunohost.

2 mains interests from here are:

- `yunohost ssh user enable-ssh` to allow a user to login with ssh
- provide all those operations in the web interface for people that don't know how to do that in cli (or are lazy)

I know that ssh key generation is also needed for federation or backup stuff.

This is a full working prototype, there is probably cleaning that needs to be done in addition to more testing and probably edge cases and some TODOs.

New commands (so we can bikeshed on the command names :yum:):

- `yunohost ssh user list` list all users with ssh related informations (access is enabled for eg)
- `yunohost ssh user allow-ssh $username` allow a user to login in ssh
- `yunohost ssh user disallow-ssh $username` inverse
- `yunohost ssh root-login status` show if root can log in ssh (`PermitRootLogin` stuff)
- `yunohost ssh root-login enable/disable`
- `yunohost ssh key list $username` list ssh keys of the users (only `.pub` files for now, don't know if that should include private files)
- `yunohost ssh key add $username` (`-a` to specify algo, `-n` for a key name) generate a new ssh key pair using `ssh-keygen`
- `yunohost ssh key import $username -u $public_key -i $private_key` import a ssh key pair (from another computer for eg)
- `yunohost ssh key remove $username -n $key_name`
- `yunohost sh authorized-keys list $username` parse and list the content of `~/.ssh/authorized_keys` (assume that a comment before a key is the title of the key)
- `yunohost ssh authorized-keys add $username -k $key` (`-c` to add a comment) add a key (with a comment before) to `~/.ssh/authorized_keys`
- `yunohost ssh authorized-keys remove $username -k $key`
                                                                                                                                                

  