### PR TITLE
Fix comment lines in DNS zone example (using ";")

### DIFF
--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -188,17 +188,17 @@ def domain_dns_conf(domain, ttl=None):
 
     result = ""
 
-    result += "# Basic ipv4/ipv6 records"
+    result += "; Basic ipv4/ipv6 records"
     for record in dns_conf["basic"]:
         result += "\n{name} {ttl} IN {type} {value}".format(**record)
 
     result += "\n\n"
-    result += "# XMPP"
+    result += "; XMPP"
     for record in dns_conf["xmpp"]:
         result += "\n{name} {ttl} IN {type} {value}".format(**record)
 
     result += "\n\n"
-    result += "# Mail"
+    result += "; Mail"
     for record in dns_conf["mail"]:
         result += "\n{name} {ttl} IN {type} {value}".format(**record)
 


### PR DESCRIPTION
## The problem

If copy-pasted into a registrar zone file, the provided DNS zone sample for a given domain will fail on a DNS zone Syntax error.

## Solution

That is because comments lines in the ynh template start with "#".  However, comment character in DNS zone files is ";" not "#".

https://en.wikipedia.org/wiki/Zone_file

## PR Status

...


## Validation

- [x] Principle agreement 2/2 : alexAubin, JimboJoe
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

  
  