### PR TITLE
[enh] Make etckeeper stfu

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -53,6 +53,9 @@ do_pre_regen() {
   else
       sudo cp services.yml /etc/yunohost/services.yml
   fi
+
+  mkdir -p "$pending_dir"/etc/etckeeper/
+  cp etckeeper.conf "$pending_dir"/etc/etckeeper/
 }
 
 _update_services() {

--- a/data/templates/yunohost/etckeeper.conf
+++ b/data/templates/yunohost/etckeeper.conf
@@ -1,0 +1,43 @@
+# The VCS to use.
+#VCS="hg"
+VCS="git"
+#VCS="bzr"
+#VCS="darcs"
+
+# Options passed to git commit when run by etckeeper.
+GIT_COMMIT_OPTIONS="--quiet"
+
+# Options passed to hg commit when run by etckeeper.
+HG_COMMIT_OPTIONS=""
+
+# Options passed to bzr commit when run by etckeeper.
+BZR_COMMIT_OPTIONS=""
+
+# Options passed to darcs record when run by etckeeper.
+DARCS_COMMIT_OPTIONS="-a"
+
+# Uncomment to avoid etckeeper committing existing changes
+# to /etc automatically once per day.
+#AVOID_DAILY_AUTOCOMMITS=1
+
+# Uncomment the following to avoid special file warning
+# (the option is enabled automatically by cronjob regardless).
+#AVOID_SPECIAL_FILE_WARNING=1
+
+# Uncomment to avoid etckeeper committing existing changes to 
+# /etc before installation. It will cancel the installation,
+# so you can commit the changes by hand.
+#AVOID_COMMIT_BEFORE_INSTALL=1
+
+# The high-level package manager that's being used.
+# (apt, pacman-g2, yum, zypper etc)
+HIGHLEVEL_PACKAGE_MANAGER=apt
+
+# The low-level package manager that's being used.
+# (dpkg, rpm, pacman, pacman-g2, etc)
+LOWLEVEL_PACKAGE_MANAGER=dpkg
+
+# To push each commit to a remote, put the name of the remote here.
+# (eg, "origin" for git). Space-separated lists of multiple remotes
+# also work (eg, "origin gitlab github" for git).
+PUSH_REMOTE=""


### PR DESCRIPTION
## The problem

c.f. https://dev.yunohost.org/issues/996

etckeeper regularly dumps a shitload of message, for instance when running `apt-get upgrade` and some new files were added to `/etc/`. Sometimes it's like hundreds of line of /etc/certificate stuff which basically nobody cares about and hide the real `apt-get` log.

## Solution

Add `--quiet` to etckeeper.conf. Since it's not really a service and it's just a static file, I put that in the yunohost regen-conf hook which already handle files like the services.yml. Not sure if that's the right solution in terms of design. I guess we can also just add a 'etckeeper' hook easily if needed.

## PR Status

Should be working

## How to test

Checkout this branch. Try to trigger the etckeeper thing, by creating a file like `/etc/foobar`, then run something like an `apt-get upgrade`.


## Validation

- [x] Principle agreement 2/2 : Bram, ljf
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [x] Deep review 1/1 :  ljf
