### PR TITLE
Change message about conf now being managed by service -> yunohost

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -392,7 +392,7 @@
     "service_conf_file_remove_failed": "Unable to remove the configuration file '{conf}'",
     "service_conf_file_removed": "The configuration file '{conf}' has been removed",
     "service_conf_file_updated": "The configuration file '{conf}' has been updated",
-    "service_conf_new_managed_file": "The configuration file '{conf}' is now managed by the service {service}.",
+    "service_conf_now_managed_by_yunohost": "The configuration file '{conf}' is now managed by YunoHost.",
     "service_conf_up_to_date": "The configuration is already up-to-date for service '{service}'",
     "service_conf_updated": "The configuration has been updated for service '{service}'",
     "service_conf_would_be_updated": "The configuration would have been updated for service '{service}'",

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -502,8 +502,8 @@ def service_regen_conf(operation_logger, names=[], with_diff=False, force=False,
                     # we assume that it is safe to regen it, since the file is backuped
                     # anyway (by default in _regen), as long as we warn the user
                     # appropriately.
-                    logger.info(m18n.n('service_conf_new_managed_file',
-                                       conf=system_path, service=service))
+                    logger.info(m18n.n('service_conf_now_managed_by_yunohost',
+                                       conf=system_path))
                     regenerated = _regen(system_path, pending_path)
                     conf_status = 'new'
                 elif force:


### PR DESCRIPTION
## The problem

During postinstall, there are quite a few messages being displayed such as : 

```
Info: The configuration file '/etc/metronome/metronome.cfg.lua' is now managed by the service metronome.
Success! The configuration has been updated for service 'metronome'
Info: The configuration file '/etc/postfix/master.cf' is now managed by the service postfix.
Info: The configuration file '/etc/postfix/main.cf' is now managed by the service postfix.
Info: The configuration file '/etc/default/postsrsd' is now managed by the service postfix.
Success! The configuration has been updated for service 'postfix'
```

While the wording "is now managed by the service postfix" is "right", it's probably a bit weird for external people because e.g. `master.cf` is anyway a conf file used by the service postfix ... What we really mean here is that this file is now managed by YunoHost.

## Solution

Change the message to be less cryptic hopefully...

## PR Status

Microdecision

## How to test

Run postinstall

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
