### PR TITLE
Set equiv as base dependance

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -86,10 +86,6 @@ ynh_package_autopurge() {
 ynh_package_install_from_equivs () {
     local controlfile=$1
 
-    # Check if the equivs package is installed. Or install it.
-    ynh_package_is_installed 'equivs' \
-        || ynh_package_install equivs
-
     # retrieve package information
     local pkgname=$(grep '^Package: ' $controlfile | cut -d' ' -f 2)	# Retrieve the name of the debian package
     local pkgversion=$(grep '^Version: ' $controlfile | cut -d' ' -f 2)	# And its version number

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , metronome
  , rspamd (>= 1.6.0), redis-server, opendkim-tools
  , haveged
+ , equivs
 Recommends: yunohost-admin
  , openssh-server, ntp, inetutils-ping | iputils-ping
  , bash-completion, rsyslog, etckeeper


### PR DESCRIPTION
## The problem

The `equivs` package is necessary to build the dependences package. Installing this package at package build is not really efficient.

## Solution

Set it as dependence.

## PR Status

Not tested because it's look like really a small change.

## How to test

- Build the debian package
- Try to install an app which use a dependence

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
