### PR TITLE
display debug information on cert-install/renew failure

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -823,7 +823,7 @@ def _check_domain_is_ready_for_ACME(domain):
             'certmanager_domain_http_not_working', domain=domain))
 
 
-def _dns_ip_match_public_ip(public_ip, domain):
+def _get_dns_ip(domain):
     try:
         resolver = dns.resolver.Resolver()
         resolver.nameservers = DNS_RESOLVERS
@@ -832,9 +832,11 @@ def _dns_ip_match_public_ip(public_ip, domain):
         raise MoulinetteError(errno.EINVAL, m18n.n(
             'certmanager_error_no_A_record', domain=domain))
 
-    dns_ip = str(answers[0])
+    return str(answers[0])
 
-    return dns_ip == public_ip
+
+def _dns_ip_match_public_ip(public_ip, domain):
+    return _get_dns_ip(domain) == public_ip
 
 
 def _domain_is_accessible_through_HTTP(ip, domain):


### PR DESCRIPTION
## The problem

When a `yunohost domain cert-install/renew" failed it's really hard to debug because you just have the information "failed" which sucks and increase our support cost (and we don't want that).

## Solution

Display some debug information to help as shown here:

![2018-04-14-134000_469x104_scrot](https://user-images.githubusercontent.com/41827/38767855-c23633c0-3fe9-11e8-9b60-ad8b72e68c09.png)

For now it only displays different ip addresses because that's the case I've encountered. We can add more information later on (or you can add more on this PR if you have some in mind).

## PR Status

Working.

## How to test

Add a domain not well configured for your testing environment and try to do a `cert-install`.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
