### PR TITLE
Make tools_ldapinit more verbose

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -78,14 +78,14 @@ def tools_ldapinit():
     for rdn, attr_dict in ldap_map['parents'].items():
         try:
             auth.add(rdn, attr_dict)
-        except:
-            pass
+        except Exception as e:
+            logger.warn("Error when trying to inject '%s' -> '%s' into ldap: %s" % (rdn, attr_dict, e))
 
     for rdn, attr_dict in ldap_map['children'].items():
         try:
             auth.add(rdn, attr_dict)
-        except:
-            pass
+        except Exception as e:
+            logger.warn("Error when trying to inject '%s' -> '%s' into ldap: %s" % (rdn, attr_dict, e))
 
     admin_dict = {
         'cn': 'admin',


### PR DESCRIPTION
Hello,

`tools_ldapinit` is used during post install to initialized the ldap db content/schema (which is stored in some yaml in `data/`).

Problem: everything is being ugly catchall try/except which mask every errors during initialization thus making things very hard to debug when they go wrong because we have strictly no informations.

This PR logs this by showing every errors.

This PR needs more testing to see if it fits the targeted used case.