### PR TITLE
[enh] allows to have several domains/path per app

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -731,6 +731,10 @@ app:
                     help: App ID
                 new_label:
                     help: New app label
+                -n:
+                    full: --number
+                    help: Label number for multi-urls apps
+                    type: int
 
         ### app_addaccess() TODO: Write help
         addaccess:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -427,17 +427,17 @@ def app_map(app=None, raw=False, user=None):
 
             domain = app_settings['domain' + number]
             path = app_settings.get('path' + number, '/')
+            label = app_settings.get('label' + number, app_settings['label'])
 
             if raw:
                 if domain not in result:
                     result[domain] = {}
                 result[domain][path] = {
-                    'label': app_settings['label'],
+                    'label': label,
                     'id': app_settings['id']
                 }
             else:
-                result[domain + path] = app_settings['label']
-
+                result[domain + path] = label
     return result
 
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -416,18 +416,27 @@ def app_map(app=None, raw=False, user=None):
                     and user not in app_settings['allowed_users'].split(','):
                 continue
 
-        domain = app_settings['domain']
-        path = app_settings.get('path', '/')
+        # let supports up to 9 additional domains.
+        #
+        # we could easily parse the key to support an infinite number of
+        # domains but that would make the code way more complex for very
+        # very marginal benefit (who needs more than 2-3 domains?)
+        for number in [""] + [str(x) for x in range(2, 10)]:
+            if 'domain' + number not in app_settings:
+                continue
 
-        if raw:
-            if domain not in result:
-                result[domain] = {}
-            result[domain][path] = {
-                'label': app_settings['label'],
-                'id': app_settings['id']
-            }
-        else:
-            result[domain + path] = app_settings['label']
+            domain = app_settings['domain' + number]
+            path = app_settings.get('path' + number, '/')
+
+            if raw:
+                if domain not in result:
+                    result[domain] = {}
+                result[domain][path] = {
+                    'label': app_settings['label'],
+                    'id': app_settings['id']
+                }
+            else:
+                result[domain + path] = app_settings['label']
 
     return result
 
@@ -1389,28 +1398,37 @@ def app_ssowatconf(auth):
             if 'no_sso' in app_settings:
                 continue
 
-            for item in _get_setting(app_settings, 'skipped_uris'):
-                if item[-1:] == '/':
-                    item = item[:-1]
-                skipped_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-            for item in _get_setting(app_settings, 'skipped_regex'):
-                skipped_regex.append(item)
-            for item in _get_setting(app_settings, 'unprotected_uris'):
-                if item[-1:] == '/':
-                    item = item[:-1]
-                unprotected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-            for item in _get_setting(app_settings, 'unprotected_regex'):
-                unprotected_regex.append(item)
-            for item in _get_setting(app_settings, 'protected_uris'):
-                if item[-1:] == '/':
-                    item = item[:-1]
-                protected_urls.append(app_settings['domain'] + app_settings['path'].rstrip('/') + item)
-            for item in _get_setting(app_settings, 'protected_regex'):
-                protected_regex.append(item)
-            if 'redirected_urls' in app_settings:
-                redirected_urls.update(app_settings['redirected_urls'])
-            if 'redirected_regex' in app_settings:
-                redirected_regex.update(app_settings['redirected_regex'])
+            # let supports up to 9 additional domains.
+            #
+            # we could easily parse the key to support an infinite number of
+            # domains but that would make the code way more complex for very
+            # very marginal benefit (who needs more than 2-3 domains?)
+            for number in [""] + [str(x) for x in range(2, 10)]:
+                if 'domain' + number not in app_settings:
+                    continue
+
+                for item in _get_setting(app_settings, 'skipped_uris' + number):
+                    if item[-1:] == '/':
+                        item = item[:-1]
+                    skipped_urls.append(app_settings['domain' + number] + app_settings['path' + number].rstrip('/') + item)
+                for item in _get_setting(app_settings, 'skipped_regex' + number):
+                    skipped_regex.append(item)
+                for item in _get_setting(app_settings, 'unprotected_uris' + number):
+                    if item[-1:] == '/':
+                        item = item[:-1]
+                    unprotected_urls.append(app_settings['domain' + number] + app_settings['path' + number].rstrip('/') + item)
+                for item in _get_setting(app_settings, 'unprotected_regex' + number):
+                    unprotected_regex.append(item)
+                for item in _get_setting(app_settings, 'protected_uris' + number):
+                    if item[-1:] == '/':
+                        item = item[:-1]
+                    protected_urls.append(app_settings['domain' + number] + app_settings['path' + number].rstrip('/') + item)
+                for item in _get_setting(app_settings, 'protected_regex' + number):
+                    protected_regex.append(item)
+                if 'redirected_urls' + number in app_settings:
+                    redirected_urls.update(app_settings['redirected_urls' + number])
+                if 'redirected_regex' + number in app_settings:
+                    redirected_regex.update(app_settings['redirected_regex' + number])
 
     for domain in domains:
         skipped_urls.extend([domain + '/yunohost/admin', domain + '/yunohost/api'])

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1465,13 +1465,13 @@ def app_ssowatconf(auth):
     logger.success(m18n.n('ssowat_conf_generated'))
 
 
-def app_change_label(auth, app, new_label):
+def app_change_label(auth, app, new_label, number=""):
     installed = _is_installed(app)
     if not installed:
         raise MoulinetteError(errno.ENOPKG,
                               m18n.n('app_not_installed', app=app))
 
-    app_setting(app, "label", value=new_label)
+    app_setting(app, "label" + (str(number) if number is not None else ""), value=new_label)
 
     app_ssowatconf(auth)
 


### PR DESCRIPTION
## The problem

Some apps wants to be able to have several domains/path because they ship several components.

## Solution

Allows up to 9 domains per applications. using "domain2/path2" "domain3/path3" ... notation for keys.

I could have made it generic and allows infinite additional domains but that would have made the code way more complex than needed and the case where an app wants 2 domains is already super rare, I can't think of someone wanting more than 3-4 so that should be a good enough marging.

Worst case those people will contact us.

## PR Status

Test and working.

BUT, there might be other places in the code where this modification need to be done but I don't know where.

## How to test

Edit the config of an app, add "domain2/path2" kind of keys, then do "yunohost app map" and "yunohost app ssowatconf" and see the result.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
