### PR TITLE
[fix] check if log exists before tailing to avoid errors

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -298,7 +298,7 @@ def service_log(name, number=50):
     for log_path in log_list:
         # log is a file, read it
         if not os.path.isdir(log_path):
-            result[log_path] = _tail(log_path, int(number))
+            result[log_path] = _tail(log_path, int(number)) if os.path.exists(log_path) else []
             continue
 
         for log_file in os.listdir(log_path):
@@ -310,7 +310,7 @@ def service_log(name, number=50):
             if not log_file.endswith(".log"):
                 continue
 
-            result[log_file_path] = _tail(log_file_path, int(number))
+            result[log_file_path] = _tail(log_file_path, int(number)) if os.path.exists(log_file_path) else []
 
     return result
 


### PR DESCRIPTION
## The problem

Due to more display of errors and removing of yolo logics, users get those errors in logs oh a `yunohost service log`:

```
2018-05-30 23:56:24,043 INFO     moulinette.actionsmap process - processing action [9018.1]: yunohost.service.log
2018-05-30 23:56:24,061 WARNING  yunohost.service _tail - [9018.1] Error while tailing file '/var/log/mysql.log': [Errno 2] No such file or directory: '/var/log/mysql.log'
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/service.py", line 671, in _tail
    with open(file, 'r') as f:
IOError: [Errno 2] No such file or directory: '/var/log/mysql.log'
2018-05-30 23:56:24,062 WARNING  yunohost.service _tail - [9018.1] Error while tailing file '/var/log/mysql.err': [Errno 2] No such file or directory: '/var/log/mysql.err'
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/service.py", line 671, in _tail
    with open(file, 'r') as f:
IOError: [Errno 2] No such file or directory: '/var/log/mysql.err'
2018-05-31 00:03:23,042 INFO     moulinette.actionsmap process - processing action [9747.1]: yunohost.service.log
2018-05-31 00:03:23,060 WARNING  yunohost.service _tail - [9747.1] Error while tailing file '/var/log/mysql.log': [Errno 2] No such file or directory: '/var/log/mysql.log'
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/service.py", line 671, in _tail
    with open(file, 'r') as f:
IOError: [Errno 2] No such file or directory: '/var/log/mysql.log'
2018-05-31 00:03:23,061 WARNING  yunohost.service _tail - [9747.1] Error while tailing file '/var/log/mysql.err': [Errno 2] No such file or directory: '/var/log/mysql.err'
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/service.py", line 671, in _tail
    with open(file, 'r') as f:
IOError: [Errno 2] No such file or directory: '/var/log/mysql.err'
```

## Solution

Check if file exists before tailing.

## PR Status

Good.

## Validation

Microdecision, but before that: I'm really wondering if we shouldn't display something like "this log file doesn't exists" instead of return an empty file.