### PR TITLE
Fix multiple value for getopts

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -129,6 +129,8 @@ ynh_handle_getopts_args () {
 							shift_value=$(( shift_value - 1 ))
 						fi
 
+						# Declare the content of option_var as a variable.
+						eval ${option_var}=""
 						# Then read the array value per value
 						for i in `seq 0 $(( ${#all_args[@]} - 1 ))`
 						do
@@ -140,8 +142,6 @@ ynh_handle_getopts_args () {
 									break
 								fi
 							else
-								# Declare the content of option_var as a variable.
-								eval ${option_var}=""
 								# Else, add this value to this option
 								# Each value will be separated by ';'
 								if [ -n "${!option_var}" ]


### PR DESCRIPTION
## The problem

If an option has multiple values, the variable use to store the values will be erased at each loop.

## Solution

Move the creation of the variable before the loop.

## PR Status

Ready to be reviewed.
Tested.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
I think it can be merged quickly, it's just a simple fix.