### PR TITLE
[enh] add commands to manage authorized-keys of users

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1337,6 +1337,74 @@ dyndns:
 
 
 #############################
+#            SSH            #
+#############################
+ssh:
+    category_help: Manage ssh keys and access
+    actions: {}
+    subcategories:
+        authorized-keys:
+            subcategory_help: Manage user's authorized ssh keys
+
+            actions:
+                ### ssh_authorized_keys_list()
+                list:
+                    action_help: Show user's authorized ssh keys
+                    api: GET /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### ssh_authorized_keys_add()
+                add:
+                    action_help: Add a new authorized ssh key for this user
+                    api: POST /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+                        -u:
+                            full: --public
+                            help: Public key
+                            extra:
+                                required: True
+                        -i:
+                            full: --private
+                            help: Private key
+                            extra:
+                                required: True
+                        -n:
+                            full: --name
+                            help: Key name
+                            extra:
+                                required: True
+
+                ### ssh_authorized_keys_remove()
+                remove:
+                    action_help: Remove an authorized ssh key for this user
+                    api: DELETE /ssh/authorized-keys
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+                        -k:
+                            full: --key
+                            help: Key as a string
+                            extra:
+                                required: True
+
+
+#############################
 #           Tools           #
 #############################
 tools:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -203,6 +203,30 @@ user:
                     extra:
                         pattern: *pattern_mailbox_quota
 
+        ### ssh_user_enable_ssh()
+        allow-ssh:
+            action_help: Allow the user to uses ssh
+            api: POST /ssh/user/enable-ssh
+            configuration:
+                authenticate: all
+            arguments:
+                username:
+                    help: Username of the user
+                    extra:
+                        pattern: *pattern_username
+
+        ### ssh_user_disable_ssh()
+        disallow-ssh:
+            action_help: Disallow the user to uses ssh
+            api: POST /ssh/user/disable-ssh
+            configuration:
+                authenticate: all
+            arguments:
+                username:
+                    help: Username of the user
+                    extra:
+                        pattern: *pattern_username
+
         ### user_info()
         info:
             action_help: Get user information

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -1,0 +1,102 @@
+# encoding: utf-8
+
+import os
+
+from moulinette.utils.filesystem import read_file, write_to_file, chown, chmod, mkdir
+
+from yunohost.user import _get_user_for_ssh
+
+
+def ssh_authorized_keys_list(auth, username):
+    user = _get_user_for_ssh(auth, username, ["homeDirectory"])
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    authorized_keys_file = os.path.join(user["homeDirectory"][0], ".ssh", "authorized_keys")
+
+    if not os.path.exists(authorized_keys_file):
+        return []
+
+    keys = []
+    last_comment = ""
+    for line in read_file(authorized_keys_file).split("\n"):
+        # empty line
+        if not line.strip():
+            continue
+
+        if line.lstrip().startswith("#"):
+            last_comment = line.lstrip().lstrip("#").strip()
+            continue
+
+        # assuming a key per non empty line
+        key = line.strip()
+        keys.append({
+            "key": key,
+            "name": last_comment,
+        })
+
+        last_comment = ""
+
+    return {"keys": keys}
+
+
+def ssh_authorized_keys_add(auth, username, key, comment):
+    user = _get_user_for_ssh(auth, username, ["homeDirectory", "uid"])
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    authorized_keys_file = os.path.join(user["homeDirectory"][0], ".ssh", "authorized_keys")
+
+    if not os.path.exists(authorized_keys_file):
+        # ensure ".ssh" exists
+        mkdir(os.path.join(user["homeDirectory"][0], ".ssh"),
+              force=True, parents=True, uid=user["uid"][0])
+
+        # create empty file to set good permissions
+        write_to_file(authorized_keys_file, "")
+        chown(authorized_keys_file, uid=user["uid"][0])
+        chmod(authorized_keys_file, 0600)
+
+    authorized_keys_content = read_file(authorized_keys_file)
+
+    authorized_keys_content += "\n"
+    authorized_keys_content += "\n"
+
+    if comment and comment.strip():
+        if not comment.lstrip().startswith("#"):
+            comment = "# " + comment
+        authorized_keys_content += comment.replace("\n", " ").strip()
+        authorized_keys_content += "\n"
+
+    authorized_keys_content += key.strip()
+    authorized_keys_content += "\n"
+
+    write_to_file(authorized_keys_file, authorized_keys_content)
+
+
+def ssh_authorized_keys_remove(auth, username, key):
+    user = _get_user(auth, username, ["homeDirectory", "uid"])
+    if not user:
+        raise Exception("User with username '%s' doesn't exists" % username)
+
+    authorized_keys_file = os.path.join(user["homeDirectory"][0], ".ssh", "authorized_keys")
+
+    if not os.path.exists(authorized_keys_file):
+        raise Exception("this key doesn't exists ({} dosesn't exists)".format(authorized_keys_file))
+
+    authorized_keys_content = read_file(authorized_keys_file)
+
+    if key not in authorized_keys_content:
+        raise Exception("Key '{}' is not present in authorized_keys".format(key))
+
+    # don't delete the previous comment because we can't verify if it's legit
+
+    # this regex approach failed for some reasons and I don't know why :(
+    # authorized_keys_content = re.sub("{} *\n?".format(key),
+    #                                  "",
+    #                                  authorized_keys_content,
+    #                                  flags=re.MULTILINE)
+
+    authorized_keys_content = authorized_keys_content.replace(key, "")
+
+    write_to_file(authorized_keys_file, authorized_keys_content)

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -57,6 +57,7 @@ def user_list(auth, fields=None):
         'cn': 'fullname',
         'mail': 'mail',
         'maildrop': 'mail-forward',
+        'loginShell': 'shell',
         'mailuserquota': 'mailbox-quota'
     }
 
@@ -72,7 +73,7 @@ def user_list(auth, fields=None):
                 raise MoulinetteError(errno.EINVAL,
                                       m18n.n('field_invalid', attr))
     else:
-        attrs = ['uid', 'cn', 'mail', 'mailuserquota']
+        attrs = ['uid', 'cn', 'mail', 'mailuserquota', 'loginShell']
 
     result = auth.search('ou=users,dc=yunohost,dc=org',
                          '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))',
@@ -82,6 +83,12 @@ def user_list(auth, fields=None):
         entry = {}
         for attr, values in user.items():
             if values:
+                if attr == "loginShell":
+                    if values[0].strip() == "/bin/false":
+                        entry["ssh_allowed"] = False
+                    else:
+                        entry["ssh_allowed"] = True
+
                 entry[user_attrs[attr]] = values[0]
 
         uid = entry[user_attrs['uid']]

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -25,6 +25,7 @@
 """
 import os
 import re
+import pwd
 import json
 import errno
 import crypt
@@ -435,6 +436,36 @@ def user_info(auth, username):
         raise MoulinetteError(167, m18n.n('user_info_failed'))
 
 
+def user_allow_ssh(auth, username):
+    """
+    Allow YunoHost user connect as ssh.
+
+    Keyword argument:
+        username -- User username
+    """
+    # TODO it would be good to support different kind of shells
+
+    if not _get_user_for_ssh(auth, username):
+        raise MoulinetteError(errno.EINVAL, m18n.n('user_unknown', user=username))
+
+    auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/bash'})
+
+
+def user_disallow_ssh(auth, username):
+    """
+    Disallow YunoHost user connect as ssh.
+
+    Keyword argument:
+        username -- User username
+    """
+    # TODO it would be good to support different kind of shells
+
+    if not _get_user_for_ssh(auth, username) :
+        raise MoulinetteError(errno.EINVAL, m18n.n('user_unknown', user=username))
+
+    auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/false'})
+
+
 def _convertSize(num, suffix=''):
     for unit in ['K', 'M', 'G', 'T', 'P', 'E', 'Z']:
         if abs(num) < 1024.0:
@@ -470,3 +501,28 @@ def _hash_user_password(password):
 
     salt = '$6$' + salt + '$'
     return '{CRYPT}' + crypt.crypt(str(password), salt)
+
+
+def _get_user_for_ssh(auth, username, attrs=None):
+    if username == "admin":
+        admin_unix = pwd.getpwnam("admin")
+        return {
+            'username': 'admin',
+            'fullname': '',
+            'mail': '',
+            'ssh_allowed': admin_unix.pw_shell.strip() != "/bin/false",
+            'shell': admin_unix.pw_shell,
+            'home_path': admin_unix.pw_dir,
+        }
+
+    # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html
+    user = auth.search('ou=users,dc=yunohost,dc=org',
+                       '(&(objectclass=person)(uid=%s))' % username,
+                       attrs)
+
+    assert len(user) in (0, 1)
+
+    if not user:
+        return None
+
+    return user[0]


### PR DESCRIPTION
Extracted from https://github.com/YunoHost/yunohost/pull/345  to allow smoother merging since this part made consensus.

You need to avoid reading the 2 first commits since they are coming from the previous PR.
  