### PR TITLE
Fix nodejs removal in ynh_remove_nodejs

### DIFF
--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -138,6 +138,8 @@ ynh_remove_nodejs () {
 	then
 		ynh_secure_remove "$n_install_dir"
 		ynh_secure_remove "/usr/local/n"
+		sed --in-place "/N_PREFIX/d" /root/.bashrc
+		rm -f /etc/cron.daily/node_update
 	fi
 }
 


### PR DESCRIPTION
## The problem

A few minor things forgotten when actually removing nodejs via the helper ?
c.f. https://github.com/YunoHost-Apps/wekan_ynh/issues/6
and https://github.com/YunoHost-Apps/wekan_ynh/blob/master/scripts/_future.sh#L162

## Solution

Add missing lines

## PR Status

To be validated / reviewed by actual nodejs / helper experts :P I have no idea if this is the right thing to do

## How to test

Uh idk :s 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
