### PR TITLE
Remove old legacy code about letsencrypt_ynh

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -130,7 +130,6 @@
     "certmanager_hit_rate_limit": "Too many certificates already issued for exact set of domains {domain:s} recently. Please try again later. See https://letsencrypt.org/docs/rate-limits/ for more details",
     "certmanager_http_check_timeout": "Timed out when server tried to contact itself through HTTP using public IP address (domain {domain:s} with ip {ip:s}). You may be experiencing hairpinning issue or the firewall/router ahead of your server is misconfigured.",
     "certmanager_no_cert_file": "Unable to read certificate file for domain {domain:s} (file: {file:s})",
-    "certmanager_old_letsencrypt_app_detected": "\nYunohost detected that the 'letsencrypt' app is installed, which conflits with the new built-in certificate management features in Yunohost. If you wish to use the new built-in features, please run the following commands to migrate your installation:\n\n    yunohost app remove letsencrypt\n    yunohost domain cert-install\n\nN.B.: this will attempt to re-install certificates for all domains with a Let's Encrypt certificate or self-signed certificate",
     "certmanager_self_ca_conf_file_not_found": "Configuration file not found for self-signing authority (file: {file:s})",
     "certmanager_unable_to_parse_self_CA_name": "Unable to parse name of self-signing authority (file: {file:s})",
     "custom_app_url_required": "You must provide a URL to upgrade your custom app {app:s}",

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -97,11 +97,6 @@ def certificate_status(auth, domain_list, full=False):
 
     import yunohost.domain
 
-    # Check if old letsencrypt_ynh is installed
-    # TODO / FIXME - Remove this in the future once the letsencrypt app is
-    # not used anymore
-    _check_old_letsencrypt_app()
-
     # If no domains given, consider all yunohost domains
     if domain_list == []:
         domain_list = yunohost.domain.domain_list(auth)['domains']
@@ -143,11 +138,6 @@ def certificate_install(auth, domain_list, force=False, no_checks=False, self_si
                        before attempting the install
         self-signed  -- Instal self-signed certificates instead of Let's Encrypt
     """
-
-    # Check if old letsencrypt_ynh is installed
-    # TODO / FIXME - Remove this in the future once the letsencrypt app is
-    # not used anymore
-    _check_old_letsencrypt_app()
 
     if self_signed:
         _certificate_install_selfsigned(domain_list, force)
@@ -328,11 +318,6 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
 
     import yunohost.domain
 
-    # Check if old letsencrypt_ynh is installed
-    # TODO / FIXME - Remove this in the future once the letsencrypt app is
-    # not used anymore
-    _check_old_letsencrypt_app()
-
     # If no domains given, consider all yunohost domains with Let's Encrypt
     # certificates
     if domain_list == []:
@@ -429,18 +414,6 @@ def certificate_renew(auth, domain_list, force=False, no_checks=False, email=Fal
 ###############################################################################
 #   Back-end stuff                                                            #
 ###############################################################################
-
-def _check_old_letsencrypt_app():
-    import yunohost.domain
-
-    installedAppIds = [app["id"] for app in yunohost.app.app_list(installed=True)["apps"]]
-
-    if "letsencrypt" not in installedAppIds:
-        return
-
-    raise MoulinetteError(errno.EINVAL, m18n.n(
-        'certmanager_old_letsencrypt_app_detected'))
-
 
 def _install_cron():
     cron_job_file = "/etc/cron.daily/yunohost-certificate-renew"


### PR DESCRIPTION
## The problem

We have this piece of legacy code. Today, because app.yunohost.org was down, people could not install a certificate. c.f. this stacktrace from @e-lie : 

```
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 213, in <module>
    timeout=opts.timeout,
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 136, in cli
    moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 390, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 498, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/domain.py", line 215, in domain_cert_install
    return yunohost.certificate.certificate_install(auth, domain_list, force, no_checks, self_signed, staging)
  File "/usr/lib/moulinette/yunohost/certificate.py", line 150, in certificate_install
    _check_old_letsencrypt_app()
  File "/usr/lib/moulinette/yunohost/certificate.py", line 412, in _check_old_letsencrypt_app
    installedAppIds = [app["id"] for app in yunohost.app.app_list(installed=True)["apps"]]
  File "/usr/lib/moulinette/yunohost/app.py", line 243, in app_list
    with open(json_path) as json_list:
[???]
```

and

```
Error: Unable to retrieve the remote application list yunohost: HTTPSConnectionPool(host='app.yunohost.org', port=443): Read timed out. (read timeout=30)
```

## Solution

Remove this legacy code, it's ressource-consuming and there's very low probability that people still have the app installed.

## PR Status

Not tested but #yolo 

## How to test

Run cert-install and cert-status

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
