### PR TITLE
[enh] Improve ynh_add_nginx_config

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -134,7 +134,7 @@ ynh_remove_systemd_config () {
 #   __PORT_2__    by $port_2
 #
 ynh_add_nginx_config () {
-	local finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
+	finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 	local others_var=${1:-}
 	ynh_backup_if_checksum_is_different "$finalnginxconf"
 	sudo cp ../conf/nginx.conf "$finalnginxconf"
@@ -161,14 +161,18 @@ ynh_add_nginx_config () {
 	fi
 
 	# Replace all other variable given as arguments
-	for v in $others_var
+	for var_to_replace in $others_var
 	do
-        ynh_replace_string "__${v^^}__" "${!v}" "$finalnginxconf"
+		# ${var_to_replace^^} make the content of the variable on upper-cases
+		# ${!var_to_replace} get the content of the variable named $var_to_replace 
+		ynh_replace_string "__${var_to_replace^^}__" "${!var_to_replace}" "$finalnginxconf"
 	done
 	
 	if [ "${path_url:-}" != "/" ]
 	then
 		ynh_replace_string "^#sub_path_only" "" "$finalnginxconf"
+	else
+		ynh_replace_string "^#root_path_only" "" "$finalnginxconf"
 	fi
 
 	ynh_store_file_checksum "$finalnginxconf"

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -117,7 +117,10 @@ ynh_remove_systemd_config () {
 
 # Create a dedicated nginx config
 #
-# usage: ynh_add_nginx_config
+# usage: ynh_add_nginx_config "list of others variables to replace"
+#
+# | arg: list of others variables to replace separeted by a space
+# |      for example : 'path_2 port_2 ...'
 #
 # This will use a template in ../conf/nginx.conf
 #   __PATH__      by  $path_url
@@ -126,8 +129,13 @@ ynh_remove_systemd_config () {
 #   __NAME__      by  $app
 #   __FINALPATH__ by  $final_path
 #
+#  And dynamic variables (from the last example) :
+#   __PATH_2__    by $path_2
+#   __PORT_2__    by $port_2
+#
 ynh_add_nginx_config () {
-	finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
+	local finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
+	local others_var=${1:-}
 	ynh_backup_if_checksum_is_different "$finalnginxconf"
 	sudo cp ../conf/nginx.conf "$finalnginxconf"
 
@@ -151,6 +159,18 @@ ynh_add_nginx_config () {
 	if test -n "${final_path:-}"; then
 		ynh_replace_string "__FINALPATH__" "$final_path" "$finalnginxconf"
 	fi
+
+	# Replace all other variable given as arguments
+	for v in $others_var
+	do
+        ynh_replace_string "__${v^^}__" "${!v}" "$finalnginxconf"
+	done
+	
+	if [ "${path_url:-}" != "/" ]
+	then
+		ynh_replace_string "^#sub_path_only" "" "$finalnginxconf"
+	fi
+
 	ynh_store_file_checksum "$finalnginxconf"
 
 	sudo systemctl reload nginx


### PR DESCRIPTION
## The problem

- Actually the helper `ynh_add_nginx_config` is not really useful if we have an other variable witch need to replaced.
- After the issue `alias_transversal` we always need uncomment the redirection while we install the app in subdir.

## Solution

Add 2 new features :
- Permit to replace some others variables in the template
- Manage automatically the redirection (alias_transversal issue fix) as we do in each apps.

## PR Status

Tested on two apps (seafile and riot).

## How to test

Test the last version of seafile and riot, or implement this new helper in your app.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
