### PR TITLE
Do not fail on missing fail2ban config during the backup

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -46,7 +46,6 @@ ynh_backup() {
     local SRC_PATH="$1"
     local DEST_PATH="${2:-}"
     local IS_BIG="${3:-0}"
-    local NEEDED="${4:-0}"
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
 
     # If backing up core only (used by ynh_backup_before_upgrade),
@@ -62,12 +61,14 @@ ynh_backup() {
     # Be sure the source path is not empty
     [[ -e "${SRC_PATH}" ]] || {
         echo "!!! Source path '${SRC_PATH}' does not exist !!!" >&2
-        if [ $NEEDED -eq 1 ]
+	
+	# This is a temporary fix for fail2ban config files missing after the migration to stretch.
+        if echo "${SRC_PATH}" | grep --quiet "/etc/fail2ban"
         then
-                return 1
+		touch "${SRC_PATH}"
+		echo "The missing file will be replaced by a dummy one for the backup !!!" >&2
         else
-                echo "The missing file will be replaced by a dummy one for the backup !!!" >&2
-                echo "This file is dummy... Please contact the maintainer of this app..." | tee "${SRC_PATH}" > /dev/null
+                return 1
         fi
     }
 

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -62,7 +62,7 @@ ynh_backup() {
     [[ -e "${SRC_PATH}" ]] || {
         echo "!!! Source path '${SRC_PATH}' does not exist !!!" >&2
 	
-	# This is a temporary fix for fail2ban config files missing after the migration to stretch.
+        # This is a temporary fix for fail2ban config files missing after the migration to stretch.
         if echo "${SRC_PATH}" | grep --quiet "/etc/fail2ban"
         then
 		touch "${SRC_PATH}"

--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -46,6 +46,7 @@ ynh_backup() {
     local SRC_PATH="$1"
     local DEST_PATH="${2:-}"
     local IS_BIG="${3:-0}"
+    local NEEDED="${4:-0}"
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
 
     # If backing up core only (used by ynh_backup_before_upgrade),
@@ -60,8 +61,14 @@ ynh_backup() {
     # ==============================================================================
     # Be sure the source path is not empty
     [[ -e "${SRC_PATH}" ]] || {
-        echo "Source path '${SRC_PATH}' does not exist" >&2
-        return 1
+        echo "!!! Source path '${SRC_PATH}' does not exist !!!" >&2
+        if [ $NEEDED -eq 1 ]
+        then
+                return 1
+        else
+                echo "The missing file will be replaced by a dummy one for the backup !!!" >&2
+                echo "This file is dummy... Please contact the maintainer of this app..." | tee "${SRC_PATH}" > /dev/null
+        fi
     }
 
     # Transform the source path as an absolute path


### PR DESCRIPTION
## The problem

Especially with the migration to stretch, it happens quite often that a file is missing in an app for php or fail2ban.
But, if a fail2ban config is missing, the app will still be working.
The current behavior can break an upgrade without any restoration of the backup, because a file is missing during the backup.

## Solution

Print a warning but do not fail if a file is missing, except if this file is really important for the app.

## PR Status

Tested on a VM.
Can be reviewed.

## How to test

Replace the helper, and remove a file used during the backup.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 