### PR TITLE
[enh] add jq as a dependancy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , python-psutil, python-requests, python-dnspython, python-openssl
  , python-apt, python-miniupnpc, python-dbus, python-jinja2
  , glances
- , dnsutils, bind9utils, unzip, git, curl, cron, wget
+ , dnsutils, bind9utils, unzip, git, curl, cron, wget, jq
  , ca-certificates, netcat-openbsd, iproute
  , mariadb-server, php-mysql | php-mysqlnd
  , slapd, ldap-utils, sudo-ldap, libnss-ldapd, unscd


### PR DESCRIPTION
## The problem

We often need to query json (and maybe modify) files in shell scripts. Right now we uses python or grep/other to do that, that's both not practical (and slow for python) and not very reliable.

## Solution

Add jq as a dependancy so scripts can rely on that, it's a tool meant for that: https://stedolan.github.io/jq/

## PR Status

Ready to merge.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
