### PR TITLE
Add access to conf folder when executing change_url script

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -485,6 +485,12 @@ def app_change_url(auth, app, domain, path):
     shutil.copytree(os.path.join(APPS_SETTING_PATH, app, "scripts"),
                     os.path.join(APP_TMP_FOLDER, "scripts"))
 
+    if os.path.exists(os.path.join(APP_TMP_FOLDER, "conf")):
+        shutil.rmtree(os.path.join(APP_TMP_FOLDER, "conf"))
+
+    shutil.copytree(os.path.join(APPS_SETTING_PATH, app, "conf"),
+                    os.path.join(APP_TMP_FOLDER, "conf"))
+
     # Execute App change_url script
     os.system('chown -R admin: %s' % INSTALL_TMP)
     os.system('chmod +x %s' % os.path.join(os.path.join(APP_TMP_FOLDER, "scripts")))


### PR DESCRIPTION
## The problem
Conf folder is now saved on YunoHost when installing, thanks to https://github.com/YunoHost/yunohost/pull/407, but it is not available when using the `change_url` script... which was the main motivation to save the conf folder 😢 .
Thanks to @Josue-T for [pointing out the exact problem](https://github.com/YunoHost/example_ynh/pull/45#issuecomment-360219642) 😉 

## Solution
Here is a proposal to make the conf folder available to the `change_url` script : it is executed in a temporary folder, in which we need to copy the conf folder the same way we copy the scripts folder.

## PR Status
Ready to be reviewed.

## How to test
Can be tested with wallabag2 application, for which I committed [this change](https://github.com/YunoHost-Apps/wallabag2_ynh/commit/2314b9b32a78). You can see here that it looks much more maintainable now 😉 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
