### PR TITLE
[enh] Maintain ssh client connexion

### DIFF
--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -66,6 +66,9 @@ PrintLastLog yes
 TCPKeepAlive yes
 #UseLogin no
 
+# keep ssh sessions fresh
+ClientAliveInterval 60
+
 #MaxStartups 10:30:60
 Banner /etc/issue.net
 


### PR DESCRIPTION
## The problem 
In some nat configuration, inactive ssh connexion are killed by the router.

https://sysadmincasts.com/episodes/39-cli-monday-how-to-keep-your-ssh-sessions-alive

Relative Redmine ticket: https://dev.yunohost.org/issues/1039

## Solution
Add the `ClientAliveInterval 60` option to keep active all client ssh connexion.

It will avoid to get Broken Pipe or freeze in some cases.

Note: User can also define a client side config with the directive ServerAliveInterval, I have tested this one, and it works well.

## PR Status
Test needed

## Validation

- [x] Principle agreement 0/2 : 
- [x] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 



  