### PR TITLE
App without sso

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1284,7 +1284,7 @@ def app_ssowatconf(auth):
     redirected_urls = {}
 
     try:
-        apps_list = app_list()['apps']
+        apps_list = app_list(installed=True)['apps']
     except:
         apps_list = []
 
@@ -1293,31 +1293,30 @@ def app_ssowatconf(auth):
         return s.split(',') if s else []
 
     for app in apps_list:
-        if _is_installed(app['id']):
-            with open(APPS_SETTING_PATH + app['id'] + '/settings.yml') as f:
-                app_settings = yaml.load(f)
-                for item in _get_setting(app_settings, 'skipped_uris'):
-                    if item[-1:] == '/':
-                        item = item[:-1]
-                    skipped_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-                for item in _get_setting(app_settings, 'skipped_regex'):
-                    skipped_regex.append(item)
-                for item in _get_setting(app_settings, 'unprotected_uris'):
-                    if item[-1:] == '/':
-                        item = item[:-1]
-                    unprotected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-                for item in _get_setting(app_settings, 'unprotected_regex'):
-                    unprotected_regex.append(item)
-                for item in _get_setting(app_settings, 'protected_uris'):
-                    if item[-1:] == '/':
-                        item = item[:-1]
-                    protected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-                for item in _get_setting(app_settings, 'protected_regex'):
-                    protected_regex.append(item)
-                if 'redirected_urls' in app_settings:
-                    redirected_urls.update(app_settings['redirected_urls'])
-                if 'redirected_regex' in app_settings:
-                    redirected_regex.update(app_settings['redirected_regex'])
+        with open(APPS_SETTING_PATH + app['id'] + '/settings.yml') as f:
+            app_settings = yaml.load(f)
+            for item in _get_setting(app_settings, 'skipped_uris'):
+                if item[-1:] == '/':
+                    item = item[:-1]
+                skipped_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
+            for item in _get_setting(app_settings, 'skipped_regex'):
+                skipped_regex.append(item)
+            for item in _get_setting(app_settings, 'unprotected_uris'):
+                if item[-1:] == '/':
+                    item = item[:-1]
+                unprotected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
+            for item in _get_setting(app_settings, 'unprotected_regex'):
+                unprotected_regex.append(item)
+            for item in _get_setting(app_settings, 'protected_uris'):
+                if item[-1:] == '/':
+                    item = item[:-1]
+                protected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
+            for item in _get_setting(app_settings, 'protected_regex'):
+                protected_regex.append(item)
+            if 'redirected_urls' in app_settings:
+                redirected_urls.update(app_settings['redirected_urls'])
+            if 'redirected_regex' in app_settings:
+                redirected_regex.update(app_settings['redirected_regex'])
 
     for domain in domains:
         skipped_urls.extend([domain + '/yunohost/admin', domain + '/yunohost/api'])

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -399,6 +399,8 @@ def app_map(app=None, raw=False, user=None):
             continue
         if 'domain' not in app_settings:
             continue
+        if 'no_sso' in app_settings:  # I don't think we need to check for the value here
+            continue
         if user is not None:
             if ('mode' not in app_settings
                 or ('mode' in app_settings
@@ -1291,6 +1293,10 @@ def app_ssowatconf(auth):
     for app in apps_list:
         with open(APPS_SETTING_PATH + app['id'] + '/settings.yml') as f:
             app_settings = yaml.load(f)
+
+            if 'no_sso' in app_settings:
+                continue
+
             for item in _get_setting(app_settings, 'skipped_uris'):
                 if item[-1:] == '/':
                     item = item[:-1]

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1270,10 +1270,6 @@ def app_ssowatconf(auth):
     main_domain = _get_maindomain()
     domains = domain_list(auth)['domains']
 
-    users = {}
-    for username in user_list(auth)['users'].keys():
-        users[username] = app_map(user=username)
-
     skipped_urls = []
     skipped_regex = []
     unprotected_urls = []
@@ -1342,7 +1338,8 @@ def app_ssowatconf(auth):
         'protected_regex': protected_regex,
         'redirected_urls': redirected_urls,
         'redirected_regex': redirected_regex,
-        'users': users,
+        'users': {username: app_map(user=username)
+                  for username in user_list(auth)['users'].keys()},
     }
 
     with open('/etc/ssowat/conf.json', 'w+') as f:

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -36,7 +36,6 @@ import subprocess
 from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_file
 from yunohost.service import service_status
 
 logger = getActionLogger('yunohost.user')
@@ -112,7 +111,6 @@ def user_create(auth, username, firstname, lastname, mail, password,
         mailbox_quota -- Mailbox size quota
 
     """
-    import pwd
     from yunohost.domain import domain_list, _get_maindomain
     from yunohost.hook import hook_callback
     from yunohost.app import app_ssowatconf


### PR DESCRIPTION
## The problem

Fixes https://github.com/YunoHost/issues/issues/1163

## Solution

Allow an application to optout of ssowat if the key 'no_sso' is defined (I don't think checking for a value makes that much sens here).

The only interesting commit of this PR is https://github.com/YunoHost/yunohost/commit/2bf327970b9f9270d6d5453a68b31fa835d22392

## PR Status

Tested and ready to merge, except if we want to bikesheed on the key name but I really don't care about that, just don't block the PR too long for that plz :/

## How to test

    yunohost app setting app_that_should_appear_in_sso no_sso -v true
    yunohost app ssowatconf
    cat /etc/ssowat/conf.json  # ← here you shouldn't see the app in the conf in the users section

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
