### PR TITLE
Remove archivemount stuff

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Recommends: yunohost-admin
  , python-pip
  , unattended-upgrades
  , libdbd-ldap-perl, libnet-dns-perl
-Suggests: htop, vim, rsync, acpi-support-base, udisks2, archivemount
+Suggests: htop, vim, rsync, acpi-support-base, udisks2
 Conflicts: iptables-persistent
  , moulinette-yunohost, yunohost-config
  , yunohost-config-others, yunohost-config-postfix


### PR DESCRIPTION
## The problem

We hoped that archivemount would be great for backup restoring and intended to use it as the default solution, but turns out that it suboptimal and leads to various issues.

Also currently, restoring an archive on a system where archivemount is not installed leads to a warning like "Failed to mount the archive", which makes it looks like the restore is failing where it falls back to "untaring" the archive which is fine.

## Solution

Remove all code related to archivemount, and just use the untar-ing as default method, which in fact is better than archivemount on several aspects.

## PR Status

Not tested :|

## How to test

Pull the branch and try to restore some backup archives (full restore and partial restores)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
