### PR TITLE
Python hooks

### DIFF
--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -25,9 +25,11 @@
 """
 import os
 import re
+import sys
 import errno
 import tempfile
 from glob import iglob
+from importlib import import_module
 
 from moulinette import m18n
 from moulinette.core import MoulinetteError
@@ -414,8 +416,14 @@ def _hook_exec_bash(path, args, no_trace, chdir, env, user, loggers):
 
 def _hook_exec_python(path, args, env, loggers):
 
-    pass
+    dir_ = os.path.dirname(path)
+    name = os.path.splitext(os.path.basename(path))[0]
 
+    if not dir_ in sys.path:
+        sys.path.append(dir_)
+    module = import_module(name)
+
+    return module.main(args, env, loggers)
 
 
 def _extract_filename_parts(filename):


### PR DESCRIPTION
## The problem

Python hooks are required for the new diagnosis system modularity / extendability, and more generally if we want to implement some hooks in python for some reason. This could be the case for example of the famous `app ssowatconf` command which should be a classical regen-conf thing but can't be so far because it has too many python calls and json stuff to be implemented in bash.

## Solution

Split the behavior of the `hook_exec` function depending on the nature of the hook. Python hooks are to be modules loaded by yunohost and expected to have a `main` function.

## PR Status

Almost done but might still move depending on #534 

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
