### PR TITLE
[fix] Silent output/warning but display errors

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -173,7 +173,7 @@ ynh_setup_source () {
     then    # Use the local source file if it is present
         cp $local_src $src_filename
     else    # If not, download the source
-        wget -nv -O $src_filename $src_url
+        local out=`wget -nv -O $src_filename $src_url 2>&1` || ynh_print_err $out
     fi
 
     # Check the control sum


### PR DESCRIPTION
## The problem
When we use ynh_setup_source there is a strange noisy warning like this. This noise is displayed to the user...

`2018-09-19 16:11:29 URL:https://github-production-release-asset-2e65be.s3.amazonaws.com/271714/6b136718-52da-11e7-93f3-2b4ee2eccece?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20180919%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180919T141124Z&X-Amz-Expires=300&X-Amz-Signature=15c6db1dc3ca633a3e4ba8e903500976d38a5100dcd1ea022deaa72cd15b5c34&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B%20filename%3Dwkhtmltox-0.12.4_linux-generic-amd64.tar.xz&response-content-type=application%2Foctet-stream [14541904/14541904] -> "app.tar.xz" [1]`

## Solution

Display only error but not output. wget has no option for that, so we need to make like in this pr or replace wget with curl.

## PR Status
Ready, tested by copy/pasta inside a vm

## How to test

Install an app, you should not see a warning about download success

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
