### PR TITLE
[fix] app_removeaccess call set.add

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1036,7 +1036,7 @@ def app_removeaccess(auth, apps, users=[]):
             else:
                 for allowed_user in user_list(auth)['users'].keys():
                     if allowed_user not in users:
-                        allowed_users.append(allowed_user)
+                        allowed_users.add(allowed_user)
 
             operation_logger.related_to += [ ('user', x) for x in allowed_users ]
             operation_logger.flush()


### PR DESCRIPTION
## The problem

In `yunohost/app.py`, `app_removeaccess` calls `allowed_users.append` which doesn't exist for the `set` `allowed_users`.

## Solution

Call `allowed_users.add`.

## PR Status

Trivial change. Tested in production. Ready to be reviewed.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
