### PR TITLE
Move ssh commands into a subcategory of 'user' + fix a few bugs

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -203,30 +203,6 @@ user:
                     extra:
                         pattern: *pattern_mailbox_quota
 
-        ### ssh_user_enable_ssh()
-        allow-ssh:
-            action_help: Allow the user to uses ssh
-            api: POST /ssh/user/enable-ssh
-            configuration:
-                authenticate: all
-            arguments:
-                username:
-                    help: Username of the user
-                    extra:
-                        pattern: *pattern_username
-
-        ### ssh_user_disable_ssh()
-        disallow-ssh:
-            action_help: Disallow the user to uses ssh
-            api: POST /ssh/user/disable-ssh
-            configuration:
-                authenticate: all
-            arguments:
-                username:
-                    help: Username of the user
-                    extra:
-                        pattern: *pattern_username
-
         ### user_info()
         info:
             action_help: Get user information
@@ -237,6 +213,91 @@ user:
             arguments:
                 username:
                     help: Username or email to get information
+
+    subcategories:
+
+        ssh:
+            subcategory_help: Manage ssh access
+            actions:
+                ### user_ssh_enable()
+                allow:
+                    action_help: Allow the user to uses ssh
+                    api: POST /users/ssh/enable
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_ssh_disable()
+                disallow:
+                    action_help: Disallow the user to uses ssh
+                    api: POST /users/ssh/disable
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_ssh_keys_list()
+                list-keys:
+                    action_help: Show user's authorized ssh keys
+                    api: GET /users/ssh/keys
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_ssh_keys_add()
+                add-key:
+                    action_help: Add a new authorized ssh key for this user
+                    api: POST /users/ssh/key
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+                        -u:
+                            full: --public
+                            help: Public key
+                            extra:
+                                required: True
+                        -i:
+                            full: --private
+                            help: Private key
+                            extra:
+                                required: True
+                        -n:
+                            full: --name
+                            help: Key name
+                            extra:
+                                required: True
+
+                ### user_ssh_keys_remove()
+                remove-key:
+                    action_help: Remove an authorized ssh key for this user
+                    api: DELETE /users/ssh/key
+                    configuration:
+                        authenticate: all
+                    arguments:
+                        username:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+                        -k:
+                            full: --key
+                            help: Key as a string
+                            extra:
+                                required: True
 
 
 #############################
@@ -1347,74 +1408,6 @@ dyndns:
         removecron:
             action_help: Remove IP update cron
             api: DELETE /dyndns/cron
-
-
-#############################
-#            SSH            #
-#############################
-ssh:
-    category_help: Manage ssh keys and access
-    actions: {}
-    subcategories:
-        authorized-keys:
-            subcategory_help: Manage user's authorized ssh keys
-
-            actions:
-                ### ssh_authorized_keys_list()
-                list:
-                    action_help: Show user's authorized ssh keys
-                    api: GET /ssh/authorized-keys
-                    configuration:
-                        authenticate: all
-                    arguments:
-                        username:
-                            help: Username of the user
-                            extra:
-                                pattern: *pattern_username
-
-                ### ssh_authorized_keys_add()
-                add:
-                    action_help: Add a new authorized ssh key for this user
-                    api: POST /ssh/authorized-keys
-                    configuration:
-                        authenticate: all
-                    arguments:
-                        username:
-                            help: Username of the user
-                            extra:
-                                pattern: *pattern_username
-                        -u:
-                            full: --public
-                            help: Public key
-                            extra:
-                                required: True
-                        -i:
-                            full: --private
-                            help: Private key
-                            extra:
-                                required: True
-                        -n:
-                            full: --name
-                            help: Key name
-                            extra:
-                                required: True
-
-                ### ssh_authorized_keys_remove()
-                remove:
-                    action_help: Remove an authorized ssh key for this user
-                    api: DELETE /ssh/authorized-keys
-                    configuration:
-                        authenticate: all
-                    arguments:
-                        username:
-                            help: Username of the user
-                            extra:
-                                pattern: *pattern_username
-                        -k:
-                            full: --key
-                            help: Key as a string
-                            extra:
-                                required: True
 
 
 #############################

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -266,21 +266,11 @@ user:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
-                        -u:
-                            full: --public
-                            help: Public key
-                            extra:
-                                required: True
-                        -i:
-                            full: --private
-                            help: Private key
-                            extra:
-                                required: True
-                        -n:
-                            full: --name
-                            help: Key name
-                            extra:
-                                required: True
+                        key:
+                            help: The key to be added
+                        -c:
+                            full: --comment
+                            help: Optionnal comment about the key
 
                 ### user_ssh_keys_remove()
                 remove-key:
@@ -293,11 +283,8 @@ user:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
-                        -k:
-                            full: --key
-                            help: Key as a string
-                            extra:
-                                required: True
+                        key:
+                            help: The key to be removed
 
 
 #############################

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -4,6 +4,7 @@ import re
 import os
 import errno
 import pwd
+import subprocess
 
 from moulinette import m18n
 from moulinette.core import MoulinetteError
@@ -26,6 +27,10 @@ def user_ssh_allow(auth, username):
 
     auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/bash'})
 
+    # Somehow this is needed otherwise the PAM thing doesn't forget about the
+    # old loginShell value ?
+    subprocess.call(['nscd', '-i', 'passwd'])
+
 
 def user_ssh_disallow(auth, username):
     """
@@ -40,6 +45,10 @@ def user_ssh_disallow(auth, username):
         raise MoulinetteError(errno.EINVAL, m18n.n('user_unknown', user=username))
 
     auth.update('uid=%s,ou=users' % username, {'loginShell': '/bin/false'})
+
+    # Somehow this is needed otherwise the PAM thing doesn't forget about the
+    # old loginShell value ?
+    subprocess.call(['nscd', '-i', 'passwd'])
 
 
 def user_ssh_list_keys(auth, username):

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -59,7 +59,7 @@ def user_ssh_list_keys(auth, username):
     authorized_keys_file = os.path.join(user["homeDirectory"][0], ".ssh", "authorized_keys")
 
     if not os.path.exists(authorized_keys_file):
-        return []
+        return {"keys": []}
 
     keys = []
     last_comment = ""


### PR DESCRIPTION
## The problem

Currently the commands to manipulate ssh keys and allow/disallow are split into two separate things, which imho doesn't make sense in terms of UX...

(Also found a few bugs related to SSH in the process...)

## Solution

Move all SSH operations into a sucategory of 'user', such that we get : 

```
# yunohost user ssh --help
usage: yunohost user ssh {allow,disallow,list-keys,add-key,remove-key} ...
                         [-h]

Manage ssh access

optional arguments:
  -h, --help            show this help message and exit

actions:
  {allow,disallow,list-keys,add-key,remove-key}
    allow               Allow the user to uses ssh
    disallow            Disallow the user to uses ssh
    list-keys           Show user's authorized ssh keys
    add-key             Add a new authorized ssh key for this user
    remove-key          Remove an authorized ssh key for this user
```

## PR Status

Tested, can be reviewed.

## How to test

Pull this branch, and test the various operations in `vagrant user ssh --help`

## Validation

- [ ] Principle agreement 0/2 : ljf
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [x] Deep review 1/1 : ljf
