### PR TITLE
Tweak the CSP config in nginx template for domains

### DIFF
--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -46,7 +46,8 @@ server {
     # https://wiki.mozilla.org/Security/Guidelines/Web_Security
     # https://observatory.mozilla.org/ 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header Content-Security-Policy "upgrade-insecure-requests; default-src https: data: 'unsafe-inline' 'unsafe-eval'";
+    add_header Content-Security-Policy "upgrade-insecure-requests;"
+    add_header Content-Security-Policy-Report-Only "default-src https: data: 'unsafe-inline' 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -46,7 +46,7 @@ server {
     # https://wiki.mozilla.org/Security/Guidelines/Web_Security
     # https://observatory.mozilla.org/ 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header Content-Security-Policy "upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";
+    add_header Content-Security-Policy "upgrade-insecure-requests; default-src https: data: 'unsafe-inline' 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Download-Options noopen;


### PR DESCRIPTION
## The problem

- Problem with the CSP

## Solution

- Add CSP by the packagers in their app conf
- More permissive CSP

## PR Status

Not tested / Reviews needed (3)

## How to test

- Install Yunohost and add this line in /etc/nginx/conf.d/domain.conf

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
