### PR TITLE
[fix] Log dyndns update only if we really update something

### DIFF
--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -206,9 +206,6 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
 
             key = keys[0]
 
-    operation_logger.related_to.append(('domain', domain))
-    operation_logger.start()
-
     # This mean that hmac-md5 is used
     # (Re?)Trigger the migration to sha256 and return immediately.
     # The actual update will be done in next run.
@@ -258,6 +255,8 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
         logger.info("No updated needed.")
         return
     else:
+        operation_logger.related_to.append(('domain', domain))
+        operation_logger.start()
         logger.info("Updated needed, going on...")
 
     dns_conf = _build_dns_conf(domain)


### PR DESCRIPTION
## The problem

`dyndns update` update rate is too damn high, and generates two log file every two minutes even if it doesn't update anything.

```
ls -l /var/log/yunohost/categories/operation/ | wc -l
43915
ls -l /var/log/yunohost/categories/operation/ | grep dyndns | wc -l
43678
```

## Solution

Stop this madness and only start logging if we really do update something.

## PR Status

Yolocomitted but should be fine :< 

## How to test



## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
