### PR TITLE
[enh] Enable HTTP2 protocol in nginx conf

### DIFF
--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -12,8 +12,8 @@ server {
 }
 
 server {
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
 
     ssl_certificate /etc/yunohost/certs/yunohost.org/crt.pem;
     ssl_certificate_key /etc/yunohost/certs/yunohost.org/key.pem;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -16,8 +16,8 @@ server {
 }
 
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name {{ domain }};
 
     ssl_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;


### PR DESCRIPTION
## The problem

- http/1 deprecated with the nginx on stretch

## Solution

- upgrade to http/2 protocol

## PR Status

Need test / Finished.

## How to test

big question :P
Requirements : Stretch

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 