### PR TITLE
[enh] Control the login shell when creating users in ynh_system_user_create

### DIFF
--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -41,9 +41,10 @@ ynh_system_user_exists() {
 
 # Create a system user
 #
-# usage: ynh_system_user_create user_name [home_dir]
+# usage: ynh_system_user_create user_name [home_dir [use_shell]]
 # | arg: user_name - Name of the system user that will be create
 # | arg: home_dir - Path of the home dir for the user. Usually the final path of the app. If this argument is omitted, the user will be created without home
+# | arg: use_shell - Create a user using the default login shell if present. If this argument is omitted, the user will be created with /usr/sbin/nologin shell
 ynh_system_user_create () {
 	if ! ynh_system_user_exists "$1"	# Check if the user exists on the system
 	then	# If the user doesn't exist
@@ -52,7 +53,12 @@ ynh_system_user_create () {
 		else
 			local user_home_dir="--no-create-home"
 		fi
-		sudo useradd $user_home_dir --system --user-group $1 --shell /usr/sbin/nologin || ynh_die "Unable to create $1 system account"
+		if [ $# -ge 3 ]; then	# If we want a shell for the user
+			local shell="" # Use default shell
+		else
+			local shell="--shell /usr/sbin/nologin"
+		fi
+		useradd $user_home_dir --system --user-group $1 $shell || ynh_die "Unable to create $1 system account"
 	fi
 }
 

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -42,31 +42,40 @@ ynh_system_user_exists() {
 # Create a system user
 #
 # examples:
-#   - ynh_system_user_create nextcloud -> creates a nextcloud user with
+#   - ynh_system_user_create --username=nextcloud -> creates a nextcloud user with
 #    no home directory and /usr/sbin/nologin login shell (hence no login capability)
-#   - ynh_system_user_create discourse /var/www/discourse 1 --> creates a
+#   - ynh_system_user_create --username=discourse --home_dir=/var/www/discourse --use_shell --> creates a
 #    discourse user using /var/www/discourse as home directory and the default login shell
 #
-# usage: ynh_system_user_create user_name [home_dir [use_shell]]
-# | arg: user_name - Name of the system user that will be create
-# | arg: home_dir - Path of the home dir for the user. Usually the final path
-# of the app. If this argument is omitted, the user will be created without home
-# | arg: use_shell - Create a user using the default login shell if present.
+# usage: ynh_system_user_create --username=user_name [--home_dir=home_dir] [--use_shell]
+# | arg: -u, --username - Name of the system user that will be create
+# | arg: -h, --home_dir - Path of the home dir for the user. Usually the final path of the app. If this argument is omitted, the user will be created without home
+# | arg: -s, --use_shell - Create a user using the default login shell if present.
 # If this argument is omitted, the user will be created with /usr/sbin/nologin shell
 ynh_system_user_create () {
-	if ! ynh_system_user_exists "$1"	# Check if the user exists on the system
+	# Declare an array to define the options of this helper.
+	local legacy_args=uh
+	declare -Ar args_array=( [u]=username= [h]=home_dir= [s]=use_shell )
+	local username
+	local home_dir
+	local use_shell
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+ 	local use_shell="${use_shell:-0}"
+
+	if ! ynh_system_user_exists "$username"	# Check if the user exists on the system
 	then	# If the user doesn't exist
-		if [ $# -ge 2 ]; then	# If a home dir is mentioned
-			local user_home_dir="-d $2"
+		if [ -n "$home_dir" ]; then	# If a home dir is mentioned
+			local user_home_dir="-d $home_dir"
 		else
 			local user_home_dir="--no-create-home"
 		fi
-		if [ $# -ge 3 ]; then	# If we want a shell for the user
+		if [ $use_shell -eq 1 ]; then	# If we want a shell for the user
 			local shell="" # Use default shell
 		else
 			local shell="--shell /usr/sbin/nologin"
 		fi
-		useradd $user_home_dir --system --user-group $1 $shell || ynh_die "Unable to create $1 system account"
+		useradd $user_home_dir --system --user-group $username $shell || ynh_die "Unable to create $username system account"
 	fi
 }
 

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -41,10 +41,18 @@ ynh_system_user_exists() {
 
 # Create a system user
 #
+# examples:
+#   - ynh_system_user_create nextcloud -> creates a nextcloud user with
+#    no home directory and /usr/sbin/nologin login shell (hence no login capability)
+#   - ynh_system_user_create discourse /var/www/discourse 1 --> creates a
+#    discourse user using /var/www/discourse as home directory and the default login shell
+#
 # usage: ynh_system_user_create user_name [home_dir [use_shell]]
 # | arg: user_name - Name of the system user that will be create
-# | arg: home_dir - Path of the home dir for the user. Usually the final path of the app. If this argument is omitted, the user will be created without home
-# | arg: use_shell - Create a user using the default login shell if present. If this argument is omitted, the user will be created with /usr/sbin/nologin shell
+# | arg: home_dir - Path of the home dir for the user. Usually the final path
+# of the app. If this argument is omitted, the user will be created without home
+# | arg: use_shell - Create a user using the default login shell if present.
+# If this argument is omitted, the user will be created with /usr/sbin/nologin shell
 ynh_system_user_create () {
 	if ! ynh_system_user_exists "$1"	# Check if the user exists on the system
 	then	# If the user doesn't exist


### PR DESCRIPTION

## The problem
Some packages need to create system users with a valid login shell, but the user creation helper only allows nologin shell.

## Solution
Allow this helper to create users using the system default login shell.

## PR Status
Finished and tested.

## How to test
You can possibly test the [Discourse package](https://github.com/YunoHost-Apps/discourse_ynh).

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
