### PR TITLE
[fix] Allow - between two name

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -105,7 +105,7 @@ user:
                         ask: ask_lastname
                         required: True
                         pattern: &pattern_lastname
-                            - !!str ^([^\W\d_]{2,30}[ ,.']{0,3})+$
+                            - !!str ^([^\W\d_]{2,30}[ ,.'-]{0,3})+$
                             - "pattern_lastname"
                 -m:
                     full: --mail


### PR DESCRIPTION
## The problem

- https://github.com/YunoHost/issues/issues/1226

## Solution

- change regex to allow "-" in lastname.

## PR Status

Tested. Work finished.
Micro-decision.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
