### PR TITLE
Better Configuration of nginx

### DIFF
--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -11,7 +11,7 @@ server {
         return 301 https://$http_host$request_uri;
     }
 
-    location /.well-known/autoconfig/mail {
+    location /.well-known/autoconfig/mail/ {
         alias /var/www/.well-known/{{ domain }}/autoconfig/mail;
     }
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -59,14 +59,14 @@ server {
     # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
     # https://wiki.mozilla.org/Security/Guidelines/Web_Security
     # https://observatory.mozilla.org/ 
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"; 
-    add_header Content-Security-Policy "upgrade-insecure-requests";
-    add_header Content-Security-Policy-Report-Only "default-src https: data: 'unsafe-inline' 'unsafe-eval'";
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
-    add_header X-Download-Options noopen;
-    add_header X-Permitted-Cross-Domain-Policies none;
-    add_header X-Frame-Options "SAMEORIGIN";
+    more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload"; 
+    more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
+    more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
+    more_set_headers "X-Content-Type-Options : nosniff";
+    more_set_headers "X-XSS-Protection : 1; mode=block";
+    more_set_headers "X-Download-Options : noopen";
+    more_set_headers "X-Permitted-Cross-Domain-Policies : none";
+    more_set_headers "X-Frame-Options : SAMEORIGIN";
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -466,7 +466,7 @@ def _configure_for_acme_challenge(auth, domain):
     nginx_conf_file = "%s/000-acmechallenge.conf" % nginx_conf_folder
 
     nginx_configuration = '''
-location ^~ '/.well-known/acme-challenge'
+location ^~ '/.well-known/acme-challenge/'
 {
         default_type "text/plain";
         alias %s;


### PR DESCRIPTION
## The problem

- Path-traversal not fixed (not really vulnerable in these cases)
- "Nested "add_header" drops parent headers." (Gixy test)

## Solution

- Use more_set_headers which allows us to set and clear output and input headers (https://github.com/openresty/headers-more-nginx-module#synopsis)
- Fix Path_traversal. 

## PR Status

Tested. Need review

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
