### PR TITLE
[enh] Local cache when using ynh_setup_source

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -150,13 +150,19 @@ ynh_setup_source () {
     fi
     local local_src="/opt/yunohost-apps-src/${YNH_APP_ID}/${src_filename}"
 
+    # simple cache mechanism
+    # if cache file exists and the checksum isn't good, download it again
+    # if not, just download the file
     if test -e "$local_src"
-    then    # Use the local source file if it is present
-        cp $local_src $src_filename
-    else    # If not, download the source
-        wget -nv -O $src_filename $src_url
+    then
+    	echo "${src_sum} ${local_src}" | ${src_sumprg} -c --status \
+        	|| wget -nv -O $local_src $src_url
+    else
+    	mkdir -p "/var/cache/yunohost/ynh_setup_source/${YNH_APP_ID}"
+    	wget -nv -O $local_src $src_url
     fi
-
+    cp $local_src $src_filename
+    
     # Check the control sum
     echo "${src_sum} ${src_filename}" | ${src_sumprg} -c --status \
         || ynh_die "Corrupt source"

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -112,7 +112,7 @@ ynh_backup_before_upgrade () {
 #
 # Details:
 # This helper downloads sources from SOURCE_URL if there is no local source
-# archive in /opt/yunohost-apps-src/APP_ID/SOURCE_FILENAME
+# archive in /var/cache/yunohost/ynh_setup_source/APP_ID/SOURCE_FILENAME
 #
 # Next, it checks the integrity with "SOURCE_SUM_PRG -c --status" command.
 #
@@ -148,7 +148,7 @@ ynh_setup_source () {
     if [ "$src_filename" = "" ] ; then
         src_filename="${src_id}.${src_format}"
     fi
-    local local_src="/opt/yunohost-apps-src/${YNH_APP_ID}/${src_filename}"
+    local local_src="/var/cache/yunohost/ynh_setup_source/${YNH_APP_ID}/${src_filename}"
 
     # simple cache mechanism
     # if cache file exists and the checksum isn't good, download it again


### PR DESCRIPTION
## The problem

When running a lot of tests (mostly using package_check), downloading takes useless time and resources. As both are limited, I try to cache everything I can.

Debian already has a cache for packages, nothing is to be done for YunoHost: https://github.com/YunoHost/package_check/issues/26

Pip also have one, but including in in core is to be discussed (not here): https://github.com/YunoHost/package_check/issues/25

YunoHost has some mechanics, but:

1. the current system doesn't cache, it only looks into a folder to check if a file is already here
2. the folder used for this cache file looks inconsistent

## Solution

add a simple cache mechanism:
 * if a local file exists: overwrite this cache file if the checksum doesn't match
 * if it doesn't: just download a cache file

I kept it simple and if there is an error, it just tells the user about it (I'm unsure this happens much).

## PR Status

Happily using it while testing application with package_check.

## How to test

You may just copy/paste this function in any application an run package_check

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
