### PR TITLE
[fix] Password constrains and checks not behaving properly

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -118,7 +118,7 @@ def tools_ldapinit():
     return auth
 
 
-def tools_adminpw(auth, new_password):
+def tools_adminpw(auth, new_password, check_strength=True):
     """
     Change admin password
 
@@ -130,7 +130,8 @@ def tools_adminpw(auth, new_password):
     from yunohost.utils.password import assert_password_is_strong_enough
     import spwd
 
-    assert_password_is_strong_enough("admin", new_password)
+    if check_strength:
+        assert_password_is_strong_enough("admin", new_password)
 
     new_hash = _hash_user_password(new_password)
 
@@ -416,7 +417,7 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
     tools_maindomain(auth, domain)
 
     # Change LDAP admin password
-    tools_adminpw(auth, password)
+    tools_adminpw(auth, password, check_strength=not force_password)
 
     # Enable UPnP silently and reload firewall
     firewall_upnp('enable', no_refresh=True)

--- a/src/yunohost/utils/password.py
+++ b/src/yunohost/utils/password.py
@@ -60,7 +60,7 @@ class PasswordValidator(object):
             # (or at least that's my understanding -- Alex)
             settings = json.load(open('/etc/yunohost/settings.json', "r"))
             setting_key = "security.password." + profile + ".strength"
-            self.validation_strength = int(settings[setting_key])
+            self.validation_strength = int(settings[setting_key]["value"])
         except Exception as e:
             # Fallback to default value if we can't fetch settings for some reason
             self.validation_strength = 1


### PR DESCRIPTION
## The problem

`--force-password` not working during postinstall, because there's a call to `tools_adminpw` which also performs a check of the strength. 

## Solution

Pass a new `check_strength` argument to `tools_adminpw` so that we can disable the check if `--force-password` is used.

## PR Status

Yolocomitted, not tested :s 

## How to test

Run a postinstall with a dummy password and `--force-install`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
