### PR TITLE
Add ynh_render_template helper to render templates with jinja2

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -234,3 +234,20 @@ ynh_local_curl () {
 	# Curl the URL
 	curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url"
 }
+
+# Render templates with Jinja2
+# 
+# Attention : Variables should be exported before calling this helper to be
+# accessible inside templates.
+#
+# usage: ynh_render_template some_template output_path
+# | arg: some_template - Template file to be rendered
+# | arg: output_path   - The path where the output will be redirected to
+ynh_render_template() {
+   local template_path=$1
+   local output_path=$2
+   # Taken from https://stackoverflow.com/a/35009576
+   python2.7 -c 'import os, sys, jinja2; sys.stdout.write(
+                    jinja2.Template(sys.stdin.read()
+                 ).render(os.environ));' < $template_path > $output_path
+}


### PR DESCRIPTION
## The problem

Following some discussion about https://github.com/YunoHost/yunohost/pull/457 and seeing https://github.com/YunoHost/yunohost/pull/462 , and there are some more ideas in the core (e.g. have a global setting to disable https redirection, etc...) we really need a proper templating solution both for the core and for the apps.

Quick-and-dirty templates with search-and-replaces are good if you have simple things to do, but at some point you will find that you need conditional blocks (or even loops maybe) which you can't do easily (you gonna use some hack to comment/uncomment lines).

## Solution

Use a proper template engine : jinja2. @zamentur already used j2cli in some apps, allowing to render templates using (exported) bash variables. For example : https://github.com/YunoHost-Apps/limesurvey_ynh/blob/master/conf/nginx.conf.j2

If you are not familiar with jinja2, look at the example and notice that you can do things like : 
```
{% if path_url != "/" %}
rewrite ^{{ path_url }}$ {{ path_url }}/ permanent;
{% else %}
{% set path_url = "" %}
{% endif %}
```
to handle the infamous "path_url is /" case smoothly.

j2cli is unfortunately only available with pip, so we can't have it as a dependency. But by ~~hacking stuff~~reading stack overflow, I found that we can build a simple helpers which call a few line of python on the fly to do what we want.

Hence with this helper, you can just call something like `ynh_render_template ../conf/my.template /etc/my/output` and voila ! (provided that you exported the variables you need at some point before)

## PR Status

...

## How to test

Source the helper and try it on a test template

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
