### PR TITLE
Add post_cert_update hook each time certificate is updated

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -805,6 +805,9 @@ def _enable_certificate(domain, new_cert_folder):
 
     _run_service_command("reload", "nginx")
 
+    from yunohost.hook import hook_callback
+    hook_callback('post_cert_update', args=[domain])
+
 
 def _backup_current_cert(domain):
     logger.debug("Backuping existing certificate for domain %s", domain)


### PR DESCRIPTION
## The problem

Some apps need to reload stuff each time the certificate changes

## Solution

Add a `post_cert_update` hook, called each time a different certificate is enabled (cert-install, cert-renew, and also self-signed cert reinstall or initialization)

## PR Status

Not tested /o\

## How to test

Try to use cert-install, cert-renew, ... check that the hook is called correctly

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
