### PR TITLE
Moar depreciation warning about checkurl

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,6 +14,7 @@
     "app_change_url_identical_domains": "The old and new domain/url_path are identical ('{domain:s}{path:s}'), nothing to do.",
     "app_change_url_no_script": "This application '{app_name:s}' doesn't support url modification yet. Maybe you should upgrade the application.",
     "app_change_url_success": "Successfully changed {app:s} url to {domain:s}{path:s}",
+    "app_checkurl_is_deprecated": "Packagers /!\ 'app checkurl' is deprecated ! Please use 'app register-url' instead !",
     "app_extraction_failed": "Unable to extract installation files",
     "app_id_invalid": "Invalid app id",
     "app_incompatible": "The app {app} is incompatible with your YunoHost version",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1149,6 +1149,9 @@ def app_checkurl(auth, url, app=None):
         app -- Write domain & path to app settings for further checks
 
     """
+
+    logger.warning(m18n.n("app_checkurl_is_deprecated"))
+
     from yunohost.domain import domain_list
 
     if "https://" == url[:8]:


### PR DESCRIPTION
## The problem

A lot of app still use `yunohost app checkurl`, but the depreciation warning doesn't really tell what else to use :/

## Solution

Try to incentivize packagers with a bigger and more explicit depreciation warning...

## PR Status

Not tested, just yolo-committed é_è

## How to test

Try to install an app that uses checkurl, see if the new message correctly shows up. 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
