### PR TITLE
[fix] php conf files not properly removed when an app is uninstalled

### DIFF
--- a/data/helpers.d/backend
+++ b/data/helpers.d/backend
@@ -237,10 +237,10 @@ ynh_add_fpm_config () {
 ynh_remove_fpm_config () {
 	local fpm_config_dir=$(ynh_app_setting_get $app fpm_config_dir)
 	local fpm_service=$(ynh_app_setting_get $app fpm_service)
-	# Assume php version 5 if not set
+	# Assume php version 7 if not set
 	if [ -z "$fpm_config_dir" ]; then
-		fpm_config_dir="/etc/php5/fpm"
-		fpm_service="php5-fpm"
+		fpm_config_dir="/etc/php/7.0/fpm"
+		fpm_service="php7.0-fpm"
 	fi
 	ynh_secure_remove "$fpm_config_dir/pool.d/$app.conf"
 	ynh_secure_remove "$fpm_config_dir/conf.d/20-$app.ini" 2>&1


### PR DESCRIPTION
## The problem

As reported here https://github.com/YunoHost/issues/issues/1213, here https://blog.genma.fr/?Yunohost-Soucis-a-la-suppression-d-une-webapp and in several posts on the forum, we currently have an important bug with PHP apps where a file is not removed and makes php7.0-fpm crashes.

## Solution

Turns out `ynh_remove_fpm_config` still assumed we were in jessie with Php5 :|

## PR Status

Tested and ready

## How to test

Follow Genma's instructions with and without the PR : https://blog.genma.fr/?Yunohost-Soucis-a-la-suppression-d-une-webapp 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
