### PR TITLE
[fix] Quotes around CAA value for letsencrypt.org

### DIFF
--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -340,7 +340,7 @@ def _build_dns_conf(domain, ttl=3600):
             {"type": "TXT", "name": "_dmarc", "value": "\"v=DMARC1; p=none\"", "ttl": 3600}
         ],
         "extra": [
-            {"type": "CAA", "name": "@", "value": "128 issue 'letsencrypt.org'", "ttl": 3600},
+            {"type": "CAA", "name": "@", "value": "128 issue \"letsencrypt.org\"", "ttl": 3600},
         ],
     }
     """
@@ -397,7 +397,7 @@ def _build_dns_conf(domain, ttl=3600):
 
     # Extra
     extra = [
-        ["@", ttl, "CAA", "128 issue 'letsencrypt.org'"]
+        ["@", ttl, "CAA", '128 issue "letsencrypt.org"']
     ]
 
     return {


### PR DESCRIPTION
## The problem

See https://github.com/YunoHost/issues/issues/1247

## Solution

Change quotes around `letsencrypt.org`

## PR Status

For review

## How to test

Print recommended DNS configuration from YunoHost admin

## Validation

- [ ] Principle agreement 0/2 : Josué
- [ ] Quick review 0/1 : 0
- [ ] Simple test 0/1 : 0
- [ ] Deep review 0/1 : 0
