### PR TITLE
Fix counter-intuitive backup API

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -809,17 +809,11 @@ backup:
                 --apps:
                     help: List of application names to backup (all by default)
                     nargs: "*"
-                --hooks:
-                    help: (Deprecated) See --system
-                    nargs: "*"
                 --ignore-system:
                     help: Do not backup system
                     action: store_true
                 --ignore-apps:
                     help: Do not backup apps
-                    action: store_true
-                --ignore-hooks:
-                    help: (Deprecated) See --ignore-system
                     action: store_true
 
 
@@ -839,17 +833,11 @@ backup:
                 --apps:
                     help: List of application names to restore (all by default)
                     nargs: "*"
-                --hooks:
-                    help: (Deprecated) See --system
-                    nargs: "*"
                 --ignore-system:
                     help: Do not restore system parts
                     action: store_true
                 --ignore-apps:
                     help: Do not restore apps
-                    action: store_true
-                --ignore-hooks:
-                    help: (Deprecated) See --ignore-system
                     action: store_true
                 --force:
                     help: Force restauration on an already installed system

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -780,7 +780,7 @@ backup:
 
         ### backup_create()
         create:
-            action_help: Create a backup local archive
+            action_help: Create a backup local archive. If neither --apps or --system are given, this will backup all apps and all system parts. If only --apps if given, this will only backup apps and no system parts. Similarly, if only --system is given, this will only backup system parts and no apps.
             api: POST /backup
             arguments:
                 -n:
@@ -804,22 +804,15 @@ backup:
                     help: List of backup methods to apply (copy or tar by default)
                     nargs: "*"
                 --system:
-                    help: List of system parts to backup (all by default)
+                    help: List of system parts to backup (or all if none given).
                     nargs: "*"
                 --apps:
-                    help: List of application names to backup (all by default)
+                    help: List of application names to backup (or all if none given)
                     nargs: "*"
-                --ignore-system:
-                    help: Do not backup system
-                    action: store_true
-                --ignore-apps:
-                    help: Do not backup apps
-                    action: store_true
-
 
         ### backup_restore()
         restore:
-            action_help: Restore from a local backup archive
+            action_help: Restore from a local backup archive. If neither --apps or --system are given, this will restore all apps and all system parts in the archive. If only --apps if given, this will only restore apps and no system parts. Similarly, if only --system is given, this will only restore system parts and no apps.
             api: POST /backup/restore/<name>
             configuration:
                 authenticate: all
@@ -828,17 +821,11 @@ backup:
                 name:
                     help: Name of the local backup archive
                 --system:
-                    help: List of system parts to restore (all by default)
+                    help: List of system parts to restore (or all if none is given)
                     nargs: "*"
                 --apps:
-                    help: List of application names to restore (all by default)
+                    help: List of application names to restore (or all if none is given)
                     nargs: "*"
-                --ignore-system:
-                    help: Do not restore system parts
-                    action: store_true
-                --ignore-apps:
-                    help: Do not restore apps
-                    action: store_true
                 --force:
                     help: Force restauration on an already installed system
                     action: store_true

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1924,8 +1924,7 @@ class CustomBackupMethod(BackupMethod):
 def backup_create(name=None, description=None, methods=[],
                   output_directory=None, no_compress=False,
                   ignore_system=False, system=[],
-                  ignore_apps=False, apps=[],
-                  ignore_hooks=False, hooks=[]):
+                  ignore_apps=False, apps=[]):
     """
     Create a backup local archive
 
@@ -1939,9 +1938,6 @@ def backup_create(name=None, description=None, methods=[],
         ignore_system -- Ignore system elements
         apps -- List of application names to backup
         ignore_apps -- Do not backup apps
-
-        hooks -- (Deprecated) Renamed to "system"
-        ignore_hooks -- (Deprecated) Renamed to "ignore_system"
     """
 
     # TODO: Add a 'clean' argument to clean output directory
@@ -1949,17 +1945,6 @@ def backup_create(name=None, description=None, methods=[],
     ###########################################################################
     #   Validate / parse arguments                                            #
     ###########################################################################
-
-    # Historical, deprecated options
-    if ignore_hooks is not False:
-        logger.warning("--ignore-hooks is deprecated and will be removed in the"
-                       "future. Please use --ignore-system instead.")
-        ignore_system = ignore_hooks
-
-    if hooks != [] and hooks is not None:
-        logger.warning("--hooks is deprecated and will be removed in the"
-                       "future. Please use --system instead.")
-        system = hooks
 
     # Validate that there's something to backup
     if ignore_system and ignore_apps:
@@ -2057,7 +2042,6 @@ def backup_create(name=None, description=None, methods=[],
 def backup_restore(auth, name,
                    system=[], ignore_system=False,
                    apps=[], ignore_apps=False,
-                   hooks=[], ignore_hooks=False,
                    force=False):
     """
     Restore from a local backup archive
@@ -2069,24 +2053,11 @@ def backup_restore(auth, name,
         ignore_system -- Do not restore any system parts
         apps -- List of application names to restore
         ignore_apps -- Do not restore apps
-
-        hooks -- (Deprecated) Renamed to "system"
-        ignore_hooks -- (Deprecated) Renamed to "ignore_system"
     """
 
     ###########################################################################
     #   Validate / parse arguments                                            #
     ###########################################################################
-
-    # Historical, deprecated options
-    if ignore_hooks is not False:
-        logger.warning("--ignore-hooks is deprecated and will be removed in the"
-                       "future. Please use --ignore-system instead.")
-        ignore_system = ignore_hooks
-    if hooks != [] and hooks is not None:
-        logger.warning("--hooks is deprecated and will be removed in the"
-                       "future. Please use --system instead.")
-        system = hooks
 
     # Validate what to restore
     if ignore_system and ignore_apps:


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1102

Currently there are some counter-intuitive behaviors with `backup create` and `backup restore`.

Typically, `yunohost backup create --apps wordpress` will backup wordpress *and the whole system*. You need to explicitly add `--ignore-system` at the end. Similarly, `yunohost backup create --system ldap` will backup the ldap base *and all the apps*. This kind of stuff also apply for the restore, so  `yunohost backup restore --apps wordpress` will restore wordpress *and all the system* ...

This would be nice to have this fix for stretch as we can expect several people to be willing to use the backup/restore instead of the straight migration.

## Solution

- (Remove old deprecated `--hooks` options)
- Remove `--ignore-system` and `--ignore-apps`
- Only backup/restore what is explicitly given in argument (or everything if neither `--apps` or `--system` are given)

To clarify, here's a table summarizing the behavior for a few example : 

| Commnand | Behavior |
| :--: | :--: |
| `yunohost backup create` | Create a backup of everything (apps and system) |
| `yunohost backup create --apps ` | Create a backup of all apps (no system) |
| `yunohost backup create --apps wordpress ` | Create a backup of wordpress only |
| `yunohost backup create --apps wordpress --system ` | Create a backup of wordpress only + all the system |
| `yunohost backup create --apps wordpress --system ldap` | Create a backup of wordpress only + ldap base |

(Same kind of behavior for restore)

## PR Status

To be tested

## How to test

Pull the branch and maybe add some debug info + a return to see what it would do without actually doing it ...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
