### PR TITLE
Return None directly if we try to calculate the hash of a file that does not exists

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -713,6 +713,10 @@ def _get_files_diff(orig_file, new_file, as_string=False, skip_header=True):
 
 def _calculate_hash(path):
     """Calculate the MD5 hash of a file"""
+
+    if not os.path.exists(path):
+        return None
+
     hasher = hashlib.md5()
 
     try:
@@ -889,7 +893,7 @@ def _get_journalctl_logs(service):
         import traceback
         return "error while get services logs from journalctl:\n%s" % traceback.format_exc()
 
-      
+
 def manually_modified_files_compared_to_debian_default():
 
     # from https://serverfault.com/a/90401


### PR DESCRIPTION
## The problem

We saw a few warning popping up with Bram during regen conf's : 

```
Warning: Error while calculating file '/etc/systemd/system/rmilter.socket' hash: [Errno 2] No such file or directory:  '/etc/systemd/system/rmilter.socket'
```

The file indeed does not exists, and in fact the regen conf wants it to not exists (old file that got removed a few months/years? ago). In fact, the function that computes hashes for the regenconf implicitly wants to return None if the file does not exists. But because this was hidden in a weird except, Bram legitimately added a warning in it to log errors ;). 

## Solution

Simply return None if the file does not exists at the beginning of the function

## PR Status

Microdecision / waiting for Bram's feedback

## How to test

Run the regen-conf with and without this branch

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
