### PR TITLE
[fix] Nginx Regression typo

### DIFF
--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -46,7 +46,7 @@ server {
     # https://wiki.mozilla.org/Security/Guidelines/Web_Security
     # https://observatory.mozilla.org/ 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header Content-Security-Policy "upgrade-insecure-requests;"
+    add_header Content-Security-Policy "upgrade-insecure-requests";
     add_header Content-Security-Policy-Report-Only "default-src https: data: 'unsafe-inline' 'unsafe-eval'";
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";


### PR DESCRIPTION
## The problem

- Error typo in the nginx conf

Descriptif de l'errreur : 
Je rappelle que le ; est le signe qui permet de revenir à la ligne dans les configuration de nginx (comme dans bcp de langage). Ici, il croit que la ligne ne s'arrête pas, donc il nous dit : 
`nginx: [emerg] invalid number of arguments in "add_header" directive in /etc/nginx/conf.d/domain.tld.conf:50`
Le ; à l'intérieur des guillement ne compte pas, car son élément parent c'est le header lui-même(l'argument de Content-Security-Policy), et pas la fonction add_header elle-même.

## Solution

- Solve the typo problem

## PR Status

Work Finished/Review Needed
Must be merged quickly. Nginx doesn't work

## How to test

Install Yunohost / + Nginx

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
