### PR TITLE
'/' was resulting in '//' in change_url

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -445,8 +445,9 @@ def app_change_url(auth, app, domain, path):
 
     # Normalize path and domain format
     domain = domain.strip().lower()
-    old_path = '/' + old_path.strip("/").strip() + '/'
-    path = '/' + path.strip("/").strip() + '/'
+
+    old_path = normalize_url_path(old_path)
+    path = normalize_url_path(path)
 
     if (domain, path) == (old_domain, old_path):
         raise MoulinetteError(errno.EINVAL, m18n.n("app_change_url_identical_domains", domain=domain, path=path))
@@ -2105,3 +2106,10 @@ def random_password(length=8):
 
     char_set = string.ascii_uppercase + string.digits + string.ascii_lowercase
     return ''.join([random.SystemRandom().choice(char_set) for x in range(length)])
+
+
+def normalize_url_path(url_path):
+    if url_path.strip("/").strip():
+        return '/' + url_path.strip("/").strip() + '/'
+
+    return "/"


### PR DESCRIPTION
Fix https://dev.yunohost.org/issues/999

Tested using "yunohost tools shell" and works as expected.

This seems to be quite blocking for the integration of change_url into apps according to feedback.

To test using "yunohost tools shell" do something like this:

```
$ yunohost tools shell
In [1]: from yunohost.app import normalize_url_path

In [2]: normalize_url_path("/")
Out[2]: '/'

In [3]: normalize_url_path("//")
Out[3]: '/'

In [4]: normalize_url_path("/////")
Out[4]: '/'

In [5]: normalize_url_path("a")                                                                                                                                                                                 
Out[5]: '/a/'

In [6]: normalize_url_path("qsd/qsd/qsd/")                                                                                                                                                                      
Out[6]: '/qsd/qsd/qsd/'
```