### PR TITLE
Fix broken ynh_replace_string

### DIFF
--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -26,6 +26,27 @@ ynh_replace_string () {
 	local replace_string=$2
 	local workfile=$3
 
+	# Escape the delimiter if it's in the string.
+	match_string=${match_string//${delimit}/"\\${delimit}"}
+	replace_string=${replace_string//${delimit}/"\\${delimit}"}
+
+	sudo sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$workfile"
+}
+
+# Substitute/replace a password by another in a file
+#
+# usage: ynh_replace_password_string match_string replace_string target_file
+# | arg: match_string - String to be searched and replaced in the file
+# | arg: replace_string - String that will replace matches
+# | arg: target_file - File in which the string will be replaced.
+#
+# This helper will use ynh_replace_string, but as you can use special
+# characters, you can't use some regular expressions and sub-expressions.
+ynh_replace_password_string () {
+	local match_string=$1
+	local replace_string=$2
+	local workfile=$3
+
         # Escape any backslash to preserve them as simple backslash.
         match_string=${match_string//\\/"\\\\"}
         replace_string=${replace_string//\\/"\\\\"}
@@ -34,9 +55,5 @@ ynh_replace_string () {
         match_string=${match_string//&/"\&"}
         replace_string=${replace_string//&/"\&"}
 
-	# Escape the delimiter if it's in the string.
-	match_string=${match_string//${delimit}/"\\${delimit}"}
-	replace_string=${replace_string//${delimit}/"\\${delimit}"}
-
-	sudo sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$workfile"
+	ynh_replace_string "$match_string" "$replace_string" "$workfile"
 }

--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -33,16 +33,16 @@ ynh_replace_string () {
 	sudo sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$workfile"
 }
 
-# Substitute/replace a password by another in a file
+# Substitute/replace a special string by another in a file
 #
-# usage: ynh_replace_password_string match_string replace_string target_file
+# usage: ynh_replace_special_string match_string replace_string target_file
 # | arg: match_string - String to be searched and replaced in the file
 # | arg: replace_string - String that will replace matches
 # | arg: target_file - File in which the string will be replaced.
 #
 # This helper will use ynh_replace_string, but as you can use special
 # characters, you can't use some regular expressions and sub-expressions.
-ynh_replace_password_string () {
+ynh_replace_special_string () {
 	local match_string=$1
 	local replace_string=$2
 	local workfile=$3


### PR DESCRIPTION
## Problem
- *The just released commit https://github.com/YunoHost/yunohost/commit/e3a4b307f7c307820c83afce9489f8a128ffb966 break ynh_replace_string if you want to use it with a some special sed characters.*
- *For example, you can't use &, or sub-expression. If you try `ynh_replace_string "\(string\)" "\1"`, the helper will change that into `s@\\(string\\)@\\1@`, which obviously doesn't work...*

## Solution
- *Remove those escapes from ynh_replace_string to restore a correct behavior.*
- *And add a new helper, `ynh_replace_password_string` which use ynh_replace_string, but escape all the potential problematics characters to allow password with special characters.*

This fix should be quickly merged in stable, because it affects most of the change_url scripts.