### PR TITLE
[enh] POC to allow applications to ship configurations panels for the software they bundle

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -780,7 +780,7 @@ app:
               ### app_config_show_panel()
               show-panel:
                   action_help: show config panel for the application
-                  api: GET /<app_id>/config/panel
+                  api: GET /apps/<app_id>/config-panel
                   arguments:
                       app_id:
                           help: App ID
@@ -788,7 +788,7 @@ app:
               ### app_config_apply()
               apply:
                   action_help: apply the new configuration
-                  api: POST /<app_id>/config
+                  api: POST /apps/<app_id>/config
                   arguments:
                       app_id:
                           help: App ID

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -785,6 +785,17 @@ app:
                       app_id:
                           help: App ID
 
+              ### app_config_apply()
+              apply:
+                  action_help: apply the new configuration
+                  api: POST /<app_id>/config
+                  arguments:
+                      app_id:
+                          help: App ID
+                      -a:
+                          full: --args
+                          help: Serialized arguments for new configuration (i.e. "domain=domain.tld&path=/path")
+
 #############################
 #          Backup           #
 #############################

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -771,6 +771,20 @@ app:
                 apps:
                     nargs: "+"
 
+    subcategories:
+
+      config:
+          subcategory_help: Applications configuration panel
+          actions:
+
+              ### app_config_show_panel()
+              show-panel:
+                  action_help: show config panel for the application
+                  api: GET /<app_id>/config/panel
+                  arguments:
+                      app_id:
+                          help: App ID
+
 #############################
 #          Backup           #
 #############################

--- a/locales/en.json
+++ b/locales/en.json
@@ -179,6 +179,7 @@
     "executing_command": "Executing command '{command:s}'...",
     "executing_script": "Executing script '{script:s}'...",
     "extracting": "Extracting...",
+    "experimental_feature": "Warning: this feature is experimental and not consider stable, you shouldn't be using it except if you know what you are doing.",
     "field_invalid": "Invalid field '{:s}'",
     "firewall_reload_failed": "Unable to reload the firewall",
     "firewall_reloaded": "The firewall has been reloaded",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1419,21 +1419,22 @@ def app_config_show_panel(app_id):
             section_id = section["id"]
             for option in section.get("options", []):
                 option_id = option["id"]
-                variable_name = ("YNH_CONFIG_%s_%s_%s" % (tab_id, section_id, option_id)).upper()
-                logger.debug(" * '%s'.'%s'.'%s' -> %s", tab.get("name"), section.get("name"), option.get("name"), variable_name)
+                generated_id = ("YNH_CONFIG_%s_%s_%s" % (tab_id, section_id, option_id)).upper()
+                option["id"] = generated_id
+                logger.debug(" * '%s'.'%s'.'%s' -> %s", tab.get("name"), section.get("name"), option.get("name"), generated_id)
 
-                if variable_name in parsed_values:
+                if generated_id in parsed_values:
                     # XXX we should probably uses the one of install here but it's at a POC state right now
                     option_type = option["type"]
                     if option_type == "bool":
-                        assert parsed_values[variable_name].lower() in ("true", "false")
-                        option["value"] = True if parsed_values[variable_name].lower() == "true" else False
+                        assert parsed_values[generated_id].lower() in ("true", "false")
+                        option["value"] = True if parsed_values[generated_id].lower() == "true" else False
                     elif option_type == "integer":
-                        option["value"] = int(parsed_values[variable_name])
+                        option["value"] = int(parsed_values[generated_id])
                     elif option_type == "text":
-                        option["value"] = parsed_values[variable_name]
+                        option["value"] = parsed_values[generated_id]
                 else:
-                    logger.debug("Variable '%s' is not declared by config script, using default", variable_name)
+                    logger.debug("Variable '%s' is not declared by config script, using default", generated_id)
                     option["value"] = option["default"]
 
     return {

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1402,14 +1402,15 @@ def app_config_show_panel(app_id):
             print "in parse_stdout", parsed_values
             print [line]
 
-    hook_exec(config_script,
+    return_code = hook_exec(config_script,
               args=["show"],
               env=env,
               user="root",
               stdout_callback=parse_stdout,
     )
 
-    # logger.debug("Env after running config script %s", env)
+    if return_code != 0:
+        raise Exception("script/config show return value code: %s (considered as an error)", return_code)
 
     logger.debug("Generating global variables:")
     for tab in config_panel.get("panel", []):

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1370,10 +1370,8 @@ def app_change_label(auth, app, new_label):
 def app_config_show_panel(app_id):
     from yunohost.hook import hook_exec
 
-    installed = _is_installed(app_id)
-    if not installed:
-        raise MoulinetteError(errno.ENOPKG,
-                              m18n.n('app_not_installed', app=app_id))
+    # this will take care of checking if the app is installed
+    app_info_dict = app_info(app_id)
 
     config_panel = os.path.join(APPS_SETTING_PATH, app_id, 'config_panel.json')
     config_script = os.path.join(APPS_SETTING_PATH, app_id, 'scripts', 'config')
@@ -1442,6 +1440,8 @@ def app_config_show_panel(app_id):
                     option["value"] = option["default"]
 
     return {
+        "app_id": app_id,
+        "app_name": app_info_dict["name"],
         "config_panel": config_panel,
     }
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1367,7 +1367,12 @@ def app_change_label(auth, app, new_label):
     app_ssowatconf(auth)
 
 
+# Config panel todo list:
+# * docstrings
+# * merge translations on the json once the workflow is in place
 def app_config_show_panel(app_id):
+    logger.warning(m18n.n('experimental_feature'))
+
     from yunohost.hook import hook_exec
 
     # this will take care of checking if the app is installed
@@ -1447,6 +1452,8 @@ def app_config_show_panel(app_id):
 
 
 def app_config_apply(app_id, args):
+    logger.warning(m18n.n('experimental_feature'))
+
     from yunohost.hook import hook_exec
 
     installed = _is_installed(app_id)

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1471,7 +1471,7 @@ def app_config_apply(app_id, args):
     config_panel = read_json(config_panel)
 
     env = {"YNH_APP_ID": app_id}
-    args = dict(urlparse.parse_qsl(args, keep_blank_values=True))
+    args = dict(urlparse.parse_qsl(args, keep_blank_values=True)) if args else {}
 
     for tab in config_panel.get("panel", []):
         tab_id = tab["id"]  # this makes things easier to debug on crash

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1403,7 +1403,7 @@ def app_config_show_panel(app_id):
             print [line]
 
     hook_exec(config_script,
-              args=[],
+              args=["show"],
               env=env,
               user="root",
               stdout_callback=parse_stdout,

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1399,8 +1399,6 @@ def app_config_show_panel(app_id):
             key, value = line.strip().split("=", 1)
             logger.debug("config script declared: %s -> %s", key, value)
             parsed_values[key] = value
-            print "in parse_stdout", parsed_values
-            print [line]
 
     return_code = hook_exec(config_script,
               args=["show"],

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -641,6 +641,9 @@ def app_upgrade(auth, app=[], url=None, file=None):
             os.system('rm -rf "%s/scripts" "%s/manifest.json %s/conf"' % (app_setting_path, app_setting_path, app_setting_path))
             os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
+            if os.path.exists(os.path.join(extracted_app_folder, "config_panel.json")):
+                os.system('cp -R %s/config_panel.json %s' % (extracted_app_folder, app_setting_path))
+
             if os.path.exists(os.path.join(extracted_app_folder, "conf")):
                 os.system('cp -R %s/conf %s' % (extracted_app_folder, app_setting_path))
 
@@ -757,6 +760,9 @@ def app_install(auth, app, label=None, args=None, no_remove_on_failure=False):
     # Move scripts and manifest to the right place
     os.system('cp %s/manifest.json %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
+
+    if os.path.exists(os.path.join(extracted_app_folder, "config_panel.json")):
+        os.system('cp -R %s/config_panel.json %s' % (extracted_app_folder, app_setting_path))
 
     if os.path.exists(os.path.join(extracted_app_folder, "conf")):
         os.system('cp -R %s/conf %s' % (extracted_app_folder, app_setting_path))

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1457,7 +1457,7 @@ def app_config_apply(app_id, args):
 
     config_panel = read_json(config_panel)
 
-    env = {}
+    env = {"YNH_APP_ID": app_id}
     args = dict(urlparse.parse_qsl(args, keep_blank_values=True))
 
     for tab in config_panel.get("panel", []):

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -297,7 +297,8 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
 
 
 def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
-              chdir=None, env=None, user="admin"):
+              chdir=None, env=None, user="admin", stdout_callback=None,
+              stderr_callback=None):
     """
     Execute hook from a file with arguments
 
@@ -361,8 +362,8 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
 
     # Define output callbacks and call command
     callbacks = (
-        lambda l: logger.debug(l.rstrip()),
-        lambda l: logger.warning(l.rstrip()),
+        stdout_callback if stdout_callback else lambda l: logger.debug(l.rstrip()),
+        stderr_callback if stderr_callback else lambda l: logger.warning(l.rstrip()),
     )
     returncode = call_async_output(
         command, callbacks, shell=False, cwd=chdir


### PR DESCRIPTION
## The problem

After spreading information about my POC on applications actions (see #486) someone asked me if YunoHost though about doing configuration panels for applications like in open media vault. Unaware of this feature I've asked more information and he provide me with some screenshots, here are 2 of those:

![1609f868-e9e4-4ac6-b2a5-e9af30c9a684](https://user-images.githubusercontent.com/41827/41196397-849a1fb8-6c3f-11e8-8d12-2d945585a515.png)
![e6b2bacc-1352-4d18-8698-2aa493b0a3fd](https://user-images.githubusercontent.com/41827/41196398-87a9859a-6c3f-11e8-98c1-5cc7e607b551.png)
![f1752432-6dbd-49ad-b64e-da5b08f39c89](https://user-images.githubusercontent.com/41827/41196399-89e7137c-6c3f-11e8-9044-e6be09ed5773.png)

He told me that this allows to manage the configuration of the applications, something than you can normally only do on CLI. After talking with @maniackcrudelis about that it appears that it look like a good and useful thing to have in YunoHost and we start thinking about how to do that.

Thinking more about it, I realise that this would have make the writting of https://github.com/labriqueinternet/vpnclient_ynh and https://github.com/labriqueinternet/hotspot_ynh since they basically only ship a php application to do a configuration page. At that time we said that it would have been great to be able to integrate them into YunoHost somehow but didn't knew how to do that. This idea of a configuration panel per application seems like a good solution for that.

## Solution

After some discussion and based on the screenshot I came up with the following solution:

- introduce 2 new commands in yunohost:
  - `yunohost app config show-panel $app_id` which will be used by the admin interface to display the configration panel
  - `yunohost app config apply $app_id --a 'a=b&c=d'` which will be called by the admin interface on a POST on the configuration panel page (like "save this new configuration")
- describe the configuration panel in a json script (I've based my work on open media vault screenshot for that, trying to redescribe a part of it as a POC)
- create a new script in the "scripts/" folder of an application named `config`

Here is an example of a `config_panel.json` based on the screenshots:

```json
{
    "name": "Transmission configuration panel",
    "version": "0.1",
    "panel": [{
        "name": "Parameters",
        "id": "parameters",
        "sections": [{
            "name": "General",
            "help": "things that fits nowhere else",
            "id": "general",
            "options": [{
                "id": "activate",
                "name": "Activate",
                "type": "bool",
                "default": true
            }]
            }, {
            "name": "Misc",
            "id": "misc",
            "options": [{
                "name": "Cache size",
                "id": "cache_size",
                "type": "number",
                "help": "Cache size (in MB) to reduce the number of disk reads and writes",
                "default": 4
            }, {
                "name": "Distributed hash table (DHT)",
                "id": "dht",
                "type": "bool",
                "help": "Enable DHT",
                "default": true
            }]
        }]
    },{
        "name": "Blocklists",
        "help": "stuff regarding blocklists",
        "id": "blocklist",
        "sections": [{
            "name": "Blocklists",
            "id": "blocklist",
            "options": [{
                "name": "Activate",
                "id": "activate",
                "type": "bool",
                "default": false,
                "help": "Use blocklists."
            },{
                "name": "Auto sync",
                "id": "autosync",
                "type": "bool",
                "default": false,
                "help": "Update blocklists automatically. This requires the RPC to be enabled."
            },{
                "name": "Sync frequency",
                "id": "sync_frequency",
                "type": "text",
                "default": "",
                "placeholder": "Journalier"
            },{
                "name": "URL",
                "id": "url",
                "type": "url",
                "default": "",
                "help": "The URL of the blocklist."
            }]
        }]
    }]
}
```

The workflow goes this way, 2 times, first time is displaying the configuration panel with the correct values:

- user look at an app, if this app gots `config_panel.json` AND `scripts/config`, say that there is a configuration panel
- user click to display it, this run the following steps:
  - this call `yunohost app config show-panel $app_id` (but on the API)
  - this code will load `config_panel.json`
  - for each configuration field in the configuration panel, YunoHost generate a deterministic unique id for it
  - it puts those ids in the json file, they will be used as `name` for HTML fields for the form of the configuration panel of the admin interface
  - then it calls `scripts/config show` (with the "show" argument, important)
  - this script will communicate to YunoHost for each unique the value it has if it wants to, otherwise the default (mandatory) value is used
    - this is the moment where the application will, for example, parsed the configuration of the installed application or read the database or wathever to say to YunoHost "this is the current used value"
  - YunoHost then merge those values with the config_panel.json
  - this config_panel.json is then communicated to the admin interface which will uses it to display the configuration panel in HTML with the current values of the installed application (the yunohost-admin is not done yet)

Second time is getting modifications from the configuration panel (the user clicks on "save") and applying it:

- the users modify things, clic on "save"
- this will communicate the forms data the same way YunoHost communicate the "app installation form" data (using "--args")
- this call `yunohost app config apply $app_id --a 'a=b&c=d&...'`
- YunoHost then loads `config_panel.json`
- then re-generate unique deterministic ids for each fields
- then parse the arguments and looks for a value for each fields
- it then calls `scripts/config apply` (with the apply arguments) while setting every new arguments as a global value for the script to grab them (the same way than for `scripts/install`)
- and it's done, the `scripts/config apply` is responsible for using those new values the way its want to modify the configuration of the installed app (doing queries in the database, modifying a config.php, whatever...)

## Rational of this design

I've tried to follow several principle while designing this mechanism:

- I've try to keep things simple and close to what we already have: `config_panel.json` is (nearly) simple and extensible and this is like the `manifest.json`
- having mapped `config_panel.json` on open media vault, which is an already existing design, guarantee to learn on the experience of others and avoid redoing this reseach job on what needs to be available
- `scripts/config` is like any other needed script and behave the same way with global values
- `scripts/config` is called with either `show` and `apply` because I'm expecting a lot of code to be common between showing and applying so putting everything in the same file will make life of the application developers simpler
- `scripts/config` also allow a full liberty on how to do things which should gave the needed flexibility to integrate that thing into any applications
- `scripts/config show` mechanism, while not being that pretty, is super simple
- I've integrated quite some `logger.debug` and other output into both commands to makes debugging way easier

#### How the communication between the `scripts/config show` and YunoHost is done:

Initially I wanted the `scripts/config show` to modify its env and putting new values in it then read it from YunoHost but this is totally impossible in linux because the parent can't read the modified context of a child (you can technically hack /proc/$pid/env but it disappears on process death and it's during execution, not at the end).

After a lot of research and discussion on how to do that, I've chosen the simplest, but not prettier, solution available which is apparently very common in the C programming world: the child communicates with its parent using a pipe, which is here : stdout. Yes.

So for `scripts/config show` to indicate a new value for an id it needs to do: `echo YNH_CONFIG_SOME_ID=value` which will be parsed by YunoHost.

This is really not pretty but is, surprisingly, a very common way to do that and it makes to code very simple to write.

Other options would have been:

* use a pipe
* use a named pipe
* use a socket
* write to a temp file in the script then read it

Pipe/named pipe/socket would have made the code way more complicated (concurrency reading) while not bringing that much. Writing to a temp file would have introduce security concern.

Also doing an echo is very simple for application developers and doesn't require much more new mechanism.

But yes, it's not that pretty.

Reading its env would have been so much prettier, it's a key/value store, it's meant for that, but it's not possible :( #ouin 

## Example of a run

`config_panel.json`: (transmission one from the screenshots)

```json
{
    "name": "Transmission configuration panel",
    "version": "0.1",
    "panel": [{
        "name": "Parameters",
        "id": "parameters",
        "sections": [{
            "name": "General",
            "id": "general",
            "options": [{
                "id": "activate",
                "name": "Activate",
                "type": "bool",
                "default": true
            }]
            }, {
            "name": "Misc",
            "id": "misc",
            "options": [{
                "name": "Cache size",
                "id": "cache_size",
                "type": "integer",
                "help": "Cache size (in MB) to reduce the number of disk reads and writes",
                "default": 4
            }, {
                "name": "Distributed hash table (DHT)",
                "id": "dht",
                "type": "bool",
                "help": "Enable DHT",
                "default": true
            }]
        }]
    },{
        "name": "Blocklists",
        "id": "blocklist",
        "sections": [{
            "name": "Blocklists",
            "id": "blocklist",
            "options": [{
                "name": "Activate",
                "id": "activate",
                "type": "bool",
                "default": false,
                "help": "Use blocklists."
            },{
                "name": "Auto sync",
                "id": "autosync",
                "type": "bool",
                "default": false,
                "help": "Update blocklists automatically. This requires the RPC to be enabled."
            },{
                "name": "Sync frequency",
                "id": "sync_frequency",
                "type": "text",
                "default": "",
                "placeholder": "Journalier"
            },{
                "name": "URL",
                "id": "url",
                "type": "url",
                "default": "",
                "help": "The URL of the blocklist."
            }]
        }]
    }]
}
```

`scripts/config`

```bash
show_config() {
        # here you are supposed to read some config file/database/other then print the values
        echo YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=false
        echo YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE=42
        # other options:
        # echo YNH_CONFIG_PARAMETERS_MISC_DHT
        # echo YNH_CONFIG_BLOCKLIST_BLOCKLIST_ACTIVATE
        # echo YNH_CONFIG_BLOCKLIST_BLOCKLIST_AUTOSYNC
        echo YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY=pouet pouet poeut
        # echo YNH_CONFIG_BLOCKLIST_BLOCKLIST_URL
}

apply_config() {
    # do some stuff with values like $YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE
}

case $1 in
  show) show_config;;
  apply) apply_config;;
esac
```

Result of running `yunohost app config show-panel zerobin --debug`

```
145  DEBUG loading actions map namespace 'yunohost'    
161  DEBUG extra parameter classes loaded: ['ask', 'password', 'required', 'pattern']
162  DEBUG initializing base actions map parser for cli
163  DEBUG registering new callback action 'yunohost.utils.packages.ynh_packages_version' to ['-v', '--version']
227  DEBUG lock has been acquired
340  DEBUG loading python module yunohost.app took 0.113s
340  INFO processing action [20195.1]: yunohost.app.config.show-panel with args={'app_id': 'zerobin'}
362  INFO Executing command 'sh -c YNH_APP_ID=zerobin YNH_CWD=/etc/yunohost/apps/zerobin/scripts BASH_XTRACEFD=7 /bin/bash -x "./config" show 7>&1'...
370  INFO + case $1 in                          
370  INFO + show_config 
371  INFO + echo YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=false
371  INFO YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=false
372  DEBUG config script declared: YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE -> false
372  INFO + echo YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE=42
373  INFO YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE=42
374  DEBUG config script declared: YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE -> 42
374  INFO + echo YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY=pouet pouet poeut
374  INFO YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY=pouet pouet poeut
375  DEBUG config script declared: YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY -> pouet pouet poeut
376  DEBUG Generating global variables:
376  DEBUG  * 'Parameters'.'General'.'Activate' -> YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE
376  DEBUG  * 'Parameters'.'Misc'.'Cache size' -> YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE
376  DEBUG  * 'Parameters'.'Misc'.'Distributed hash table (DHT)' -> YNH_CONFIG_PARAMETERS_MISC_DHT
376  DEBUG Variable 'YNH_CONFIG_PARAMETERS_MISC_DHT' is not declared by config script, using default
377  DEBUG  * 'Blocklists'.'Blocklists'.'Activate' -> YNH_CONFIG_BLOCKLIST_BLOCKLIST_ACTIVATE
377  DEBUG Variable 'YNH_CONFIG_BLOCKLIST_BLOCKLIST_ACTIVATE' is not declared by config script, using default
377  DEBUG  * 'Blocklists'.'Blocklists'.'Auto sync' -> YNH_CONFIG_BLOCKLIST_BLOCKLIST_AUTOSYNC
377  DEBUG Variable 'YNH_CONFIG_BLOCKLIST_BLOCKLIST_AUTOSYNC' is not declared by config script, using default
377  DEBUG  * 'Blocklists'.'Blocklists'.'Sync frequency' -> YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY
378  DEBUG  * 'Blocklists'.'Blocklists'.'URL' -> YNH_CONFIG_BLOCKLIST_BLOCKLIST_URL
378  DEBUG Variable 'YNH_CONFIG_BLOCKLIST_BLOCKLIST_URL' is not declared by config script, using default
378  DEBUG action [20195.1] executed in 0.037s
378  DEBUG lock has been released
config_panel:       
  name: Transmission configuration panel                     
  panel:                        
    0:                             
      id: parameters  
      name: Parameters              
      sections:
        0:          
          id: general                      
          name: General                           
          options:   
            default: True
            id: YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE
            name: Activate
            type: bool                                                                            
            value: False                         
        1:        
          id: misc
          name: Misc                                
          options:                                                                              
            0:                                         
              default: 4                                                             
              help: Cache size (in MB) to reduce the number of disk reads and writes            
              id: YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE                                                         
              name: Cache size                                                       
              type: integer                              
              value: 42                                                                                         
            1:                                                                                                                                        
              default: True                              
              help: Enable DHT                                                                       
              id: YNH_CONFIG_PARAMETERS_MISC_DHT                                                                                                      
              name: Distributed hash table (DHT)      
              type: bool                                                          
              value: True                                    
    1:                                                
      id: blocklist                                                               
      name: Blocklists                                                          
      sections:                                                          
        id: blocklist                                                                                
        name: Blocklists                                                        
        options:                                                                         
          0:                                                                                         
            default: False                                                                        
            help: Use blocklists.                                                                   
            id: YNH_CONFIG_BLOCKLIST_BLOCKLIST_ACTIVATE                                      
            name: Activate                                                                                   
            type: bool                                                                              
            value: False                                                                                     
          1:                                                                                                 
            default: False                                                                    
            help: Update blocklists automatically. This requires the RPC to be enabled.                      
            id: YNH_CONFIG_BLOCKLIST_BLOCKLIST_AUTOSYNC                                                  
            name: Auto sync                                                        
            type: bool                                                                                  
            value: False                                     
          2:                     
            default:               
            id: YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY
            name: Sync frequency    
            placeholder: Journalier
            type: text
            value: pouet pouet poeut       
          3:                                      
            default: 
            help: The URL of the blocklist.
            id: YNH_CONFIG_BLOCKLIST_BLOCKLIST_URL    
            name: URL     
            type: url                                                                             
            value:                                    
  version: 0.1                                   
```

Here you can see the generated ids and the parsing of the output of the script and the result modified `config_panel.json`.

Result of `yunohost app config apply zerobin --debug -a "YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=prout"`

```
141  DEBUG loading actions map namespace 'yunohost'
156  DEBUG extra parameter classes loaded: ['ask', 'password', 'required', 'pattern']
157  DEBUG initializing base actions map parser for cli
158  DEBUG registering new callback action 'yunohost.utils.packages.ynh_packages_version' to ['-v', '--version']
222  DEBUG lock has been acquired
367  DEBUG loading python module yunohost.app took 0.144s
367  INFO processing action [20202.1]: yunohost.app.config.apply with args={'args': 'YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=prout', 'app_id': 'zerobin'}
369  DEBUG include into env YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=prout
370  DEBUG no value for key id YNH_CONFIG_PARAMETERS_MISC_CACHE_SIZE
370  DEBUG no value for key id YNH_CONFIG_PARAMETERS_MISC_DHT
370  DEBUG no value for key id YNH_CONFIG_BLOCKLIST_BLOCKLIST_ACTIVATE
371  DEBUG no value for key id YNH_CONFIG_BLOCKLIST_BLOCKLIST_AUTOSYNC
371  DEBUG no value for key id YNH_CONFIG_BLOCKLIST_BLOCKLIST_SYNC_FREQUENCY
371  DEBUG no value for key id YNH_CONFIG_BLOCKLIST_BLOCKLIST_URL
405  INFO Executing command 'sh -c YNH_CONFIG_PARAMETERS_GENERAL_ACTIVATE=prout YNH_CWD=/etc/yunohost/apps/zerobin/scripts BASH_XTRACEFD=7 /bin/bash -x "./config" apply 7>&1'...
415  INFO + case $1 in
417  INFO + apply_config
417  INFO + echo prout
418  INFO prout
522  SUCCESS Config updated as expected
522  DEBUG action [20202.1] executed in 0.154s
523  DEBUG lock has been released
```

#### How does the actions diverges from the configuration panel

One might ask himself: how does that diverges from the actions?

Then answer is that those serves 2 different purposes:

- the configuration panel is used to configure the installed software installed by the application (for example "transmission"). It solves the problem of having to modify text configuration files from the admin interface
- actions are here to, well, perform actions: importation/exportation/run procedures (eg: rescan files for nextcloud)/put website offline for maintainance/whatever...

## PR Status

The POC is working, the hardest part way the design on how to do that in a simple way. Now, the biggest things to do are:

- write the YunoHost-admin POC
- confront it to reality by implementing it into an application

Because this is quite a total new mechanism with quite some part I would really suggest to do gradual improvements following feedback from the applications developers (like "needed fields", "missing types of semantics for this kind of configuration panel") while getting pretty fast to a full working workflow in the admin interface.

I'm also aware that this is not super usable on a full CLI configuration, we'll probably need to work on a bit on a better API for that part but I think this needs to come after that the current part is more or less validated.

To give an idea of what I already have in mind, we probably need:

- `yunohost app config show $app_id` (without the `-panel`) which will simply list the key ids and their current values
- `yunohost app config set $app_id $key $value` (or `yunohost app config set $app_id -k $key -v $value`) which will do the equivalent of `yunohost app config apply $app_id -a "$key=$value"` but with a friendlier interface with only one id

Some details TODO:

- [ ] save config_panel.json in app dir
- [ ] save script/config in app dir (I think it's already done?)
- [ ] do a prototype on the web admin

## How to test

- switch to the branch
- put example `config_panel.json` at `/etc/yunohost/apps/$app_id/config_panel.json`
- put example `config` script at `/etc/yunohost/apps/$app_id/scripts/config`
- run the commands as shown in the example

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
