### PR TITLE
[enh] Add fake-hwclock

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dnsmasq, openssl, avahi-daemon, libnss-mdns, resolvconf, libnss-myhostname
  , metronome
  , rspamd (>= 1.6.0), redis-server, opendkim-tools
- , haveged
+ , haveged, fake-hwclock
 Recommends: yunohost-admin
  , openssh-server, ntp, inetutils-ping | iputils-ping
  , bash-completion, rsyslog, etckeeper


### PR DESCRIPTION
## The problem
Sometimes there is no Real Time Clock Battery (arm board, old battery ...). The time is needed to be able to make TLS/openvpn authentication securely.


## Solution

Set fake-hwclock as dependency of yunohost.

Fake-hwclock save the clock each hours and at shutdown. On boot, it will check if the current date is under the registered date and if it's the case load the registered date. This is needed 

## PR Status
Ready, Micro decision

## How to test

I think it's ok

## Validation

- [x] Principle agreement 1/1 : 
- [x] Quick review 1/1 : 
