### PR TITLE
[ux] display human understandable choice for boolean type on installation

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2074,7 +2074,7 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
 
                 if arg_default is not None:
                     if arg_type == 'boolean':
-                        ask_string += ' (default: {0})'.format("yes" if arg_type == 1 else "no")
+                        ask_string += ' (default: {0})'.format("yes" if arg_default == 1 else "no")
                     else:
                         ask_string += ' (default: {0})'.format(arg_default)
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2068,11 +2068,15 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
 
                 # Append extra strings
                 if arg_type == 'boolean':
-                    ask_string += ' [0 | 1]'
+                    ask_string += ' [yes | no]'
                 elif arg_choices:
                     ask_string += ' [{0}]'.format(' | '.join(arg_choices))
+
                 if arg_default is not None:
-                    ask_string += ' (default: {0})'.format(arg_default)
+                    if arg_type == 'boolean':
+                        ask_string += ' (default: {0})'.format("yes" if arg_type == 1 else "no")
+                    else:
+                        ask_string += ' (default: {0})'.format(arg_default)
 
                 # Check for a password argument
                 is_password = True if arg_type == 'password' else False
@@ -2133,14 +2137,14 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
             if isinstance(arg_value, bool):
                 arg_value = 1 if arg_value else 0
             else:
-                try:
-                    arg_value = int(arg_value)
-                    if arg_value not in [0, 1]:
-                        raise ValueError()
-                except (TypeError, ValueError):
+                if str(arg_value).lower() in ["1", "yes", "y"]:
+                    arg_value = 1
+                elif str(arg_value).lower() in ["0", "no", "n"]:
+                    arg_value = 0
+                else:
                     raise MoulinetteError(errno.EINVAL,
                         m18n.n('app_argument_choice_invalid',
-                            name=arg_name, choices='0, 1'))
+                            name=arg_name, choices='yes, no, y, n, 1, 0'))
         args_dict[arg_name] = arg_value
 
     # END loop over action_args...


### PR DESCRIPTION
## The problem

Right now, the CLI help to chose a value for a boolean type during an app installation is horrible from a UX point of view, it looks like this:

    Is it a public Zerobin site ? [1 | 0] (default: 0):

Good luck guessing what is true and what is false.

It's a long know problem and it happen to have pissed me off once too often and I was working on that part of the code.

## Solution

Do something that regular non nerdy humans can understand, like this:

    Is it a public Zerobin site ? [yes | no] (default: no): 

It also now accept: "yes", "y", "no", "n", "1", "0" as valid answers and ignore the case.

## PR Status

Tested for me and ready to merge.

## How to test

Install zerobin.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
