### PR TITLE
[fix] Cron issue during custom backup

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1543,9 +1543,13 @@ class BackupMethod(object):
                 # Can create a hard link only if files are on the same fs
                 # (i.e. we can't if it's on a different fs)
                 if os.stat(src).st_dev == os.stat(dest_dir).st_dev:
-                    os.link(src, dest)
-                    # Success, go to next file to organize
-                    continue
+                    # Don't hardlink /etc/cron.d files to avoid cron bug
+                    # 'NUMBER OF HARD LINKS > 1' see #1043
+                    cron_path = os.path.abspath('/etc/cron') + '.'
+                    if not os.path.abspath(src).startswith(cron_path):
+                        os.link(src, dest)
+                        # Success, go to next file to organize
+                        continue
 
             # If mountbind or hardlink couldnt be created,
             # prepare a list of files that need to be copied


### PR DESCRIPTION
## The problem
My borg custom backup method uses the reorganize feature, it appears this feature conflict with a cron security limitation, because this feature creates hardlink on cronfile.

I have this in my /var/log/syslog

```
Jan  9 11:16:01 xxx cron[1132]: (*system*monitor) NUMBER OF HARD LINKS > 1 (/etc/cron.d/monitor)
```

## Solution
I suggest to check in the reorganize function if the file begin with '/etc/cron.' before to make the hardlink. This kind of file are very small so there is no performance loss.

## PR Status
I have tested the fix on a yunohost with borg method, it works.

## How to test
You can test by applying the remote borg tuto on the forum and with an application like nextcloud.
https://github.com/YunoHost-Apps/nextcloud_ynh/blob/testing/scripts/backup#L75

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
