### PR TITLE
Use systemd for all service operations (+ update postinstall firewall enable/start)

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -506,7 +506,7 @@ def _run_service_command(action, service):
     else:
         raise ValueError("Unknown action '%s'" % action)
 
-    need_lock = (services[service].get('need_lock') or False) \
+    need_lock = services[service].get('need_lock', False) \
                 and action in ['start', 'stop', 'restart', 'reload']
 
     try:

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -498,11 +498,8 @@ def _run_service_command(action, service):
         raise MoulinetteError(errno.EINVAL, m18n.n('service_unknown', service=service))
 
     cmd = None
-    if action in ['start', 'stop', 'restart', 'reload']:
-        cmd = 'service %s %s' % (service, action)
-    elif action in ['enable', 'disable']:
-        arg = 'defaults' if action == 'enable' else 'remove'
-        cmd = 'update-rc.d %s %s' % (service, arg)
+    if action in ['start', 'stop', 'restart', 'reload', 'enable', 'disable']:
+        cmd = 'systemctl %s %s' % (action, service)
     else:
         raise ValueError("Unknown action '%s'" % action)
 

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -47,7 +47,7 @@ from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, a
 from yunohost.domain import domain_add, domain_list, get_public_ip, _get_maindomain, _set_maindomain
 from yunohost.dyndns import _dyndns_available, _dyndns_provides
 from yunohost.firewall import firewall_upnp
-from yunohost.service import service_status, service_regen_conf, service_log
+from yunohost.service import service_status, service_regen_conf, service_log, service_start, service_enable
 from yunohost.monitor import monitor_disk, monitor_system
 from yunohost.utils.packages import ynh_packages_version
 
@@ -398,8 +398,8 @@ def tools_postinstall(domain, password, ignore_dyndns=False):
     os.system('touch /etc/yunohost/installed')
 
     # Enable and start YunoHost firewall at boot time
-    os.system('update-rc.d yunohost-firewall enable')
-    os.system('service yunohost-firewall start &')
+    service_enable("yunohost-firewall")
+    service_start("yunohost-firewall")
 
     service_regen_conf(force=True)
     logger.success(m18n.n('yunohost_configured'))


### PR DESCRIPTION
### Problem

When updating/cleaning the commands used at postinstall to enable/start the firewall, I realized that our current way of enabling/disabling services is weird and actually doesn't work ?

Basically doing a `service_enable("yunohost-firewall")` doesn't seem to really work, since the firewall was still disabled after postinstall. 

I'm not a init expert, but our current way of doing things, which is using `update_rc.d <service> defaults|remove` is pretty weird and I'm not sure it's the right thing ? When trying to use `systemctl enable <service>`, I see that it's actually running both these commands :

```
update-rc.d <service> defaults
update-rc.d <service> enable
```

(and same thing for disable, replacing 'enable' by 'disable') ...

### Solution

Apparently the current code dates back from 2014 at which point YunoHost was still on Wheezy I guess, and the enable/disable API of update-rc.d might not have been there yet. Nowadays, it looks like we can just use systemctl anyway... (though, again, I don't know much about the init systems)