### PR TITLE
Add libpam-ldapd as dependency to be able to login through SSH with LDAP?

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , dnsutils, bind9utils, unzip, git, curl, cron, wget, jq
  , ca-certificates, netcat-openbsd, iproute
  , mariadb-server, php-mysql | php-mysqlnd
- , slapd, ldap-utils, sudo-ldap, libnss-ldapd, unscd
+ , slapd, ldap-utils, sudo-ldap, libnss-ldapd, unscd, libpam-ldapd
  , postfix-ldap, postfix-policyd-spf-perl, postfix-pcre, procmail, mailutils, postsrsd
  , dovecot-ldap, dovecot-lmtpd, dovecot-managesieved
  , dovecot-antispam, fail2ban


### PR DESCRIPTION
## The problem

c.f. https://forum.yunohost.org/t/impossible-connection-sur-le-compte-admin-en-ssh-ssh-could-not-resolve-hostname-service/6129/13 : authentication doesn't work for LDAP user on some setup. Apparently related to the fact that libpam-ldapd was not installed. I believe it works on most setup though because libpam-ldapd is in Recommendeds for nslcd (but maybe on some setups those recommended packages are not installed...)

## Solution

Add libpam-ldapd as dependency

## PR Status

Not tested but meh that should be ok

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
