### PR TITLE
More agressive deprecation messages for app checkurl and initdb

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,7 +14,6 @@
     "app_change_url_identical_domains": "The old and new domain/url_path are identical ('{domain:s}{path:s}'), nothing to do.",
     "app_change_url_no_script": "This application '{app_name:s}' doesn't support url modification yet. Maybe you should upgrade the application.",
     "app_change_url_success": "Successfully changed {app:s} url to {domain:s}{path:s}",
-    "app_checkurl_is_deprecated": "Packagers /!\\ 'app checkurl' is deprecated ! Please use 'app register-url' instead !",
     "app_extraction_failed": "Unable to extract installation files",
     "app_id_invalid": "Invalid app id",
     "app_incompatible": "The app {app} is incompatible with your YunoHost version",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1181,7 +1181,7 @@ def app_checkurl(auth, url, app=None):
 
     """
 
-    logger.warning(m18n.n("app_checkurl_is_deprecated"))
+    logger.error("Packagers /!\\ : 'app checkurl' is deprecated ! Please use the helper 'ynh_webpath_register' instead !")
 
     from yunohost.domain import domain_list
 
@@ -1238,6 +1238,9 @@ def app_initdb(user, password=None, db=None, sql=None):
         sql -- Initial SQL file
 
     """
+
+    logger.error("Packagers /!\\ : 'app initdb' is deprecated ! Please use the helper 'ynh_mysql_setup_db' instead !")
+
     if db is None:
         db = user
 


### PR DESCRIPTION
## The problem

`app checkurl` and `app initdb` are deprecated but still used in some ~maintained apps.

## Solution

Propose to put a more agressive message (error instead of warning) so that hopefully one day we can decide to get rid of this legacy code :| ...

Also : 
- I pointed to the helper instead of "use app register-url" since it's probably more relevant
- I moved the entire message to app.py because it doesn't make much sense to bother translators with that message. The message is aimed to app packagers which should understand english ? :s 

## PR Status

Ready to merge if people agree

## How to test

Run `app checkurl` and `app initdb`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
