### PR TITLE
[fix] Use random serial number for CA

### DIFF
--- a/data/templates/ssl/openssl.cnf
+++ b/data/templates/ssl/openssl.cnf
@@ -43,7 +43,7 @@ unique_subject	= no			# Set to 'no' to allow creation of
 new_certs_dir	= $dir/newcerts		# default place for new certs.
 
 certificate	= $dir/ca/cacert.pem 	# The CA certificate
-serial		= $dir/serial 		# The current serial number
+#serial		= $dir/serial 		# The current serial number
 #crlnumber	= $dir/crlnumber	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir/crl.pem 		# The current CRL

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -358,7 +358,6 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False):
     service_regen_conf(['ssl'], force=True)
     ssl_dir = '/usr/share/yunohost/yunohost-config/ssl/yunoCA'
     commands = [
-        'echo "01" > %s/serial' % ssl_dir,
         'rm %s/index.txt' % ssl_dir,
         'touch %s/index.txt' % ssl_dir,
         'cp %s/openssl.cnf %s/openssl.ca.cnf' % (ssl_dir, ssl_dir),


### PR DESCRIPTION
## The problem

When a user reinstall a yunohost with the same domain, an error ssl is displayed on the browser:

An error occurred during a connection to 192.168.0.12. You have received
an invalid certificate. Please contact the server administrator or email
correspondent and give them the following information: Your certificate
contains the same serial number as another certificate issued by the
certificate authority. Please get a new certificate containing a unique
serial number. Error code: SEC_ERROR_REUSED_ISSUER_AND_SERIAL

## Solution

Put a random serial number into the CA certificate.

## PR Status
Ready BUT i have just test by applying manually the change on a yunohost instance.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
