### PR TITLE
[enh] Add MUA autoconfig.

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -38,11 +38,18 @@ do_pre_regen() {
   for domain in $domain_list; do
     domain_conf_dir="${nginx_conf_dir}/${domain}.d"
     mkdir -p "$domain_conf_dir"
+    mail_autoconfig_dir="${pending_dir}/var/www/.well-known/${domain}/autoconfig/mail/"
+    mkdir -p "$mail_autoconfig_dir"
 
     # NGINX server configuration
     cat server.tpl.conf \
       | sed "s/{{ domain }}/${domain}/g" \
       > "${nginx_conf_dir}/${domain}.conf"
+
+    cat autoconfig.tpl.xml \
+      | sed "s/{{ domain }}/${domain}/g" \
+      > "${mail_autoconfig_dir}/config-v1.1.xml"
+
 
     [[ $main_domain != $domain ]] \
       && touch "${domain_conf_dir}/yunohost_local.conf" \
@@ -56,6 +63,14 @@ do_pre_regen() {
     domain=${file%.conf}
     [[ $domain_list =~ $domain ]] \
       || touch "${nginx_conf_dir}/${file}"
+  done
+
+  # remove old mail-autoconfig files
+  autoconfig_files=$(ls -1 /var/www/.well-known/*/autoconfig/mail/config-v1.1.xml)
+  for file in $autoconfig_files; do
+    domain=$(basename $(readlink -f $(dirname $file)/../..))
+    [[ $domain_list =~ $domain ]] \
+      || (mkdir -p "$(dirname ${pending_dir}/${file})" && touch "${pending_dir}/${file}")
   done
 
   # disable default site

--- a/data/templates/nginx/autoconfig.tpl.xml
+++ b/data/templates/nginx/autoconfig.tpl.xml
@@ -1,0 +1,19 @@
+<clientConfig version="1.1">
+  <emailProvider id="{{ domain }}">
+    <domain>{{ domain }}</domain>
+    <incomingServer type="imap">
+      <hostname>{{ domain }}</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILLOCALPART%</username>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>{{ domain }}</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <authentication>password-cleartext</authentication>
+      <username>%EMAILLOCALPART%</username>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -11,6 +11,10 @@ server {
         return 301 https://$http_host$request_uri;
     }
 
+    location /.well-known/autoconfig/mail {
+        alias /var/www/.well-known/{{ domain }}/autoconfig/mail;
+    }
+
     access_log /var/log/nginx/{{ domain }}-access.log;
     error_log /var/log/nginx/{{ domain }}-error.log;
 }

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1321,6 +1321,7 @@ def app_ssowatconf(auth):
 
     # Authorize ACME challenge url
     skipped_regex.append("^[^/]*/%.well%-known/acme%-challenge/.*$")
+    skipped_regex.append("^[^/]*/%.well%-known/autoconfig/mail/config%-v1%.1%.xml.*$")
 
     conf_dict = {
         'portal_domain': main_domain,


### PR DESCRIPTION
## The problem

Configuring Thunderbird can be tedious.
You have to select the proper protocols and ports for both incoming and outgoing emails.

## Solution

Fortunately there is a mechanism called [Autoconfiguration](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration ) we can use to make life easier for users of Thunderbird.
TL;DR, the yunohost server only needs to publish a specific XML file on http://domain.tld/.well-known/autoconfig/mail/config-v1.1.xml, Thunderbird will find it and then automatically configure the proper ports and protocols.

## PR Status

- [x] test the publishing mechanism (tested by pitchum)
- [x] update autoconfigs of existing domains each time regenconf is invoked
- [x] remove autoconfigs for removed domains each time regenconf is invoked
- [x] test a complete scenario in thunderbird with a real domain name (tested by pitchum)

## How to test

Create a new domain like *example.net* and create a user account like john@example.net.
Don't forget to update the DNS configuration for this new domain.

Then open Thunderbird, add a new mail account.
In the popup, fill the 3 fields (name, email address *john@example.net* and the password) and then click next.
After a few seconds Thunderbird should display "Configuration found for mail provider" and no manual configuration should be needed.
...

## Validation

- [ ] Principle agreement 1/2 : ljf
- [ ] Quick review 0/1 :
- [x] Simple test 1/1 : pitchum
- [x] Deep review 1/1 :  ljf
