### PR TITLE
Add ynh_check_app_version_changed

### DIFF
--- a/data/helpers.d/system
+++ b/data/helpers.d/system
@@ -126,7 +126,7 @@ ynh_app_package_version () {
 # To force an upgrade, even if the package is up to date,
 # you have to set the variable YNH_FORCE_UPGRADE before.
 # example: sudo YNH_FORCE_UPGRADE=1 yunohost app upgrade MyApp
-
+#
 # usage: ynh_check_app_version_changed
 ynh_check_app_version_changed () {
   local force_upgrade=${YNH_FORCE_UPGRADE:-0}

--- a/data/helpers.d/system
+++ b/data/helpers.d/system
@@ -67,6 +67,11 @@ ynh_read_manifest () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
+	if [ ! -e "$manifest" ]; then
+		# If the manifest isn't found, try the common place for backup and restore script.
+		manifest="../settings/manifest.json"
+	fi
+
 	jq ".$manifest_key" "$manifest" --raw-output
 }
 
@@ -85,9 +90,6 @@ ynh_app_upstream_version () {
     ynh_handle_getopts_args "$@"
 
     manifest="${manifest:-../manifest.json}"
-    if [ ! -e "$manifest" ]; then
-        manifest="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
-    fi
     version_key=$(ynh_read_manifest --manifest="$manifest" --manifest_key="version")
     echo "${version_key/~ynh*/}"
 }
@@ -107,9 +109,6 @@ ynh_app_package_version () {
     ynh_handle_getopts_args "$@"
 
     manifest="${manifest:-../manifest.json}"
-    if [ ! -e "$manifest" ]; then
-        manifest="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
-    fi
     version_key=$(ynh_read_manifest --manifest="$manifest" --manifest_key="version")
     echo "${version_key/*~ynh/}"
 }

--- a/data/helpers.d/system
+++ b/data/helpers.d/system
@@ -67,7 +67,7 @@ ynh_read_manifest () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	python3 -c "import sys, json;print(json.load(open('$manifest', encoding='utf-8'))['$manifest_key'])"
+	jq ".$manifest_key" "$manifest" --raw-output
 }
 
 # Read the upstream version from the manifest

--- a/data/helpers.d/system
+++ b/data/helpers.d/system
@@ -53,3 +53,108 @@ ynh_abort_if_errors () {
 ynh_get_debian_release () {
 	echo $(lsb_release --codename --short)
 }
+
+# Read the value of a key in a ynh manifest file
+#
+# usage: ynh_read_manifest manifest key
+# | arg: -m, --manifest= - Path of the manifest to read
+# | arg: -k, --key= - Name of the key to find
+ynh_read_manifest () {
+	# Declare an array to define the options of this helper.
+        declare -Ar args_array=( [m]=manifest= [k]=manifest_key= )
+        local manifest
+        local manifest_key
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	python3 -c "import sys, json;print(json.load(open('$manifest', encoding='utf-8'))['$manifest_key'])"
+}
+
+# Read the upstream version from the manifest
+# The version number in the manifest is defined by <upstreamversion>~ynh<packageversion>
+# For example : 4.3-2~ynh3
+# This include the number before ~ynh
+# In the last example it return 4.3-2
+#
+# usage: ynh_app_upstream_version [-m manifest]
+# | arg: -m, --manifest= - Path of the manifest to read
+ynh_app_upstream_version () {
+    declare -Ar args_array=( [m]=manifest= )
+    local manifest
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+
+    manifest="${manifest:-../manifest.json}"
+    if [ ! -e "$manifest_path" ]; then
+        manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
+    fi
+    version_key=$(ynh_read_manifest --manifest="$manifest_path" --manifest_key="version")
+    echo "${version_key/~ynh*/}"
+}
+
+# Read package version from the manifest
+# The version number in the manifest is defined by <upstreamversion>~ynh<packageversion>
+# For example : 4.3-2~ynh3
+# This include the number after ~ynh
+# In the last example it return 3
+#
+# usage: ynh_app_package_version [-m manifest]
+# | arg: -m, --manifest= - Path of the manifest to read
+ynh_app_package_version () {
+    declare -Ar args_array=( [m]=manifest= )
+    local manifest
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+
+    manifest="${manifest:-../manifest.json}"
+    if [ ! -e "$manifest_path" ]; then
+        manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
+    fi
+    version_key=$(ynh_read_manifest --manifest="$manifest_path" --manifest_key="version")
+    echo "${version_key/*~ynh/}"
+}
+
+# Checks the app version to upgrade with the existing app version and returns:
+# - UPGRADE_APP if the upstream app version has changed
+# - UPGRADE_PACKAGE if only the YunoHost package has changed
+#
+## It stops the current script without error if the package is up-to-date
+#
+# This helper should be used to avoid an upgrade of an app, or the upstream part
+# of it, when it's not needed
+#
+# To force an upgrade, even if the package is up to date,
+# you have to set the variable YNH_FORCE_UPGRADE before.
+# example: sudo YNH_FORCE_UPGRADE=1 yunohost app upgrade MyApp
+
+# usage: ynh_check_app_version_changed
+ynh_check_app_version_changed () {
+  local force_upgrade=${YNH_FORCE_UPGRADE:-0}
+  local package_check=${PACKAGE_CHECK_EXEC:-0}
+
+  # By default, upstream app version has changed
+  local return_value="UPGRADE_APP"
+
+  local current_version=$(ynh_read_manifest --manifest="/etc/yunohost/apps/$YNH_APP_INSTANCE_NAME/manifest.json" --manifest_key="version" || echo 1.0)
+  local current_upstream_version="$(ynh_app_upstream_version --manifest="/etc/yunohost/apps/$YNH_APP_INSTANCE_NAME/manifest.json")"
+  local update_version=$(ynh_read_manifest --manifest="../manifest.json" --manifest_key="version" || echo 1.0)
+  local update_upstream_version="$(ynh_app_upstream_version)"
+
+  if [ "$current_version" == "$update_version" ] ; then
+      # Complete versions are the same
+      if [ "$force_upgrade" != "0" ]
+      then
+        echo "Upgrade forced by YNH_FORCE_UPGRADE." >&2
+        unset YNH_FORCE_UPGRADE
+      elif [ "$package_check" != "0" ]
+      then
+        echo "Upgrade forced for package check." >&2
+      else
+        ynh_die "Up-to-date, nothing to do" 0
+      fi
+  elif [ "$current_upstream_version" == "$update_upstream_version" ] ; then
+    # Upstream versions are the same, only YunoHost package versions differ
+    return_value="UPGRADE_PACKAGE"
+  fi
+  echo $return_value
+}

--- a/data/helpers.d/system
+++ b/data/helpers.d/system
@@ -85,10 +85,10 @@ ynh_app_upstream_version () {
     ynh_handle_getopts_args "$@"
 
     manifest="${manifest:-../manifest.json}"
-    if [ ! -e "$manifest_path" ]; then
-        manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
+    if [ ! -e "$manifest" ]; then
+        manifest="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest --manifest="$manifest_path" --manifest_key="version")
+    version_key=$(ynh_read_manifest --manifest="$manifest" --manifest_key="version")
     echo "${version_key/~ynh*/}"
 }
 
@@ -107,10 +107,10 @@ ynh_app_package_version () {
     ynh_handle_getopts_args "$@"
 
     manifest="${manifest:-../manifest.json}"
-    if [ ! -e "$manifest_path" ]; then
-        manifest_path="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
+    if [ ! -e "$manifest" ]; then
+        manifest="../settings/manifest.json"	# Into the restore script, the manifest is not at the same place
     fi
-    version_key=$(ynh_read_manifest --manifest="$manifest_path" --manifest_key="version")
+    version_key=$(ynh_read_manifest --manifest="$manifest" --manifest_key="version")
     echo "${version_key/*~ynh/}"
 }
 


### PR DESCRIPTION
## The problem

During the upgrade of an app, the app itself and the package are always upgraded, even if no upgrade is really needed.

## Solution

- Add the new helper ynh_check_app_version_changed to check the version before an upgrade
- Add also the helpers ynh_read_manifest, ynh_app_upstream_version and ynh_app_package_version.
- These previous helper have been modified (from the experimental version) to support getopts
- ynh_check_app_version_changed has been modified to use ynh_app_upstream_version

## PR Status

Ready to be reviewed

## How to test

Use `ynh_check_app_version_changed` in a package.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 