### PR TITLE
[enh] --verbose for backup during upgrade

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -44,7 +44,7 @@ ynh_restore_upgradebackup () {
 		# Remove the application then restore it
 		sudo yunohost app remove $app
 		# Restore the backup
-		sudo yunohost backup restore --ignore-system $app_bck-pre-upgrade$backup_number --apps $app --force
+		sudo yunohost backup restore --ignore-system $app_bck-pre-upgrade$backup_number --apps $app --force --verbose
 		ynh_die "The app was restored to the way it was before the failed upgrade."
 	fi
 }
@@ -77,7 +77,7 @@ ynh_backup_before_upgrade () {
 	fi
 
 	# Create backup
-	sudo yunohost backup create --ignore-system --apps $app --name $app_bck-pre-upgrade$backup_number
+	sudo yunohost backup create --ignore-system --apps $app --name $app_bck-pre-upgrade$backup_number --verbose
 	if [ "$?" -eq 0 ]
 	then
 		# If the backup succeeded, remove the previous backup


### PR DESCRIPTION
## The problem

In case of usage of --verbose during upgrade, neither backup or restore will print their log.

## Solution

Add --verbose to the backup and restore commands.

## PR Status

Tested, ready to review.

## How to test

Add a `false` at the end of an upgrade script.
And add `--verbose` to your upgrade.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
