### PR TITLE
[fix] [critical] Fail2ban conf/filter was not matching failed login attempts...

### DIFF
--- a/data/templates/fail2ban/jail.conf
+++ b/data/templates/fail2ban/jail.conf
@@ -581,5 +581,6 @@ enabled  = true
 port     = http,https
 protocol = tcp
 filter   = yunohost
-logpath  = /var/log/nginx*/*error.log
+logpath  = /var/log/nginx/*error.log
+           /var/log/nginx/*access.log
 maxretry = 6

--- a/data/templates/fail2ban/yunohost.conf
+++ b/data/templates/fail2ban/yunohost.conf
@@ -14,8 +14,8 @@
 #          (?:::f{4,6}:)?(?P<host>[\w\-.^_]+)
 # Values:  TEXT
 #
-failregex = helpers.lua:[1-9]+: authenticate\(\): Connection failed for: .*, client: <HOST>
-            ^<HOST> -.*\"POST /yunohost/api/login HTTP/1.1\" 401 22
+failregex = helpers.lua:[0-9]+: authenticate\(\): Connection failed for: .*, client: <HOST>
+            ^<HOST> -.*\"POST /yunohost/api/login HTTP/1.1\" 401
 
 # Option:  ignoreregex
 # Notes.:  regex to ignore. If this regex matches, the line is ignored.


### PR DESCRIPTION
## The problem

After somebody made some brute force tests on the forum, it appeared that it wasn't working. I was able to reproduce the issue, both for the SSO and the webadmin ...  Turns out we had 3 different issues in the conf.

In the meantime, :warning:  **brute force protection on the SSO and webadmin is broken on many machines** :warning:

## Solution

- Also parse the <domain>-access.log (this is where webadmin failed login attempts are logged)
- For failed webadmin login attempt, we should not parse the "22" after the "401" ... Apparently this number refers to the number of bytes sent, but thing is, on my machine it was "16".
- There was a mistake in the regex to parse login attempts on the SSO (line numbers are `[0-9]+`, not `[1-9]+`

## PR Status

Should be working, read for review. Would be nice if some people could test this on their machines...

## How to test

Pull this branch, and try to brute-force your SSO or webadmin. If you don't want to be banned from your own server, use a proxy. Or connect in SSH before doing so, then you can unban yourself with this procedure : https://serverfault.com/questions/285256/how-to-unban-an-ip-properly-with-fail2ban

## Validation

- [x] Principle agreement 0/2 : JimboJoe
- [x] Quick review 0/1 : JimboJoe
- [x] Simple test 0/1 : JimboJoe
- [ ] Deep review 0/1 : 
