### PR TITLE
[fix] some services are marked as None

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -574,6 +574,12 @@ def _get_services():
     except:
         return {}
     else:
+        # some services are marked as None to remove them from YunoHost
+        # filter this
+        for key, value in services.items():
+            if value is None:
+                del services[key]
+
         return services
 
 


### PR DESCRIPTION
## The problem

Fix this problem probably created by a very old change of mine to cleanup services.yml https://dev.yunohost.org/issues/1082

## PR Status

Ready to be merged.

## How to test

Put "stuff: null" in /etc/yunohost/services.yml

## Validation

Micro decision, just waiting some days in case of.