### PR TITLE
[mod] propagate the no_checks logic to acme-tiny code

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -289,7 +289,7 @@ def _certificate_install_letsencrypt(auth, domain_list, force=False, no_checks=F
                 _check_domain_is_ready_for_ACME(domain)
 
             _configure_for_acme_challenge(auth, domain)
-            _fetch_and_enable_new_certificate(domain, staging)
+            _fetch_and_enable_new_certificate(domain, staging, no_checks=no_checks)
             _install_cron()
 
             logger.success(
@@ -383,7 +383,7 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
             if not no_checks:
                 _check_domain_is_ready_for_ACME(domain)
 
-            _fetch_and_enable_new_certificate(domain, staging)
+            _fetch_and_enable_new_certificate(domain, staging, no_checks=no_checks)
 
             logger.success(
                 m18n.n("certmanager_cert_renew_success", domain=domain))
@@ -521,7 +521,7 @@ def _check_acme_challenge_configuration(domain):
         return True
 
 
-def _fetch_and_enable_new_certificate(domain, staging=False):
+def _fetch_and_enable_new_certificate(domain, staging=False, no_checks=False):
     # Make sure tmp folder exists
     logger.debug("Making sure tmp folders exists...")
 
@@ -562,6 +562,7 @@ def _fetch_and_enable_new_certificate(domain, staging=False):
                                               domain_csr_file,
                                               WEBROOT_FOLDER,
                                               log=logger,
+                                              no_checks=no_checks,
                                               CA=certification_authority)
     except ValueError as e:
         if "urn:acme:error:rateLimited" in str(e):

--- a/src/yunohost/vendor/acme_tiny/acme_tiny.py
+++ b/src/yunohost/vendor/acme_tiny/acme_tiny.py
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.INFO)
 
-def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
+def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA, no_checks=False):
     # helper function base64 encode for jose spec
     def _b64(b):
         return base64.urlsafe_b64encode(b).decode('utf8').replace("=", "")
@@ -111,16 +111,17 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
         with open(wellknown_path, "w") as wellknown_file:
             wellknown_file.write(keyauthorization)
 
-        # check that the file is in place
-        wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
-        try:
-            resp = urlopen(wellknown_url)
-            resp_data = resp.read().decode('utf8').strip()
-            assert resp_data == keyauthorization
-        except (IOError, AssertionError):
-            os.remove(wellknown_path)
-            raise ValueError("Wrote file to {0}, but couldn't download {1}".format(
-                wellknown_path, wellknown_url))
+        if not no_checks:  # sometime the local g
+            # check that the file is in place
+            wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
+            try:
+                resp = urlopen(wellknown_url)
+                resp_data = resp.read().decode('utf8').strip()
+                assert resp_data == keyauthorization
+            except (IOError, AssertionError):
+                os.remove(wellknown_path)
+                raise ValueError("Wrote file to {0}, but couldn't download {1}".format(
+                    wellknown_path, wellknown_url))
 
         # notify challenge are met
         code, result = _send_signed_request(challenge['uri'], {


### PR DESCRIPTION
## The problem

The "no-check" logic is not propagated to acme-tiny, this can cause a bug in the following situation:

- domain DNS is correctly configured and is accessible from outside
- but locally the IP to this domain is wrong for some reason
- acme-tiny will attempt to get the certificate through http to make a check
- this check will fail

It's also important to note that this is pretty hard to debug, the error message is bad and in english and is confusing because it doesn't tell that it's a LOCAL attempt to download the file.

If we agree on modifying acme-tiny I will also modify this error message if I don't forgot to do it.

## Solution

Have no respect and modify acme-tiny code.

## PR Status

Ready to merge.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
