### PR TITLE
[enh] Clean + harden sshd config using Mozilla recommendation

### DIFF
--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -5,7 +5,7 @@ ip=$(hostname --all-ip-address)
 
 # Fetch SSH fingerprints
 i=0
-for key in $(ls /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key.pub 2> /dev/null) ; do 
+for key in $(ls /etc/ssh/ssh_host_{ed25519,rsa,ecdsa}_key.pub 2> /dev/null) ; do 
     output=$(ssh-keygen -l -f $key)
     fingerprint[$i]=" - $(echo $output | cut -d' ' -f2) $(echo $output| cut -d' ' -f4)"
     i=$(($i + 1))

--- a/data/hooks/conf_regen/03-ssh
+++ b/data/hooks/conf_regen/03-ssh
@@ -16,7 +16,7 @@ do_pre_regen() {
         || sed -i "s/ListenAddress ::/#ListenAddress ::/g" sshd_config
 
       # Support legacy setting (this setting might be disabled by a user during a migration)
-      ssh_keys=$(ls /etc/ssh/ssh_host_{rsa,ecdsa,ed25519}_key 2>/dev/null)
+      ssh_keys=$(ls /etc/ssh/ssh_host_{ed25519,rsa,ecdsa}_key 2>/dev/null)
       if [[ "$(yunohost settings get 'service.ssh.allow_deprecated_dsa_hostkey')" == "True" ]]; then
           ssh_keys="$ssh_keys $(ls /etc/ssh/ssh_host_dsa_key 2>/dev/null)"
       fi

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -10,80 +10,60 @@ ListenAddress 0.0.0.0
 {% for key in ssh_keys.split() %}
 HostKey {{ key }}{% endfor %}
 
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
+# ##############################################
+# Stuff recommended by Mozilla "modern" compat'
+# https://infosec.mozilla.org/guidelines/openssh
+# ##############################################
 
-# Logging
+# Keys, ciphers and MACS
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+
+# Use kernel sandbox mechanisms where possible in unprivileged processes
+UsePrivilegeSeparation sandbox
+
+# LogLevel VERBOSE logs user's key fingerprint on login.
+# Needed to have a clear audit track of which key was using to log in.
 SyslogFacility AUTH
-LogLevel INFO
+LogLevel VERBOSE
 
-# Authentication:
+# #######################
+# Authentication settings
+# #######################
+
+# Comment from Mozilla about the motivation behind disabling root login
+#
+# Root login is not allowed for auditing reasons. This is because it's difficult to track which process belongs to which root user:
+#
+# On Linux, user sessions are tracking using a kernel-side session id, however, this session id is not recorded by OpenSSH.
+# Additionally, only tools such as systemd and auditd record the process session id.
+# On other OSes, the user session id is not necessarily recorded at all kernel-side.
+# Using regular users in combination with /bin/su or /usr/bin/sudo ensure a clear audit track.
+
 LoginGraceTime 120
 PermitRootLogin no
 StrictModes yes
-
 PubkeyAuthentication yes
-#AuthorizedKeysFile     %h/.ssh/authorized_keys
-
-# Don't read the user's ~/.rhosts and ~/.shosts files
-IgnoreRhosts yes
-# similar for protocol version 2
-HostbasedAuthentication no
-# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
-#IgnoreUserKnownHosts yes
-
-# To enable empty passwords, change to yes (NOT RECOMMENDED)
 PermitEmptyPasswords no
-
-# Change to yes to enable challenge-response passwords (beware issues with
-# some PAM modules and threads)
 ChallengeResponseAuthentication no
-
-# Change to no to disable tunnelled clear text passwords
-#PasswordAuthentication yes
-
-# Kerberos options
-#KerberosAuthentication no
-#KerberosGetAFSToken no
-#KerberosOrLocalPasswd yes
-#KerberosTicketCleanup yes
-
-# GSSAPI options
-#GSSAPIAuthentication no
-#GSSAPICleanupCredentials yes
-
-X11Forwarding yes
-X11DisplayOffset 10
-PrintMotd no
-PrintLastLog yes
-TCPKeepAlive yes
-#UseLogin no
-
-# keep ssh sessions fresh
-ClientAliveInterval 60
-
-#MaxStartups 10:30:60
-Banner /etc/issue.net
-
-# Allow client to pass locale environment variables
-AcceptEnv LANG LC_*
-
-Subsystem sftp internal-sftp
-
-# Set this to 'yes' to enable PAM authentication, account processing,
-# and session processing. If this is enabled, PAM authentication will
-# be allowed through the ChallengeResponseAuthentication and
-# PasswordAuthentication.  Depending on your PAM configuration,
-# PAM authentication via ChallengeResponseAuthentication may bypass
-# the setting of "PermitRootLogin without-password".
-# If you just want the PAM account and session checks to run without
-# PAM authentication, then enable this but set PasswordAuthentication
-# and ChallengeResponseAuthentication to 'no'.
 UsePAM yes
 
+# Change to no to disable tunnelled clear text passwords
+# (i.e. everybody will need to authenticate using ssh keys)
+#PasswordAuthentication yes
+
+# Post-login stuff
+Banner /etc/issue.net
+PrintMotd no
+PrintLastLog yes
+ClientAliveInterval 60
+AcceptEnv LANG LC_*
+
+# SFTP stuff
+Subsystem sftp internal-sftp
 Match User sftpusers
         ForceCommand internal-sftp
         ChrootDirectory /home/%u
         AllowTcpForwarding no
         GatewayPorts no
-        X11Forwarding no


### PR DESCRIPTION
## The problem

There are various settings which can be improved in the sshd configuration to increase security.

## Solution

I used the Mozilla recommendation which I found here : https://infosec.mozilla.org/guidelines/openssh

I also cleaned a few things : many weird commented settings which are unlikely to be used, or settings which corresponds to the default setting and therefore unnecessary to state them.

Of course, the best security gain in here would be to disable password authentication... To quote a guy from Stack Overflow : « The authentication and negotiation ciphers are far more important than the symmetric algorithm for the overall security »

## PR Status

Tested in a dev environnement ... but we should be careful and test this in various setups. (e.g. does this break putty ? etc...)

## How to test

This is built on top of https://github.com/YunoHost/yunohost/pull/518 - you'll need to apply the migration, make sure you are using the new conf and see if everything works as expected

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
