### PR TITLE
[fix] Use SHA-512 for passwords in LDAP

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -78,17 +78,6 @@ user:
                --fields:
                     help: fields to fetch
                     nargs: "+"
-               -f:
-                    full: --filter
-                    help: LDAP filter used to search
-               -l:
-                    full: --limit
-                    help: Maximum number of user fetched
-                    type: int
-               -o:
-                    full: --offset
-                    help: Starting number for user fetching
-                    type: int
 
         ### user_create()
         create:

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -122,8 +122,11 @@ def tools_adminpw(auth, new_password):
         new_password
 
     """
+    from yunohost.user import _hash_user_password
     try:
-        auth.con.passwd_s('cn=admin,dc=yunohost,dc=org', None, new_password)
+        auth.update("cn=admin", {
+            "userPassword": _hash_user_password(new_password),
+        })
     except:
         logger.exception('unable to change admin password')
         raise MoulinetteError(errno.EPERM,

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -289,10 +289,7 @@ def user_update(auth, username, firstname=None, lastname=None, mail=None,
         new_attr_dict['cn'] = new_attr_dict['displayName'] = firstname + ' ' + lastname
 
     if change_password:
-        char_set = string.ascii_uppercase + string.digits
-        salt = ''.join(random.sample(char_set, 8))
-        salt = '$1$' + salt + '$'
-        new_attr_dict['userPassword'] = '{CRYPT}' + crypt.crypt(str(change_password), salt)
+        new_attr_dict['userPassword'] = _hash_user_password(change_password)
 
     if mail:
         auth.validate_uniqueness({'mail': mail})

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -80,10 +80,9 @@ def user_list(auth, fields=None):
     for user in result:
         entry = {}
         for attr, values in user.items():
-            try:
+            if values:
                 entry[user_attrs[attr]] = values[0]
-            except:
-                pass
+
         uid = entry[user_attrs['uid']]
         users[uid] = entry
 

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -445,6 +445,16 @@ def _convertSize(num, suffix=''):
 
 def _hash_user_password(password):
     char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
+    # This 16 number is chosen according to this documentation stating that
+    # this is the maximum number of salt possible
+    # https://www.safaribooksonline.com/library/view/practical-unix-and/0596003234/ch04s03.html
+    #
+    # SystemRandom is the cryptographically secure random method provided by python stl
+    # You can refer to this https://docs.python.org/2/library/random.html for
+    # confirmation (read the red square), it internally uses /dev/urandom
     salt = ''.join([random.SystemRandom().choice(char_set) for x in range(16)])
+
+    # Using "$6$" means that we uses sha-512 which is the strongest hash available on the system
+    # You can refer to this for more explainations https://www.redpill-linpro.com/techblog/2016/08/16/ldap-password-hash.html
     salt = '$6$' + salt + '$'
     return '{CRYPT}' + crypt.crypt(str(password), salt)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -444,17 +444,29 @@ def _convertSize(num, suffix=''):
 
 
 def _hash_user_password(password):
+    """
+    This function computes and return a salted hash for the password in input.
+    This implementation is inspired from [1].
+
+    The hash follows SHA-512 scheme from Linux/glibc.
+    Hence the {CRYPT} and $6$ prefixes
+    - {CRYPT} means it relies on the OS' crypt lib
+    - $6$ corresponds to SHA-512, the strongest hash available on the system
+
+    The salt is generated using random.SystemRandom(). It is the crypto-secure
+    pseudo-random number generator according to the python doc [2] (c.f. the
+    red square). It internally relies on /dev/urandom
+
+    The salt is made of 16 characters from the set [./a-zA-Z0-9]. This is the
+    max sized allowed for salts according to [3]
+
+    [1] https://www.redpill-linpro.com/techblog/2016/08/16/ldap-password-hash.html
+    [2] https://docs.python.org/2/library/random.html
+    [3] https://www.safaribooksonline.com/library/view/practical-unix-and/0596003234/ch04s03.html
+    """
+
     char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
-    # This 16 number is chosen according to this documentation stating that
-    # this is the maximum number of salt possible
-    # https://www.safaribooksonline.com/library/view/practical-unix-and/0596003234/ch04s03.html
-    #
-    # SystemRandom is the cryptographically secure random method provided by python stl
-    # You can refer to this https://docs.python.org/2/library/random.html for
-    # confirmation (read the red square), it internally uses /dev/urandom
     salt = ''.join([random.SystemRandom().choice(char_set) for x in range(16)])
 
-    # Using "$6$" means that we uses sha-512 which is the strongest hash available on the system
-    # You can refer to this for more explainations https://www.redpill-linpro.com/techblog/2016/08/16/ldap-password-hash.html
     salt = '$6$' + salt + '$'
     return '{CRYPT}' + crypt.crypt(str(password), salt)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -115,11 +115,8 @@ def user_create(auth, username, firstname, lastname, mail, password,
     })
 
     # Validate uniqueness of username in system users
-    try:
-        pwd.getpwnam(username)
-    except KeyError:
-        pass
-    else:
+    all_existing_usernames = {x.pw_name for x in pwd.getpwall()}
+    if username in all_existing_usernames:
         raise MoulinetteError(errno.EEXIST, m18n.n('system_username_exists'))
 
     # Check that the mail domain exists

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -136,7 +136,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
 
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
-    char_set = string.ascii_uppercase + string.digits
+    char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
     salt = ''.join([random.SystemRandom().choice(char_set) for x in range(8)])
     salt = '$1$' + salt + '$'
     user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -136,10 +136,6 @@ def user_create(auth, username, firstname, lastname, mail, password,
 
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
-    char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
-    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(16)])
-    salt = '$6$' + salt + '$'
-    user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)
     attr_dict = {
         'objectClass': ['mailAccount', 'inetOrgPerson', 'posixAccount'],
         'givenName': firstname,
@@ -150,7 +146,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
         'mail': mail,
         'maildrop': username,
         'mailuserquota': mailbox_quota,
-        'userPassword': user_pwd,
+        'userPassword': _hash_user_password(password),
         'gidNumber': uid,
         'uidNumber': uid,
         'homeDirectory': '/home/' + username,
@@ -448,3 +444,10 @@ def _convertSize(num, suffix=''):
             return "%3.1f%s%s" % (num, unit, suffix)
         num /= 1024.0
     return "%.1f%s%s" % (num, 'Yi', suffix)
+
+
+def _hash_user_password(password):
+    char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
+    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(16)])
+    salt = '$6$' + salt + '$'
+    return '{CRYPT}' + crypt.crypt(str(password), salt)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -51,11 +51,14 @@ def user_list(auth, fields=None):
         fields -- fields to fetch
 
     """
-    user_attrs = {'uid': 'username',
-                  'cn': 'fullname',
-                  'mail': 'mail',
-                  'maildrop': 'mail-forward',
-                  'mailuserquota': 'mailbox-quota'}
+    user_attrs = {
+        'uid': 'username',
+        'cn': 'fullname',
+        'mail': 'mail',
+        'maildrop': 'mail-forward',
+        'mailuserquota': 'mailbox-quota'
+    }
+
     attrs = ['uid']
     users = {}
 
@@ -70,7 +73,9 @@ def user_list(auth, fields=None):
     else:
         attrs = ['uid', 'cn', 'mail', 'mailuserquota']
 
-    result = auth.search('ou=users,dc=yunohost,dc=org', '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))', attrs)
+    result = auth.search('ou=users,dc=yunohost,dc=org',
+                         '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))',
+                         attrs)
 
     for user in result:
         entry = {}

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -138,7 +138,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
     fullname = '%s %s' % (firstname, lastname)
     char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
     salt = ''.join([random.SystemRandom().choice(char_set) for x in range(12)])
-    salt = '$1$' + salt + '$'
+    salt = '$6$' + salt + '$'
     user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)
     attr_dict = {
         'objectClass': ['mailAccount', 'inetOrgPerson', 'posixAccount'],

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -137,7 +137,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
     char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
-    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(12)])
+    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(16)])
     salt = '$6$' + salt + '$'
     user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)
     attr_dict = {

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -137,7 +137,6 @@ def user_create(auth, username, firstname, lastname, mail, password,
 
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
-    rdn = 'uid=%s,ou=users' % username
     char_set = string.ascii_uppercase + string.digits
     salt = ''.join(random.sample(char_set, 8))
     salt = '$1$' + salt + '$'
@@ -189,7 +188,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
                 raise MoulinetteError(errno.EPERM,
                                       m18n.n('ssowat_persistent_conf_write_error', error=e.strerror))
 
-    if auth.add(rdn, attr_dict):
+    if auth.add('uid=%s,ou=users' % username, attr_dict):
         # Invalidate passwd to take user creation into account
         subprocess.call(['nscd', '-i', 'passwd'])
 

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -129,11 +129,13 @@ def user_create(auth, username, firstname, lastname, mail, password,
                                      domain=mail.split("@")[1]))
 
     # Get random UID/GID
-    uid_check = gid_check = 0
-    while uid_check == 0 and gid_check == 0:
+    all_uid = {x.pw_uid for x in pwd.getpwall()}
+    all_gid = {x.pw_gid for x in pwd.getpwall()}
+
+    uid_guid_found = False
+    while not uid_guid_found:
         uid = str(random.randint(200, 99999))
-        uid_check = os.system("getent passwd %s" % uid)
-        gid_check = os.system("getent group %s" % uid)
+        uid_guid_found = uid not in all_uid and uid not in all_gid
 
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -40,7 +40,7 @@ from yunohost.service import service_status
 logger = getActionLogger('yunohost.user')
 
 
-def user_list(auth, fields=None, filter=None, limit=None, offset=None):
+def user_list(auth, fields=None):
     """
     List users
 
@@ -59,13 +59,6 @@ def user_list(auth, fields=None, filter=None, limit=None, offset=None):
     attrs = ['uid']
     users = {}
 
-    # Set default arguments values
-    if offset is None:
-        offset = 0
-    if limit is None:
-        limit = 1000
-    if filter is None:
-        filter = '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))'
     if fields:
         keys = user_attrs.keys()
         for attr in fields:
@@ -77,18 +70,18 @@ def user_list(auth, fields=None, filter=None, limit=None, offset=None):
     else:
         attrs = ['uid', 'cn', 'mail', 'mailuserquota']
 
-    result = auth.search('ou=users,dc=yunohost,dc=org', filter, attrs)
+    result = auth.search('ou=users,dc=yunohost,dc=org', '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))', attrs)
 
-    if len(result) > offset and limit > 0:
-        for user in result[offset:offset + limit]:
-            entry = {}
-            for attr, values in user.items():
-                try:
-                    entry[user_attrs[attr]] = values[0]
-                except:
-                    pass
-            uid = entry[user_attrs['uid']]
-            users[uid] = entry
+    for user in result:
+        entry = {}
+        for attr, values in user.items():
+            try:
+                entry[user_attrs[attr]] = values[0]
+            except:
+                pass
+        uid = entry[user_attrs['uid']]
+        users[uid] = entry
+
     return {'users': users}
 
 

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -123,10 +123,10 @@ def user_create(auth, username, firstname, lastname, mail, password,
         raise MoulinetteError(errno.EEXIST, m18n.n('system_username_exists'))
 
     # Check that the mail domain exists
-    if mail[mail.find('@') + 1:] not in domain_list(auth)['domains']:
+    if mail.split("@")[1] not in domain_list(auth)['domains']:
         raise MoulinetteError(errno.EINVAL,
                               m18n.n('mail_domain_unknown',
-                                     domain=mail[mail.find('@') + 1:]))
+                                     domain=mail.split("@")[1]))
 
     # Get random UID/GID
     uid_check = gid_check = 0

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -24,13 +24,13 @@
     Manage users
 """
 import os
+import re
+import json
+import errno
 import crypt
 import random
 import string
-import json
-import errno
 import subprocess
-import re
 
 from moulinette import m18n
 from moulinette.core import MoulinetteError

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -137,7 +137,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
     char_set = string.ascii_uppercase + string.digits
-    salt = ''.join(random.sample(char_set, 8))
+    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(8)])
     salt = '$1$' + salt + '$'
     user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)
     attr_dict = {

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -137,7 +137,7 @@ def user_create(auth, username, firstname, lastname, mail, password,
     # Adapt values for LDAP
     fullname = '%s %s' % (firstname, lastname)
     char_set = string.ascii_uppercase + string.ascii_lowercase + string.digits + "./"
-    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(8)])
+    salt = ''.join([random.SystemRandom().choice(char_set) for x in range(12)])
     salt = '$1$' + salt + '$'
     user_pwd = '{CRYPT}' + crypt.crypt(str(password), salt)
     attr_dict = {


### PR DESCRIPTION
This started as a "let's clean a bit user.py" until I realized that we were using md5 to store users password. In reaction to that, I went rampage and destroyed every occurrence I could find of using bad hashing algorithm and integrated auto upgrade code ON LOGIN of weakly hashed password to sha-512.

We actually managed to impressive exploit of using: MD5, SSHA and SHA1 for password hashing depending from where it's used.

This PR is **important** and security related, we should merge it soon and probably do a security release only for that.

Since password handling is spread across all YunoHost, this PR also depends on https://github.com/YunoHost/moulinette/pull/152 and https://github.com/YunoHost/SSOwat/pull/87

The information we need to transmit to our users is: you need to ask every account on your YunoHost to successfully relog at least once OR chance their password.

I've personally tested every situation possible EXCEPT a fresh new installation.

I've taken care of splitting every commit according to what it does, IT MIGHT BE EASIER TO READ THIS PR COMMIT BY COMMIT.

As a reference, here is a blogpost that explains how to uses "{CRYPT}" the linux auth system instead of LDAP one that is totally lame and only supports at best SHA1 https://www.redpill-linpro.com/techblog/2016/08/16/ldap-password-hash.html This explains this "$6$" thingy.

Things to test:

* user creation
* user modification
* yunohost tools adminpw
* login using sso
* login on the webadmin

Those are the python commands to read and modify the password of a user:

```python
In [9]: auth.search('uid=neutrinet,ou=users,dc=yunohost,dc=org', attrs=["userPassword"])
Out[9]: [{'userPassword': ['{CRYPT}$6$ULY00E6N7eAID$TEZbi3cZArkWp8oXoFw122YHuoXl4wkxkUouyMZ3z..XnUjHiwA63QTsjwKT7YpxWyvYxSRo/WZGBO5OG5bv51']}]

In [10]: auth.update('uid=neutrinet,ou=users', {"userPassword": "{CRYPT}$1$GQVT7JLZ$hkQN0IxWUp8NKp9ummIrN."})
```

And for admin:

```python
In [4]: auth.search("cn=admin,dc=yunohost,dc=org", attrs=["userPassword"])                                                                                                                                       
Out[4]: [{'userPassword': ['{CRYPT}$6$KIiwe9dnaQYBBd0j$tWK0jR8dU4bsms.lCEiQa23NeYzas1bao5V5.5IlmmwM8lcv9aqrxydK1KdBWXDTorqRIKUsl19LrD4srPlAr0']}]

In [3]: auth.update('cn=admin', {"userPassword": "{SSHA}bJumO0uTJcqXp8N+f2wEcTFVLB7oXFLT"})                                                                                                                      
Out[3]: True
```

Both of those set the password to be "neutrinet" (this is my dev vm password, not a prod password).

Those can be used to set the user/admin password to a crappy hash (`SSHA` or `md5`), then you can test:

* login on sso
* login on admin if
* login on a shell command

And see if those modify the crappy hashed password to uses sha-512 (the one starting with `{CRYPT}$6$` that you can see in the `auth.search`).