### PR TITLE
new commands to display yunohost logs for the admin UI

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1462,6 +1462,23 @@ tools:
 
     subcategories:
 
+      yunohost-logs:
+          subcategory_help: Access YunoHost logs
+          actions:
+              ### tools_migrations_list()
+              list:
+                  action_help: List available YunoHost logs
+                  api: GET /yunohost-logs
+
+
+              ### tools_migrations_list()
+              display:
+                  action_help: Display log file content
+                  api: GET /migrations/<log>
+                  arguments:
+                      log:
+                          help: log file name
+
       migrations:
           subcategory_help: Manage migrations
           actions:

--- a/locales/en.json
+++ b/locales/en.json
@@ -353,5 +353,6 @@
     "yunohost_ca_creation_success": "The local certification authority has been created.",
     "yunohost_configured": "YunoHost has been configured",
     "yunohost_installing": "Installing YunoHost...",
+    "yunohost_log_file_doesnt_exist": "Log file '{log}' doesn't exist, available logs files are: {available_logs}",
     "yunohost_not_installed": "YunoHost is not or not correctly installed. Please execute 'yunohost tools postinstall'"
 }

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -28,6 +28,7 @@ import os
 import yaml
 import requests
 import json
+import gzip
 import errno
 import logging
 import subprocess
@@ -42,7 +43,7 @@ import apt.progress
 from moulinette import msettings, msignals, m18n
 from moulinette.core import MoulinetteError, init_authenticator
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_json, write_to_json
+from moulinette.utils.filesystem import read_json, write_to_json, read_file
 from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, app_list, _install_appslist_fetch_cron
 from yunohost.domain import domain_add, domain_list, get_public_ip, _get_maindomain, _set_maindomain
 from yunohost.dyndns import _dyndns_available, _dyndns_provides
@@ -854,6 +855,42 @@ def tools_shell(auth, command=None):
         vars.update(locals())
         shell = code.InteractiveConsole(vars)
         shell.interact()
+
+
+def tools_yunohost_logs_list():
+    """
+    List available YunoHost logs.
+    """
+
+    return {"logs": list(sorted(os.listdir("/var/log/yunohost")))}
+
+
+def tools_yunohost_logs_display(log):
+    """
+    List available YunoHost logs.
+    """
+
+    PATH_TO_LOGS = "/var/log/yunohost/"
+
+    logs = tools_yunohost_logs_list()["logs"]
+
+    if log in logs:
+        pass
+    elif log + ".log" in logs:
+        log += ".log"
+    elif log + ".gz" in logs:
+        log += ".gz"
+    else:
+        raise MoulinetteError(errno.EINVAL, m18n.n('yunohost_log_file_doesnt_exist', log=log, available_logs=", ".join(logs)))
+
+    log = os.path.join(PATH_TO_LOGS, log)
+
+    if log.endswith(".gz"):
+        content = gzip.open(log).read()
+    else:
+        content = read_file(log)
+
+    return content
 
 
 def _get_migrations_list():


### PR DESCRIPTION
## The problem 
Sometime we ask the users to look at YunoHost logs during a failure (this is an exception raised from moulinette core) but the user doesn't have access to those logs in the admin UI therefor he is blocked.

## Solution
Add new commands to expose logs to the API (and handle gunziping them).

In the future we'll be able to redirect the user to the correct page on the admin UI 

## PR Status
Tested and works as expected, this is ready for review and merge.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 