### PR TITLE
mod_auth_ldap: reflect SASL API changes in latest Metronome.

### DIFF
--- a/lib/metronome/modules/mod_auth_ldap2.lua
+++ b/lib/metronome/modules/mod_auth_ldap2.lua
@@ -56,8 +56,9 @@ function new_default_provider(host)
      return nil, "Account creation/modification not available with LDAP.";
  end
 
- function provider.get_sasl_handler()
+ function provider.get_sasl_handler(session)
      local testpass_authentication_profile = {
+         session = session,
          plain_test = function(sasl, username, password, realm)
              return provider.test_password(username, password), true;
          end,


### PR DESCRIPTION
# The problem

Users traces with 3.10.13+

## Solution

The session state should always be passed in the profile as util.sasl functioning now relies on it

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
