### PR TITLE
[fix] timeout on get_public_ip otherwish dyndns update is stucked

### DIFF
--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -21,7 +21,9 @@
 import logging
 import re
 import subprocess
-from urllib import urlopen
+import requests
+
+from requests import ConnectionError
 
 logger = logging.getLogger('yunohost.utils.network')
 
@@ -37,8 +39,8 @@ def get_public_ip(protocol=4):
         raise ValueError("invalid protocol version")
 
     try:
-        return urlopen(url).read().strip()
-    except IOError:
+        return requests.get(url, timeout=30).content.strip()
+    except ConnectionError:
         return None
 
 

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -21,9 +21,7 @@
 import logging
 import re
 import subprocess
-import requests
-
-from requests import ConnectionError
+from moulinette.utils.network import download_text
 
 logger = logging.getLogger('yunohost.utils.network')
 
@@ -38,10 +36,7 @@ def get_public_ip(protocol=4):
     else:
         raise ValueError("invalid protocol version")
 
-    try:
-        return requests.get(url, timeout=30).content.strip()
-    except ConnectionError:
-        return None
+    return download_text(url, timeout=30).strip()
 
 
 def get_network_interfaces():


### PR DESCRIPTION
## The problem

`get_public_ip` is used by `dyndns_update`. In some networking configuration (because network) ipv6 is up but goes nowhere, therefor the request never finish.

Currently, we use urllib (yes, urllib1) which never timeout, therefor `dyndns_update` never complet, get stuck and the cron keep spawning more and more which ends up eating all the RAM of the server and making it unusable, which is a pretty serious problem.

Since this is quite server and pretty easy to fix I think we should also release a fix for jessie.

## Solution

Add modern code that times out.

## PR Status

Ready to merge.

## How to test

Run dyndns_update.

## Validation

Microdecision.