### PR TITLE
Pass Host header to YunoHost API

### DIFF
--- a/data/templates/nginx/plain/yunohost_api.conf.inc
+++ b/data/templates/nginx/plain/yunohost_api.conf.inc
@@ -4,6 +4,7 @@ location /yunohost/api/ {
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
 
     # Custom 502 error page
     error_page 502 /yunohost/api/error/502;


### PR DESCRIPTION
This is useful to validate Origin/Referer headers in order to prevent CSRF.

## The problem

We might want to validate `Referer`/`Origin` headers to prevent CSRF but the `Host` header passed to the application is `localhost:$port` instead of the original one.

## Solution

Let nginx pass the original `Host` header.

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
