### PR TITLE
[fix] Manual migration and disclaimer behaviors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -305,6 +305,7 @@
     "migrations_show_currently_running_migration": "Running migration {number} {name}...",
     "migrations_show_last_migration": "Last ran migration is {}",
     "migrations_skip_migration": "Skipping migration {number} {name}...",
+    "migrations_success": "Successfully ran migration {number} {name}!",
     "migrations_to_be_ran_manually":  "Migration {number} {name} has to be ran manually. Please go to Tools > Migrations on the webadmin, or run `yunohost tools migrations migrate`.",
     "migrations_need_to_accept_disclaimer": "To run the migration {number} {name}, your must accept the following disclaimer:\n---\n{disclaimer}\n---\nIf you accept to run the migration, please re-run the command with the option --accept-disclaimer.",
     "monitor_disabled": "The server monitoring has been disabled",

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -938,6 +938,10 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
 
         operation_logger.success()
 
+        # Skip migrations one at a time
+        if skip:
+            break
+
     # special case where we want to go back from the start
     if target == 0:
         state["last_run_migration"] = None

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -903,7 +903,7 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
 
         if not skip:
 
-            logger.warn(m18n.n('migrations_show_currently_running_migration',
+            logger.info(m18n.n('migrations_show_currently_running_migration',
                                number=migration.number, name=migration.name))
 
             try:

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -872,30 +872,33 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
     else:  # can't happen, this case is handle before
         raise Exception()
 
-    # If we are migrating in "automatic mode" (i.e. from debian
-    # configure during an upgrade of the package) but we are asked to run
-    # migrations is to be ran manually by the user
-    manual_migrations = [m for m in migrations if m.mode == "manual"]
-    if not skip and auto and manual_migrations:
-        for m in manual_migrations:
-            logger.warn(m18n.n('migrations_to_be_ran_manually',
-                               number=m.number,
-                               name=m.name))
-        return
-
-    # If some migrations have disclaimers, require the --accept-disclaimer
-    # option
-    migrations_with_disclaimer = [m for m in migrations if m.disclaimer]
-    if not skip and not accept_disclaimer and migrations_with_disclaimer:
-        for m in migrations_with_disclaimer:
-            logger.warn(m18n.n('migrations_need_to_accept_disclaimer',
-                               number=m.number,
-                               name=m.name,
-                               disclaimer=m.disclaimer))
-        return
-
     # effectively run selected migrations
     for migration in migrations:
+
+        if not skip:
+            # If we are migrating in "automatic mode" (i.e. from debian configure
+            # during an upgrade of the package) but we are asked to run migrations
+            # to be ran manually by the user, stop there and ask the user to
+            # run the migration manually.
+            if auto and migration.mode == "manual":
+                logger.warn(m18n.n('migrations_to_be_ran_manually',
+                                   number=migration.number,
+                                   name=migration.name))
+                break
+
+            # If some migrations have disclaimers,
+            if migration.disclaimer:
+                # require the --accept-disclaimer option. Otherwise, stop everything
+                # here and display the disclaimer
+                if not accept_disclaimer:
+                    logger.warn(m18n.n('migrations_need_to_accept_disclaimer',
+                                       number=migration.number,
+                                       name=migration.name,
+                                       disclaimer=migration.disclaimer))
+                    break
+                # --accept-disclaimer will only work for the first migration
+                else:
+                    accept_disclaimer = False
 
         # Start register change on system
         operation_logger= OperationLogger('tools_migrations_migrate_' + mode)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -432,7 +432,7 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
     _install_appslist_fetch_cron()
 
     # Init migrations (skip them, no need to run them on a fresh system)
-    tools_migrations_migrate(skip=True, auto=True)
+    _skip_all_migrations()
 
     os.system('touch /etc/yunohost/installed')
 
@@ -948,7 +948,6 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
 
     write_to_json(MIGRATIONS_STATE_PATH, state)
 
-
 def tools_migrations_state():
     """
     Show current migration state
@@ -1047,6 +1046,25 @@ def _load_migration(migration_file):
 
         raise MoulinetteError(errno.EINVAL, m18n.n('migrations_error_failed_to_load_migration',
             number=number, name=name))
+
+def _skip_all_migrations():
+    """
+    Skip all pending migrations.
+    This is meant to be used during postinstall to
+    initialize the migration system.
+    """
+    state = tools_migrations_state()
+
+    # load all migrations
+    migrations = _get_migrations_list()
+    migrations = sorted(migrations, key=lambda x: x.number)
+    last_migration = migrations[-1]
+
+    state["last_run_migration"] = {
+        "number": last_migration.number,
+        "name": last_migration.name
+    }
+    write_to_json(MIGRATIONS_STATE_PATH, state)
 
 
 class Migration(object):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -924,6 +924,9 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
                 logger.error(msg, exc_info=1)
                 operation_logger.error(msg)
                 break
+            else:
+                logger.success(m18n.n('migrations_success',
+                                      number=migration.number, name=migration.name))
 
         else:  # if skip
             logger.warn(m18n.n('migrations_skip_migration',


### PR DESCRIPTION
## The problem

There are a few issues in the way migrations currently works : 
- if for instance 2 auto migrations are pending followed by 1 manual migration, none will be ran during a `dist-upgrade`. This currently partially breaks migration to stretch because migration 6 is manual. Hence migrations 3, 4 and 5 are not ran and therefore migration to php 7 does not happen entirely ...!
- if there are several migrations pending, one cannot skip one migration and run the others
- if several migrations with disclaimers are pending, using `--accept-disclaimer` will accept all disclaimer and not just the first one
- (minor/cosmetic) Postinstall shows weird Warnings about skipped migrations

## Solution

Fix the behavior of `--auto`, `--accept-disclaimer` and `--skip` such that all migrations that can be ran are ran until a "blocking" point where a disclaimer agreement is required. Accepting a disclaimer or skipping a migration works only once such that you need to run the command multiple time if there are several disclaimers to accept for instance.

Also tweaked the initialization of the migration stuff during postinstall to make it quiet and simpler.

Planning to release this in 3.3.x to fix the jessie->stretch migration.

## PR Status

Tested, ready to be reviewed and merged

## How to test

Checkout this branch ... you need to have several migrations pending to properly test this. Personally I rebased on top of the SSH PR and went back to migration 4 then ran `yunohost tools migrations migrate` with appropriate options.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
