### PR TITLE
Mysql mariadb get status

### DIFF
--- a/data/templates/yunohost/services.yml
+++ b/data/templates/yunohost/services.yml
@@ -18,6 +18,7 @@ redis-server:
   log: /var/log/redis/redis-server.log
 mysql:
   log: [/var/log/mysql.log,/var/log/mysql.err]
+  alternates: ['mariadb']
 glances: {}
 ssh:
   log: /var/log/auth.log

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -263,7 +263,7 @@ def service_status(names=[]):
                 'active': str(status.get("ActiveState", "unknown")),
                 'active_at': {
                     "timestamp": str(status.get("ActiveEnterTimestamp", "unknown")),
-                    "human": datetime.fromtimestamp(status.get("ActiveEnterTimestamp") / 1000000).strftime("%F %X"),
+                    "human": datetime.fromtimestamp(status["ActiveEnterTimestamp"] / 1000000).strftime("%F %X") if "ActiveEnterTimestamp" in status else "unknown",
                 },
                 'description': description,
                 'service_file_path': str(status.get("FragmentPath", "unknown")),


### PR DESCRIPTION
## The problem

Fixes https://github.com/YunoHost/issues/issues/1134

## Solution

Offers a list of alternates names, doesn't fail on failed to grab a service.

## PR Status

Tested and working.

## How to test

Do a regen-conf.

Have a situations where you have mariadb instead of mysql or hack `/etc/yunohost/services.yml` to replace "mysql" by "mariadb" then put "mysql" as an alternates on "mariadb" and do a `yunohost service status mariadb`.

## Validation

Since it's a fix to an already accepted PR I'm really tempted to put that as a microdecision. Let's way a bit in case of.
