### PR TITLE
[enh] Allow to not fail on backup and restore for some files

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -10,12 +10,13 @@ CAN_BIND=${CAN_BIND:-1}
 # 
 # If DEST is ended by a slash it complete this path with the basename of SRC.
 #
-# usage: ynh_backup src [dest [is_big [arg]]]
+# usage: ynh_backup src [dest [is_big [not_mandatory [arg]]]]
 # | arg: src - file or directory to bind or symlink or copy. it shouldn't be in
 # the backup dir. 
 # | arg: dest - destination file or directory inside the
 # backup dir
 # | arg: is_big - 1 to indicate data are big (mail, video, image ...)
+# | arg: not_mandatory - 1 to indicate that if the file is missing, the backup can ignore it.
 # | arg: arg - Deprecated arg
 #
 # example:
@@ -46,6 +47,7 @@ ynh_backup() {
     local SRC_PATH="$1"
     local DEST_PATH="${2:-}"
     local IS_BIG="${3:-0}"
+    local NOT_MANDATORY="${4:-0}"
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
 
     # If backing up core only (used by ynh_backup_before_upgrade),
@@ -61,7 +63,13 @@ ynh_backup() {
     # Be sure the source path is not empty
     [[ -e "${SRC_PATH}" ]] || {
         echo "Source path '${SRC_PATH}' does not exist" >&2
-        return 1
+
+        if [ "$NOT_MANDATORY" == "0" ]
+        then
+                return 1
+        else
+                return 0
+        fi
     }
 
     # Transform the source path as an absolute path
@@ -168,12 +176,13 @@ with open(sys.argv[1], 'r') as backup_file:
 # Use the registered path in backup_list by ynh_backup to restore the file at
 # the good place.
 #
-# usage: ynh_restore_file ORIGIN_PATH [ DEST_PATH ]
+# usage: ynh_restore_file ORIGIN_PATH [ DEST_PATH [NOT_MANDATORY]]
 # | arg: ORIGIN_PATH - Path where was located the file or the directory before
 # to be backuped or relative path to $YNH_CWD where it is located in the backup archive
 # | arg: DEST_PATH   - Path where restore the file or the dir, if unspecified,
 # the destination will be ORIGIN_PATH or if the ORIGIN_PATH doesn't exist in
 # the archive, the destination will be searched into backup.csv
+# | arg: NOT_MANDATORY - 1 to indicate that if the file is missing, the restore process can ignore it.
 #
 # If DEST_PATH already exists and is lighter than 500 Mo, a backup will be made in 
 # /home/yunohost.conf/backup/. Otherwise, the existing file is removed.
@@ -193,10 +202,16 @@ ynh_restore_file () {
     local ARCHIVE_PATH="$YNH_CWD${ORIGIN_PATH}"
     # Default value for DEST_PATH = /$ORIGIN_PATH
     local DEST_PATH="${2:-$ORIGIN_PATH}"
+    local NOT_MANDATORY="${3:-0}"
 
     # If ARCHIVE_PATH doesn't exist, search for a corresponding path in CSV
     if [ ! -d "$ARCHIVE_PATH" ] && [ ! -f "$ARCHIVE_PATH" ] && [ ! -L "$ARCHIVE_PATH" ]; then
-        ARCHIVE_PATH="$YNH_BACKUP_DIR/$(_get_archive_path \"$ORIGIN_PATH\")"
+        if [ "$NOT_MANDATORY" == "0" ]
+        then
+            ARCHIVE_PATH="$YNH_BACKUP_DIR/$(_get_archive_path \"$ORIGIN_PATH\")"
+        else
+            return 0
+        fi
     fi
 
     # Move the old directory if it already exists


### PR DESCRIPTION
## The problem

Following https://github.com/YunoHost/yunohost/pull/558, this PR allow to specify that, for a file, the backup process can continue if the file is missing.
The same argument has to be added to the restore command to ignore it as well.

## Solution

Simply ignore the file during the backup and the restore process, and do not fail.

## PR Status

Tested on a VM.
Can be reviewed.

## How to test

Add the argument in the backup and restore script for a file.
Replace the helper, and remove a file used during the backup.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 