### PR TITLE
[enh] Improve ssh security

### DIFF
--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -9,13 +9,10 @@ ListenAddress 0.0.0.0
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes
-
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 768
 
 # Logging
 SyslogFacility AUTH


### PR DESCRIPTION
## The problem

I am working on standardize sshd config between instances. I detect this change could obliged users to recheck the fingerprint of their server. Indeed, they might doesn't have old dsa fingerprint but our own config activate dsa fingerprint !



## Solution

So I suggest to remove dsa and configure ed25519 in the meantime.

In more I have detected some old instruction unused by the SSH2 Protocol (we don't accept SSH 1).
See https://stackoverflow.com/questions/25256819/has-keyregenerationinterval-any-effect-in-ssh2

## PR Status

Need an other PR to let user display with the webadmin their SSH Fingerprint

## How to test

Regen conf and reconnect to your server

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
