### PR TITLE
Be able to give lock to son processes detached by systemctl

### DIFF
--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -47,6 +47,7 @@ yunohost-api:
    log: /var/log/yunohost/yunohost-api.log
 yunohost-firewall:
    status: service
+   need_lock: true
 nslcd:
    status: service
    log: /var/log/syslog

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -506,7 +506,8 @@ def _run_service_command(action, service):
     else:
         raise ValueError("Unknown action '%s'" % action)
 
-    need_lock = services[service].get('need_lock')
+    need_lock = (services[service].get('need_lock') or False) \
+                and action in ['start', 'stop', 'restart', 'reload']
 
     try:
         # Launch the command

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -484,7 +484,7 @@ def service_regen_conf(names=[], with_diff=False, force=False, dry_run=False,
     return result
 
 
-def _run_service_command(action, service, need_lock=True):
+def _run_service_command(action, service):
     """
     Run services management command (start, stop, enable, disable, restart, reload)
 
@@ -493,7 +493,8 @@ def _run_service_command(action, service, need_lock=True):
         service -- Service name
 
     """
-    if service not in _get_services().keys():
+    services = _get_services()
+    if service not in services.keys():
         raise MoulinetteError(errno.EINVAL, m18n.n('service_unknown', service=service))
 
     cmd = None
@@ -504,6 +505,8 @@ def _run_service_command(action, service, need_lock=True):
         cmd = 'update-rc.d %s %s' % (service, arg)
     else:
         raise ValueError("Unknown action '%s'" % action)
+
+    need_lock = services[service].get('need_lock')
 
     try:
         # Launch the command


### PR DESCRIPTION
### Problem

Following the changes in the lock system in Moulinette, it was noticed that it causes an issue for services that need to run yunohost command. Basically this kind of situation : 

```
PID     PPID
  5     N/A     yunohost service foo start
  6      5      '-- systemctl foo start

 10     1       ./foo_start.sh
 11     10      '-- yunohost app foo setting bar -v meh
```

Process 10 is detached from process 6, therefore the lock taken by 5 cannot be used by 11...

This kind of situation happens at least in three different context : 
- Firewall reload at the end of postinstall
- Firewall reload at any time from the yunohost admin
- All (?) apps of Internet Cube (e.g. [here](https://github.com/labriqueinternet/hotspot_ynh/blob/master/conf/ynh-hotspot#L263))

### Solution

The proposed solution is that, everytime we have to restart a service which needs to be able to run yunohost commands, we launch the service/systemctl command in background, get the PID of the command launched by systemctl (using `systemctl show`), and add a lock for it to be able to run yunohost commands. For this, we need https://github.com/YunoHost/moulinette/pull/154

A flag is set in services.yml (`need_lock: true`) to define which services need the lock.

With this design, only the process currently having the lock (A) gives the lock to another process (B). A waits for B to ends its execution, hence there's no issue for concurrence since only one of these is active at a time. There's no possibility for a process C to grab the lock as long as A has it (except of course if C decide to mess with the lock file).

### How to test

Run the following : 

```
yunohost service stop yunohost-firewall --debug
yunohost service start yunohost-firewall --debug
```

A debug message should say that a lock was added for a given PID (except if the service is already stopped/started)

### Validation

- [x] Principle agreement 1/2 : ljf
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1? :