### PR TITLE
[enh] Remove date from sql dump

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -73,7 +73,7 @@ ynh_mysql_drop_db() {
 # | arg: db - the database name to dump
 # | ret: the mysqldump output
 ynh_mysql_dump_db() {
-    mysqldump -u "root" -p"$(sudo cat $MYSQL_ROOT_PWD_FILE)" "$1"
+    mysqldump -u "root" -p"$(sudo cat $MYSQL_ROOT_PWD_FILE)" --skip-dump-date "$1"
 }
 
 # Create a user


### PR DESCRIPTION
## Problems
Currently, if you make 2 successive dumps, their checksum will be different only because the dump dates are different.
So, you can't compare sql dumps.

## Solution
Adding the `skip-dump-date` option will remove this date in the sql dump.
So, you can make a comparaison between 2 dumps by comparing their checksums.
You keep a date by the timestamp of the file.

## PR Status
Tested on my own server with the fallback app.

## Validation

- [X] Principle agreement 2/2 : opi, Aleks
- [x] Quick review 1/1 : opi
- [X] Simple test 1/1 : JimboJoe 
- [X] Deep review 1/1 : JimboJoe 