### PR TITLE
[fix] Simplify get_public_ip

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -44,6 +44,7 @@ from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
 import yunohost.domain
+from yunohost.utils.network import get_public_ip
 
 from moulinette import m18n
 from yunohost.app import app_ssowatconf
@@ -809,7 +810,7 @@ def _backup_current_cert(domain):
 
 
 def _check_domain_is_ready_for_ACME(domain):
-    public_ip = yunohost.domain.get_public_ip()
+    public_ip = get_public_ip()
 
     # Check if IP from DNS matches public IP
     if not _dns_ip_match_public_ip(public_ip, domain):
@@ -856,14 +857,9 @@ def _regen_dnsmasq_if_needed():
     """
     Update the dnsmasq conf if some IPs are not up to date...
     """
-    try:
-        ipv4 = yunohost.domain.get_public_ip()
-    except:
-        ipv4 = None
-    try:
-        ipv6 = yunohost.domain.get_public_ip(6)
-    except:
-        ipv6 = None
+
+    ipv4 = get_public_ip()
+    ipv6 = get_public_ip(6)
 
     do_regen = False
 

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -37,6 +37,7 @@ from moulinette.utils.log import getActionLogger
 import yunohost.certificate
 
 from yunohost.service import service_regen_conf
+from yunohost.utils.network import get_public_ip
 
 logger = getActionLogger('yunohost.domain')
 
@@ -318,15 +319,8 @@ def _build_dns_conf(domain, ttl=3600):
     }
     """
 
-    try:
-        ipv4 = get_public_ip()
-    except:
-        ipv4 = None
-
-    try:
-        ipv6 = get_public_ip(6)
-    except:
-        ipv6 = None
+    ipv4 = get_public_ip()
+    ipv6 = get_public_ip(6)
 
     basic = []
 

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -30,8 +30,6 @@ import yaml
 import errno
 import requests
 
-from urllib import urlopen
-
 from moulinette import m18n, msettings
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
@@ -258,42 +256,6 @@ def domain_url_available(auth, domain, path):
                 break
 
     return available
-
-
-def get_public_ip(protocol=4):
-    """Retrieve the public IP address from ip.yunohost.org"""
-    if protocol == 4:
-        url = 'https://ip.yunohost.org'
-    elif protocol == 6:
-        url = 'https://ip6.yunohost.org'
-    else:
-        raise ValueError("invalid protocol version")
-
-    try:
-        return urlopen(url).read().strip()
-    except IOError:
-        logger.debug('cannot retrieve public IPv%d' % protocol, exc_info=1)
-        raise MoulinetteError(errno.ENETUNREACH,
-                              m18n.n('no_internet_connection'))
-
-def get_public_ips():
-    """
-    Retrieve the public IPv4 and v6 from ip. and ip6.yunohost.org
-
-    Returns a 2-tuple (ipv4, ipv6). ipv4 or ipv6 can be None if they were not
-    found.
-    """
-
-    try:
-        ipv4 = get_public_ip()
-    except:
-        ipv4 = None
-    try:
-        ipv6 = get_public_ip(6)
-    except:
-        ipv6 = None
-
-    return (ipv4, ipv6)
 
 
 def _get_maindomain():

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -40,7 +40,7 @@ from moulinette.utils.filesystem import read_file, write_to_file, rm
 from moulinette.utils.network import download_json
 
 from yunohost.domain import _get_maindomain, _build_dns_conf
-from yunohost.utils.network import get_public_ips
+from yunohost.utils.network import get_public_ip
 
 logger = getActionLogger('yunohost.dyndns')
 
@@ -194,7 +194,8 @@ def dyndns_update(dyn_host="dyndns.yunohost.org", domain=None, key=None,
         old_ipv6 = read_file(OLD_IPV6_FILE).rstrip()
 
     # Get current IPv4 and IPv6
-    (ipv4_, ipv6_) = get_public_ips()
+    ipv4_ = get_public_ip()
+    ipv6_ = get_public_ip(6)
 
     if ipv4 is None:
         ipv4 = ipv4_

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -39,7 +39,8 @@ from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import read_file, write_to_file, rm
 from moulinette.utils.network import download_json
 
-from yunohost.domain import get_public_ips, _get_maindomain, _build_dns_conf
+from yunohost.domain import _get_maindomain, _build_dns_conf
+from yunohost.utils.network import get_public_ips
 
 logger = getActionLogger('yunohost.dyndns')
 

--- a/src/yunohost/monitor.py
+++ b/src/yunohost/monitor.py
@@ -41,7 +41,8 @@ from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
-from yunohost.domain import get_public_ip, _get_maindomain
+from yunohost.utils.network import get_public_ip
+from yunohost.domain import _get_maindomain
 
 logger = getActionLogger('yunohost.monitor')
 
@@ -210,10 +211,7 @@ def monitor_network(units=None, human_readable=False):
                 else:
                     logger.debug('interface name %s was not found', iname)
         elif u == 'infos':
-            try:
-                p_ipv4 = get_public_ip()
-            except:
-                p_ipv4 = 'unknown'
+            p_ipv4 = get_public_ip() or 'unknown'
 
             l_ip = 'unknown'
             for name, addrs in devices.items():

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -45,12 +45,13 @@ from moulinette.utils.log import getActionLogger
 from moulinette.utils.process import check_output
 from moulinette.utils.filesystem import read_json, write_to_json
 from yunohost.app import app_fetchlist, app_info, app_upgrade, app_ssowatconf, app_list, _install_appslist_fetch_cron
-from yunohost.domain import domain_add, domain_list, get_public_ip, _get_maindomain, _set_maindomain
+from yunohost.domain import domain_add, domain_list, _get_maindomain, _set_maindomain
 from yunohost.dyndns import _dyndns_available, _dyndns_provides
 from yunohost.firewall import firewall_upnp
 from yunohost.service import service_status, service_regen_conf, service_log, service_start, service_enable
 from yunohost.monitor import monitor_disk, monitor_system
 from yunohost.utils.packages import ynh_packages_version
+from yunohost.utils.network import get_public_ip
 
 # FIXME this is a duplicate from apps.py
 APPS_SETTING_PATH = '/etc/yunohost/apps/'
@@ -621,16 +622,11 @@ def tools_diagnosis(auth, private=False):
     # Private data
     if private:
         diagnosis['private'] = OrderedDict()
+
         # Public IP
         diagnosis['private']['public_ip'] = {}
-        try:
-            diagnosis['private']['public_ip']['IPv4'] = get_public_ip(4)
-        except MoulinetteError as e:
-            pass
-        try:
-            diagnosis['private']['public_ip']['IPv6'] = get_public_ip(6)
-        except MoulinetteError as e:
-            pass
+        diagnosis['private']['public_ip']['IPv4'] = get_public_ip(4)
+        diagnosis['private']['public_ip']['IPv6'] = get_public_ip(6)
 
         # Domains
         diagnosis['private']['domains'] = domain_list(auth)['domains']

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -2,7 +2,7 @@
 
 """ License
 
-    Copyright (C) 2015 YUNOHOST.ORG
+    Copyright (C) 2017 YUNOHOST.ORG
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -37,4 +37,3 @@ def get_public_ip(protocol=4):
         return urlopen(url).read().strip()
     except IOError:
         return None
-

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+""" License
+
+    Copyright (C) 2015 YUNOHOST.ORG
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program; if not, see http://www.gnu.org/licenses
+
+"""
+import logging
+from urllib import urlopen
+
+logger = logging.getLogger('yunohost.utils.network')
+
+def get_public_ip(protocol=4):
+    """Retrieve the public IP address from ip.yunohost.org"""
+
+    if protocol == 4:
+        url = 'https://ip.yunohost.org'
+    elif protocol == 6:
+        url = 'https://ip6.yunohost.org'
+    else:
+        raise ValueError("invalid protocol version")
+
+    try:
+        return urlopen(url).read().strip()
+    except IOError:
+        return None
+
+
+def get_public_ips():
+
+    ipv4 = get_public_ip()
+    ipv6 = get_public_ip(6)
+
+    return (ipv4, ipv6)
+

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -38,11 +38,3 @@ def get_public_ip(protocol=4):
     except IOError:
         return None
 
-
-def get_public_ips():
-
-    ipv4 = get_public_ip()
-    ipv6 = get_public_ip(6)
-
-    return (ipv4, ipv6)
-


### PR DESCRIPTION
## The problem

Currently, `get_public_ip(6)` display a dirty traceback and confusing error message for instance when running `dyndns update` with no IPv6 sat up. This repeatedly confused user when debugging some nohost.me/noho.st situations, because it appeared to them that something was broken - when in fact it's just that they did not have IPv6, which is fine.

Also we use `get_public_ip` in many places, but always have to do a `try/except` to keep 'None' (or similar value) in the exception.

## Solution

Just return `None` if no ip was found. Also, move `get_public_ip` to a dedicated 'util' file instead of having it in domain.py leading to weird imports.

## PR Status

Not fully tested, so still kinda WIP

## How to test

Check all occurrences of `get_public_ip` are still working properly.

## Validation

- [x] Principle agreement 0/2 : 
- [x] Quick review 0/1 : 
- [x] Simple test 0/1 : 
- [x] Deep review 0/1 : 
