### PR TITLE
HPKP

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -40,7 +40,7 @@ do_pre_regen() {
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
     if [$domain_ca_type = "CA_type: Let's Encrypt"]; then
-      if [ ! -f "${pending_dir}/etc/yunohost/certs/${domain}/chain.pem" ];then
+      if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ];then
         wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
       fi
       sed "s/#ssl_stapling/ssl_stapling/g" "${nginx_conf_dir}/${domain}.conf"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -38,8 +38,8 @@ do_pre_regen() {
   for domain in $domain_list; do
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
-    domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
-    if [[ "$domain_ca_type" = "    CA_type: Let's Encrypt" ]]; then
+    domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type | tr -d " ")
+    if [[ "$domain_ca_type" = "CA_type:Let'sEncrypt" ]]; then
       ### OCSP Stapling
       if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
         wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -39,13 +39,24 @@ do_pre_regen() {
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
-    if [$domain_ca_type = "CA_type: Let's Encrypt"]; then
-      if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ];then
+    if [ $domain_ca_type = "CA_type: Let's Encrypt" ]; then
+      ### OCSP Stapling
+      if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
         wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
       fi
       sed "s/#ssl_stapling/ssl_stapling/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#ssl_trusted_certificate/ssl_trusted_certificate/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#resolver/resolver/g" "${nginx_conf_dir}/${domain}.conf"
+      
+      ### HPKP
+      if [ -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
+        hash1=$(openssl x509 -pubkey -in ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64)
+        hash2=$(openssl x509 -pubkey -in ${pending_dir}/etc/yunohost/certs/${domain}/crt.pem | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64)
+        popd
+        sed "s/HASH1/$hash1/g" "${nginx_conf_dir}/${domain}.conf"
+        sed "s/HASH2/$hash2/g" "${nginx_conf_dir}/${domain}.conf"
+        sed "s/#add_header Public-Key-Pins/add_header Public-Key-Pins/g" "${nginx_conf_dir}/${domain}.conf"
+      fi
     fi
 
     # NGINX server configuration

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -39,8 +39,10 @@ do_pre_regen() {
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
-    if [domain_ca_type == "CA_type: Let's Encrypt"]; then
-      wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
+    if [$domain_ca_type = "CA_type: Let's Encrypt"]; then
+      if [ ! -f "${pending_dir}/etc/yunohost/certs/${domain}/chain.pem" ];then
+        wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
+      fi
       sed "s/#ssl_stapling/ssl_stapling/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#ssl_trusted_certificate/ssl_trusted_certificate/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#resolver/resolver/g" "${nginx_conf_dir}/${domain}.conf"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -52,7 +52,6 @@ do_pre_regen() {
       if [ -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
         hash1=$(openssl x509 -pubkey -in ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64)
         hash2=$(openssl x509 -pubkey -in ${pending_dir}/etc/yunohost/certs/${domain}/crt.pem | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | base64)
-        popd
         sed "s/HASH1/$hash1/g" "${nginx_conf_dir}/${domain}.conf"
         sed "s/HASH2/$hash2/g" "${nginx_conf_dir}/${domain}.conf"
         sed "s/#add_header Public-Key-Pins/add_header Public-Key-Pins/g" "${nginx_conf_dir}/${domain}.conf"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -40,7 +40,7 @@ do_pre_regen() {
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
     if [domain_ca_type == "CA_type: Let's Encrypt"]; then
-      wget -O /etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
+      wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
       sed "s/#ssl_stapling/ssl_stapling/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#ssl_trusted_certificate/ssl_trusted_certificate/g" "${nginx_conf_dir}/${domain}.conf"
       sed "s/#resolver/resolver/g" "${nginx_conf_dir}/${domain}.conf"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -38,6 +38,13 @@ do_pre_regen() {
   for domain in $domain_list; do
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
+    domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
+    if [domain_ca_type == "CA_type: Let's Encrypt"]; then
+      wget -O /etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
+      sed "s/#ssl_stapling/ssl_stapling/g" "${nginx_conf_dir}/${domain}.conf"
+      sed "s/#ssl_trusted_certificate/ssl_trusted_certificate/g" "${nginx_conf_dir}/${domain}.conf"
+      sed "s/#resolver/resolver/g" "${nginx_conf_dir}/${domain}.conf"
+    fi
 
     # NGINX server configuration
     cat server.tpl.conf \

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -39,7 +39,7 @@ do_pre_regen() {
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
-    if [ "$domain_ca_type" = "CA_type: Let's Encrypt" ]; then
+    if [[ "$domain_ca_type" = "    CA_type: Let's Encrypt" ]]; then
       ### OCSP Stapling
       if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
         wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -39,7 +39,7 @@ do_pre_regen() {
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
     domain_ca_type=$(yunohost domain cert-status ${domain} | grep CA_type)
-    if [ $domain_ca_type = "CA_type: Let's Encrypt" ]; then
+    if [ "$domain_ca_type" = "CA_type: Let's Encrypt" ]; then
       ### OCSP Stapling
       if [ ! -f "/etc/yunohost/certs/${domain}/chain.pem" ]; then
         wget -O ${pending_dir}/etc/yunohost/certs/${domain}/chain.pem "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -68,6 +68,9 @@ server {
     #resolver 80.67.169.12 80.67.169.40 valid=300s;
     #resolver_timeout 5s;
 
+    # HPKP: HTTP Public Key Pinning Extension
+    #add_header Public-Key-Pins 'pin-sha256="HASH1"; pin-sha256="HASH2"; max-age=2592000; includeSubDomains';
+
     access_by_lua_file /usr/share/ssowat/access.lua;
 
     include conf.d/{{ domain }}.d/*.conf;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -61,6 +61,13 @@ server {
     add_header X-Permitted-Cross-Domain-Policies none;
     add_header X-Frame-Options "SAMEORIGIN";
 
+    # OCSP settings
+    #ssl_stapling on;
+    #ssl_stapling_verify on;
+    #ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/chain.pem;
+    #resolver 80.67.169.12 80.67.169.40 valid=300s;
+    #resolver_timeout 5s;
+
     access_by_lua_file /usr/share/ssowat/access.lua;
 
     include conf.d/{{ domain }}.d/*.conf;


### PR DESCRIPTION
## The problem


"HTTP Public Key Pinning Extension
An example might be your bank, which always have their certificate from CA Company A. With the current certificate system, CA Company B, CA Company C and the NSA CA can all create a certificate for your bank, which your browser will hapily accept because those companies are also trusted root CA's.

If the bank implements HPKP and pin's their first intermidiate certificate (from CA Company A), browsers will not accept certificates from CA Company B and CA Company C, even if they have a valid trust path. HPKP also allows your browser to report back the failure to the bank, so that they know they are under attack." cf. https://raymii.org/s/articles/HTTP_Public_Key_Pinning_Extension_HPKP.html

## Solution

Implement HPKP for LE certificate

## PR Status

Work finished / Not tested

## How to test

Require OCSP (build code on previous PR to avoid conflicts : https://github.com/YunoHost/yunohost/pull/492)
Install yunohost + nginx

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
