### PR TITLE
[fix] Untrusted TLS connection established to

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -45,7 +45,8 @@ smtp_tls_exclude_ciphers = $smtpd_tls_exclude_ciphers
 smtp_tls_mandatory_ciphers= $smtpd_tls_mandatory_ciphers
 smtp_tls_loglevel=1
 
-# Fix "Untrusted TLS connection established to" message in log
+# Configure Root CA certificates
+# (for example, avoids getting "Untrusted TLS connection established to" messages in logs)
 smtpd_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -45,6 +45,10 @@ smtp_tls_exclude_ciphers = $smtpd_tls_exclude_ciphers
 smtp_tls_mandatory_ciphers= $smtpd_tls_mandatory_ciphers
 smtp_tls_loglevel=1
 
+# Fix "Untrusted TLS connection established to" message in log
+smtpd_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
+smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
+
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 


### PR DESCRIPTION
## The problem

In mail log we can found some "Untrusted TLS connection established" message

## Solution

Indicate where are certs

## PR Status

Tested

## How to test

Apply this patch, reload postfix, and try to send a mail, you should see in log this message:

"Trusted TLS connection established to"

## Validation

- [x] Principle agreement 2/2 : Aleks, Jimbojoe
- [x] Quick review 1/1 : Aleks
- [x] Simple test 1/1 : Jimbojoe
- [x] Deep review 1/1 : Jimbojoe
