### PR TITLE
Fix upgrade fake package

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -126,10 +126,7 @@ ynh_install_app_dependencies () {
     version=$(grep '\"version\": ' "$manifest_path" | cut -d '"' -f 4)	# Retrieve the version number in the manifest file.
     dep_app=${app//_/-}	# Replace all '_' by '-'
 
-    if ynh_package_is_installed "${dep_app}-ynh-deps"; then
-		echo "A package named ${dep_app}-ynh-deps is already installed" >&2
-    else
-        cat > /tmp/${dep_app}-ynh-deps.control << EOF	# Make a control file for equivs-build
+    cat > /tmp/${dep_app}-ynh-deps.control << EOF	# Make a control file for equivs-build
 Section: misc
 Priority: optional
 Package: ${dep_app}-ynh-deps
@@ -139,11 +136,10 @@ Architecture: all
 Description: Fake package for ${app} (YunoHost app) dependencies
  This meta-package is only responsible of installing its dependencies.
 EOF
-        ynh_package_install_from_equivs /tmp/${dep_app}-ynh-deps.control \
-            || ynh_die "Unable to install dependencies"	# Install the fake package and its dependencies
-        rm /tmp/${dep_app}-ynh-deps.control
-        ynh_app_setting_set $app apt_dependencies $dependencies
-    fi
+    ynh_package_install_from_equivs /tmp/${dep_app}-ynh-deps.control \
+        || ynh_die "Unable to install dependencies"	# Install the fake package and its dependencies
+    rm /tmp/${dep_app}-ynh-deps.control
+    ynh_app_setting_set $app apt_dependencies $dependencies
 }
 
 # Remove fake package and its dependencies


### PR DESCRIPTION
## Problem
- *Fake packages can't be updated, because it will be filtrate by ynh_package_is_installed
In case of upgrade of a fake package, nothing will be done. So you can't add or remove a dependency.*

## Solution
- *Remove the condition with ynh_package_is_installed. Not sure why I added that before (in this [commit](https://github.com/YunoHost/yunohost/commit/5f3fcefc882c66ccb7cd60b05fef6cde3d4f81d0)).*