### PR TITLE
[fix] Redirect corectly php5 to php7 file during restore

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -103,6 +103,7 @@
     "backup_output_directory_not_empty": "The output directory is not empty",
     "backup_output_directory_required": "You must provide an output directory for the backup",
     "backup_output_symlink_dir_broken": "You have a broken symlink instead of your archives directory '{path:s}'. You may have a specific setup to backup your data on an other filesystem, in this case you probably forgot to remount or plug your hard dirve or usb key.",
+    "backup_php5_to_php7_migration_may_fail": "Could not convert your archive to support php7, your php apps may fail to restore (reason: {error:s})",
     "backup_running_app_script": "Running backup script of app '{app:s}'...",
     "backup_running_hooks": "Running backup hooks...",
     "backup_system_part_failed": "Unable to backup the '{part:s}' system part",

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1161,7 +1161,6 @@ class RestoreManager():
                     writer.writerow(row)
         except (IOError, OSError, csv.Error) as e:
             logger.warning(m18n.n('backup_php5_to_php7_migration_may_fail',
-                                  file=backup_csv,
                                   error=str(e)))
 
     def _restore_system(self):

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1128,22 +1128,23 @@ class RestoreManager():
 
         backup_csv = os.path.join(self.work_dir, 'backup.csv')
 
-        if os.path.isfile(backup_csv):
-            with open(backup_csv) as f:
-                lines = f.readlines()
+        if not os.path.isfile(backup_csv):
+            return
 
-                newlines = []
-                for line in lines:
-                    newline = line.replace('backup/etc/php5', 'backup/etc/php6') \
-                    .replace('"/etc/php5', '"/etc/php/7.0') \
-                    .replace('backup/var/run/php5-fpm', 'backup/var/run/php/php6-fpm') \
-                    .replace('"/var/run/php5-fpm', '"/var/run/php/php7.0-fpm') \
-                    .replace('php5','php7', 1) \
-                    .replace('php6', 'php5')
-                    newlines.append(newline)
+        lines = filesystem.read_file(backup_csv).split('\n')
 
-            with open(backup_csv, 'w') as f:
-                f.writelines(newlines)
+        newlines = []
+        for line in lines:
+            if 'php5' in line:
+                line = line.replace('backup/etc/php5', 'backup/etc/php6') \
+                .replace('"/etc/php5', '"/etc/php/7.0') \
+                .replace('backup/var/run/php5-fpm', 'backup/var/run/php/php6-fpm') \
+                .replace('"/var/run/php5-fpm', '"/var/run/php/php7.0-fpm') \
+                .replace('php5','php7', 1) \
+                .replace('php6', 'php5')
+            newlines.append(line)
+
+        filesystem.write_to_file(backup_csv, newlines)
 
     def _restore_system(self):
         """ Restore user and system parts """
@@ -1233,8 +1234,7 @@ class RestoreManager():
 
         # Delete _common.sh file in backup
         common_file = os.path.join(app_backup_in_archive, '_common.sh')
-        if os.path.isfile(common_file):
-            os.remove(common_file)
+        filesystem.rm(common_file, force=True)
 
         # Check if the app has a restore script
         app_restore_script_in_archive = os.path.join(app_scripts_in_archive,


### PR DESCRIPTION
## The problem

I tried to restore a backup of nextcloud made in jessie on my new stretch instance.

Was not working due to bad php5/php7 management.
https://github.com/YunoHost/issues/issues/1140

## Solution

I use here the backup.csv fileto redirect correctly the file in the good place.

I also delete a _common.sh file, because it's a bad pactice of packaging, that stores accidentally this file in /backup dir.

## PR Status

Untested, I just test the methodology, but i have done a sed manually and delete the _common.sh with pdb.

## How to test

Try to restore a nextcloud from jessie on a stretch version. Other php app are concerned too.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
