### PR TITLE
Check migration before yunohost operation

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -50,6 +50,10 @@ _global:
                     uri: ldap://localhost:389
                     base_dn: dc=yunohost,dc=org
         argument_auth: true
+
+    preaction:
+        yunohost.preactions.checkmigrations:
+            - main
     arguments:
         -v:
             full: --version

--- a/locales/en.json
+++ b/locales/en.json
@@ -318,6 +318,7 @@
     "migrations_loading_migration": "Loading migration {number} {name}…",
     "migrations_migration_has_failed": "Migration {number} {name} has failed with exception {exception}, aborting",
     "migrations_no_migrations_to_run": "No migrations to run",
+    "migrations_required": "To be able do the yunohost operation you need to do the migration",
     "migrations_show_currently_running_migration": "Running migration {number} {name}…",
     "migrations_show_last_migration": "Last ran migration is {}",
     "migrations_skip_migration": "Skipping migration {number} {name}…",

--- a/src/yunohost/preactions/checkmigrations.py
+++ b/src/yunohost/preactions/checkmigrations.py
@@ -1,0 +1,63 @@
+import os
+import re
+from importlib import import_module
+
+from moulinette import m18n
+from yunohost.utils.error import YunohostError
+from moulinette.utils.filesystem import read_json
+from moulinette.utils.log import getActionLogger
+
+logger = getActionLogger('yunohost.preactions.checkmigrations')
+
+# FIXME this is a duplicate from tools.py
+MIGRATIONS_STATE_PATH = "/etc/yunohost/migrations_state.json"
+
+def main(function, arguements):
+    # Allow to do any action about migrations
+    if 'tools_' in function or '_list' in function or 'service_' in function:
+        return
+
+    try:
+        import yunohost.data_migrations
+    except ImportError:
+        # not data migrations present, return
+        return
+
+    migrations_path = yunohost.data_migrations.__path__[0]
+
+    if not os.path.exists(migrations_path):
+        logger.warn(m18n.n('migrations_cant_reach_migration_file', migrations_path))
+        return
+
+    last_migration = -1
+    if os.path.exists(MIGRATIONS_STATE_PATH):
+        last_migration = read_json(MIGRATIONS_STATE_PATH)['last_run_migration']['number']
+
+    migrations = sorted(filter(lambda x: re.match("^\d+_[a-zA-Z0-9_]+\.py$", x), os.listdir(migrations_path)), reverse=True)
+
+    # Check for each migration which are not done if it's required
+    for migration_file in migrations:
+        migration_id = migration_file[:-len(".py")]
+        number, name = migration_id.split("_", 1)
+
+        # Skype all migration already done
+        if int(number) <= last_migration:
+            return
+
+        logger.debug(m18n.n('migrations_loading_migration',
+                            number=number, name=name))
+        try:
+            # this is python builtin method to import a module using a name, we
+            # use that to import the migration as a python object so we'll be
+            # able to run it in the next loop
+            module = import_module("yunohost.data_migrations.{}".format(migration_id))
+            migration =  module.MyMigration(migration_id)
+        except Exception:
+            import traceback
+            traceback.print_exc()
+
+            raise YunohostError('migrations_error_failed_to_load_migration',
+                                  number=number, name=name)
+
+        if migration.required:
+            raise YunohostError('migrations_required')

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -812,12 +812,13 @@ def tools_migrations_list(pending=False, done=False):
             migrations = [m for m in migrations if m.number > last_migration]
 
     # Reduce to dictionnaries
-    migrations = [{"id": migration.id,
-                   "number": migration.number,
-                   "name": migration.name,
-                   "mode": migration.mode,
-                   "description": migration.description,
-                   "disclaimer": migration.disclaimer} for migration in migrations]
+    migrations = [{ "id": migration.id,
+                    "number": migration.number,
+                    "name": migration.name,
+                    "mode": migration.mode,
+                    "description": migration.description,
+                    "disclaimer": migration.disclaimer,
+                    "required": migration.required } for migration in migrations ]
 
     return {"migrations": migrations}
 
@@ -1090,6 +1091,7 @@ class Migration(object):
     # Those are to be implemented by daughter classes
 
     mode = "auto"
+    required = False
 
     def forward(self):
         raise NotImplementedError()


### PR DESCRIPTION
## The problem

Doing the migration is not mandatory to be able to use Yunohost.

By example we can have a use case of a user which upgrade the debian package but don't do the migration.

If the migration change the structure of data in yunohost, using Yunohost without doing the migration could make some data corruption.

## Solution

Add a mechanism to check if a migration is mandatory before to do the actions.

## PR Status

Should be ready. Need more tests.

## How to test

Create a migration mandatory. If your migration contains this code is mandatory : 
```python
    @property
    def required(self):
        return True
```
Try to do some yunohost action before before the migration is done. Normally you should have this message : 
```
Erreur : To be able do the yunohost operation you need to do the migration
```

After do the migration and check that you can do everything you want.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
