### PR TITLE
[fix] Tell user that domain dns-conf shows a recommendation only

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -141,6 +141,7 @@
     "domain_creation_failed": "Unable to create domain",
     "domain_deleted": "The domain has been deleted",
     "domain_deletion_failed": "Unable to delete domain",
+    "domain_dns_conf_is_just_a_recommendation": "This command shows you what is the *recommended* configuration. It does not actually set up the DNS configuration for you. It is your responsability to configure your DNS zone in your registrar according to this recommendation.",
     "domain_dyndns_already_subscribed": "You've already subscribed to a DynDNS domain",
     "domain_dyndns_invalid": "Invalid domain to use with DynDNS",
     "domain_dyndns_root_unknown": "Unknown DynDNS root domain",

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -33,7 +33,7 @@ import requests
 
 from urllib import urlopen
 
-from moulinette import m18n
+from moulinette import m18n, msettings
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
@@ -219,6 +219,10 @@ def domain_dns_conf(domain, ttl=None):
     result += "# Mail"
     for record in dns_conf["mail"]:
         result += "\n{name} {ttl} IN {type} {value}".format(**record)
+
+    is_cli = True if msettings.get('interface') == 'cli' else False
+    if is_cli:
+        logger.warning(m18n.n("domain_dns_conf_is_just_a_recommendation"))
 
     return result
 


### PR DESCRIPTION
### Problem

Users who use `yunohost domain dns-conf` sometimes think that this shows some sort of actual configuration. We should tell them explicitly that this is only the recommended configuration which should be configured in the registrar.

Related issue on redmine : https://dev.yunohost.org/issues/559

### Solution

For the CLI, display a warning. For the webadmin, display a warning block (see [related PR](https://github.com/YunoHost/yunohost-admin/pull/168))