### PR TITLE
[enh] Add fail2ban helpers

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -185,11 +185,18 @@ ynh_remove_fpm_config () {
 }
 
 # Create a dedicated fail2ban config (jail and filter conf files)
+# usage 1: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
+# | arg: -l, --logpath=   - Log file to be checked by fail2ban
+# | arg: -r, --failregex= - Failregex to be looked for by fail2ban
+# | arg: -m, --max_retry= - Maximum number of retries allowed before banning IP address - default: 3
+# | arg: -p, --ports= - Ports blocked for a banned IP address - default: http,https
 #
-# usage: ynh_add_fail2ban_config "list of others variables to replace"
+# -----------------------------------------------------------------------------
 #
-# | arg: list of others variables to replace separeted by a space
-# |      for example : 'var_1 var_2 ...'
+# usage 2: ynh_add_fail2ban_config -t [-v "list of others variables to replace"]
+# | arg: -t, --use_template - Use this helper in template mode
+# | arg: -v, --others_var=  - List of others variables to replace separeted by a space
+# |                           for example : 'var_1 var_2 ...'
 #
 # This will use a template in ../conf/f2b_jail.conf and ../conf/f2b_filter.conf
 #   __APP__      by  $app
@@ -235,7 +242,16 @@ ynh_remove_fpm_config () {
 # To validate your regex you can test with this command:
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf
 ynh_add_fail2ban_config () {
-  local others_var=${1:-}
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= [t]=use_template [v]=others_var=)
+  local logpath
+  local failregex
+  local max_retry
+  local ports
+  local others_var
+  local use_template
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
 
   finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
   finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
@@ -245,18 +261,42 @@ ynh_add_fail2ban_config () {
   cp ../conf/f2b_jail.conf $finalfail2banjailconf
   cp ../conf/f2b_filter.conf $finalfail2banfilterconf
 
-  if test -n "${app:-}"; then
-    ynh_replace_string "__APP__" "$app" "$finalfail2banjailconf"
-    ynh_replace_string "__APP__" "$app" "$finalfail2banfilterconf"
-  fi
+  if [[ ${use_template:-0} == 1 ]]; then
+    if test -n "${app:-}"; then
+      ynh_replace_string "__APP__" "$app" "$finalfail2banjailconf"
+      ynh_replace_string "__APP__" "$app" "$finalfail2banfilterconf"
+    fi
 
-  # Replace all other variable given as arguments
-  for var_to_replace in $others_var; do
-    # ${var_to_replace^^} make the content of the variable on upper-cases
-    # ${!var_to_replace} get the content of the variable named $var_to_replace
-    ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banjailconf"
-    ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banfilterconf"
-  done
+    # Replace all other variable given as arguments
+    for var_to_replace in ${others_var:-}; do
+      # ${var_to_replace^^} make the content of the variable on upper-cases
+      # ${!var_to_replace} get the content of the variable named $var_to_replace
+      ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banjailconf"
+      ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banfilterconf"
+    done
+  else
+    max_retry=${max_retry:-3}
+    ports=${ports:-http,https}
+    test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
+    test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+
+    tee $finalfail2banjailconf <<EOF
+[$app]
+enabled = true
+port = $ports
+filter = $app
+logpath = $logpath
+maxretry = $max_retry
+EOF
+
+    tee $finalfail2banfilterconf <<EOF
+[INCLUDES]
+before = common.conf
+[Definition]
+failregex = $failregex
+ignoreregex =
+EOF
+  fi
 
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -256,17 +256,23 @@ ynh_add_fail2ban_config () {
   local use_template
   # Manage arguments with getopts
   ynh_handle_getopts_args "$@"
+  use_template="${use_template:-0}"
+  max_retry=${max_retry:-3}
+  ports=${ports:-http,https}
 
   finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
   finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
   ynh_backup_if_checksum_is_different "$finalfail2banjailconf"
   ynh_backup_if_checksum_is_different "$finalfail2banfilterconf"
 
-  cp ../conf/f2b_jail.conf $finalfail2banjailconf
-  cp ../conf/f2b_filter.conf $finalfail2banfilterconf
+  if [ $use_template -eq 1 ]
+  then
+    # Usage 2, templates
+    cp ../conf/f2b_jail.conf $finalfail2banjailconf
+    cp ../conf/f2b_filter.conf $finalfail2banfilterconf
 
-  if [[ ${use_template:-0} == 1 ]]; then
-    if test -n "${app:-}"; then
+    if [ -n "${app:-}" ]
+    then
       ynh_replace_string "__APP__" "$app" "$finalfail2banjailconf"
       ynh_replace_string "__APP__" "$app" "$finalfail2banfilterconf"
     fi
@@ -278,9 +284,9 @@ ynh_add_fail2ban_config () {
       ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banjailconf"
       ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banfilterconf"
     done
+
   else
-    max_retry=${max_retry:-3}
-    ports=${ports:-http,https}
+    # Usage 1, no template. Build a config file from scratch.
     test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
     test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
 
@@ -302,6 +308,7 @@ ignoreregex =
 EOF
   fi
 
+  # Common to usage 1 and 2.
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
 
@@ -309,8 +316,8 @@ EOF
 
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
   if [[ -n "$fail2ban_error" ]]; then
-    echo "[ERR] Fail2ban failed to load the jail for $app" >&2
-    echo "WARNING${fail2ban_error#*WARNING}" >&2
+    ynh_print_err --message="Fail2ban failed to load the jail for $app"
+    ynh_print_warn --message="${fail2ban_error#*WARNING}"
   fi
 }
 

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -185,15 +185,15 @@ ynh_remove_fpm_config () {
 }
 
 # Create a dedicated fail2ban config (jail and filter conf files)
-# usage 1: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
+# usage 1: ynh_add_fail2ban_config --logpath=log_file --failregex=filter [--max_retry=max_retry] [--ports=ports]
 # | arg: -l, --logpath=   - Log file to be checked by fail2ban
 # | arg: -r, --failregex= - Failregex to be looked for by fail2ban
 # | arg: -m, --max_retry= - Maximum number of retries allowed before banning IP address - default: 3
-# | arg: -p, --ports= - Ports blocked for a banned IP address - default: http,https
+# | arg: -p, --ports=     - Ports blocked for a banned IP address - default: http,https
 #
 # -----------------------------------------------------------------------------
 #
-# usage 2: ynh_add_fail2ban_config -t [-v "list of others variables to replace"]
+# usage 2: ynh_add_fail2ban_config --use_template [--others_var="list of others variables to replace"]
 # | arg: -t, --use_template - Use this helper in template mode
 # | arg: -v, --others_var=  - List of others variables to replace separeted by a space
 # |                           for example : 'var_1 var_2 ...'

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -192,41 +192,47 @@ ynh_remove_fpm_config () {
 # | arg: max_retry - Maximum number of retries allowed before banning IP address - default: 3
 # | arg: ports - Ports blocked for a banned IP address - default: http,https
 ynh_add_fail2ban_config () {
-   # Process parameters
-   logpath=$1
-   failregex=$2
-   max_retry=${3:-3}
-   ports=${4:-http,https}
-   
-  test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
-  test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
-  
+	# Process parameters
+	logpath=$1
+	failregex=$2
+	max_retry=${3:-3}
+	ports=${4:-http,https}
+	
+	test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
+	test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+
 	finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
 	finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
 	ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
 	ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
-  
-  sudo tee $finalfail2banjailconf <<EOF
+
+	tee $finalfail2banjailconf <<EOF
 [$app]
 enabled = true
 port = $ports
 filter = $app
 logpath = $logpath
-maxretry = $max_retry" 
+maxretry = $max_retry
 EOF
 
-  sudo tee $finalfail2banfilterconf <<EOF
+	sudo tee $finalfail2banfilterconf <<EOF
 [INCLUDES]
 before = common.conf
 [Definition]
 failregex = $failregex
-ignoreregrex =" 
+ignoreregex =
 EOF
 
 	ynh_store_file_checksum "$finalfail2banjailconf"
 	ynh_store_file_checksum "$finalfail2banfilterconf"
-  
-	sudo systemctl restart fail2ban
+
+	systemctl reload fail2ban
+	local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
+	if [ -n "$fail2ban_error" ]
+	then
+		echo "[ERR] Fail2ban failed to load the jail for $app" >&2
+		echo "WARNING${fail2ban_error#*WARNING}" >&2
+	fi
 }
 
 # Remove the dedicated fail2ban config (jail and filter conf files)
@@ -234,6 +240,6 @@ EOF
 # usage: ynh_remove_fail2ban_config
 ynh_remove_fail2ban_config () {
 	ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
-  ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-	sudo systemctl restart fail2ban
+	ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
+	systemctl reload fail2ban
 }

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -185,6 +185,7 @@ ynh_remove_fpm_config () {
 }
 
 # Create a dedicated fail2ban config (jail and filter conf files)
+#
 # usage 1: ynh_add_fail2ban_config --logpath=log_file --failregex=filter [--max_retry=max_retry] [--ports=ports]
 # | arg: -l, --logpath=   - Log file to be checked by fail2ban
 # | arg: -r, --failregex= - Failregex to be looked for by fail2ban
@@ -204,17 +205,6 @@ ynh_remove_fpm_config () {
 #  You can dynamically replace others variables by example :
 #   __VAR_1__    by $var_1
 #   __VAR_2__    by $var_2
-#
-# Note about the "failregex" option:
-#          regex to match the password failure messages in the logfile. The
-#          host must be matched by a group named "host". The tag "<HOST>" can
-#          be used for standard IP/hostname matching and is only an alias for
-#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
-#
-#          You can find some more explainations about how to make a regex here :
-#          https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
-#
-# Note that the logfile need to exist before to call this helper !!
 #
 # Generally your template will look like that by example (for synapse):
 #
@@ -239,8 +229,22 @@ ynh_remove_fpm_config () {
 #
 #     ignoreregex =
 #
+# -----------------------------------------------------------------------------
+#
+# Note about the "failregex" option:
+#          regex to match the password failure messages in the logfile. The
+#          host must be matched by a group named "host". The tag "<HOST>" can
+#          be used for standard IP/hostname matching and is only an alias for
+#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
+#
+#          You can find some more explainations about how to make a regex here :
+#          https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
+#
+# Note that the logfile need to exist before to call this helper !!
+#
 # To validate your regex you can test with this command:
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf
+#
 ynh_add_fail2ban_config () {
   # Declare an array to define the options of this helper.
   declare -Ar args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= [t]=use_template [v]=others_var=)

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -220,7 +220,7 @@ logpath = $logpath
 maxretry = $max_retry
 EOF
 
-  sudo tee $finalfail2banfilterconf <<EOF
+  tee $finalfail2banfilterconf <<EOF
 [INCLUDES]
 before = common.conf
 [Definition]

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -187,26 +187,31 @@ ynh_remove_fpm_config () {
 # Create a dedicated fail2ban config (jail and filter conf files)
 #
 # usage: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
-# | arg: log_file - Log file to be checked by fail2ban
-# | arg: failregex - Failregex to be looked for by fail2ban
-# | arg: max_retry - Maximum number of retries allowed before banning IP address - default: 3
-# | arg: ports - Ports blocked for a banned IP address - default: http,https
+# | arg: -l, --logpath= - Log file to be checked by fail2ban
+# | arg: -r, --failregex= - Failregex to be looked for by fail2ban
+# | arg: -m, --max_retry= - Maximum number of retries allowed before banning IP address - default: 3
+# | arg: -p, --ports= - Ports blocked for a banned IP address - default: http,https
 ynh_add_fail2ban_config () {
-	# Process parameters
-	logpath=$1
-	failregex=$2
-	max_retry=${3:-3}
-	ports=${4:-http,https}
-	
-	test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
-	test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+  # Declare an array to define the options of this helper.
+  declare -Ar args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= )
+  local logpath
+  local failregex
+  local max_retry
+  local ports
+  # Manage arguments with getopts
+  ynh_handle_getopts_args "$@"
+  max_retry=${max_retry:-3}
+  ports=${ports:-http,https}
 
-	finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
-	finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
-	ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
-	ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
+  test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
+  test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
 
-	tee $finalfail2banjailconf <<EOF
+  finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
+  finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
+  ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
+  ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
+
+  sudo tee $finalfail2banjailconf <<EOF
 [$app]
 enabled = true
 port = $ports
@@ -215,7 +220,7 @@ logpath = $logpath
 maxretry = $max_retry
 EOF
 
-	sudo tee $finalfail2banfilterconf <<EOF
+  sudo tee $finalfail2banfilterconf <<EOF
 [INCLUDES]
 before = common.conf
 [Definition]
@@ -223,23 +228,31 @@ failregex = $failregex
 ignoreregex =
 EOF
 
-	ynh_store_file_checksum "$finalfail2banjailconf"
-	ynh_store_file_checksum "$finalfail2banfilterconf"
+  ynh_store_file_checksum "$finalfail2banjailconf"
+  ynh_store_file_checksum "$finalfail2banfilterconf"
 
-	systemctl reload fail2ban
-	local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
-	if [ -n "$fail2ban_error" ]
-	then
-		echo "[ERR] Fail2ban failed to load the jail for $app" >&2
-		echo "WARNING${fail2ban_error#*WARNING}" >&2
-	fi
+  if [ "$(lsb_release --codename --short)" != "jessie" ]; then
+    systemctl reload fail2ban
+  else
+    systemctl restart fail2ban
+  fi
+  local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
+  if [ -n "$fail2ban_error" ]
+  then
+    echo "[ERR] Fail2ban failed to load the jail for $app" >&2
+    echo "WARNING${fail2ban_error#*WARNING}" >&2
+  fi
 }
 
 # Remove the dedicated fail2ban config (jail and filter conf files)
 #
 # usage: ynh_remove_fail2ban_config
 ynh_remove_fail2ban_config () {
-	ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
-	ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-	systemctl reload fail2ban
+  ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
+  ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
+  if [ "$(lsb_release --codename --short)" != "jessie" ]; then
+    systemctl reload fail2ban
+  else
+    systemctl restart fail2ban
+  fi
 }

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -183,3 +183,57 @@ ynh_remove_fpm_config () {
 	ynh_secure_remove "/etc/php5/fpm/conf.d/20-$app.ini" 2>&1
 	sudo systemctl reload php5-fpm
 }
+
+# Create a dedicated fail2ban config (jail and filter conf files)
+#
+# usage: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
+# | arg: log_file - Log file to be checked by fail2ban
+# | arg: failregex - Failregex to be looked for by fail2ban
+# | arg: max_retry - Maximum number of retries allowed before banning IP address - default: 3
+# | arg: ports - Ports blocked for a banned IP address - default: http,https
+ynh_add_fail2ban_config () {
+   # Process parameters
+   logpath=$1
+   failregex=$2
+   max_retry=${3:-3}
+   ports=${4:-http,https}
+   
+  test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
+  test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+  
+	finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
+	finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
+	ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
+	ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
+  
+  sudo tee $finalfail2banjailconf <<EOF
+[$app]
+enabled = true
+port = $ports
+filter = $app
+logpath = $logpath
+maxretry = $max_retry" 
+EOF
+
+  sudo tee $finalfail2banfilterconf <<EOF
+[INCLUDES]
+before = common.conf
+[Definition]
+failregex = $failregex
+ignoreregrex =" 
+EOF
+
+	ynh_store_file_checksum "$finalfail2banjailconf"
+	ynh_store_file_checksum "$finalfail2banfilterconf"
+  
+	sudo systemctl restart fail2ban
+}
+
+# Remove the dedicated fail2ban config (jail and filter conf files)
+#
+# usage: ynh_remove_fail2ban_config
+ynh_remove_fail2ban_config () {
+	ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
+  ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
+	sudo systemctl restart fail2ban
+}

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -211,7 +211,7 @@ ynh_add_fail2ban_config () {
   ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
   ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
 
-  sudo tee $finalfail2banjailconf <<EOF
+  tee $finalfail2banjailconf <<EOF
 [$app]
 enabled = true
 port = $ports

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -186,59 +186,85 @@ ynh_remove_fpm_config () {
 
 # Create a dedicated fail2ban config (jail and filter conf files)
 #
-# usage: ynh_add_fail2ban_config log_file filter [max_retry [ports]]
-# | arg: -l, --logpath= - Log file to be checked by fail2ban
-# | arg: -r, --failregex= - Failregex to be looked for by fail2ban
-# | arg: -m, --max_retry= - Maximum number of retries allowed before banning IP address - default: 3
-# | arg: -p, --ports= - Ports blocked for a banned IP address - default: http,https
+# usage: ynh_add_fail2ban_config "list of others variables to replace"
+#
+# | arg: list of others variables to replace separeted by a space
+# |      for example : 'var_1 var_2 ...'
+#
+# This will use a template in ../conf/f2b_jail.conf and ../conf/f2b_filter.conf
+#   __APP__      by  $app
+#
+#  You can dynamically replace others variables by example :
+#   __VAR_1__    by $var_1
+#   __VAR_2__    by $var_2
+#
+# Note about the "failregex" option:
+#          regex to match the password failure messages in the logfile. The
+#          host must be matched by a group named "host". The tag "<HOST>" can
+#          be used for standard IP/hostname matching and is only an alias for
+#          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
+#
+#          You can find some more explainations about how to make a regex here :
+#          https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
+#
+# Note that the logfile need to exist before to call this helper !!
+#
+# Generally your template will look like that by example (for synapse):
+#
+# f2b_jail.conf:
+#     [__APP__]
+#     enabled = true
+#     port = http,https
+#     filter = __APP__
+#     logpath = /var/log/__APP__/logfile.log
+#     maxretry = 3
+#
+# f2b_filter.conf:
+#     [INCLUDES]
+#     before = common.conf
+#     [Definition]
+#
+#     # Part of regex definition (just used to make more easy to make the global regex)
+#     __synapse_start_line = .? \- synapse\..+ \-
+#
+#    # Regex definition.
+#    failregex = ^%(__synapse_start_line)s INFO \- POST\-(\d+)\- <HOST> \- \d+ \- Received request\: POST /_matrix/client/r0/login\??<SKIPLINES>%(__synapse_start_line)s INFO \- POST\-\1\- Got login request with identifier: \{u'type': u'm.id.user', u'user'\: u'(.+?)'\}, medium\: None, address: None, user\: u'\5'<SKIPLINES>%(__synapse_start_line)s WARNING \- \- (Attempted to login as @\5\:.+ but they do not exist|Failed password login for user @\5\:.+)$
+#
+#     ignoreregex =
+#
+# To validate your regex you can test with this command:
+# fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf
 ynh_add_fail2ban_config () {
-  # Declare an array to define the options of this helper.
-  declare -Ar args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= )
-  local logpath
-  local failregex
-  local max_retry
-  local ports
-  # Manage arguments with getopts
-  ynh_handle_getopts_args "$@"
-  max_retry=${max_retry:-3}
-  ports=${ports:-http,https}
-
-  test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
-  test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
+  local others_var=${1:-}
 
   finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
   finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
-  ynh_backup_if_checksum_is_different "$finalfail2banjailconf" 1
-  ynh_backup_if_checksum_is_different "$finalfail2banfilterconf" 1
+  ynh_backup_if_checksum_is_different "$finalfail2banjailconf"
+  ynh_backup_if_checksum_is_different "$finalfail2banfilterconf"
 
-  tee $finalfail2banjailconf <<EOF
-[$app]
-enabled = true
-port = $ports
-filter = $app
-logpath = $logpath
-maxretry = $max_retry
-EOF
+  cp ../conf/f2b_jail.conf $finalfail2banjailconf
+  cp ../conf/f2b_filter.conf $finalfail2banfilterconf
 
-  tee $finalfail2banfilterconf <<EOF
-[INCLUDES]
-before = common.conf
-[Definition]
-failregex = $failregex
-ignoreregex =
-EOF
+  if test -n "${app:-}"; then
+    ynh_replace_string "__APP__" "$app" "$finalfail2banjailconf"
+    ynh_replace_string "__APP__" "$app" "$finalfail2banfilterconf"
+  fi
+
+  # Replace all other variable given as arguments
+  for var_to_replace in $others_var; do
+    # ${var_to_replace^^} make the content of the variable on upper-cases
+    # ${!var_to_replace} get the content of the variable named $var_to_replace
+    ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banjailconf"
+    ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banfilterconf"
+  done
 
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
 
-  if [ "$(lsb_release --codename --short)" != "jessie" ]; then
-    systemctl reload fail2ban
-  else
-    systemctl restart fail2ban
-  fi
+  systemctl try-reload-or-restart fail2ban
+
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
-  if [ -n "$fail2ban_error" ]
-  then
+  if [[ -n "$fail2ban_error" ]]; then
     echo "[ERR] Fail2ban failed to load the jail for $app" >&2
     echo "WARNING${fail2ban_error#*WARNING}" >&2
   fi
@@ -250,9 +276,5 @@ EOF
 ynh_remove_fail2ban_config () {
   ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
   ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"
-  if [ "$(lsb_release --codename --short)" != "jessie" ]; then
-    systemctl reload fail2ban
-  else
-    systemctl restart fail2ban
-  fi
+  systemctl try-reload-or-restart fail2ban
 }


### PR DESCRIPTION
## Problems
To enhance applications protection against hackers/spammers, etc., we can propose helpers to ease the creating of fail2ban jails.

## Solution
Add `ynh_add_fail2ban_config` and `ynh_remove_fail2ban_config` helpers.
A successful implementation example is the [piwigo app](https://github.com/YunoHost-Apps/piwigo_ynh).

## PR Status
Working, but opinion welcome!
And should be implemented in other applications to validate its principle.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 