### PR TITLE
[enh] save the conf/ directory of app during installation and upgrade

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -621,9 +621,12 @@ def app_upgrade(auth, app=[], url=None, file=None):
             with open(app_setting_path + '/status.json', 'w+') as f:
                 json.dump(status, f)
 
-            # Replace scripts and manifest
-            os.system('rm -rf "%s/scripts" "%s/manifest.json"' % (app_setting_path, app_setting_path))
+            # Replace scripts and manifest and conf (if exists)
+            os.system('rm -rf "%s/scripts" "%s/manifest.json %/conf"' % (app_setting_path, app_setting_path, app_setting_path))
             os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
+
+            if os.path.exists(os.path.join(extracted_app_folder, "conf")):
+                os.system('cp -R %s/conf %s' % (extracted_app_folder, app_setting_path))
 
             # So much win
             upgraded_apps.append(app_instance_name)
@@ -732,6 +735,9 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     # Move scripts and manifest to the right place
     os.system('cp %s/manifest.json %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
+
+    if os.path.exists(os.path.join(extracted_app_folder, "conf")):
+        os.system('cp -R %s/conf %s' % (extracted_app_folder, app_setting_path))
 
     # Execute the app install script
     install_retcode = 1

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -622,7 +622,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
                 json.dump(status, f)
 
             # Replace scripts and manifest and conf (if exists)
-            os.system('rm -rf "%s/scripts" "%s/manifest.json %/conf"' % (app_setting_path, app_setting_path, app_setting_path))
+            os.system('rm -rf "%s/scripts" "%s/manifest.json %s/conf"' % (app_setting_path, app_setting_path, app_setting_path))
             os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
             if os.path.exists(os.path.join(extracted_app_folder, "conf")):


### PR DESCRIPTION
## The problem 
When install an application (or upgrading it), the "conf" folder is not saved which makes some operations quite hard to do, in particular the `change_url` one. This is a long time requested feature from the app group.

Redmine ticket https://dev.yunohost.org/issues/871

## Solution
Save it #lol

## PR Status
Personally tested, work as expected.

## Validation

- [x] Principle agreement 0/2 : JimboJoe
- [x] Quick review 0/1 : JimboJoe
- [x] Simple test 0/1 : JimboJoe
- [ ] Deep review 0/1 :
  