### PR TITLE
[fix] Add --verbose again for backward compatibility (issue 1215)

### DIFF
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -197,7 +197,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     parser, opts, args = _parse_cli_args()
-    _init_moulinette(opts.debug, opts.quiet)
+    _init_moulinette(opts.debug, opts.verbose, opts.quiet)
 
     # Check that YunoHost is installed
     if not os.path.isfile('/etc/yunohost/installed') and \

--- a/bin/yunohost
+++ b/bin/yunohost
@@ -58,6 +58,10 @@ def _parse_cli_args():
         action='store_true', default=False,
         help="Log and print debug messages",
     )
+    parser.add_argument('--verbose',
+        action='store_true', default=False,
+        help="Be more verbose in the output",
+    )
     parser.add_argument('--quiet',
         action='store_true', default=False,
         help="Don't produce any output",
@@ -88,7 +92,7 @@ def _parse_cli_args():
 
     return (parser, opts, args)
 
-def _init_moulinette(debug=False, quiet=False):
+def _init_moulinette(debug=False, verbose=False, quiet=False):
     """Configure logging and initialize the moulinette"""
     # Define loggers handlers
     handlers = set(LOGGERS_HANDLERS)
@@ -104,6 +108,9 @@ def _init_moulinette(debug=False, quiet=False):
     # Define loggers level
     level = LOGGERS_LEVEL
     tty_level = TTY_LOG_LEVEL
+    if verbose:
+        tty_level = 'DEBUG'
+        logger.warning(m18n.n('verbose_deprecated'))
     if debug:
         tty_level = 'DEBUG'
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -447,6 +447,7 @@
     "user_update_failed": "Unable to update user",
     "user_updated": "The user has been updated",
     "users_available": "Available users:",
+    "verbose_deprecated": "--verbose option is deprecated. Use --debug instead",
     "yunohost_already_installed": "YunoHost is already installed",
     "yunohost_ca_creation_failed": "Unable to create certificate authority",
     "yunohost_ca_creation_success": "The local certification authority has been created.",


### PR DESCRIPTION
## The problem

fixes https://github.com/YunoHost/issues/issues/1215

## Solution

- Add --verbose option again but with a Warning. + Same result as the --debug option.

## PR Status

Work finished.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
