### PR TITLE
[fix] was replacing the dictionnary with a string and thus breaking everything

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -570,8 +570,8 @@ def tools_diagnosis(auth, private=False):
     else:
         diagnosis['system']['disks'] = {}
         for disk in disks:
-            if isinstance(disk, str):
-                diagnosis['system']['disks'] = disk
+            if isinstance(disks[disk], str):
+                diagnosis['system']['disks'][disk] = disks[disk]
             else:
                 diagnosis['system']['disks'][disk] = 'Mounted on %s, %s (%s free)' % (
                     disks[disk]['mnt_point'],


### PR DESCRIPTION
## The problem

When a disk was not available, the current code was replace the whole dictionnary with a string and the following commands failed.

As reported here https://dev.yunohost.org/issues/1023

For validation, this was the value of the various variable during his run:

```python
    print disks, disk, diagnosis['system']['disks']
    # yunohost tools diagnosis
    {'dm-1': 'not-available', u'sda2': {u'mnt_point': u'/home', u'used': '3.2GiB', u'percent': 0.7, 'avail': '435.4GiB', u'fs_type': u'ext4', u'size': '438.6GiB'}, u'sda1': {u'mnt_point': u'/', u'used': '16.0GiB', u'percent': 83.8, 'avail': '3.1GiB', u'fs_type': u'ext4', u'size': '19.1GiB'}} dm-1 {}
    {'dm-1': 'not-available', u'sda2': {u'mnt_point': u'/home', u'used': '3.2GiB', u'percent': 0.7, 'avail': '435.4GiB', u'fs_type': u'ext4', u'size': '438.6GiB'}, u'sda1': {u'mnt_point': u'/', u'used': '16.0GiB', u'percent': 83.8, 'avail': '3.1GiB', u'fs_type': u'ext4', u'size': '19.1GiB'}} sda2 dm-1
    Traceback (most recent call last):
      File "/usr/bin/yunohost", line 219, in <module>
        timeout=opts.timeout,
      File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 136, in cli
        moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
      File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 390, in run
        ret = self.actionsmap.process(args, timeout=timeout)
      File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 495, in process
        return func(**arguments)
      File "/usr/lib/moulinette/yunohost/tools.py", line 580, in tools_diagnosis
        disks[disk]['avail']
    TypeError: 'str' object does not support item assignment
```

## PR Status

I've test is with nicofrand and it work as expected.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
