### PR TITLE
[fix] use cryptorandom to generate password

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2104,4 +2104,4 @@ def random_password(length=8):
     import random
 
     char_set = string.ascii_uppercase + string.digits + string.ascii_lowercase
-    return ''.join(random.sample(char_set, length))
+    return ''.join([random.SystemRandom().choice(char_set) for x in range(length)])


### PR DESCRIPTION
Hello,

This is a security micro decision, there was another place where we weren't using good random generator for passwords. This code is nearly identical to this already existing and working code https://github.com/YunoHost/yunohost/blob/c6b5284be8da39cf2da4e1036a730eb5e0515096/src/yunohost/user.py#L469 (the only difference is the 16 -> length).

This is not critical security situation but it's still quite meh.

I've tagged it as a micro decision but I did a PR for communication purpose. I'll probably merge it soon.