### PR TITLE
[Fix] Fix ynh_restore_upgradebackup

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -64,7 +64,7 @@ ynh_backup_before_upgrade () {
 		echo "This app doesn't have any backup script." >&2
 		return
 	fi
-	local backup_number=1
+	backup_number=1
 	local old_backup_number=2
 	local app_bck=${app//_/-}	# Replace all '_' by '-'
 


### PR DESCRIPTION
## The problem
In case of failure during the upgrade, the function ynh_restore_upgradebackup will be used. But, because '$backup_number' is defined as local in ynh_backup_before_upgrade, this variable does not exist in ynh_restore_upgradebackup.
So the app is deleted...

## Solution

Define '$backup_number' as a standard variable.

## PR Status

Nice and kind ? :)
Or maybe not tested... :D

## How to test

Add a `false` somewhere in the upgrade script.

## Validation

- [ ] Principle agreement 1/2 : ljf
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 