### PR TITLE
[fix] Do not modify the settings too soon in change_url

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -451,10 +451,7 @@ def app_change_url(auth, app, domain, path):
     if (domain, path) == (old_domain, old_path):
         raise MoulinetteError(errno.EINVAL, m18n.n("app_change_url_identical_domains", domain=domain, path=path))
 
-    # WARNING / FIXME : checkurl will modify the settings
-    # (this is a non intuitive behavior that should be changed)
-    # (or checkurl renamed in reserve_url)
-    app_checkurl(auth, '%s%s' % (domain, path), app)
+    domain_url_available(auth, domain, path)
 
     manifest = json.load(open(os.path.join(APPS_SETTING_PATH, app, "manifest.json")))
 


### PR DESCRIPTION
## Problems
If the domain is stored too soon, the backup script, used before any modification, fail because it loads the new domain instead of the old one.
The domain, and the path should be changed only at the end of the script.

## Solution
Can't we use the new `domain_url_available` function instead ?

## PR Status
Not tested.
Only a proposition.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 :