### PR TITLE
Fix http2 with curl

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -253,6 +253,9 @@ ynh_local_curl () {
 		# Add --data arg and remove the last character, which is an unecessary '&'
 		POST_data="--data ${POST_data::-1}"
 	fi
+	
+	# Wait untils nginx has fully reloaded (avoid curl fail with http2)
+	sleep 2
 
 	# Curl the URL
 	curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url"


### PR DESCRIPTION
## The problem

- Curl fail with http2 with wordpress app.

## Solution

- Add a sleep after nginx is reloaded.

By example if we have a code like that it fail : 
```bash
# Reload Nginx
systemctl reload nginx

# Wordpress installation
ynh_local_curl "/wp-admin/install.php?step=2" "&weblog_title=YunoBlog" "user_name=$admin_wordpress" "admin_password=$db_pwd" "admin_password2=$db_pwd" "admin_email=$admin_wordpress@$domain" "Submit=Install+WordPress"
```

But this code won't fail : 
```bash
# Reload Nginx
systemctl reload nginx

# Wait untils nginx has fully reloaded (fix http2 issue)
sleep 2

# Wordpress installation
ynh_local_curl "/wp-admin/install.php?step=2" "&weblog_title=YunoBlog" "user_name=$admin_wordpress" "admin_password=$db_pwd" "admin_password2=$db_pwd" "admin_email=$admin_wordpress@$domain" "Submit=Install+WordPress"
```

## PR Status

Tested with the CI, but need more test.

## How to test

- Checkout the branch
- Enable http2 in the nginx config
- Try to install wordpress

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
