### PR TITLE
Fix container detection

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -234,14 +234,14 @@ def _is_inside_container():
     Returns True or False
     """
 
-    # See https://stackoverflow.com/a/37016302
-    p = subprocess.Popen("sudo cat /proc/1/sched".split(),
+    # See https://www.2daygeek.com/check-linux-system-physical-virtual-machine-virtualization-technology/
+    p = subprocess.Popen("sudo systemd-detect-virt".split(),
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
 
     out, _ = p.communicate()
-
-    return out.split()[1] != "(1,"
+    container = ['lxc','lxd','docker']
+    return out.split()[0] in container
 
 
 def tools_postinstall(domain, password, ignore_dyndns=False):


### PR DESCRIPTION


## The problem

As documented [here in section "Support for daemonized app containers"](https://linuxcontainers.org/fr/lxc/news/#major-changes) since LXC 3.0 the init process ID is 1. So it's not possible to detect if we are in a container by just getting the init process ID.

## Solution

Use an other solution which might be more strong which is using the `systemd-detect-virt` command.

## PR Status

- Tested with lxc 3.0 (which need to return true).
- Tested with virtualbox (which need to return false).
- I just wrote 'lxd', 'docker' but I didn't test it, so it could be false. If somebody use docker, lxd, or an other container manager it could be interesting to know what return the command `systemd-detect-virt`.

## How to test

- Testing what return `systemd-detect-virt` in some different architecture could be useful to improve this PR.
- Get this patch and try a postinstall on some different architecture.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
