### PR TITLE
Fix app_addaccess behaviour when 'allowed_users' is initially empty

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -965,7 +965,7 @@ def app_addaccess(auth, apps, users=[]):
             operation_logger.start()
 
             allowed_users = set()
-            if 'allowed_users' in app_settings:
+            if 'allowed_users' in app_settings and app_settings['allowed_users']:
                 allowed_users = set(app_settings['allowed_users'].split(','))
 
             for allowed_user in users:


### PR DESCRIPTION
## The problem

When the setting `allowed_users` exists but is empty, `app_addaccess` produces a "ghost" user.

The problem lies on line [969](https://github.com/YunoHost/yunohost/blob/stretch-unstable/src/yunohost/app.py#L969). If `app_settings['allowed_users']` is an empty string, `set(app_settings['allowed_users'].split(','))` evaluates to `set([''])` which represents an unnamed user. Since the initial value for the `allowed_users` set is not checked by the call to `user_info` on line [974](https://github.com/YunoHost/yunohost/blob/stretch-unstable/src/yunohost/app.py#L974), this prepends an empty string to the result.

### How to reproduce the problem

Take a test app `my_app`.

```bash
# start with a clean setting
yunohost app clearaccess my_app
# add a test user
yunohost app addaccess my_app -u user1
# no problem
# now empty the allowed users list
yunohost app removeaccess my_app
# and add the user again
yunohost app addaccess my_app -u user1
# there is a ghost user in the beginning of the list (e.g. in the web interface)
yunohost app setting my_app allowed_users
# returns ',user1', not 'user1'
```

## Solution

Ensure `app_settings['allowed_users']` is not empty before splitting it.

## PR Status

_A priori_ trivial change. Tested on test machine.

## Validation

- [ ] Principle agreement 1/2 : ljf
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [x] Deep review 1/1 : ljf
