### PR TITLE
[fix] fix recursive super slow import in certificate.py

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -40,7 +40,6 @@ from yunohost.vendor.acme_tiny.acme_tiny import get_crt as sign_certificate
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 
-import yunohost.domain
 from yunohost.utils.network import get_public_ip
 
 from moulinette import m18n
@@ -95,6 +94,8 @@ def certificate_status(auth, domain_list, full=False):
         domain_list -- Domains to be checked
         full        -- Display more info about the certificates
     """
+
+    import yunohost.domain
 
     # Check if old letsencrypt_ynh is installed
     # TODO / FIXME - Remove this in the future once the letsencrypt app is
@@ -243,6 +244,8 @@ def _certificate_install_selfsigned(domain_list, force=False):
 
 
 def _certificate_install_letsencrypt(auth, domain_list, force=False, no_checks=False, staging=False):
+    import yunohost.domain
+
     if not os.path.exists(ACCOUNT_KEY_FILE):
         _generate_account_key()
 
@@ -308,6 +311,8 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
                       before attempting the renewing
         email      -- Emails root if some renewing failed
     """
+
+    import yunohost.domain
 
     # Check if old letsencrypt_ynh is installed
     # TODO / FIXME - Remove this in the future once the letsencrypt app is
@@ -402,6 +407,8 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
 ###############################################################################
 
 def _check_old_letsencrypt_app():
+    import yunohost.domain
+
     installedAppIds = [app["id"] for app in yunohost.app.app_list(installed=True)["apps"]]
 
     if "letsencrypt" not in installedAppIds:


### PR DESCRIPTION
## The problem

Due to the files hierarchy in YunoHost we end up having a recursive import in `certificate.py` (between this file and `domain.py`) which slow down things a lot.

On my vagrant this makes importing `domain.py` take up to 24(!) secondes(!!).

Ironically this is probably my fault.

## Solution

Remove this crap.

## PR Status

Ready to merge, would be more confident with more test but yeah...

I've runt pyflake that told me that everything was fine.

## How to test

Uses "time yunohost domain list" with and without the patch I guess, or anything that imports `domain.py` or `certificate.py`.

## Validation

- [ ] Principle agreement 1/2 : ljf
- [x] Quick review 1/1 : ljf
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

Adding some debug prints, here is an importation session of `domain.py` before my patch:

```
system imports: 6.99999999998e-06
moulinette imports: 1.9e-05
system imports: 0.012668
moulinette imports: 0.00262
system imports: 0.019746
moulinette imports: 0.003927
system imports: 0.02602
moulinette imports: 0.005485
system imports: 0.032604
moulinette imports: 0.006573
system imports: 0.038929
moulinette imports: 0.008204
system imports: 0.045817
moulinette imports: 0.009309
system imports: 0.053812
moulinette imports: 0.010856
system imports: 0.059976
moulinette imports: 0.012029
system imports: 0.066959
moulinette imports: 0.013604
system imports: 0.071888
moulinette imports: 0.015141
system imports: 0.079747
moulinette imports: 0.015909
system imports: 0.087392
moulinette imports: 0.017361
system imports: 0.096054
moulinette imports: 0.018837
system imports: 0.097081
moulinette imports: 0.021145
system imports: 0.108139
moulinette imports: 0.024715
system imports: 0.117391
moulinette imports: 0.022745
system imports: 0.121339
moulinette imports: 0.024676
system imports: 0.130603
moulinette imports: 0.029829
system imports: 0.142887
moulinette imports: 0.027147
certificate imports: 0.110859
service imports: 0.003056
utils.network imports: 0.005131
certificate imports: 1.928747
service imports: 0.203484
utils.network imports: 0.187313
certificate imports: 4.213748
service imports: 0.197247
utils.network imports: 0.197359
certificate imports: 6.360801
service imports: 0.172201
utils.network imports: 0.167251
certificate imports: 8.452225
service imports: 0.16161
utils.network imports: 0.15872
certificate imports: 10.396474
service imports: 0.157291
utils.network imports: 0.148567
certificate imports: 12.148343
service imports: 0.147888
utils.network imports: 0.137294
certificate imports: 13.856643
service imports: 0.138361
utils.network imports: 0.132939
certificate imports: 15.419749
service imports: 0.136398
utils.network imports: 0.12446
certificate imports: 16.834579
service imports: 0.109282
utils.network imports: 0.108967
certificate imports: 18.103295
service imports: 0.104191
utils.network imports: 0.100148
certificate imports: 19.258947
service imports: 0.090601
utils.network imports: 0.089293
certificate imports: 20.301753
service imports: 0.081334
utils.network imports: 0.078989
certificate imports: 21.2395
service imports: 0.070817
utils.network imports: 0.069088
certificate imports: 22.034963
service imports: 0.063319
utils.network imports: 0.059467
certificate imports: 22.720922
service imports: 0.05557
utils.network imports: 0.049853
certificate imports: 23.299306
service imports: 0.043575
utils.network imports: 0.04733
certificate imports: 23.763651
service imports: 0.034766
utils.network imports: 0.033099
certificate imports: 24.120261
service imports: 0.023974
utils.network imports: 0.023014
certificate imports: 24.352509
service imports: 8.00000000112e-06
utils.network imports: 0.006815
```

It looks like this after:

```
system imports: 6.99999999998e-06
moulinette imports: 1.2e-05
certificate imports: 0.291755
service imports: 0.014951
utils.network imports: 0.01419
```
