### PR TITLE
Add su directive as option for logroate

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -34,7 +34,7 @@ ynh_use_logrotate () {
 	local su_directive=""
 	if [[ -n $user_group ]]; then
 		su_directive="	# Run logorotate as specific user - group
-	su ${user_group#*/} ${user_group%/*}"
+	su ${user_group%/*} ${user_group#*/}"
 	fi
 
 	cat > ./${app}-logrotate << EOF	# Build a config file for logrotate

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -34,7 +34,7 @@ ynh_use_logrotate () {
 	local su_directive=""
 	if [[ -n $user_group ]]; then
 		su_directive="	# Run logorotate as specific user - group
-		su ${user_group%/*} ${user_group#*/}"
+	su ${user_group%/*} ${user_group#*/}"
 	fi
 
 	cat > ./${app}-logrotate << EOF	# Build a config file for logrotate

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -34,7 +34,7 @@ ynh_use_logrotate () {
 	local su_directive=""
 	if [[ -n $user_group ]]; then
 		su_directive="	# Run logorotate as specific user - group
-	su ${user_group%/*} ${user_group#*/}"
+		su ${user_group%/*} ${user_group#*/}"
 	fi
 
 	cat > ./${app}-logrotate << EOF	# Build a config file for logrotate

--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -1,8 +1,9 @@
 # Use logrotate to manage the logfile
 #
-# usage: ynh_use_logrotate [logfile] [--non-append]
+# usage: ynh_use_logrotate [logfile] [--non-append|--append] [specific_user/specific_group]
 # | arg: logfile - absolute path of logfile
 # | arg: --non-append - (Option) Replace the config file instead of appending this new config.
+# | arg: specific_user : run logrotate as the specified user and group. If not specified logrotate is runned as root.
 #
 # If no argument provided, a standard directory will be use. /var/log/${app}
 # You can provide a path with the directory only or with the logfile.
@@ -13,6 +14,7 @@
 # Unless you use the option --non-append
 ynh_use_logrotate () {
 	local customtee="tee -a"
+	local user_group="${3:-}"
 	if [ $# -gt 0 ] && [ "$1" == "--non-append" ]; then
 		customtee="tee"
 		# Destroy this argument for the next command.
@@ -29,6 +31,12 @@ ynh_use_logrotate () {
 	else
 		local logfile="/var/log/${app}/*.log" # Without argument, use a defaut directory in /var/log
 	fi
+	local su_directive=""
+	if [[ -n $user_group ]]; then
+		su_directive="	# Run logorotate as specific user - group
+	su ${user_group#*/} ${user_group%/*}"
+	fi
+
 	cat > ./${app}-logrotate << EOF	# Build a config file for logrotate
 $logfile {
 		# Rotate if the logfile exceeds 100Mo
@@ -47,6 +55,7 @@ $logfile {
 	notifempty
 		# Keep old logs in the same dir
 	noolddir
+	$su_directive
 }
 EOF
 	sudo mkdir -p $(dirname "$logfile")	# Create the log directory, if not exist


### PR DESCRIPTION
## The problem

If the owner of a log file is not root we could receive this message from logrotate : 
```
/etc/cron.daily/logrotate:
error: skipping "/var/www/horde/horde/log.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/var/www/horde/horde/services/log.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
error: skipping "/var/www/horde/horde/services/portal/log.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
run-parts: /etc/cron.daily/logrotate exited with return code 1
```

The helper `ynh_use_logrotate` don't support the `su` directive witch could be really usefull for some apps.

## Solution

As the `su` directive optionally.

## PR Status

Tested with horde with some different case of parameters.

In this case the management of the argument is not the best way. It will be better when we will implement `ynh_handle_getopts_args` in the core.

## How to test

Test it on any apps.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [x] Simple test 0/1 : Maniack C
- [x] Deep review 0/1 : Maniack C
