### PR TITLE
backup filename limit set to 50

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -788,7 +788,7 @@ backup:
                     help: Name of the backup archive
                     extra:
                         pattern: &pattern_backup_archive_name
-                            - !!str ^[\w\-\._]{1,30}(?<!\.)$
+                            - !!str ^[\w\-\._]{1,50}(?<!\.)$
                             - "pattern_backup_archive_name"
                 -d:
                     full: --description


### PR DESCRIPTION
## The problem

Apparently 30 chars is too short https://github.com/YunoHost/issues/issues/962

## Solution

Move to 50 as requested (shouldn't we put more actually? I don't see the point of the limit)

## PR Status

Gud

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
