### PR TITLE
Solve ynh_use_logrotate

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -6,7 +6,7 @@
 #
 # If no argument provided, a standard directory will be use. /var/log/${app}
 # You can provide a path with the directory only or with the logfile.
-# /parentdir/logdir/
+# /parentdir/logdir
 # /parentdir/logdir/logfile.log
 #
 # It's possible to use this helper several times, each config will be added to the same logrotate config file.
@@ -24,7 +24,7 @@ ynh_use_logrotate () {
 		if [ "$(echo ${1##*.})" == "log" ]; then	# Keep only the extension to check if it's a logfile
 			logfile=$1	# In this case, focus logrotate on the logfile
 		else
-			logfile=$1/.log	# Else, uses the directory and all logfile into it.
+			logfile=$1/*.log	# Else, uses the directory and all logfile into it.
 		fi
 	else
 		logfile="/var/log/${app}/*.log" # Without argument, use a defaut directory in /var/log


### PR DESCRIPTION
Actually when we use the command `ynh_use_logrotate /var/log/abcd/` the result in the logrotate conf file is `/opt/yunohost/abcd/logs//.log` witch is not what we want.