### PR TITLE
[fix] Remove warning from equivs

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -97,6 +97,10 @@ ynh_package_install_from_equivs () {
 
     # Build and install the package
     local TMPDIR=$(mktemp -d)
+
+    # Force the compatibility level at 10, levels below are deprecated 
+    echo 10 > /usr/share/equivs/template/debian/compat
+
     # Note that the cd executes into a sub shell
     # Create a fake deb package with equivs-build and the given control file
     # Install the fake package without its dependencies with dpkg


### PR DESCRIPTION
## The problem

equivs-build prints 3 warnings:
```
dh_install: Compatibility levels before 9 are deprecated (level 7 in use)
dh_installdocs: Compatibility levels before 9 are deprecated (level 7 in use)                       
dh_installdeb: Compatibility levels before 9 are deprecated (level 7 in use)
```

## Solution

Fix the compatibility level at 10 in the compat file used by equivs-build

## PR Status

Tested on stretch and jessie.

## How to test

Install an app, like piwigo or nextcloud.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 