### PR TITLE
[enh] display backports .deb in diagnosis

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -562,6 +562,8 @@ def tools_diagnosis(auth, private=False):
     # Packages version
     diagnosis['packages'] = ynh_packages_version()
 
+    diagnosis["backports"] = check_output("dpkg -l |awk '/^ii/ && $3 ~ /bpo[6-8]/ {print $2}'").split()
+
     # Server basic monitoring
     diagnosis['system'] = OrderedDict()
     try:


### PR DESCRIPTION
## The problem

Source: https://dev.yunohost.org/issues/694

Backport packages can easily breaks YunoHost, having this information in the diagnosis tool could help in some situations.

## PR Status

Work and tested.

## Validation

- [x] Principle agreement 0/2 : JimboJoe
- [x] Quick review 0/1 : JimboJoe
- [x] Simple test 0/1 : JimboJoe
- [ ] Deep review 0/1 : 