### PR TITLE
Add wget as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , python-psutil, python-requests, python-dnspython, python-openssl
  , python-apt, python-miniupnpc
  , glances
- , dnsutils, bind9utils, unzip, git, curl, cron
+ , dnsutils, bind9utils, unzip, git, curl, cron, wget
  , ca-certificates, netcat-openbsd, iproute
  , mariadb-server | mysql-server, php5-mysql | php5-mysqlnd
  , slapd, ldap-utils, sudo-ldap, libnss-ldapd, nscd


### PR DESCRIPTION
## The problem

It seems wget is not in dependency but we use it with ynh_setup_source ... 

## Solution

Add wget in the dependency.

## PR Status

Untested but very simple

## Validation
I think it's a micro decision so I will just wait if someone want to say something and next merge