### PR TITLE
Add a sorting lambda function when sorting the backups list

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2155,7 +2155,7 @@ def backup_list(with_info=False, human_readable=False):
             except ValueError:
                 continue
             result.append(name)
-        result.sort(key=lambda x: os.path.getctime(x))
+        result.sort(key=lambda x: os.path.getctime(os.path.join(ARCHIVES_PATH, x+".tar.gz")))
 
     if result and with_info:
         d = OrderedDict()

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2155,7 +2155,7 @@ def backup_list(with_info=False, human_readable=False):
             except ValueError:
                 continue
             result.append(name)
-        result.sort()
+        result.sort(key=lambda x: os.path.getctime(x))
 
     if result and with_info:
         d = OrderedDict()


### PR DESCRIPTION
## The problem
Issue https://github.com/YunoHost/issues/issues/1001

## Solution
When sorting the list of backups, instead of sorting them by name (default) use a lambda function that sort them by creation date of the file.

## PR Status
I'm sorry, I was not able to test it... I can't have the testing VM to work on my computer :(

## How to test
Create some backups by giving them different names. See how the backups are sorted.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
