### PR TITLE
[enh] new command 'app change-label'

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -649,16 +649,16 @@ app:
 
         ### app_change_label()
         change-label:
-            action_help: Change an application label
+            action_help: Change app label
             api: PUT /apps/<app>/label
             configuration:
                 authenticate: all
                 authenticator: ldap-anonymous
             arguments:
                 app:
-                    help: the application id
+                    help: App ID
                 new_label:
-                    help: the new application label
+                    help: New app label
 
         ### app_addaccess() TODO: Write help
         addaccess:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -647,6 +647,19 @@ app:
                 authenticate: all
                 authenticator: ldap-anonymous
 
+        ### app_change_label()
+        change-label:
+            action_help: Change an application label
+            api: PUT /apps/<app>/label
+            configuration:
+                authenticate: all
+                authenticator: ldap-anonymous
+            arguments:
+                app:
+                    help: the application id
+                new_label:
+                    help: the new application label
+
         ### app_addaccess() TODO: Write help
         addaccess:
             action_help: Grant access right to users (everyone by default)

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1320,6 +1320,17 @@ def app_ssowatconf(auth):
     logger.success(m18n.n('ssowat_conf_generated'))
 
 
+def app_change_label(auth, app, new_label):
+    installed = _is_installed(app)
+    if not installed:
+        raise MoulinetteError(errno.ENOPKG,
+                              m18n.n('app_not_installed', app=app))
+
+    app_setting(app, "label", value=new_label)
+
+    app_ssowatconf(auth)
+
+
 def _get_app_settings(app_id):
     """
     Get settings of an installed app


### PR DESCRIPTION
## The problem

You can't change the label of an application in YunoHost once it's installed if you don't know how to play with the settings and regenerating ssowatconf. This is a long time requested feature and we got yet another ticket for that https://dev.yunohost.org/issues/1045

## Solution

Add a command for that and a new api entry point.

## PR Status

Tested and working.

## How to test

    yunohost app change-label $app_id $new_label

Then open the ssowat to see that the label has been updated.

## Validation

- [x] Principle agreement 0/2 : JimboJoe
- [x] Quick review 0/1 : JimboJoe
- [x] Simple test 0/1 : JimboJoe
- [ ] Deep review 0/1 : 
