### PR TITLE
[enh] Escape some special character in ynh_replace_string

### DIFF
--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -18,8 +18,18 @@ ynh_string_random() {
 # | arg: target_file - File in which the string will be replaced.
 ynh_replace_string () {
 	delimit=@
-	match_string=${1//${delimit}/"\\${delimit}"}	# Escape the delimiter if it's in the string.
+	# Escape the delimiter if it's in the string.
+	match_string=${1//${delimit}/"\\${delimit}"}
 	replace_string=${2//${delimit}/"\\${delimit}"}
+
+        # Escape any backslash to preserve them as simple backslash.
+        match_string=${match_string//\\/"\\\\"}
+        replace_string=${replace_string//\\/"\\\\"}
+
+        # Escape the & character, who has a special function in sed.
+        match_string=${match_string//&/"\&"}
+        replace_string=${replace_string//&/"\&"}
+
 	workfile=$3
 
 	sudo sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$workfile"

--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -18,9 +18,6 @@ ynh_string_random() {
 # | arg: target_file - File in which the string will be replaced.
 ynh_replace_string () {
 	delimit=@
-	# Escape the delimiter if it's in the string.
-	match_string=${1//${delimit}/"\\${delimit}"}
-	replace_string=${2//${delimit}/"\\${delimit}"}
 
         # Escape any backslash to preserve them as simple backslash.
         match_string=${match_string//\\/"\\\\"}
@@ -29,6 +26,10 @@ ynh_replace_string () {
         # Escape the & character, who has a special function in sed.
         match_string=${match_string//&/"\&"}
         replace_string=${replace_string//&/"\&"}
+
+	# Escape the delimiter if it's in the string.
+	match_string=${1//${delimit}/"\\${delimit}"}
+	replace_string=${2//${delimit}/"\\${delimit}"}
 
 	workfile=$3
 


### PR DESCRIPTION
## Problem
- *Some characters are interpreted by sed, especially in strong password.  
It sometimes fails the install script*

## Solution
- *Escape backslash and &
Both of them are special characters for sed.*

## Validation
*Medium decision*
- [ ] **Complete test** : 
- ~**Upgrade previous version** :~
- [ ] **Code review** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- ~**CI succeeded** :~
- ~**CI succeeded** :~
~One public package check log is enough instead of two checks.~  
When the PR is mark as ready to merge, you have to wait for 7 days before really merge it.