### PR TITLE
Return instead of break, otherwise warning is shown

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -15,7 +15,7 @@ ynh_wait_dpkg_free() {
             # Sleep an exponential time at each round
             sleep $(( try * try ))
         else
-            break
+            return 0
         fi
     done
     echo "apt still used, but timeout reached !"


### PR DESCRIPTION
## The problem

In `ynh_wait_dpkg_free`, there's a `break` if the lock is free. But right after the function, a warning is displayed (in all cases) saying the lock ain't free.

## Solution

Use `return` because we don't wanna show a warning if the lock is free

## PR Status

Microdecision / waiting for confirmation from @maniackcrudelis  ;)

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
