### PR TITLE
Fix potential key error when retrieving install_time

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -346,7 +346,8 @@ def app_info(app, show_status=False, raw=False):
         ret['settings'] = _get_app_settings(app)
 
         # Determine upgradability
-        local_update_time = ret['settings'].get('update_time', ret['settings']['install_time'])
+        # In case there is neither update_time nor install_time, we assume the app can/has to be upgraded
+        local_update_time = ret['settings'].get('update_time', ret['settings'].get('install_time', 0))
 
         if 'lastUpdate' not in ret or 'git' not in ret:
             upgradable = "url_required"


### PR DESCRIPTION
## The problem

Sometimes, on edge cases, the "install time" key is not in settings, it then triggers a KeyError.

## Solution

Prevent from triggering such an error adding a fallback on 0, which will cause the app to be considered "upgradable".

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
