### PR TITLE
[fix] Unhold metronome for migration

### DIFF
--- a/src/yunohost/data_migrations/0003_migrate_to_stretch.py
+++ b/src/yunohost/data_migrations/0003_migrate_to_stretch.py
@@ -47,6 +47,7 @@ class MyMigration(Migration):
         self.backup_files_to_keep()
         self.apt_update()
         apps_packages = self.get_apps_equivs_packages()
+        self.unhold(["metronome"])
         self.hold(YUNOHOST_PACKAGES + apps_packages + ["fail2ban"])
 
         # Main dist-upgrade


### PR DESCRIPTION
## The problem

The stretch migration does not work because the metronome package is hold
```
The following packages have been kept back: 
metronome
```

## Solution

Unhold the Metronome package in the migration

## PR Status

Ready to be reviewed

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
