### PR TITLE
[fix] Broken symlink to the archives dir

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -101,7 +101,7 @@
     "backup_output_directory_forbidden": "Forbidden output directory. Backups can't be created in /bin, /boot, /dev, /etc, /lib, /root, /run, /sbin, /sys, /usr, /var or /home/yunohost.backup/archives sub-folders",
     "backup_output_directory_not_empty": "The output directory is not empty",
     "backup_output_directory_required": "You must provide an output directory for the backup",
-    "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}', may be you have a specific setup, to backup your data on an other filesystem, in this case you probably miss to remount or plug your hard dirve or usb key.",
+    "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}'. You may have a specific setup to backup your data on an other filesystem, in this case you probably miss to remount or plug your hard dirve or usb key.",
     "backup_running_app_script": "Running backup script of app '{app:s}'...",
     "backup_running_hooks": "Running backup hooks...",
     "backup_system_part_failed": "Unable to backup the '{part:s}' system part",

--- a/locales/en.json
+++ b/locales/en.json
@@ -101,7 +101,7 @@
     "backup_output_directory_forbidden": "Forbidden output directory. Backups can't be created in /bin, /boot, /dev, /etc, /lib, /root, /run, /sbin, /sys, /usr, /var or /home/yunohost.backup/archives sub-folders",
     "backup_output_directory_not_empty": "The output directory is not empty",
     "backup_output_directory_required": "You must provide an output directory for the backup",
-    "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}'. You may have a specific setup to backup your data on an other filesystem, in this case you probably miss to remount or plug your hard dirve or usb key.",
+    "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}'. You may have a specific setup to backup your data on an other filesystem, in this case you probably forgot to remount or plug your hard dirve or usb key.",
     "backup_running_app_script": "Running backup script of app '{app:s}'...",
     "backup_running_hooks": "Running backup hooks...",
     "backup_system_part_failed": "Unable to backup the '{part:s}' system part",

--- a/locales/en.json
+++ b/locales/en.json
@@ -101,6 +101,7 @@
     "backup_output_directory_forbidden": "Forbidden output directory. Backups can't be created in /bin, /boot, /dev, /etc, /lib, /root, /run, /sbin, /sys, /usr, /var or /home/yunohost.backup/archives sub-folders",
     "backup_output_directory_not_empty": "The output directory is not empty",
     "backup_output_directory_required": "You must provide an output directory for the backup",
+    "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}', may be you have a specific setup, to backup your data on an other filesystem, in this case you probably miss to remount or plug your hard dirve or usb key.",
     "backup_running_app_script": "Running backup script of app '{app:s}'...",
     "backup_running_hooks": "Running backup hooks...",
     "backup_system_part_failed": "Unable to backup the '{part:s}' system part",

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2300,7 +2300,7 @@ def backup_delete(name):
 
 def _create_archive_dir():
     """ Create the YunoHost archives directory if doesn't exist """
-    if not os.path.isdir(ARCHIVES_PATH):
+    if not os.path.isdir(ARCHIVES_PATH) and not os.path.islink(ARCHIVES_PATH):
         os.mkdir(ARCHIVES_PATH, 0750)
 
 

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2300,7 +2300,12 @@ def backup_delete(name):
 
 def _create_archive_dir():
     """ Create the YunoHost archives directory if doesn't exist """
-    if not os.path.isdir(ARCHIVES_PATH) and not os.path.islink(ARCHIVES_PATH):
+    if not os.path.isdir(ARCHIVES_PATH):
+        if os.path.lexists(ARCHIVES_PATH):
+            raise MoulinetteError(errno.EINVAL,
+                                  m18n.n('backup_output_symlink_dir_broken',
+                                         path=ARCHIVES_PATH))
+
         os.mkdir(ARCHIVES_PATH, 0750)
 
 


### PR DESCRIPTION
## The problem
Symlink /home/yunohost.backup/archives make the backup fails if they are broken, even if we use a custom backup methods...
See the error on https://dev.yunohost.org/issues/1044

## Solution
I suggest to warn the users who have made this kind of symlink like inthis howto https://forum.yunohost.org/t/backup-on-an-usb-key/1811

## PR Status
Tested on an arm yunohost

## Validation
Microdecision, but i would like the point of view of one of you (and a review of this english sentences)
- [ ] Principle agreement 0/1 : 

  
  
  
  