### PR TITLE
[enh] Lazy-load some module for perf improvements

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -32,7 +32,6 @@ import re
 import urlparse
 import errno
 import subprocess
-import requests
 import glob
 import pwd
 import grp
@@ -129,6 +128,7 @@ def app_fetchlist(url=None, name=None):
     else:
         appslists_to_be_fetched = appslists.keys()
 
+    import requests # lazy loading this module for performance reasons
     # Fetch all appslists to be fetched
     for name in appslists_to_be_fetched:
 

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -572,7 +572,7 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
     import requests # lazy loading this module for performance reasons
     try:
         intermediate_certificate = requests.get(INTERMEDIATE_CERTIFICATE_URL, timeout=30).text
-    except Timeout as e:
+    except requests.exceptions.Timeout as e:
         raise MoulinetteError(errno.EINVAL, m18n.n('certmanager_couldnt_fetch_intermediate_cert'))
 
     # Now save the key and signed certificate
@@ -841,7 +841,7 @@ def _domain_is_accessible_through_HTTP(ip, domain):
     import requests # lazy loading this module for performance reasons
     try:
         requests.head("http://" + ip, headers={"Host": domain}, timeout=10)
-    except Timeout as e:
+    except requests.exceptions.Timeout as e:
         logger.warning(m18n.n('certmanager_http_check_timeout', domain=domain, ip=ip))
         return False
     except Exception as e:

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -29,14 +29,11 @@ import shutil
 import pwd
 import grp
 import smtplib
-import requests
 import subprocess
 import dns.resolver
 import glob
 
-from OpenSSL import crypto
 from datetime import datetime
-from requests.exceptions import Timeout
 
 from yunohost.vendor.acme_tiny.acme_tiny import get_crt as sign_certificate
 
@@ -572,6 +569,7 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
         raise MoulinetteError(errno.EINVAL, m18n.n(
             'certmanager_cert_signing_failed'))
 
+    import requests # lazy loading this module for performance reasons
     try:
         intermediate_certificate = requests.get(INTERMEDIATE_CERTIFICATE_URL, timeout=30).text
     except Timeout as e:
@@ -623,6 +621,7 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
 
 
 def _prepare_certificate_signing_request(domain, key_file, output_folder):
+    from OpenSSL import crypto # lazy loading this module for performance reasons
     # Init a request
     csr = crypto.X509Req()
 
@@ -654,6 +653,7 @@ def _get_status(domain):
         raise MoulinetteError(errno.EINVAL, m18n.n(
             'certmanager_no_cert_file', domain=domain, file=cert_file))
 
+    from OpenSSL import crypto # lazy loading this module for performance reasons
     try:
         cert = crypto.load_certificate(
             crypto.FILETYPE_PEM, open(cert_file).read())
@@ -756,6 +756,7 @@ def _generate_account_key():
 
 
 def _generate_key(destination_path):
+    from OpenSSL import crypto # lazy loading this module for performance reasons
     k = crypto.PKey()
     k.generate_key(crypto.TYPE_RSA, KEY_SIZE)
 
@@ -837,6 +838,7 @@ def _dns_ip_match_public_ip(public_ip, domain):
 
 
 def _domain_is_accessible_through_HTTP(ip, domain):
+    import requests # lazy loading this module for performance reasons
     try:
         requests.head("http://" + ip, headers={"Host": domain}, timeout=10)
     except Timeout as e:

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -28,7 +28,6 @@ import re
 import json
 import yaml
 import errno
-import requests
 
 from urllib import urlopen
 

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -30,7 +30,6 @@ import glob
 import time
 import base64
 import errno
-import requests
 import subprocess
 
 from moulinette import m18n
@@ -151,6 +150,7 @@ def dyndns_subscribe(subscribe_host="dyndns.yunohost.org", domain=None, key=None
         with open(key_file) as f:
             key = f.readline().strip().split(' ', 6)[-1]
 
+    import requests # lazy loading this module for performance reasons
     # Send subscription
     try:
         r = requests.post('https://%s/key/%s?key_algo=hmac-sha512' % (subscribe_host, base64.b64encode(key)), data={'subdomain': domain}, timeout=30)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -26,7 +26,6 @@
 import re
 import os
 import yaml
-import requests
 import json
 import errno
 import logging


### PR DESCRIPTION
*Sorry this is a clone of the [previous PR](https://github.com/YunoHost/yunohost/pull/450) that I closed accidentally*

## The problem

On some hardware python imports can be very slow.
For example importing module *requests* can take up to 5 seconds:

    python -m timeit -n 1 -r 1 'import requests'
    1 loops, best of 1: 5.53 sec per loop

## Solution

This PR moves some of these slow imports where they are really needed (this is sometimes called lazy module import).

After that these commands became way faster:
- yunohost app setting ...
- yunohost app list
- yunohost domain list
- yunohost domain dns-conf
- yunohost dyndns installcron/removecron
- ... and maybe others

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
