### PR TITLE
Move avahi-daemon to recommended, fix issues#1097

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban
  , nginx-extras (>=1.6.2), php5-fpm, php5-ldap, php5-intl
- , dnsmasq, openssl, avahi-daemon, libnss-mdns, resolvconf, libnss-myhostname
+ , dnsmasq, openssl, libnss-mdns, resolvconf, libnss-myhostname
  , metronome
  , rspamd (>= 1.2.0), rmilter (>=1.7.0), redis-server, opendkim-tools
  , haveged
@@ -33,6 +33,7 @@ Recommends: yunohost-admin
  , python-pip
  , unattended-upgrades
  , libdbd-ldap-perl, libnet-dns-perl
+ , avahi-daemon
 Suggests: htop, vim, rsync, acpi-support-base, udisks2, archivemount
 Conflicts: iptables-persistent
  , moulinette-yunohost, yunohost-config


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1097

## Solution

Move avahi-daemon to recommended in debian control file

## PR Status

Weeeell not tested. It should be okay but maybe some more work is needed to adapt the regen-conf because there are explicit references to avahi-daemon in it ...

## How to test

Find a way to uninstall avahi-daemon on an instance and test the regen conf :s

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
