### PR TITLE
[enh] Add SOURCE_EXTRACT (true/false) in ynh_setup_source

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -110,7 +110,7 @@ ynh_backup_before_upgrade () {
 # # default: ${src_id}.${src_format}
 # SOURCE_FILENAME=example.tar.gz 
 # # (Optional) If it set as false don't extract the source.
-# # (Usefull to get a debian package of a python wheel.)
+# # (Useful to get a debian package or a python wheel.)
 # # default: true
 # SOURCE_EXTRACT=(true|false)
 #

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -109,6 +109,10 @@ ynh_backup_before_upgrade () {
 # # (Optionnal) Name of the local archive (offline setup support)
 # # default: ${src_id}.${src_format}
 # SOURCE_FILENAME=example.tar.gz 
+# # (Optional) If it set as false don't extract the source.
+# # (Usefull to get a debian package of a python wheel.)
+# # default: true
+# SOURCE_EXTRACT=(true|false)
 #
 # Details:
 # This helper downloads sources from SOURCE_URL if there is no local source
@@ -137,6 +141,7 @@ ynh_setup_source () {
     local src_sum=$(grep 'SOURCE_SUM=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
     local src_sumprg=$(grep 'SOURCE_SUM_PRG=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
     local src_format=$(grep 'SOURCE_FORMAT=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
+    local src_extract=$(grep 'SOURCE_EXTRACT=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
     local src_in_subdir=$(grep 'SOURCE_IN_SUBDIR=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
     local src_filename=$(grep 'SOURCE_FILENAME=' "$YNH_CWD/../conf/${src_id}.src" | cut -d= -f2-)
 
@@ -145,6 +150,7 @@ ynh_setup_source () {
     src_in_subdir=${src_in_subdir:-true}
     src_format=${src_format:-tar.gz}
     src_format=$(echo "$src_format" | tr '[:upper:]' '[:lower:]')
+    src_extract=${src_extract:-true}
     if [ "$src_filename" = "" ] ; then
         src_filename="${src_id}.${src_format}"
     fi
@@ -163,7 +169,11 @@ ynh_setup_source () {
 
     # Extract source into the app dir
     mkdir -p "$dest_dir"
-    if [ "$src_format" = "zip" ]
+    
+    if ! "$src_extract"
+    then
+        mv $src_filename $dest_dir
+    elif [ "$src_format" = "zip" ]
     then 
         # Zip format
         # Using of a temp directory, because unzip doesn't manage --strip-components


### PR DESCRIPTION
## The problem

Actually we don't have a helper to just download the source and check the checksum. By example we need that while we want to install a specific debian package or a python wheel.

## Solution

Add a option `SOURCE_EXTRACT` in the actual helper `ynh_setup_source`.

## PR Status

Ready for a review. Tested on a specific branch of [synapse](https://github.com/YunoHost-Apps/synapse_ynh/tree/new_setup_source_helper). Might be also implemented in [monitorix](https://github.com/YunoHost-Apps/monitorix_ynh).

## How to test

Try a synapse install from this specific branch. You could also try an implementation on an other app.

## Validation

- [x] Principle agreement 1/2 : Maniack C
- [x] Quick review 0/1 : Maniack C
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
