### PR TITLE
Update ECDH curves recommended by Mozilla, now that we are on stretch

### DIFF
--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -37,7 +37,7 @@ server {
     # ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
 
     # As suggested by https://cipherli.st/
-    ssl_ecdh_curve secp384r1;
+    #ssl_ecdh_curve secp384r1;
 
     ssl_prefer_server_ciphers on;
 

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -33,12 +33,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    # (this doesn't work on jessie though ...?)
-    # ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
-
-    # As suggested by https://cipherli.st/
-    #ssl_ecdh_curve secp384r1;
-
+    ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility


### PR DESCRIPTION
Better security is option is not recommended.

## The problem

...

## Solution

...

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
