### PR TITLE
[fix] sometime nginx is not running

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -77,7 +77,7 @@ do_post_regen() {
   done
 
   # Reload nginx configuration
-  sudo service nginx reload
+  pgrep nginx && sudo service nginx reload
 }
 
 FORCE=${2:-0}


### PR DESCRIPTION
## The problem

Sometime (for example at the first time of a vagrant or because the user has decided to), nginx is not running.

That breaks the regen-conf with this error:

    Warning: nginx.service is not active, cannot reload.
    Error: Script execution failed: /usr/share/yunohost/hooks/conf_regen/15-nginx

## Solution

Check if nginx is running before trying to reload it.

I'm not 100% sure if we want to do that :/

## PR Status

Ready to merge

## How to test

    yunohost service regen-conf nginx

With nginx stopped.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
