### PR TITLE
[Fix] Stronger match for acme-challenge nginx location

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -463,7 +463,7 @@ def _configure_for_acme_challenge(auth, domain):
     nginx_conf_file = "%s/000-acmechallenge.conf" % nginx_conf_folder
 
     nginx_configuration = '''
-location '/.well-known/acme-challenge'
+location ^~ '/.well-known/acme-challenge'
 {
         default_type "text/plain";
         alias %s;


### PR DESCRIPTION
## The problem

If an application (for instance roundcube) installed at the root of a
subdomain has the following nginx configuration:

	location ~ ^/(.+/|)\. {
		deny all;
	}

acme-challenge matching location:

	location '/.well-known/acme-challenge'
	{
		default_type "text/plain";
		alias /tmp/acme-challenge-public/;
	}

will not be used.

## Solution

After acme-challenge match, prevent further matching by regular expressions.

## PR Status


## How to test

Create a subdomain.
Install roundcube on the subdomain.
Try to generate a lets encrypt certificate.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 