### PR TITLE
Update Metronome configuration file to v3.11 standard

### DIFF
--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -65,7 +65,7 @@ modules_enabled = {
 		--"service_directory"; -- Enables Service Directories extension support
 		--"public_service"; -- Enables Server vCard support for public services in directories and advertises in features
 		--"register_api"; -- Provides secure API for both Out-Of-Band and In-Band registration for E-Mail verification
-		"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
+		--"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
 };
 
 -- Server PID
@@ -94,8 +94,8 @@ consider_bosh_secure = true
 cross_domain_bosh = true
 
 -- WebSocket configuration (mod_websocket)
-consider_websocket_secure = true
-cross_domain_websocket = true
+--consider_websocket_secure = true
+--cross_domain_websocket = true
 
 -- Disable account creation by default, for security
 allow_registration = false

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -122,10 +122,10 @@ Component "muc.{{ main_domain }}" "muc"
     name = "{{ main_domain }} Chatrooms"
 
     modules_enabled = {
-        "muc_limits";
-        "muc_log";
+		"muc_limits";
+		"muc_log";
 		"muc_log_mam";
-        "muc_log_http";
+		"muc_log_http";
 		"muc_vcard";
     }
 

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -9,16 +9,63 @@
 -- A table is a list of values, except each value has a name. An 
 -- example would be:
 --
--- ssl = { key = "keyfile.key", certificate = "certificate.crt" }
+-- ssl = { key = "keyfile.key", certificate = "certificate.cert" }
 --
 -- Tip: You can check that the syntax of this file is correct when you have finished
 -- by running: luac -p metronome.cfg.lua
 -- If there are any errors, it will let you know what and where they are, otherwise it 
 -- will keep quiet.
 
----------- Server-wide settings ----------
--- Settings in this section apply to the whole server and are the default settings
--- for any virtual hosts
+-- Global settings go in this section
+ 
+-- This is the list of modules Metronome will load on startup.
+-- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
+
+modules_enabled = {
+		-- Generally required
+			"roster"; -- Allow users to have a roster. Recommended.
+			"saslauth"; -- Authentication for clients. Recommended if you want to log in.
+			"tls"; -- Add support for secure TLS on c2s/s2s connections
+		  	"disco"; -- Service discovery
+ 
+		-- Not essential, but recommended
+			"private"; -- Private XML storage (for room bookmarks, etc.)
+			"vcard"; -- Allow users to set vCards
+			"pep"; -- Allows setting of mood, tune, etc.
+			"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+			"bidi"; -- Enables Bidirectional Server-to-Server Streams.
+ 
+		-- Nice to have
+			"version"; -- Replies to server version requests
+		  	"uptime"; -- Report how long server has been running
+		  	"time"; -- Let others know the time here on this server
+		  	"ping"; -- Replies to XMPP pings with pongs
+			"register"; -- Allow users to register on this server using a client and change passwords
+			"stream_management"; -- Allows clients and servers to use Stream Management
+			"stanza_optimizations"; -- Allows clients to use Client State Indication and SIFT
+			"message_carbons"; -- Allows clients to enable carbon copies of messages
+			"mam"; -- Enable server-side message archives using Message Archive Management
+			"push"; -- Enable Push Notifications via PubSub using XEP-0357
+			"lastactivity"; -- Enables clients to know the last presence status of an user
+			"adhoc_cm"; -- Allow to set client certificates to login through SASL External via adhoc
+			"admin_adhoc"; -- administration adhoc commands
+			"bookmarks"; -- XEP-0048 Bookmarks synchronization between PEP and Private Storage
+			"sec_labels"; -- Allows to use a simplified version XEP-0258 Security Labels and related ACDFs.
+
+			-- Other specific functionality
+		  	--"admin_telnet"; -- administration console, telnet to port 5582
+			--"admin_web"; -- administration web interface
+			"bosh"; -- Enable support for BOSH clients, aka "XMPP over Bidirectional Streams over Synchronous HTTP"
+			--"compression"; -- Allow clients to enable Stream Compression
+			--"spim_block"; -- Require authorization via OOB form for messages from non-contacts and block unsollicited messages
+			--"gate_guard"; -- Enable config-based blacklisting and hit-based auto-banning features
+			--"incidents_handling"; -- Enable Incidents Handling support (can be administered via adhoc commands)
+			--"server_presence"; -- Enables Server Buddies extension support
+			--"service_directory"; -- Enables Service Directories extension support
+			--"public_service"; -- Enables Server vCard support for public services in directories and advertises in features
+			--"register_api"; -- Provides secure API for both Out-Of-Band and In-Band registration for E-Mail verification
+			"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
+};
 
 -- Server PID
 pidfile = "/var/run/metronome/metronome.pid"
@@ -33,65 +80,6 @@ http_interfaces = { "127.0.0.1", "::1" }
 -- Enable IPv6
 use_ipv6 = true
 
--- This is the list of modules Metronome will load on startup.
--- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
-modules_enabled = {
-
-    -- Generally required
-        "roster"; -- Allow users to have a roster. Recommended ;)
-        "saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
-        "tls"; -- Add support for secure TLS on c2s/s2s connections
-        "dialback"; -- s2s dialback support
-        "disco"; -- Service discovery
-        --"discoitems"; -- Service discovery items
-        --"extdisco"; -- External Service Discovery
-
-    -- Not essential, but recommended
-        "private"; -- Private XML storage (for room bookmarks, etc.)
-        "vcard"; -- Allow users to set vCards
-        "privacy"; -- Support privacy lists
-
-    -- These are commented by default as they have a performance impact
-        --"compression"; -- Stream compression (Debian: requires lua-zlib module to work)
-
-    -- Nice to have
-        "version"; -- Replies to server version requests
-        "uptime"; -- Report how long server has been running
-        "time"; -- Let others know the time here on this server
-        "ping"; -- Replies to XMPP pings with pongs
-        "pep"; -- Enables users to publish their mood, activity, playing music and more
-        "message_carbons"; -- Allow clients to keep in sync with messages send on other resources
-        "register"; -- Allow users to register on this server using a client and change passwords
-        "adhoc"; -- Support for "ad-hoc commands" that can be executed with an XMPP client
-
-    -- Admin interfaces
-        "admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
-        "admin_telnet"; -- Opens telnet console interface on localhost port 5582
-
-    -- HTTP modules
-        "bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
-        --"websockets"; -- Enable WebSocket clients
-        --"http_files"; -- Serve static files from a directory over HTTP
-
-    -- Other specific functionality
---        "bidi"; -- Bidirectional Streams for S2S connections
---        "stream_management"; -- Stream Management support
-        --"groups"; -- Shared roster support
-        --"announce"; -- Send announcement to all online users
-        --"welcome"; -- Welcome users who register accounts
-        --"watchregistrations"; -- Alert admins of registrations
-        --"motd"; -- Send a message to users when they log in
-        "mam"; -- Nice archive management
-        --"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
-        "offline"; -- Store offline messages
-        "c2s"; -- Handle client connections
-        "s2s"; -- Handle server-to-server connections
-
-    -- Debian: do not remove this module, or you lose syslog
-    -- support
-        "posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
-};
-
 -- Discovery items
 disco_items = {
     { "muc.{{ main_domain }}" },
@@ -100,41 +88,15 @@ disco_items = {
 };
 
 -- BOSH configuration (mod_bosh)
-bosh_max_inactivity = 30
 consider_bosh_secure = true
 cross_domain_bosh = true
 
+-- WebSocket configuration (mod_websocket)
+consider_websocket_secure = true
+cross_domain_websocket = true
+
 -- Disable account creation by default, for security
 allow_registration = false
-
--- SSL/TLS configuration
-ssl = {
-    options = {
-        "no_sslv2",
-        "no_sslv3",
-        "no_ticket",
-        "no_compression",
-        "cipher_server_preference"
-    };
-}
-
--- Force clients to use encrypted connections? This option will
--- prevent clients from authenticating unless they are using encryption.
-c2s_require_encryption = true
-
--- Force servers to use encrypted connections? This option will
--- prevent servers from connecting unless they are using encryption.
-s2s_require_encryption = true
-
--- Allow servers to use an unauthenticated encryption channel
-s2s_allow_encryption = true
-
-allow_unencrypted_plain_auth = false;
-
-s2s_secure = true
-s2s_secure_auth = false
-
---anonymous_login = false
 
 -- Use LDAP storage backend for all stores
 storage = "ldap"
@@ -146,7 +108,6 @@ log = {
     -- "*syslog"; -- Uncomment this for logging to syslog
     -- "*console"; -- Log to the console, useful for debugging with daemonize=false
 }
-
 
 ------ Components ------
 -- You can specify components to add hosts that provide special services,

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -65,7 +65,7 @@ modules_enabled = {
 		--"service_directory"; -- Enables Service Directories extension support
 		--"public_service"; -- Enables Server vCard support for public services in directories and advertises in features
 		--"register_api"; -- Provides secure API for both Out-Of-Band and In-Band registration for E-Mail verification
-		--"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
+		"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
 };
 
 -- Server PID
@@ -94,8 +94,8 @@ consider_bosh_secure = true
 cross_domain_bosh = true
 
 -- WebSocket configuration (mod_websocket)
---consider_websocket_secure = true
---cross_domain_websocket = true
+consider_websocket_secure = true
+cross_domain_websocket = true
 
 -- Disable account creation by default, for security
 allow_registration = false

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -124,16 +124,12 @@ Component "muc.{{ main_domain }}" "muc"
     modules_enabled = {
         "muc_limits";
         "muc_log";
+		"muc_log_mam";
         "muc_log_http";
     }
 
     muc_event_rate = 0.5
     muc_burst_factor = 10
-
-    muc_log_http_config = {
-        url_base = "logs";
-        theme = "metronome";
-    }
 
 ---Set up a PubSub server
 Component "pubsub.{{ main_domain }}" "pubsub"

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -126,6 +126,7 @@ Component "muc.{{ main_domain }}" "muc"
         "muc_log";
 		"muc_log_mam";
         "muc_log_http";
+		"muc_vcard";
     }
 
     muc_event_rate = 0.5

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -22,49 +22,49 @@
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
 
 modules_enabled = {
-		-- Generally required
-			"roster"; -- Allow users to have a roster. Recommended.
-			"saslauth"; -- Authentication for clients. Recommended if you want to log in.
-			"tls"; -- Add support for secure TLS on c2s/s2s connections
-		  	"disco"; -- Service discovery
+	-- Generally required
+		"roster"; -- Allow users to have a roster. Recommended.
+		"saslauth"; -- Authentication for clients. Recommended if you want to log in.
+		"tls"; -- Add support for secure TLS on c2s/s2s connections
+		"disco"; -- Service discovery
  
-		-- Not essential, but recommended
-			"private"; -- Private XML storage (for room bookmarks, etc.)
-			"vcard"; -- Allow users to set vCards
-			"pep"; -- Allows setting of mood, tune, etc.
-			"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
-			"bidi"; -- Enables Bidirectional Server-to-Server Streams.
+	-- Not essential, but recommended
+		"private"; -- Private XML storage (for room bookmarks, etc.)
+		"vcard"; -- Allow users to set vCards
+		"pep"; -- Allows setting of mood, tune, etc.
+		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+		"bidi"; -- Enables Bidirectional Server-to-Server Streams.
  
-		-- Nice to have
-			"version"; -- Replies to server version requests
-		  	"uptime"; -- Report how long server has been running
-		  	"time"; -- Let others know the time here on this server
-		  	"ping"; -- Replies to XMPP pings with pongs
-			"register"; -- Allow users to register on this server using a client and change passwords
-			"stream_management"; -- Allows clients and servers to use Stream Management
-			"stanza_optimizations"; -- Allows clients to use Client State Indication and SIFT
-			"message_carbons"; -- Allows clients to enable carbon copies of messages
-			"mam"; -- Enable server-side message archives using Message Archive Management
-			"push"; -- Enable Push Notifications via PubSub using XEP-0357
-			"lastactivity"; -- Enables clients to know the last presence status of an user
-			"adhoc_cm"; -- Allow to set client certificates to login through SASL External via adhoc
-			"admin_adhoc"; -- administration adhoc commands
-			"bookmarks"; -- XEP-0048 Bookmarks synchronization between PEP and Private Storage
-			"sec_labels"; -- Allows to use a simplified version XEP-0258 Security Labels and related ACDFs.
+	-- Nice to have
+		"version"; -- Replies to server version requests
+		"uptime"; -- Report how long server has been running
+		"time"; -- Let others know the time here on this server
+		"ping"; -- Replies to XMPP pings with pongs
+		"register"; -- Allow users to register on this server using a client and change passwords
+		"stream_management"; -- Allows clients and servers to use Stream Management
+		"stanza_optimizations"; -- Allows clients to use Client State Indication and SIFT
+		"message_carbons"; -- Allows clients to enable carbon copies of messages
+		"mam"; -- Enable server-side message archives using Message Archive Management
+		"push"; -- Enable Push Notifications via PubSub using XEP-0357
+		"lastactivity"; -- Enables clients to know the last presence status of an user
+		"adhoc_cm"; -- Allow to set client certificates to login through SASL External via adhoc
+		"admin_adhoc"; -- administration adhoc commands
+		"bookmarks"; -- XEP-0048 Bookmarks synchronization between PEP and Private Storage
+		"sec_labels"; -- Allows to use a simplified version XEP-0258 Security Labels and related ACDFs.
 
-			-- Other specific functionality
-		  	--"admin_telnet"; -- administration console, telnet to port 5582
-			--"admin_web"; -- administration web interface
-			"bosh"; -- Enable support for BOSH clients, aka "XMPP over Bidirectional Streams over Synchronous HTTP"
-			--"compression"; -- Allow clients to enable Stream Compression
-			--"spim_block"; -- Require authorization via OOB form for messages from non-contacts and block unsollicited messages
-			--"gate_guard"; -- Enable config-based blacklisting and hit-based auto-banning features
-			--"incidents_handling"; -- Enable Incidents Handling support (can be administered via adhoc commands)
-			--"server_presence"; -- Enables Server Buddies extension support
-			--"service_directory"; -- Enables Service Directories extension support
-			--"public_service"; -- Enables Server vCard support for public services in directories and advertises in features
-			--"register_api"; -- Provides secure API for both Out-Of-Band and In-Band registration for E-Mail verification
-			"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
+		-- Other specific functionality
+		--"admin_telnet"; -- administration console, telnet to port 5582
+		--"admin_web"; -- administration web interface
+		"bosh"; -- Enable support for BOSH clients, aka "XMPP over Bidirectional Streams over Synchronous HTTP"
+		--"compression"; -- Allow clients to enable Stream Compression
+		--"spim_block"; -- Require authorization via OOB form for messages from non-contacts and block unsollicited messages
+		--"gate_guard"; -- Enable config-based blacklisting and hit-based auto-banning features
+		--"incidents_handling"; -- Enable Incidents Handling support (can be administered via adhoc commands)
+		--"server_presence"; -- Enables Server Buddies extension support
+		--"service_directory"; -- Enables Service Directories extension support
+		--"public_service"; -- Enables Server vCard support for public services in directories and advertises in features
+		--"register_api"; -- Provides secure API for both Out-Of-Band and In-Band registration for E-Mail verification
+		"websocket"; -- Enable support for WebSocket clients, aka "XMPP over WebSockets"
 };
 
 -- Server PID
@@ -82,9 +82,10 @@ use_ipv6 = true
 
 -- Discovery items
 disco_items = {
-    { "muc.{{ main_domain }}" },
-    { "pubsub.{{ main_domain }}" },
-    { "vjud.{{ main_domain }}" }
+	{ "muc.{{ main_domain }}" },
+	{ "pubsub.{{ main_domain }}" },
+	{ "upload.{{ main_domain }}" },
+	{ "vjud.{{ main_domain }}" }
 };
 
 -- BOSH configuration (mod_bosh)
@@ -103,10 +104,10 @@ storage = "ldap"
 
 -- Logging configuration
 log = {
-    info = "/var/log/metronome/metronome.log"; -- Change 'info' to 'debug' for verbose logging
-    error = "/var/log/metronome/metronome.err";
-    -- "*syslog"; -- Uncomment this for logging to syslog
-    -- "*console"; -- Log to the console, useful for debugging with daemonize=false
+	info = "/var/log/metronome/metronome.log"; -- Change 'info' to 'debug' for verbose logging
+	error = "/var/log/metronome/metronome.err";
+	-- "*syslog"; -- Uncomment this for logging to syslog
+	-- "*console"; -- Log to the console, useful for debugging with daemonize=false
 }
 
 ------ Components ------
@@ -115,13 +116,13 @@ log = {
 
 ---Set up a local BOSH service
 Component "localhost" "http"
-    modules_enabled = { "bosh" }
+	modules_enabled = { "bosh" }
 
 ---Set up a MUC (multi-user chat) room server
 Component "muc.{{ main_domain }}" "muc"
-    name = "{{ main_domain }} Chatrooms"
+	name = "{{ main_domain }} Chatrooms"
 
-    modules_enabled = {
+	modules_enabled = {
 		"muc_limits";
 		"muc_log";
 		"muc_log_mam";
@@ -129,18 +130,26 @@ Component "muc.{{ main_domain }}" "muc"
 		"muc_vcard";
     }
 
-    muc_event_rate = 0.5
-    muc_burst_factor = 10
+	muc_event_rate = 0.5
+	muc_burst_factor = 10
 
 ---Set up a PubSub server
 Component "pubsub.{{ main_domain }}" "pubsub"
-    name = "{{ main_domain }} Publish/Subscribe"
+	name = "{{ main_domain }} Publish/Subscribe"
 
-    unrestricted_node_creation = true -- Anyone can create a PubSub node (from any server)
+	unrestricted_node_creation = true -- Anyone can create a PubSub node (from any server)
+
+---Set up a HTTP Upload service
+Component "upload.{{ main_domain }}" "http_upload"
+	name = "{{ main_domain }} Sharing Service"
+
+	http_file_size_limit = 6*1024*1024
+	http_file_quota = 60*1024*1024
+
 
 ---Set up a VJUD service
 Component "vjud.{{ main_domain }}" "vjud"
-    ud_disco_name = "{{ main_domain }} User Directory"
+	ud_disco_name = "{{ main_domain }} User Directory"
 
 
 ----------- Virtual hosts -----------
@@ -148,4 +157,3 @@ Component "vjud.{{ main_domain }}" "vjud"
 -- Settings under each VirtualHost entry apply *only* to that host.
 
 Include "conf.d/*.cfg.lua"
-

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -51,6 +51,7 @@ modules_enabled = {
 		"admin_adhoc"; -- administration adhoc commands
 		"bookmarks"; -- XEP-0048 Bookmarks synchronization between PEP and Private Storage
 		"sec_labels"; -- Allows to use a simplified version XEP-0258 Security Labels and related ACDFs.
+		"privacy"; -- Add privacy lists and simple blocking command support
 
 		-- Other specific functionality
 		--"admin_telnet"; -- administration console, telnet to port 5582


### PR DESCRIPTION
## The problem
Some now wanted features aren't loaded because Metronome uses a very old file

## Solution
Conform configuration file to latest v3.11 release file, Metronome v3.11.x is best package or Metronome might throw a few (non-fatal) errors on startup

- [ ] Principle agreement 1/2: @M5oul
- [ ] Quick review 0/1:
- [x] Simple test 1/1: @M5oul 
- [x] Deep review 1/1: @M5oul 
