### PR TITLE
[enh] Display only used fingerprint in bootprompt

### DIFF
--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -5,7 +5,7 @@ ip=$(hostname --all-ip-address)
 
 # Fetch SSH fingerprints
 i=0
-for key in /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub ; do 
+for key in /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub 2> /dev/null ; do 
     output=$(ssh-keygen -l -f $key)
     fingerprint[$i]=" - $(echo $output | cut -d' ' -f2) $(echo $output| cut -d' ' -f4)"
     i=$(($i + 1))

--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -5,7 +5,7 @@ ip=$(hostname --all-ip-address)
 
 # Fetch SSH fingerprints
 i=0
-for key in /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub 2> /dev/null ; do 
+for key in $(ls /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub 2> /dev/null) ; do 
     output=$(ssh-keygen -l -f $key)
     fingerprint[$i]=" - $(echo $output | cut -d' ' -f2) $(echo $output| cut -d' ' -f4)"
     i=$(($i + 1))

--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -5,7 +5,7 @@ ip=$(hostname --all-ip-address)
 
 # Fetch SSH fingerprints
 i=0
-for key in /etc/ssh/ssh_host_*_key.pub ; do 
+for key in /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub ; do 
     output=$(ssh-keygen -l -f $key)
     fingerprint[$i]=" - $(echo $output | cut -d' ' -f2) $(echo $output| cut -d' ' -f4)"
     i=$(($i + 1))


### PR DESCRIPTION
## The problem

Some fingerprints are display but can't be used because SSH conf don't allow to use those fingerprint.

## Solution

Just display fingerprint used by SSH

## PR Status

Ready, this PR is derivated from an other one which change SSH config...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
