### PR TITLE
[fix] fix this UnicodeDecodingError on backup-restore

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -166,11 +166,11 @@ class BackupRestoreTargetsManager(object):
             or (exclude and isinstance(exclude, list) and not include)
 
         if include:
-            return [target for target in self.targets[category]
+            return [target.encode("Utf-8") for target in self.targets[category]
                     if self.results[category][target] in include]
 
         if exclude:
-            return [target for target in self.targets[category]
+            return [target.encode("Utf-8") for target in self.targets[category]
                     if self.results[category][target] not in exclude]
 
 


### PR DESCRIPTION
Hello,

This fix the infamous UnicodeDecodeError that we have on backup-restore. Tested on a buggy backup, I can confirm that this is working.

This is worth a small release I think.

The problem was that we were returning unicode strings and trying to merge them against regular strings, I've fixed the problem at the source.