### PR TITLE
Package version stable testing unstable

### DIFF
--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -414,6 +414,8 @@ def get_installed_version(*pkgnames, **kwargs):
             if strict:
                 raise UnknownPackage(pkgname)
             logger.warning(m18n.n('package_unknown', pkgname=pkgname))
+            continue
+
         try:
             version = pkg.installed.version
         except AttributeError:

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -422,7 +422,21 @@ def get_installed_version(*pkgnames, **kwargs):
             if strict:
                 raise UninstalledPackage(pkgname)
             version = None
-        versions[pkgname] = version
+
+        try:
+            # stable, testing, unstable
+            repo = pkg.installed.origins[0].component
+        except AttributeError:
+            if strict:
+                raise UninstalledPackage(pkgname)
+            repo = ""
+
+        versions[pkgname] = {
+            "version": version,
+            # when we don't have component it's because it's from a local
+            # install or from an image (like in vagrant)
+            "repo": repo if repo else "local",
+        }
 
     if len(pkgnames) == 1 and not as_dict:
         return versions[pkgnames[0]]
@@ -438,6 +452,9 @@ def meets_version_specifier(pkgname, specifier):
 # YunoHost related methods ---------------------------------------------------
 
 def ynh_packages_version(*args, **kwargs):
+    # from cli the received arguments are:
+    # (Namespace(_callbacks=deque([]), _tid='_global', _to_return={}), []) {}
+    # they don't seems to serve any purpose
     """Return the version of each YunoHost package"""
     return get_installed_version(
         'yunohost', 'yunohost-admin', 'moulinette', 'ssowat',

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -454,7 +454,7 @@ def meets_version_specifier(pkgname, specifier):
 def ynh_packages_version(*args, **kwargs):
     # from cli the received arguments are:
     # (Namespace(_callbacks=deque([]), _tid='_global', _to_return={}), []) {}
-    # they don't seems to serve any purpose
+    # they don't seem to serve any purpose
     """Return the version of each YunoHost package"""
     return get_installed_version(
         'yunohost', 'yunohost-admin', 'moulinette', 'ssowat',


### PR DESCRIPTION
## The problem

We want to display if the installed version of YunoHost is from stable/testing/unstable on the admin internface. Solve this ticket https://dev.yunohost.org/issues/718

## Solution

Provide this information.

## PR Status

Tested and working. Admin code needs to be adapted.

## Validation

- [x] Principle agreement 0/2 : JimboJoe
- [x] Quick review 0/1 : JimboJoe
- [x] Simple test 0/1 : JimboJoe
- [ ] Deep review 0/1 : 

  
  