### PR TITLE
[fix] Local domain resolution in cert-install/renew

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -819,13 +819,6 @@ def _check_domain_is_ready_for_ACME(domain):
         raise MoulinetteError(errno.EINVAL, m18n.n(
             'certmanager_domain_http_not_working', domain=domain))
 
-    # Check if domain is resolved locally (Might happen despite the previous
-    # checks because of dns propagation ?... Acme-tiny won't work in that case,
-    # because it explicitly requests() the domain.)
-    if not _domain_is_resolved_locally(public_ip, domain):
-        raise MoulinetteError(errno.EINVAL, m18n.n(
-            'certmanager_domain_not_resolved_locally', domain=domain))
-
 
 def _dns_ip_match_public_ip(public_ip, domain):
     try:
@@ -852,17 +845,6 @@ def _domain_is_accessible_through_HTTP(ip, domain):
         return False
 
     return True
-
-
-def _domain_is_resolved_locally(public_ip, domain):
-    try:
-        ip = socket.gethostbyname(domain)
-    except socket.error as e:
-        logger.debug("Couldn't get domain '%s' ip because: %s" % (domain, e))
-        return False
-
-    logger.debug("Domain '%s' IP address is resolved to %s, expect it to be %s or in the 127.0.0.0/8 address block" % (domain, public_ip, ip))
-    return ip.startswith("127.") or ip == public_ip
 
 
 def _name_self_CA():

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -31,7 +31,6 @@ import grp
 import smtplib
 import requests
 import subprocess
-import socket
 import dns.resolver
 import glob
 


### PR DESCRIPTION
### Problem

Many people report that `domain cert-install/cert-renew` often thinks that the domain is not correctly configured. After investigating some cases, it appears that we do a check that the domain is correctly resolved locally via `socket.gethostbyname` (in [here](https://github.com/YunoHost/yunohost/blob/baf0d098f5c3547076f9f8477d383c4a3a5e21cb/src/yunohost/certificate.py#L859)). At the time we wrote this, a domain in Yunohost was not necessarily resolved (because of missing DNS conf and/or because domains were not automatically in /etc/hosts). 

BUT sometimes `socket.gethostbyname` gets crazy and returns stuff like `192.168.x.y` which is neither the global ip nor 127.0.0.1. Thus we cannot assert that domain is correctly resolved locally...

Nowadays, we should not need this because, if dnsmasq is correctly running (and conf up to date), then the domain is properly resolved locally (even if no DNS conf is available on public resolvers).

### Solution

Remove the check that domain is resolved locally, since `socket.gethostbyname` returns confusing values and we should trust dnsmasq to be running. Also, I added a regen-conf of DNSmasq if it is found to not be up to date (this can happen for dynamic IP because at the moment we don't have a proper mechanism to refresh stuff if the IP changed...)