### PR TITLE
Fix security of nginx headers .

### DIFF
--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -39,7 +39,7 @@ server {
     
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
     add_header 'Referrer-Policy' 'same-origin';
-    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
+    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -38,7 +38,7 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
     
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+    add_header 'Referrer-Policy' 'same-origin';
     add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -36,8 +36,14 @@ server {
     # Uncomment the following directive after DH generation
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
-
-    add_header Strict-Transport-Security "max-age=31536000;";
+    
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
+    add_header 'Referrer-Policy' 'no-referrer';
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Download-Options noopen;
+    add_header X-Permitted-Cross-Domain-Policies none;
+    add_header X-Frame-Options "SAMEORIGIN";
 
     location / {
         return 302 https://$http_host/yunohost/admin;

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -37,6 +37,9 @@ server {
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
     
+    # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
+    # https://wiki.mozilla.org/Security/Guidelines/Web_Security
+    # https://observatory.mozilla.org/ 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
     add_header 'Referrer-Policy' 'same-origin';
     add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -38,7 +38,8 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
     
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header 'Referrer-Policy' 'no-referrer';
+    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -43,8 +43,7 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header 'Referrer-Policy' 'same-origin';
-    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
+    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -42,7 +42,12 @@ server {
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
-    add_header Strict-Transport-Security "max-age=31536000;";
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+    add_header 'Referrer-Policy' 'no-referrer';
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Permitted-Cross-Domain-Policies none;
+    add_header X-Frame-Options "SAMEORIGIN";
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -43,7 +43,7 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+    add_header 'Referrer-Policy' 'same-origin';
     add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -42,7 +42,7 @@ server {
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
     add_header 'Referrer-Policy' 'no-referrer';
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -42,6 +42,9 @@ server {
     # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
+    # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
+    # https://wiki.mozilla.org/Security/Guidelines/Web_Security
+    # https://observatory.mozilla.org/ 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
     add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -43,9 +43,11 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header 'Referrer-Policy' 'no-referrer';
+    add_header 'Referrer-Policy' 'origin-when-cross-origin';
+    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';report-uri /csp-violation-report-endpoint/";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
+    add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;
     add_header X-Frame-Options "SAMEORIGIN";
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -43,7 +43,7 @@ server {
     #ssl_dhparam /etc/ssl/private/dh2048.pem;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval';";
+    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;


### PR DESCRIPTION
# Problem

Security problems due to unsafe header : 
  - check : https://wiki.mozilla.org/Security/Guidelines/Web_Security
  - Test of the header : https://observatory.mozilla.org/ ; https://securityheaders.io/ ; https://hstspreload.org

# Solution

- Add preload to the HSTS header
- Add XSS protection (need CSP too)
- Add Referrer-Policy (need to be tesing for other applications) only in ADMIN conf.

# Improvement in future PR :

- Add OCSP Stapling
- Add HPKP-pining to SSL cert.
- Add referrer to server.tpl
- Improve CSP
- Add Report-URI header with proper PHP file in .well-known/report-uri/index.php 

# Status
Need to be testing.