### PR TITLE
[enh] Return log after app upgrade with api

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -38,7 +38,7 @@ import pwd
 import grp
 from collections import OrderedDict
 
-from moulinette import msignals, m18n
+from moulinette import msignals, m18n, msettings
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
@@ -531,6 +531,9 @@ def app_upgrade(auth, app=[], url=None, file=None):
     """
     from yunohost.hook import hook_add, hook_remove, hook_exec
 
+    # Retrieve interface
+    is_api = msettings.get('interface') == 'api'
+
     try:
         app_list()
     except MoulinetteError:
@@ -631,6 +634,10 @@ def app_upgrade(auth, app=[], url=None, file=None):
     app_ssowatconf(auth)
 
     logger.success(m18n.n('upgrade_complete'))
+
+    # Return API logs if it is an API call
+    if is_api:
+        return {"log": service_log('yunohost-api', number="100").values()[0]}
 
 
 def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):


### PR DESCRIPTION
## Problem
I need to display log info after app upgrade in the web admin

## Solution
Do like in yunohost tools upgrade return the log if it's an api call

## How to test
This PR is related to the web admin PR https://github.com/YunoHost/yunohost-admin/pull/172
You can test with by upgrading an app

To upgrade an app, you can change the update_time by editing your apps settings /etc/yunohost/apps/APP/settings.yml

## PR Status
Opinion needed 

## Validation

- [x] **Principle agreement** 1/2 : Bram
- [ ] **Quick review** 0/1 : 
- [ ] **Simple test** 0/1 : 
- [ ] **Deep review** 0/1: 
