### PR TITLE
Run hook_exec as root by default

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -513,7 +513,7 @@ def app_change_url(operation_logger, auth, app, domain, path):
     os.system('chmod +x %s' % os.path.join(os.path.join(APP_TMP_FOLDER, "scripts", "change_url")))
 
     if hook_exec(os.path.join(APP_TMP_FOLDER, 'scripts/change_url'),
-                 args=args_list, env=env_dict, user="root") != 0:
+                 args=args_list, env=env_dict) != 0:
         msg = "Failed to change '%s' url." % app
         logger.error(msg)
         operation_logger.error(msg)
@@ -640,7 +640,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
         # Execute App upgrade script
         os.system('chown -hR admin: %s' % INSTALL_TMP)
         if hook_exec(extracted_app_folder + '/scripts/upgrade',
-                     args=args_list, env=env_dict, user="root") != 0:
+                     args=args_list, env=env_dict) != 0:
             msg = m18n.n('app_upgrade_failed', app=app_instance_name)
             logger.error(msg)
             operation_logger.error(msg)
@@ -800,7 +800,7 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
     try:
         install_retcode = hook_exec(
             os.path.join(extracted_app_folder, 'scripts/install'),
-            args=args_list, env=env_dict, user="root"
+            args=args_list, env=env_dict
         )
     except (KeyboardInterrupt, EOFError):
         install_retcode = -1
@@ -824,7 +824,7 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
 
                 remove_retcode = hook_exec(
                     os.path.join(extracted_app_folder, 'scripts/remove'),
-                    args=[app_instance_name], env=env_dict_remove, user="root"
+                    args=[app_instance_name], env=env_dict_remove
                 )
                 if remove_retcode != 0:
                     msg = m18n.n('app_not_properly_removed',
@@ -912,7 +912,7 @@ def app_remove(operation_logger, auth, app):
     operation_logger.flush()
 
     if hook_exec('/tmp/yunohost_remove/scripts/remove', args=args_list,
-                 env=env_dict, user="root") == 0:
+                 env=env_dict) == 0:
         logger.success(m18n.n('app_removed', app=app))
 
         hook_callback('post_app_remove', args=args_list, env=env_dict)
@@ -1573,7 +1573,6 @@ def app_config_show_panel(app_id):
     return_code = hook_exec(config_script,
               args=["show"],
               env=env,
-              user="root",
               stdout_callback=parse_stdout,
     )
 
@@ -1656,7 +1655,6 @@ def app_config_apply(app_id, args):
     return_code = hook_exec(config_script,
               args=["apply"],
               env=env,
-              user="root",
     )
 
     if return_code != 0:

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -680,7 +680,7 @@ class BackupManager():
             subprocess.call(['install', '-Dm555', app_script, tmp_script])
 
             hook_exec(tmp_script, args=[tmp_app_bkp_dir, app],
-                      raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict, user="root")
+                      raise_on_error=True, chdir=tmp_app_bkp_dir, env=env_dict)
 
             self._import_to_list_to_backup(env_dict["YNH_BACKUP_CSV"])
         except:
@@ -1310,8 +1310,7 @@ class RestoreManager():
                       args=[app_backup_in_archive, app_instance_name],
                       chdir=app_backup_in_archive,
                       raise_on_error=True,
-                      env=env_dict,
-                      user="root")
+                      env=env_dict)
         except:
             msg = m18n.n('restore_app_failed',app=app_instance_name)
             logger.exception(msg)
@@ -1336,7 +1335,7 @@ class RestoreManager():
             # Execute remove script
             # TODO: call app_remove instead
             if hook_exec(remove_script, args=[app_instance_name],
-                         env=env_dict_remove, user="root") != 0:
+                         env=env_dict_remove) != 0:
                 msg = m18n.n('app_not_properly_removed', app=app_instance_name)
                 logger.warning(msg)
                 operation_logger.error(msg)

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -281,7 +281,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
                 hook_args = pre_callback(name=name, priority=priority,
                                          path=path, args=args)
                 hook_exec(path, args=hook_args, chdir=chdir, env=env,
-                          no_trace=no_trace, raise_on_error=True, user="root")
+                          no_trace=no_trace, raise_on_error=True)
             except MoulinetteError as e:
                 state = 'failed'
                 logger.error(e.strerror, exc_info=1)
@@ -298,7 +298,7 @@ def hook_callback(action, hooks=[], args=None, no_trace=False, chdir=None,
 
 
 def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
-              chdir=None, env=None, user="admin", stdout_callback=None,
+              chdir=None, env=None, user="root", stdout_callback=None,
               stderr_callback=None):
     """
     Execute hook from a file with arguments


### PR DESCRIPTION
## The problem

Historically `hook_exec` was run with admin, nowadays almost all call set `user="root"` so we can simplify the code

## Solution

Simplify the code

## PR Status

Microdecision, ready to merge

## How to test

Does it need testing /o\

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
