### PR TITLE
[enh] Improve upnp support

### DIFF
--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -343,7 +343,8 @@ def firewall_upnp(action='status', no_refresh=False):
     # Refresh port mapping using UPnP
     if not no_refresh:
         upnpc = miniupnpc.UPnP()
-        upnpc.discoverdelay = 3000
+        upnpc.discoverdelay = 62000
+        upnpc.localport = 1900
 
         # Discover UPnP device(s)
         logger.debug('discovering UPnP devices...')


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/work-around-router-upnp-shortcomming-implementations-netgear-cbvg834g/5730

## Solution

teajay-fr suggest to increase discover time and listen on 1900 to support some router that doesn't respond to discover query

Note: i don't know if it's solution increase the postinstall time ?

## PR Status
Need Feedback, i don't know if it's a good idea

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
