### PR TITLE
Better error path conflict

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,7 @@
     "app_location_already_used": "The app '{app}' is already installed on that location ({path})",
     "app_make_default_location_already_used": "Can't make the app '{app}' the default on the domain {domain} is already used by the other app '{other_app}'",
     "app_location_install_failed": "Unable to install the app in this location because it conflit with the app '{other_app}' already installed on '{other_path}'",
-    "app_location_unavailable": "This url is not available or conflicts with the already installed app '{app_label:s}' ({app_id:s}) on '{domain:s}{path:s}'",
+    "app_location_unavailable": "This url is not available or conflicts with the already installed app(s):\n{apps:s}",
     "app_manifest_invalid": "Invalid app manifest: {error}",
     "app_no_upgrade": "No app to upgrade",
     "app_not_correctly_installed": "{app:s} seems to be incorrectly installed",

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,7 @@
     "app_location_already_used": "The app '{app}' is already installed on that location ({path})",
     "app_make_default_location_already_used": "Can't make the app '{app}' the default on the domain {domain} is already used by the other app '{other_app}'",
     "app_location_install_failed": "Unable to install the app in this location because it conflit with the app '{other_app}' already installed on '{other_path}'",
-    "app_location_unavailable": "This url is not available or conflicts with an already installed app",
+    "app_location_unavailable": "This url is not available or conflicts with the already installed app '{app_label:s}' ({app_id:s}) on '{domain:s}{path:s}'",
     "app_manifest_invalid": "Invalid app manifest: {error}",
     "app_no_upgrade": "No app to upgrade",
     "app_not_correctly_installed": "{app:s} seems to be incorrectly installed",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1147,7 +1147,7 @@ def app_register_url(auth, app, domain, path):
 
     # This line can't be moved on top of file, otherwise it creates an infinite
     # loop of import with tools.py...
-    from domain import _get_conflicting_app, _normalize_domain_path
+    from domain import _get_conflicting_apps, _normalize_domain_path
 
     domain, path = _normalize_domain_path(domain, path)
 
@@ -1163,11 +1163,18 @@ def app_register_url(auth, app, domain, path):
                                   m18n.n('app_already_installed_cant_change_url'))
 
     # Check the url is available
-    path_and_app = _get_conflicting_app(auth, domain, path)
-    if not path_and_app:
-        path, app_id, app_label = path_and_app
-        raise MoulinetteError(errno.EINVAL,
-                              m18n.n('app_location_unavailable', app_id=app_id, app_label=app_label, path=path, domain=domain))
+    conflicts = _get_conflicting_apps(auth, domain, path)
+    if conflicts:
+        apps = []
+        for path, app_id, app_label in conflicts:
+            apps.append(" * {domain:s}{path:s} → {app_label:s} ({app_id:s})".format(
+                domain=domain,
+                path=path,
+                app_id=app_id,
+                app_label=app_label,
+            ))
+
+        raise MoulinetteError(errno.EINVAL, m18n.n('app_location_unavailable', apps="\n".join(apps)))
 
     app_setting(app, 'domain', value=domain)
     app_setting(app, 'path', value=path)
@@ -2052,7 +2059,7 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
     """Parse arguments store in either manifest.json or actions.json
     """
     from yunohost.domain import (domain_list, _get_maindomain,
-                                 _get_conflicting_app, _normalize_domain_path)
+                                 _get_conflicting_apps, _normalize_domain_path)
     from yunohost.user import user_info, user_list
 
     args_dict = OrderedDict()
@@ -2180,11 +2187,18 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
         domain, path = _normalize_domain_path(domain, path)
 
         # Check the url is available
-        path_and_app = _get_conflicting_app(auth, domain, path)
-        if not path_and_app:
-            path, app_id, app_label = path_and_app
-            raise MoulinetteError(errno.EINVAL,
-                                  m18n.n('app_location_unavailable', app_id=app_id, app_label=app_label, path=path, domain=domain))
+        conflicts = _get_conflicting_apps(auth, domain, path)
+        if conflicts:
+            apps = []
+            for path, app_id, app_label in conflicts:
+                apps.append(" * {domain:s}{path:s} → {app_label:s} ({app_id:s})".format(
+                    domain=domain,
+                    path=path,
+                    app_id=app_id,
+                    app_label=app_label,
+                ))
+
+            raise MoulinetteError(errno.EINVAL, m18n.n('app_location_unavailable', "\n".join(apps=apps)))
 
         # (We save this normalized path so that the install script have a
         # standard path format to deal with no matter what the user inputted)

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -219,7 +219,7 @@ def domain_cert_renew(auth, domain_list, force=False, no_checks=False, email=Fal
     return yunohost.certificate.certificate_renew(auth, domain_list, force, no_checks, email, staging)
 
 
-def domain_url_available(auth, domain, path):
+def _get_conflicting_app(auth, domain, path):
     """
     Check availability of a web path
 
@@ -246,13 +246,25 @@ def domain_url_available(auth, domain, path):
         # Loop through apps
         for p, a in apps_map[domain].items():
             if path == p:
-                return False
+                return (p, a["id"], a["label"])
             # We also don't want conflicts with other apps starting with
             # same name
             elif path.startswith(p) or p.startswith(path):
-                return False
+                return (p, a["id"], a["label"])
 
-    return True
+    return None
+
+
+def domain_url_available(auth, domain, path):
+    """
+    Check availability of a web path
+
+    Keyword argument:
+        domain -- The domain for the web path (e.g. your.domain.tld)
+        path -- The path to check (e.g. /coffee)
+    """
+
+    return bool(_get_conflicting_app(auth, domain, path))
 
 
 def _get_maindomain():

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -242,20 +242,17 @@ def domain_url_available(auth, domain, path):
     apps_map = app_map(raw=True)
 
     # Loop through all apps to check if path is taken by one of them
-    available = True
     if domain in apps_map:
         # Loop through apps
         for p, a in apps_map[domain].items():
             if path == p:
-                available = False
-                break
+                return False
             # We also don't want conflicts with other apps starting with
             # same name
             elif path.startswith(p) or p.startswith(path):
-                available = False
-                break
+                return False
 
-    return available
+    return True
 
 
 def _get_maindomain():

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -219,9 +219,9 @@ def domain_cert_renew(auth, domain_list, force=False, no_checks=False, email=Fal
     return yunohost.certificate.certificate_renew(auth, domain_list, force, no_checks, email, staging)
 
 
-def _get_conflicting_app(auth, domain, path):
+def _get_conflicting_apps(auth, domain, path):
     """
-    Check availability of a web path
+    Return a list of all conflicting apps with a domain/path (it can be empty)
 
     Keyword argument:
         domain -- The domain for the web path (e.g. your.domain.tld)
@@ -242,17 +242,18 @@ def _get_conflicting_app(auth, domain, path):
     apps_map = app_map(raw=True)
 
     # Loop through all apps to check if path is taken by one of them
+    conflicts = []
     if domain in apps_map:
         # Loop through apps
         for p, a in apps_map[domain].items():
             if path == p:
-                return (p, a["id"], a["label"])
+                conflicts.append((p, a["id"], a["label"]))
             # We also don't want conflicts with other apps starting with
             # same name
             elif path.startswith(p) or p.startswith(path):
-                return (p, a["id"], a["label"])
+                conflicts.append((p, a["id"], a["label"]))
 
-    return None
+    return conflicts
 
 
 def domain_url_available(auth, domain, path):
@@ -264,7 +265,7 @@ def domain_url_available(auth, domain, path):
         path -- The path to check (e.g. /coffee)
     """
 
-    return bool(_get_conflicting_app(auth, domain, path))
+    return bool(_get_conflicting_apps(auth, domain, path))
 
 
 def _get_maindomain():

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -265,7 +265,7 @@ def domain_url_available(auth, domain, path):
         path -- The path to check (e.g. /coffee)
     """
 
-    return bool(_get_conflicting_apps(auth, domain, path))
+    return len(_get_conflicting_apps(auth, domain, path)) == 0
 
 
 def _get_maindomain():


### PR DESCRIPTION
## The problem

Right now when we try to install an application but it conflicts with an already installed application at the path level we get a kinda "fuck you" error that just says that there is a conflict.

It sucks for the users and doesn't give any hint on how to fix that.

## Solution

Display all conflicting applications.

Example:

![2018-08-06-012424_883x465_scrot](https://user-images.githubusercontent.com/41827/43691129-91edd4f2-9917-11e8-87aa-a90e07f29760.png)


## PR Status

Test in "yunohost tools shell" and should be good.

## How to test

Like on the screenshot.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
