### PR TITLE
[enh] Use more blocks for dd in ynh_string_random

### DIFF
--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -5,7 +5,7 @@
 # usage: ynh_string_random [length]
 # | arg: length - the string length to generate (default: 24)
 ynh_string_random() {
-    dd if=/dev/urandom bs=1 count=200 2> /dev/null \
+    dd if=/dev/urandom bs=1 count=1000 2> /dev/null \
       | tr -c -d 'A-Za-z0-9' \
       | sed -n 's/\(.\{'"${1:-24}"'\}\).*/\1/p'
 }


### PR DESCRIPTION
## The problem

200 are not enough if you try to generate a 64 characters string.

## Solution

Use 1000 blocks instead

## PR Status

Ready to be reviewed

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 