### PR TITLE
We need to set status:null for yunohost pseudo-service

### DIFF
--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -37,6 +37,8 @@ nslcd:
   log: /var/log/syslog
 nsswitch:
   status: null
+yunohost:
+  status: null
 bind9: null
 tahoe-lafs: null
 memcached: null


### PR DESCRIPTION
## The problem

Following #469, we need to add status: null for "pseudo-services" in services.yml. There's a pseudo-service "yunohost" which was forgotten

## Solution

Add `status: null` for the yunohost key in services.yml

## PR Status

Microdecision / waiting for Bram's feedback

## How to test

If you're on the latest unstable, `yunohost service status` should be broken because it can't fetch the status of the "yunohost" service.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
