### PR TITLE
[fix] Improve the message w.a. when admins tries to create users with a reserved Email Address (Issue 1216)

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -255,7 +255,7 @@
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",
     "mail_forward_remove_failed": "Unable to remove mail forward '{mail:s}'",
     "mailbox_used_space_dovecot_down": "Dovecot mailbox service need to be up, if you want to get mailbox used space",
-    "mail_unavailable": "This email address is reserved. It will be assigned to the first user",
+    "mail_unavailable": "This email address is reserved and shall be automatically allocated to the very first user",
     "maindomain_change_failed": "Unable to change the main domain",
     "maindomain_changed": "The main domain has been changed",
     "migrate_tsig_end": "Migration to hmac-sha512 finished",

--- a/locales/en.json
+++ b/locales/en.json
@@ -255,7 +255,7 @@
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",
     "mail_forward_remove_failed": "Unable to remove mail forward '{mail:s}'",
     "mailbox_used_space_dovecot_down": "Dovecot mailbox service need to be up, if you want to get mailbox used space",
-    "mail_unavailable": "Mail adress unavailable",
+    "mail_unavailable": "This email address is reserved. It will be assigned to the first user",
     "maindomain_change_failed": "Unable to change the main domain",
     "maindomain_changed": "The main domain has been changed",
     "migrate_tsig_end": "Migration to hmac-sha512 finished",

--- a/locales/en.json
+++ b/locales/en.json
@@ -255,6 +255,7 @@
     "mail_domain_unknown": "Unknown mail address domain '{domain:s}'",
     "mail_forward_remove_failed": "Unable to remove mail forward '{mail:s}'",
     "mailbox_used_space_dovecot_down": "Dovecot mailbox service need to be up, if you want to get mailbox used space",
+    "mail_unavailable": "Mail adress unavailable",
     "maindomain_change_failed": "Unable to change the main domain",
     "maindomain_changed": "The main domain has been changed",
     "migrate_tsig_end": "Migration to hmac-sha512 finished",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -122,7 +122,6 @@
     "mail_alias_remove_failed": "Impossible de supprimer l'alias courriel « {mail:s} »",
     "mail_domain_unknown": "Le domaine « {domain:s} » du courriel est inconnu",
     "mail_forward_remove_failed": "Impossible de supprimer le courriel de transfert « {mail:s} »",
-    "mail_unavailable": "Adresse mail indisponible",
     "maindomain_change_failed": "Impossible de modifier le domaine principal",
     "maindomain_changed": "Le domaine principal a été modifié",
     "monitor_disabled": "La supervision du serveur a été désactivé",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -122,6 +122,7 @@
     "mail_alias_remove_failed": "Impossible de supprimer l'alias courriel « {mail:s} »",
     "mail_domain_unknown": "Le domaine « {domain:s} » du courriel est inconnu",
     "mail_forward_remove_failed": "Impossible de supprimer le courriel de transfert « {mail:s} »",
+    "mail_unavailable": "Adresse mail indisponible",
     "maindomain_change_failed": "Impossible de modifier le domaine principal",
     "maindomain_changed": "Le domaine principal a été modifié",
     "monitor_disabled": "La supervision du serveur a été désactivé",

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -318,7 +318,7 @@ def user_update(operation_logger, auth, username, firstname=None, lastname=None,
             raise MoulinetteError(errno.EINVAL,
                                   m18n.n('mail_domain_unknown',
                                          domain=mail[mail.find('@') + 1:]))
-        if mail not in aliases:
+        if mail in aliases:
             raise MoulinetteError(errno.EINVAL,
                                   m18n.n('mail_unavailable'))
         del user['mail'][0]

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -306,11 +306,21 @@ def user_update(operation_logger, auth, username, firstname=None, lastname=None,
         new_attr_dict['userPassword'] = _hash_user_password(change_password)
 
     if mail:
+        main_domain = _get_maindomain()
+        aliases = [
+            'root@' + main_domain,
+            'admin@' + main_domain,
+            'webmaster@' + main_domain,
+            'postmaster@' + main_domain,
+        ]
         auth.validate_uniqueness({'mail': mail})
         if mail[mail.find('@') + 1:] not in domains:
             raise MoulinetteError(errno.EINVAL,
                                   m18n.n('mail_domain_unknown',
                                          domain=mail[mail.find('@') + 1:]))
+        if mail not in aliases:
+            raise MoulinetteError(errno.EINVAL,
+                                  m18n.n('mail_unavailable'))
         del user['mail'][0]
         new_attr_dict['mail'] = [mail] + user['mail']
 

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -127,6 +127,17 @@ def user_create(operation_logger, auth, username, firstname, lastname, mail, pas
     all_existing_usernames = {x.pw_name for x in pwd.getpwall()}
     if username in all_existing_usernames:
         raise MoulinetteError(errno.EEXIST, m18n.n('system_username_exists'))
+        
+    main_domain = _get_maindomain()
+    aliases = [
+        'root@' + main_domain,
+        'admin@' + main_domain,
+        'webmaster@' + main_domain,
+        'postmaster@' + main_domain,
+    ]
+    
+    if mail in aliases:
+        raise MoulinetteError(errno.EEXIST,m18n.n('mail_unavailable'))    
 
     # Check that the mail domain exists
     if mail.split("@")[1] not in domain_list(auth)['domains']:
@@ -166,13 +177,6 @@ def user_create(operation_logger, auth, username, firstname, lastname, mail, pas
 
     # If it is the first user, add some aliases
     if not auth.search(base='ou=users,dc=yunohost,dc=org', filter='uid=*'):
-        main_domain = _get_maindomain()
-        aliases = [
-            'root@' + main_domain,
-            'admin@' + main_domain,
-            'webmaster@' + main_domain,
-            'postmaster@' + main_domain,
-        ]
         attr_dict['mail'] = [attr_dict['mail']] + aliases
 
         # If exists, remove the redirection from the SSO
@@ -319,8 +323,8 @@ def user_update(operation_logger, auth, username, firstname=None, lastname=None,
                                   m18n.n('mail_domain_unknown',
                                          domain=mail[mail.find('@') + 1:]))
         if mail in aliases:
-            raise MoulinetteError(errno.EINVAL,
-                                  m18n.n('mail_unavailable'))
+            raise MoulinetteError(errno.EEXIST,m18n.n('mail_unavailable'))
+            
         del user['mail'][0]
         new_attr_dict['mail'] = [mail] + user['mail']
 


### PR DESCRIPTION
## The problem

- Error message is not useful to inform user that email adress will be created by default ( fixes https://github.com/YunoHost/issues/issues/1216)

## Solution

- Add a custom Message.

## PR Status

Finished. Not tested.

## How to test

- Install Yunohost (ynh-dev)
- Modify app.py
- Try to create a user and add an already-used alias for this email

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
