### PR TITLE
[fix] Regen nginx conf to be sure it integrates OCSP Stapling

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -304,6 +304,8 @@ def _certificate_install_letsencrypt(auth, domain_list, force=False, no_checks=F
             logger.error(msg)
             operation_logger.error(msg)
 
+      service_regen_conf(names=['nginx')
+
 def certificate_renew(auth, domain_list, force=False, no_checks=False, email=False, staging=False):
     """
     Renew Let's Encrypt certificate for given domains (all by default)


### PR DESCRIPTION
## The problem

- When a LE certificate is created, user must run `yunohost service regen-conf` to add OCSP Block in nginx template.  

## Solution

- Regen_conf automatically

## PR Status

Work finished. Not tested.

## How to test

Install yunohost. Create a LE cert

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
