### PR TITLE
[enh] list available users on app installation user argument

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -404,6 +404,7 @@
     "user_unknown": "Unknown user: {user:s}",
     "user_update_failed": "Unable to update user",
     "user_updated": "The user has been updated",
+    "users_available": "Available users:",
     "yunohost_already_installed": "YunoHost is already installed",
     "yunohost_ca_creation_failed": "Unable to create certificate authority",
     "yunohost_ca_creation_success": "The local certification authority has been created.",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2043,7 +2043,7 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
     """
     from yunohost.domain import (domain_list, _get_maindomain,
                                  domain_url_available, _normalize_domain_path)
-    from yunohost.user import user_info
+    from yunohost.user import user_info, user_list
 
     args_dict = OrderedDict()
 
@@ -2084,6 +2084,11 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
                     msignals.display(m18n.n('domains_available'))
                     for domain in domain_list(auth)['domains']:
                         msignals.display("- {}".format(domain))
+
+                if arg_type == 'user':
+                    msignals.display(m18n.n('users_available'))
+                    for user in user_list(auth)['users'].keys():
+                        msignals.display("- {}".format(user))
 
                 try:
                     input_string = msignals.prompt(ask_string, is_password)


### PR DESCRIPTION
## The problem

On app installation it can happen that a user is required. On CLI interface we don't have a drop down menu to select the user so we need to remember from memory the username of the right user. That sucks.

Solves https://github.com/YunoHost/issues/issues/1149

## Solution

Display available users. Code is based on domain listing just above.

## PR Status

Ready to merge.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
