### PR TITLE
Integrate a command to launch a dev shell from within moulinette context

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1478,6 +1478,12 @@ tools:
                     extra:
                         pattern: *pattern_port
 
+        ### tools_shell()
+        shell:
+            configuration:
+                authenticate: all
+            action_help: Launch a development shell
+
         ### tools_shutdown()
         shutdown:
             action_help: Shutdown the server

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1483,6 +1483,10 @@ tools:
             configuration:
                 authenticate: all
             action_help: Launch a development shell
+            arguments:
+                -c:
+                    help: python command to execute
+                    full: --command
 
         ### tools_shutdown()
         shutdown:

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -814,12 +814,16 @@ def tools_migrations_state():
     return read_json(MIGRATIONS_STATE_PATH)
 
 
-def tools_shell(auth):
+def tools_shell(auth, command=None):
     """
     Launch an (i)python shell in the YunoHost context.
 
     This is entirely aim for development.
     """
+
+    if command:
+        exec(command)
+        return
 
     logger.warn("The \033[1;34mauth\033[0m is available in this context")
     try:

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -814,6 +814,30 @@ def tools_migrations_state():
     return read_json(MIGRATIONS_STATE_PATH)
 
 
+def tools_shell(auth):
+    """
+    Launch an (i)python shell in the YunoHost context.
+
+    This is entirely aim for development.
+    """
+
+    logger.warn("The \033[1;34mauth\033[0m is available in this context")
+    try:
+        from IPython import embed
+        embed()
+    except ImportError:
+        logger.warn("You don't have IPython installed, consider installing it as it is way better than the standard shell.")
+        logger.warn("Falling back on the standard shell.")
+
+        import readline # will allow Up/Down/History in the console
+        readline  # to please pyflakes
+        import code
+        vars = globals().copy()
+        vars.update(locals())
+        shell = code.InteractiveConsole(vars)
+        shell.interact()
+
+
 def _get_migrations_list():
     migrations = []
 


### PR DESCRIPTION
This PR allows to do a

    yunohost tools shell

And be drop into an IPython shell (if installed, else python default shell) in the moulinette context for rapid prototyping and debugging (for example to talk to ldap using the `auth` object)

This also allows

    yunohost tools shell -c "command"

À la

    python -c "command"

I've been using this a lot during the sha-512 thingy for rapid debugging.

This is exactly the same thing that Django's `python manage.py shell`. Once you get addicted to it, it become quite life changer.

I'm tempted to pass this as a micro decision since this is trivial and not that much worth it discussing.