### PR TITLE
Add service name as arg (optionnal) in helper systemd

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -64,13 +64,13 @@ ynh_remove_logrotate () {
 
 # Create a dedicated systemd config
 #
-# usage: ynh_add_systemd_config [Service name] [Source file]
-# | arg: Service name
-# | arg: Systemd source file (for example appname.service)
+# usage: ynh_add_systemd_config [Service name] [Template name]
+# | arg: Service name (optionnal, $app by default)
+# | arg: Name of template file (optionnal, this is 'systemd' by default, meaning ./conf/systemd.service will be used as template)
 #
-# This will use a template in ../conf/systemd.service
-# and will replace the following keywords with 
-# global variables that should be defined before calling
+# This will use the template ../conf/<templatename>.service
+# to generate a systemd config, by replacing the following keywords
+# with global variables that should be defined before calling
 # this helper :
 #
 #   __APP__       by  $app
@@ -102,7 +102,7 @@ ynh_add_systemd_config () {
 # Remove the dedicated systemd config
 #
 # usage: ynh_remove_systemd_config [Service name]
-# | arg: Service name
+# | arg: Service name (optionnal, $app by default)
 #
 # usage: ynh_remove_systemd_config
 ynh_remove_systemd_config () {

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -64,6 +64,10 @@ ynh_remove_logrotate () {
 
 # Create a dedicated systemd config
 #
+# usage: ynh_add_systemd_config [Service name] [Source file]
+# | arg: Service name
+# | arg: Systemd source file (for example appname.service)
+#
 # This will use a template in ../conf/systemd.service
 # and will replace the following keywords with 
 # global variables that should be defined before calling
@@ -74,9 +78,11 @@ ynh_remove_logrotate () {
 #
 # usage: ynh_add_systemd_config
 ynh_add_systemd_config () {
-	finalsystemdconf="/etc/systemd/system/$app.service"
+	local service_name="${1:-$app}"
+
+	finalsystemdconf="/etc/systemd/system/$service_name.service"
 	ynh_backup_if_checksum_is_different "$finalsystemdconf"
-	sudo cp ../conf/systemd.service "$finalsystemdconf"
+	sudo cp ../conf/${2:-systemd.service} "$finalsystemdconf"
 
 	# To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
 	# Substitute in a nginx config file only if the variable is not empty
@@ -89,19 +95,25 @@ ynh_add_systemd_config () {
 	ynh_store_file_checksum "$finalsystemdconf"
 
 	sudo chown root: "$finalsystemdconf"
-	sudo systemctl enable $app
+	sudo systemctl enable $service_name
 	sudo systemctl daemon-reload
 }
 
 # Remove the dedicated systemd config
 #
+# usage: ynh_remove_systemd_config [Service name]
+# | arg: Service name
+#
 # usage: ynh_remove_systemd_config
 ynh_remove_systemd_config () {
-	local finalsystemdconf="/etc/systemd/system/$app.service"
+	local service_name="${1:-$app}"
+
+	local finalsystemdconf="/etc/systemd/system/$service_name.service"
 	if [ -e "$finalsystemdconf" ]; then
-		sudo systemctl stop $app
-		sudo systemctl disable $app
+		sudo systemctl stop $service_name
+		sudo systemctl disable $service_name
 		ynh_secure_remove "$finalsystemdconf"
+		sudo systemctl daemon-reload
 	fi
 }
 


### PR DESCRIPTION
## The problem

Actually we can't use the helper `ynh_add_systemd_config` and `ynh_remove_systemd_config` with a custom service name. We have actually this problem with synapse how have two systemd service per instance.

## Solution

Create an argument of these both function (as optional) wich give an argument. And create a second argument witch give the name of the service file in the conf directory because actually the service filename is hardcoded `systemd.service`.

## How to test

#### Check without argument
- Checkout this branch
- Clone an app locally witch use this helper
- Run the script install and remove with --verbose

 #### Check with arguement

- You can try the synapse app with the testing branch (https://github.com/YunoHost-Apps/synapse_ynh/tree/testing), it use this new helper.

## Validation

- [x] Principle agreement 2/2 : Maniack C
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [x] Deep review 1/1 : Maniack C
