### PR TITLE
Autopep8

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -137,7 +137,7 @@ def app_fetchlist(url=None, name=None):
     else:
         appslists_to_be_fetched = appslists.keys()
 
-    import requests # lazy loading this module for performance reasons
+    import requests  # lazy loading this module for performance reasons
     # Fetch all appslists to be fetched
     for name in appslists_to_be_fetched:
 
@@ -172,7 +172,7 @@ def app_fetchlist(url=None, name=None):
         appslist = appslist_request.text
         try:
             json.loads(appslist)
-        except ValueError, e:
+        except ValueError as e:
             logger.error(m18n.n('appslist_retrieve_bad_format',
                                 appslist=name))
             continue
@@ -542,7 +542,7 @@ def app_change_url(operation_logger, auth, app, domain, path):
         raise YunohostError("app_change_url_failed_nginx_reload", nginx_errors=nginx_errors)
 
     logger.success(m18n.n("app_change_url_success",
-                         app=app, domain=domain, path=path))
+                          app=app, domain=domain, path=path))
 
     hook_callback('post_app_change_url', args=args_list, env=env_dict)
 
@@ -701,7 +701,6 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
     from yunohost.hook import hook_add, hook_remove, hook_exec, hook_callback
     from yunohost.log import OperationLogger
 
-
     # Fetch or extract sources
     try:
         os.listdir(INSTALL_TMP)
@@ -758,7 +757,7 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(instance_number)
 
     # Start register change on system
-    operation_logger.extra.update({'env':env_dict})
+    operation_logger.extra.update({'env': env_dict})
     operation_logger.related_to = [s for s in operation_logger.related_to if s[0] != "app"]
     operation_logger.related_to.append(("app", app_id))
     operation_logger.start()
@@ -816,8 +815,8 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
 
                 # Execute remove script
                 operation_logger_remove = OperationLogger('remove_on_failed_install',
-                                                 [('app', app_instance_name)],
-                                                 env=env_dict_remove)
+                                                          [('app', app_instance_name)],
+                                                          env=env_dict_remove)
                 operation_logger_remove.start()
 
                 remove_retcode = hook_exec(
@@ -944,7 +943,6 @@ def app_addaccess(auth, apps, users=[]):
 
     for app in apps:
 
-
         app_settings = _get_app_settings(app)
         if not app_settings:
             continue
@@ -957,7 +955,7 @@ def app_addaccess(auth, apps, users=[]):
 
             # Start register change on system
             related_to = [('app', app)]
-            operation_logger= OperationLogger('app_addaccess', related_to)
+            operation_logger = OperationLogger('app_addaccess', related_to)
             operation_logger.start()
 
             allowed_users = set()
@@ -1020,7 +1018,7 @@ def app_removeaccess(auth, apps, users=[]):
 
             # Start register change on system
             related_to = [('app', app)]
-            operation_logger= OperationLogger('app_removeaccess', related_to)
+            operation_logger = OperationLogger('app_removeaccess', related_to)
             operation_logger.start()
 
             if remove_all:
@@ -1034,7 +1032,7 @@ def app_removeaccess(auth, apps, users=[]):
                     if allowed_user not in users:
                         allowed_users.add(allowed_user)
 
-            operation_logger.related_to += [ ('user', x) for x in allowed_users ]
+            operation_logger.related_to += [('user', x) for x in allowed_users]
             operation_logger.flush()
             new_users = ','.join(allowed_users)
             app_setting(app, 'allowed_users', new_users)
@@ -1069,7 +1067,7 @@ def app_clearaccess(auth, apps):
 
         # Start register change on system
         related_to = [('app', app)]
-        operation_logger= OperationLogger('app_clearaccess', related_to)
+        operation_logger = OperationLogger('app_clearaccess', related_to)
         operation_logger.start()
 
         if 'mode' in app_settings:
@@ -1126,7 +1124,7 @@ def app_makedefault(operation_logger, auth, app, domain=None):
 
     if domain is None:
         domain = app_domain
-        operation_logger.related_to.append(('domain',domain))
+        operation_logger.related_to.append(('domain', domain))
     elif domain not in domain_list(auth)['domains']:
         raise YunohostError('domain_unknown')
 
@@ -1218,7 +1216,7 @@ def app_register_url(auth, app, domain, path):
 
     # This line can't be moved on top of file, otherwise it creates an infinite
     # loop of import with tools.py...
-    from domain import _get_conflicting_apps, _normalize_domain_path
+    from .domain import _get_conflicting_apps, _normalize_domain_path
 
     domain, path = _normalize_domain_path(domain, path)
 
@@ -1569,10 +1567,10 @@ def app_config_show_panel(app):
             parsed_values[key] = value
 
     return_code = hook_exec(config_script,
-              args=["show"],
-              env=env,
-              stdout_callback=parse_stdout,
-    )
+                            args=["show"],
+                            env=env,
+                            stdout_callback=parse_stdout,
+                            )
 
     if return_code != 0:
         raise Exception("script/config show return value code: %s (considered as an error)", return_code)
@@ -1656,9 +1654,9 @@ def app_config_apply(app, args):
             logger.warning("Ignore key '%s' from arguments because it is not in the config", key)
 
     return_code = hook_exec(config_script,
-              args=["apply"],
-              env=env,
-    )
+                            args=["apply"],
+                            env=env,
+                            )
 
     if return_code != 0:
         raise Exception("'script/config apply' return value code: %s (considered as an error)", return_code)
@@ -2185,7 +2183,6 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
                 elif arg_type == 'password':
                     msignals.display(m18n.n('good_practices_about_user_password'))
 
-
                 try:
                     input_string = msignals.prompt(ask_string, is_password)
                 except NotImplementedError:
@@ -2385,7 +2382,7 @@ def _install_appslist_fetch_cron():
     with open(cron_job_file, "w") as f:
         f.write('\n'.join(cron_job))
 
-    _set_permissions(cron_job_file, "root", "root", 0755)
+    _set_permissions(cron_job_file, "root", "root", 0o755)
 
 
 # FIXME - Duplicate from certificate.py, should be moved into a common helper
@@ -2431,7 +2428,7 @@ def _write_appslist_list(appslist_lists):
             json.dump(appslist_lists, f)
     except Exception as e:
         raise YunohostError("Error while writing list of appslist %s: %s" %
-                              (APPSLISTS_JSON, str(e)), __raw_msg__=True)
+                            (APPSLISTS_JSON, str(e)), __raw_msg__=True)
 
 
 def _register_new_appslist(url, name):
@@ -2541,7 +2538,7 @@ def _patch_php5(app_folder):
             continue
 
         c = "sed -i -e 's@/etc/php5@/etc/php/7.0@g' " \
-                   "-e 's@/var/run/php5-fpm@/var/run/php/php7.0-fpm@g' " \
-                   "-e 's@php5@php7.0@g' " \
-                   "%s" % filename
+            "-e 's@/var/run/php5-fpm@/var/run/php/php7.0-fpm@g' " \
+            "-e 's@php5@php7.0@g' " \
+            "%s" % filename
         os.system(c)

--- a/src/yunohost/data_migrations/0001_change_cert_group_to_sslcert.py
+++ b/src/yunohost/data_migrations/0001_change_cert_group_to_sslcert.py
@@ -3,7 +3,9 @@ import glob
 from yunohost.tools import Migration
 from moulinette.utils.filesystem import chown
 
+
 class MyMigration(Migration):
+
     "Change certificates group permissions from 'metronome' to 'ssl-cert'"
 
     all_certificate_files = glob.glob("/etc/yunohost/certs/*/*.pem")

--- a/src/yunohost/data_migrations/0002_migrate_to_tsig_sha256.py
+++ b/src/yunohost/data_migrations/0002_migrate_to_tsig_sha256.py
@@ -16,6 +16,7 @@ logger = getActionLogger('yunohost.migration')
 
 
 class MyMigration(Migration):
+
     "Migrate Dyndns stuff from MD5 TSIG to SHA512 TSIG"
 
     def backward(self):
@@ -70,7 +71,7 @@ class MyMigration(Migration):
             os.system("mv /etc/yunohost/dyndns/*+165* /tmp")
 
             raise YunohostError('migrate_tsig_failed', domain=domain,
-                                  error_code=str(r.status_code), error=error)
+                                error_code=str(r.status_code), error=error)
 
         # remove old certificates
         os.system("mv /etc/yunohost/dyndns/*+157* /tmp")
@@ -87,4 +88,3 @@ class MyMigration(Migration):
 
         logger.info(m18n.n('migrate_tsig_end'))
         return
-

--- a/src/yunohost/data_migrations/0003_migrate_to_stretch.py
+++ b/src/yunohost/data_migrations/0003_migrate_to_stretch.py
@@ -24,6 +24,7 @@ YUNOHOST_PACKAGES = ["yunohost", "yunohost-admin", "moulinette", "ssowat"]
 
 
 class MyMigration(Migration):
+
     "Upgrade the system to Debian Stretch and Yunohost 3.0"
 
     mode = "manual"
@@ -168,11 +169,11 @@ class MyMigration(Migration):
         # - switch yunohost's repo to forge
         for f in sources_list:
             command = "sed -i -e 's@ jessie @ stretch @g' " \
-                             "-e '/backports/ s@^#*@#@' " \
-                             "-e 's@ jessie/updates @ stretch/updates @g' " \
-                             "-e 's@ jessie-updates @ stretch-updates @g' " \
-                             "-e 's@repo.yunohost@forge.yunohost@g' " \
-                             "{}".format(f)
+                      "-e '/backports/ s@^#*@#@' " \
+                      "-e 's@ jessie/updates @ stretch/updates @g' " \
+                      "-e 's@ jessie-updates @ stretch-updates @g' " \
+                      "-e 's@repo.yunohost@forge.yunohost@g' " \
+                      "{}".format(f)
             os.system(command)
 
     def get_apps_equivs_packages(self):
@@ -286,7 +287,7 @@ class MyMigration(Migration):
         # Create tmp directory if it does not exists
         tmp_dir = os.path.join("/tmp/", self.name)
         if not os.path.exists(tmp_dir):
-            os.mkdir(tmp_dir, 0700)
+            os.mkdir(tmp_dir, 0o700)
 
         for f in self.files_to_keep:
             dest_file = f.strip('/').replace("/", "_")

--- a/src/yunohost/data_migrations/0004_php5_to_php7_pools.py
+++ b/src/yunohost/data_migrations/0004_php5_to_php7_pools.py
@@ -19,6 +19,7 @@ MIGRATION_COMMENT = "; YunoHost note : this file was automatically moved from {}
 
 
 class MyMigration(Migration):
+
     "Migrate php5-fpm 'pool' conf files to php7 stuff"
 
     def migrate(self):
@@ -58,7 +59,7 @@ class MyMigration(Migration):
         _run_service_command("enable", "php7.0-fpm")
         os.system("systemctl stop php5-fpm")
         os.system("systemctl disable php5-fpm")
-        os.system("rm /etc/logrotate.d/php5-fpm") # We remove this otherwise the logrotate cron will be unhappy
+        os.system("rm /etc/logrotate.d/php5-fpm")  # We remove this otherwise the logrotate cron will be unhappy
 
         # Get list of nginx conf file
         nginx_conf_files = glob.glob("/etc/nginx/conf.d/*.d/*.conf")

--- a/src/yunohost/data_migrations/0005_postgresql_9p4_to_9p6.py
+++ b/src/yunohost/data_migrations/0005_postgresql_9p4_to_9p6.py
@@ -11,6 +11,7 @@ logger = getActionLogger('yunohost.migration')
 
 
 class MyMigration(Migration):
+
     "Migrate DBs from Postgresql 9.4 to 9.6 after migrating to Stretch"
 
     def migrate(self):

--- a/src/yunohost/data_migrations/0006_sync_admin_and_root_passwords.py
+++ b/src/yunohost/data_migrations/0006_sync_admin_and_root_passwords.py
@@ -15,7 +15,9 @@ from yunohost.tools import Migration
 logger = getActionLogger('yunohost.migration')
 SMALL_PWD_LIST = ["yunohost", "olinuxino", "olinux", "raspberry", "admin", "root", "test", "rpi"]
 
+
 class MyMigration(Migration):
+
     "Synchronize admin and root passwords"
 
     def migrate(self):

--- a/src/yunohost/data_migrations/0007_ssh_conf_managed_by_yunohost_step1.py
+++ b/src/yunohost/data_migrations/0007_ssh_conf_managed_by_yunohost_step1.py
@@ -8,8 +8,10 @@ from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import mkdir, rm
 
 from yunohost.tools import Migration
-from yunohost.service import service_regen_conf, _get_conf_hashes, \
-                             _calculate_hash, _run_service_command
+from yunohost.service import service_regen_conf, \
+                             _get_conf_hashes, \
+                             _calculate_hash, \
+                             _run_service_command
 from yunohost.settings import settings_set
 from yunohost.utils.error import YunohostError
 
@@ -19,6 +21,7 @@ SSHD_CONF = '/etc/ssh/sshd_config'
 
 
 class MyMigration(Migration):
+
     """
     This is the first step of a couple of migrations that ensure SSH conf is
     managed by YunoHost (even if the "from_script" flag is present, which was
@@ -48,7 +51,7 @@ class MyMigration(Migration):
 
         # Create sshd_config.d dir
         if not os.path.exists(SSHD_CONF + '.d'):
-            mkdir(SSHD_CONF + '.d', 0755, uid='root', gid='root')
+            mkdir(SSHD_CONF + '.d', 0o755, uid='root', gid='root')
 
         # Here, we make it so that /etc/ssh/sshd_config is managed
         # by the regen conf (in particular in the case where the

--- a/src/yunohost/data_migrations/0008_ssh_conf_managed_by_yunohost_step2.py
+++ b/src/yunohost/data_migrations/0008_ssh_conf_managed_by_yunohost_step2.py
@@ -3,7 +3,8 @@ import re
 from moulinette.utils.log import getActionLogger
 
 from yunohost.tools import Migration
-from yunohost.service import service_regen_conf, _get_conf_hashes, \
+from yunohost.service import service_regen_conf, \
+                             _get_conf_hashes, \
                              _calculate_hash
 from yunohost.settings import settings_set, settings_get
 from yunohost.utils.error import YunohostError
@@ -12,7 +13,9 @@ logger = getActionLogger('yunohost.migration')
 
 SSHD_CONF = '/etc/ssh/sshd_config'
 
+
 class MyMigration(Migration):
+
     """
     In this second step, the admin is asked if it's okay to use
     the recommended SSH configuration - which also implies

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -115,8 +115,8 @@ def domain_add(operation_logger, auth, domain, dyndns=False):
             service_regen_conf(names=['nginx', 'metronome', 'dnsmasq', 'postfix'])
             app_ssowatconf(auth)
 
-    except Exception, e:
-        from sys import exc_info;
+    except Exception as e:
+        from sys import exc_info
         t, v, tb = exc_info()
 
         # Force domain removal silently

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -104,7 +104,7 @@ def _dyndns_available(provider, domain):
     except MoulinetteError as e:
         logger.error(str(e))
         raise YunohostError('dyndns_could_not_check_available',
-                                     domain=domain, provider=provider)
+                            domain=domain, provider=provider)
 
     return r == u"Domain %s is available" % domain
 
@@ -149,7 +149,7 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
         with open(key_file) as f:
             key = f.readline().strip().split(' ', 6)[-1]
 
-    import requests # lazy loading this module for performance reasons
+    import requests  # lazy loading this module for performance reasons
     # Send subscription
     try:
         r = requests.post('https://%s/key/%s?key_algo=hmac-sha512' % (subscribe_host, base64.b64encode(key)), data={'subdomain': domain}, timeout=30)
@@ -211,7 +211,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
                                 exception=e,
                                 number=migration.number,
                                 name=migration.name),
-                                exc_info=1)
+                         exc_info=1)
         return
 
     # Extract 'host', e.g. 'nohost.me' from 'foo.nohost.me'
@@ -224,7 +224,6 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
         'server %s' % dyn_host,
         'zone %s' % host,
     ]
-
 
     old_ipv4 = check_output("dig @%s +short %s" % (dyn_host, domain)).strip() or None
     old_ipv6 = check_output("dig @%s +short aaaa %s" % (dyn_host, domain)).strip() or None
@@ -252,7 +251,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
         logger.info("Updated needed, going on...")
 
     dns_conf = _build_dns_conf(domain)
-    del dns_conf["extra"] # Ignore records from the 'extra' category
+    del dns_conf["extra"]  # Ignore records from the 'extra' category
 
     # Delete the old records for all domain/subdomains
 
@@ -273,7 +272,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
             # should be muc.the.domain.tld. or the.domain.tld
             if record["value"] == "@":
                 record["value"] = domain
-            record["value"] = record["value"].replace(";","\;")
+            record["value"] = record["value"].replace(";", "\;")
 
             action = "update add {name}.{domain}. {ttl} {type} {value}".format(domain=domain, **record)
             action = action.replace(" @.", " ")

--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -374,10 +374,10 @@ def firewall_upnp(action='status', no_refresh=False):
                         try:
                             # Add new port mapping
                             upnpc.addportmapping(port, protocol, upnpc.lanaddr,
-                                port, 'yunohost firewall: port %d' % port, '')
+                                                 port, 'yunohost firewall: port %d' % port, '')
                         except:
                             logger.debug('unable to add port %d using UPnP',
-                                        port, exc_info=1)
+                                         port, exc_info=1)
                             enabled = False
 
     if enabled != firewall['uPnP']['enabled']:

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -354,7 +354,7 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     # prepend environment variables
     cmd = '{0} {1}'.format(
         ' '.join(['{0}={1}'.format(k, shell_quote(v))
-                for k, v in env.items()]), cmd)
+                  for k, v in env.items()]), cmd)
     command.append(cmd.format(script=cmd_script, args=cmd_args))
 
     if logger.isEnabledFor(log.DEBUG):
@@ -369,8 +369,8 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     )
 
     if stdinfo:
-        callbacks = ( callbacks[0], callbacks[1],
-                       lambda l: logger.info(l.rstrip()))
+        callbacks = (callbacks[0], callbacks[1],
+                     lambda l: logger.info(l.rstrip()))
 
     logger.debug("About to run the command '%s'" % command)
 

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -283,6 +283,7 @@ def is_unit_operation(entities=['app', 'domain', 'service', 'user'],
 
 
 class OperationLogger(object):
+
     """
     Instances of this class represents unit operation done on the ynh instance.
 
@@ -423,7 +424,7 @@ class OperationLogger(object):
         else:
             if is_api:
                 msg = "<strong>" + m18n.n('log_link_to_failed_log',
-                                    name=self.name, desc=desc) + "</strong>"
+                                          name=self.name, desc=desc) + "</strong>"
             else:
                 msg = m18n.n('log_help_to_get_failed_log', name=self.name,
                              desc=desc)

--- a/src/yunohost/monitor.py
+++ b/src/yunohost/monitor.py
@@ -288,7 +288,7 @@ def monitor_system(units=None, human_readable=False):
         else:
             raise YunohostError('unit_unknown', unit=u)
 
-    if len(units) == 1 and type(result[units[0]]) is not str:
+    if len(units) == 1 and not isinstance(result[units[0]], str):
         return result[units[0]]
     return result
 
@@ -404,7 +404,7 @@ def monitor_enable(with_stats=False):
 
     """
     from yunohost.service import (service_status, service_enable,
-        service_start)
+                                  service_start)
 
     glances = service_status('glances')
     if glances['status'] != 'running':
@@ -414,7 +414,7 @@ def monitor_enable(with_stats=False):
 
     # Install crontab
     if with_stats:
-        #  day: every 5 min  #  week: every 1 h  #  month: every 4 h  #
+        # day: every 5 min  #  week: every 1 h  #  month: every 4 h  #
         rules = ('*/5 * * * * root {cmd} day >> /dev/null\n'
                  '3 * * * * root {cmd} week >> /dev/null\n'
                  '6 */4 * * * root {cmd} month >> /dev/null').format(
@@ -431,7 +431,7 @@ def monitor_disable():
 
     """
     from yunohost.service import (service_status, service_disable,
-        service_stop)
+                                  service_stop)
 
     glances = service_status('glances')
     if glances['status'] != 'inactive':

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -88,12 +88,12 @@ def settings_set(key, value):
     if key_type == "bool":
         if not isinstance(value, bool):
             raise YunohostError('global_settings_bad_type_for_setting', setting=key,
-                received_type=type(value).__name__, expected_type=key_type)
+                                received_type=type(value).__name__, expected_type=key_type)
     elif key_type == "int":
         if not isinstance(value, int) or isinstance(value, bool):
             if isinstance(value, str):
                 try:
-                    value=int(value)
+                    value = int(value)
                 except:
                     raise YunohostError('global_settings_bad_type_for_setting',
                                         setting=key,
@@ -101,19 +101,19 @@ def settings_set(key, value):
                                         expected_type=key_type)
             else:
                 raise YunohostError('global_settings_bad_type_for_setting', setting=key,
-                    received_type=type(value).__name__, expected_type=key_type)
+                                    received_type=type(value).__name__, expected_type=key_type)
     elif key_type == "string":
         if not isinstance(value, basestring):
             raise YunohostError('global_settings_bad_type_for_setting', setting=key,
-                received_type=type(value).__name__, expected_type=key_type)
+                                received_type=type(value).__name__, expected_type=key_type)
     elif key_type == "enum":
         if value not in settings[key]["choices"]:
             raise YunohostError('global_settings_bad_choice_for_enum', setting=key,
-                received_type=type(value).__name__,
-                expected_type=", ".join(settings[key]["choices"]))
+                                received_type=type(value).__name__,
+                                expected_type=", ".join(settings[key]["choices"]))
     else:
         raise YunohostError('global_settings_unknown_type', setting=key,
-            unknown_type=key_type)
+                            unknown_type=key_type)
 
     settings[key]["value"] = value
 

--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -98,7 +98,7 @@ def user_ssh_add_key(auth, username, key, comment):
         # create empty file to set good permissions
         write_to_file(authorized_keys_file, "")
         chown(authorized_keys_file, uid=user["uid"][0])
-        chmod(authorized_keys_file, 0600)
+        chmod(authorized_keys_file, 0o600)
 
     authorized_keys_content = read_file(authorized_keys_file)
 

--- a/src/yunohost/tests/conftest.py
+++ b/src/yunohost/tests/conftest.py
@@ -7,12 +7,14 @@ sys.path.append("..")
 def pytest_addoption(parser):
     parser.addoption("--yunodebug", action="store_true", default=False)
 
-###############################################################################
-#   Tweak translator to raise exceptions if string keys are not defined       #
-###############################################################################
+#
+# Tweak translator to raise exceptions if string keys are not defined       #
+#
 
 
 old_translate = moulinette.core.Translator.translate
+
+
 def new_translate(self, key, *args, **kwargs):
 
     if key not in self._translations[self.default_locale].keys():
@@ -21,14 +23,15 @@ def new_translate(self, key, *args, **kwargs):
     return old_translate(self, key, *args, **kwargs)
 moulinette.core.Translator.translate = new_translate
 
+
 def new_m18nn(self, key, *args, **kwargs):
     return self._namespaces[self._current_namespace].translate(key, *args, **kwargs)
 
 moulinette.core.Moulinette18n.n = new_m18nn
 
-###############################################################################
-#   Init the moulinette to have the cli loggers stuff                         #
-###############################################################################
+#
+# Init the moulinette to have the cli loggers stuff                         #
+#
 
 
 def pytest_cmdline_main(config):

--- a/src/yunohost/tests/test_appslist.py
+++ b/src/yunohost/tests/test_appslist.py
@@ -17,7 +17,7 @@ APPSLISTS_JSON = '/etc/yunohost/appslists.json'
 def setup_function(function):
 
     # Clear all appslist
-    files = glob.glob(REPO_PATH+"/*")
+    files = glob.glob(REPO_PATH + "/*")
     for f in files:
         os.remove(f)
 
@@ -42,9 +42,9 @@ def cron_job_is_there():
     return r == 0
 
 
-###############################################################################
-#   Test listing of appslists and registering of appslists                      #
-###############################################################################
+#
+# Test listing of appslists and registering of appslists                      #
+#
 
 
 def test_appslist_list_empty():
@@ -103,9 +103,9 @@ def test_appslist_list_register_conflict_url():
     assert "plopette" not in appslist_dict.keys()
 
 
-###############################################################################
-#   Test fetching of appslists                                                 #
-###############################################################################
+#
+# Test fetching of appslists                                                 #
+#
 
 
 def test_appslist_fetch():
@@ -244,9 +244,9 @@ def test_appslist_fetch_timeout():
         app_fetchlist()
 
 
-###############################################################################
-#   Test remove of appslist                                                    #
-###############################################################################
+#
+# Test remove of appslist                                                    #
+#
 
 
 def test_appslist_remove():
@@ -274,9 +274,9 @@ def test_appslist_remove_unknown():
         app_removelist("dummy")
 
 
-###############################################################################
-#   Test migration from legacy appslist system                                 #
-###############################################################################
+#
+# Test migration from legacy appslist system                                 #
+#
 
 
 def add_legacy_cron(name, url):

--- a/src/yunohost/tests/test_appurl.py
+++ b/src/yunohost/tests/test_appurl.py
@@ -22,6 +22,7 @@ def setup_function(function):
     except:
         pass
 
+
 def teardown_function(function):
 
     try:
@@ -50,18 +51,18 @@ def test_urlavailable():
 def test_registerurl():
 
     app_install(auth, "./tests/apps/register_url_app_ynh",
-            args="domain=%s&path=%s" % (maindomain, "/urlregisterapp"))
+                args="domain=%s&path=%s" % (maindomain, "/urlregisterapp"))
 
     assert not domain_url_available(auth, maindomain, "/urlregisterapp")
 
     # Try installing at same location
     with pytest.raises(YunohostError):
         app_install(auth, "./tests/apps/register_url_app_ynh",
-                args="domain=%s&path=%s" % (maindomain, "/urlregisterapp"))
+                    args="domain=%s&path=%s" % (maindomain, "/urlregisterapp"))
 
 
 def test_registerurl_baddomain():
 
     with pytest.raises(YunohostError):
         app_install(auth, "./tests/apps/register_url_app_ynh",
-                args="domain=%s&path=%s" % ("yolo.swag", "/urlregisterapp"))
+                    args="domain=%s&path=%s" % ("yolo.swag", "/urlregisterapp"))

--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -22,6 +22,7 @@ AUTH_IDENTIFIER = ('ldap', 'ldap-anonymous')
 AUTH_PARAMETERS = {'uri': 'ldap://localhost:389', 'base_dn': 'dc=yunohost,dc=org'}
 auth = None
 
+
 def setup_function(function):
 
     global maindomain
@@ -87,9 +88,9 @@ def teardown_function(function):
         shutil.rmtree("/opt/test_backup_output_directory")
 
 
-###############################################################################
-#  Helpers                                                                    #
-###############################################################################
+#
+# Helpers                                                                    #
+#
 
 def app_is_installed(app):
 
@@ -111,12 +112,14 @@ def backup_test_dependencies_are_met():
 
     return True
 
+
 def tmp_backup_directory_is_empty():
 
     if not os.path.exists("/home/yunohost.backup/tmp/"):
         return True
     else:
         return len(os.listdir('/home/yunohost.backup/tmp/')) == 0
+
 
 def clean_tmp_backup_directory():
 
@@ -125,10 +128,10 @@ def clean_tmp_backup_directory():
 
     mount_lines = subprocess.check_output("mount").split("\n")
 
-    points_to_umount = [ line.split(" ")[2]
-                         for line in mount_lines
-                            if  len(line) >= 3
-                            and line.split(" ")[2].startswith("/home/yunohost.backup/tmp") ]
+    points_to_umount = [line.split(" ")[2]
+                        for line in mount_lines
+                        if len(line) >= 3
+                        and line.split(" ")[2].startswith("/home/yunohost.backup/tmp")]
 
     for point in reversed(points_to_umount):
         os.system("umount %s" % point)
@@ -137,6 +140,7 @@ def clean_tmp_backup_directory():
         shutil.rmtree("/home/yunohost.backup/tmp/%s" % f)
 
     shutil.rmtree("/home/yunohost.backup/tmp/")
+
 
 def reset_ssowat_conf():
 
@@ -191,9 +195,10 @@ def add_archive_system_from_2p4():
     os.system("cp ./tests/apps/backup_system_from_2p4/backup.tar.gz \
                /home/yunohost.backup/archives/backup_system_from_2p4.tar.gz")
 
-###############################################################################
-#  System backup                                                              #
-###############################################################################
+#
+# System backup                                                              #
+#
+
 
 def test_backup_only_ldap():
 
@@ -220,9 +225,10 @@ def test_backup_system_part_that_does_not_exists(mocker):
     m18n.n.assert_any_call('backup_hook_unknown', hook="yolol")
     m18n.n.assert_any_call('backup_nothings_done')
 
-###############################################################################
-#  System backup and restore                                                  #
-###############################################################################
+#
+# System backup and restore                                                  #
+#
+
 
 def test_backup_and_restore_all_sys():
 
@@ -250,9 +256,9 @@ def test_backup_and_restore_all_sys():
     assert os.path.exists("/etc/ssowat/conf.json")
 
 
-###############################################################################
-#  System restore from 2.4                                                    #
-###############################################################################
+#
+# System restore from 2.4                                                    #
+#
 
 @pytest.mark.with_system_archive_from_2p4
 def test_restore_system_from_Ynh2p4(monkeypatch, mocker):
@@ -265,19 +271,20 @@ def test_restore_system_from_Ynh2p4(monkeypatch, mocker):
     # Restore system archive from 2.4
     try:
         backup_restore(auth, name=backup_list()["archives"][1],
-                             system=[],
-                             apps=None,
-                             force=True)
+                       system=[],
+                       apps=None,
+                       force=True)
     finally:
         # Restore system as it was
         backup_restore(auth, name=backup_list()["archives"][0],
-                             system=[],
-                             apps=None,
-                             force=True)
+                       system=[],
+                       apps=None,
+                       force=True)
 
-###############################################################################
-#  App backup                                                                 #
-###############################################################################
+#
+# App backup                                                                 #
+#
+
 
 @pytest.mark.with_backup_recommended_app_installed
 def test_backup_script_failure_handling(monkeypatch, mocker):
@@ -299,6 +306,7 @@ def test_backup_script_failure_handling(monkeypatch, mocker):
         backup_create(system=None, apps=["backup_recommended_app"])
 
     m18n.n.assert_any_call('backup_app_failed', app='backup_recommended_app')
+
 
 @pytest.mark.with_backup_recommended_app_installed
 def test_backup_not_enough_free_space(monkeypatch, mocker):
@@ -385,6 +393,7 @@ def test_backup_with_different_output_directory():
     assert len(archives_info["system"].keys()) == 1
     assert "conf_ssh" in archives_info["system"].keys()
 
+
 @pytest.mark.clean_opt_dir
 def test_backup_with_no_compress():
     # Create the backup
@@ -396,15 +405,15 @@ def test_backup_with_no_compress():
     assert os.path.exists("/opt/test_backup_output_directory/info.json")
 
 
-###############################################################################
-#  App restore                                                                #
-###############################################################################
+#
+# App restore                                                                #
+#
 
 @pytest.mark.with_wordpress_archive_from_2p4
 def test_restore_app_wordpress_from_Ynh2p4():
 
     backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                         apps=["wordpress"])
+                   apps=["wordpress"])
 
 
 @pytest.mark.with_wordpress_archive_from_2p4
@@ -422,7 +431,7 @@ def test_restore_app_script_failure_handling(monkeypatch, mocker):
 
     with pytest.raises(YunohostError):
         backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                             apps=["wordpress"])
+                       apps=["wordpress"])
 
     m18n.n.assert_any_call('restore_app_failed', app='wordpress')
     m18n.n.assert_any_call('restore_nothings_done')
@@ -443,12 +452,12 @@ def test_restore_app_not_enough_free_space(monkeypatch, mocker):
 
     with pytest.raises(YunohostError):
         backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                             apps=["wordpress"])
+                       apps=["wordpress"])
 
     m18n.n.assert_any_call('restore_not_enough_disk_space',
-        free_space=0,
-        margin=ANY,
-        needed_space=ANY)
+                           free_space=0,
+                           margin=ANY,
+                           needed_space=ANY)
     assert not _is_installed("wordpress")
 
 
@@ -462,7 +471,7 @@ def test_restore_app_not_in_backup(mocker):
 
     with pytest.raises(YunohostError):
         backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                             apps=["yoloswag"])
+                       apps=["yoloswag"])
 
     m18n.n.assert_any_call('backup_archive_app_not_found', app="yoloswag")
     assert not _is_installed("wordpress")
@@ -475,14 +484,14 @@ def test_restore_app_already_installed(mocker):
     assert not _is_installed("wordpress")
 
     backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                         apps=["wordpress"])
+                   apps=["wordpress"])
 
     assert _is_installed("wordpress")
 
     mocker.spy(m18n, "n")
     with pytest.raises(YunohostError):
         backup_restore(auth, system=None, name=backup_list()["archives"][0],
-                             apps=["wordpress"])
+                       apps=["wordpress"])
 
     m18n.n.assert_any_call('restore_already_installed_app', app="wordpress")
     m18n.n.assert_any_call('restore_nothings_done')
@@ -531,9 +540,10 @@ def _test_backup_and_restore_app(app):
 
     assert app_is_installed(app)
 
-###############################################################################
-#  Some edge cases                                                            #
-###############################################################################
+#
+# Some edge cases                                                            #
+#
+
 
 def test_restore_archive_with_no_json(mocker):
 
@@ -555,10 +565,9 @@ def test_backup_binds_are_readonly(monkeypatch):
         self.manager = backup_manager
         self._organize_files()
 
-
         confssh = os.path.join(self.work_dir, "conf/ssh")
         output = subprocess.check_output("touch %s/test 2>&1 || true" % confssh,
-                                         shell=True, env={'LANG' : 'en_US.UTF-8'})
+                                         shell=True, env={'LANG': 'en_US.UTF-8'})
 
         assert "Read-only file system" in output
 
@@ -568,7 +577,7 @@ def test_backup_binds_are_readonly(monkeypatch):
         self.clean()
 
     monkeypatch.setattr("yunohost.backup.BackupMethod.mount_and_backup",
-            custom_mount_and_backup)
+                        custom_mount_and_backup)
 
     # Create the backup
     backup_create(system=[])

--- a/src/yunohost/tests/test_changeurl.py
+++ b/src/yunohost/tests/test_changeurl.py
@@ -53,6 +53,7 @@ def test_appchangeurl():
 
     check_changeurl_app("/newchangeurl")
 
+
 def test_appchangeurl_sameurl():
     install_changeurl_app("/changeurl")
     check_changeurl_app("/changeurl")

--- a/src/yunohost/tests/test_settings.py
+++ b/src/yunohost/tests/test_settings.py
@@ -18,7 +18,8 @@ def teardown_function(function):
 
 
 def test_settings_get_bool():
-    assert settings_get("example.bool") == True
+    assert settings_get("example.bool")
+
 
 def test_settings_get_full_bool():
     assert settings_get("example.bool", True) == {"type": "bool", "value": True, "default": True, "description": "Example boolean option"}
@@ -27,6 +28,7 @@ def test_settings_get_full_bool():
 def test_settings_get_int():
     assert settings_get("example.int") == 42
 
+
 def test_settings_get_full_int():
     assert settings_get("example.int", True) == {"type": "int", "value": 42, "default": 42, "description": "Example int option"}
 
@@ -34,12 +36,14 @@ def test_settings_get_full_int():
 def test_settings_get_string():
     assert settings_get("example.string") == "yolo swag"
 
+
 def test_settings_get_full_string():
     assert settings_get("example.string", True) == {"type": "string", "value": "yolo swag", "default": "yolo swag", "description": "Example string option"}
 
 
 def test_settings_get_enum():
     assert settings_get("example.enum") == "a"
+
 
 def test_settings_get_full_enum():
     assert settings_get("example.enum", True) == {"type": "enum", "value": "a", "default": "a", "description": "Example enum option", "choices": ["a", "b", "c"]}
@@ -150,7 +154,6 @@ def test_reset_all_backup():
         del settings_after_modification[i]["description"]
 
     assert settings_after_modification == json.load(open(old_settings_backup_path, "r"))
-
 
 
 def test_unknown_keys():

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -136,7 +136,7 @@ def tools_adminpw(auth, new_password, check_strength=True):
     new_hash = _hash_user_password(new_password)
 
     try:
-        auth.update("cn=admin", { "userPassword": new_hash, })
+        auth.update("cn=admin", {"userPassword": new_hash, })
     except:
         logger.exception('unable to change admin password')
         raise YunohostError('admin_password_change_failed')
@@ -265,7 +265,7 @@ def _is_inside_container():
                          stderr=subprocess.STDOUT)
 
     out, _ = p.communicate()
-    container = ['lxc','lxd','docker']
+    container = ['lxc', 'lxd', 'docker']
     return out.split()[0] in container
 
 
@@ -322,7 +322,6 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
             dyndns = False
     else:
         dyndns = False
-
 
     operation_logger.start()
     logger.info(m18n.n('yunohost_installing'))
@@ -539,7 +538,7 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
         # If API call
         if is_api:
             critical_packages = ("moulinette", "yunohost",
-                "yunohost-admin", "ssowat", "python")
+                                 "yunohost-admin", "ssowat", "python")
             critical_upgrades = set()
 
             for pkg in cache.get_changes():
@@ -574,7 +573,6 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
                 operation_logger.success()
         else:
             logger.info(m18n.n('packages_no_upgrade'))
-
 
     if not ignore_apps:
         try:
@@ -719,7 +717,7 @@ def _check_if_vulnerable_to_meltdown():
     try:
         call = subprocess.Popen("bash %s --batch json --variant 3" %
                                 SCRIPT_PATH, shell=True,
-                                  stdout=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
 
         output, _ = call.communicate()
@@ -815,12 +813,12 @@ def tools_migrations_list(pending=False, done=False):
             migrations = [m for m in migrations if m.number > last_migration]
 
     # Reduce to dictionnaries
-    migrations = [{ "id": migration.id,
-                    "number": migration.number,
-                    "name": migration.name,
-                    "mode": migration.mode,
-                    "description": migration.description,
-                    "disclaimer": migration.disclaimer } for migration in migrations ]
+    migrations = [{"id": migration.id,
+                   "number": migration.number,
+                   "name": migration.name,
+                   "mode": migration.mode,
+                   "description": migration.description,
+                   "disclaimer": migration.disclaimer} for migration in migrations]
 
     return {"migrations": migrations}
 
@@ -914,7 +912,7 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
                     accept_disclaimer = False
 
         # Start register change on system
-        operation_logger= OperationLogger('tools_migrations_migrate_' + mode)
+        operation_logger = OperationLogger('tools_migrations_migrate_' + mode)
         operation_logger.start()
 
         if not skip:
@@ -934,9 +932,9 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
                 # migration failed, let's stop here but still update state because
                 # we managed to run the previous ones
                 msg = m18n.n('migrations_migration_has_failed',
-                                    exception=e,
-                                    number=migration.number,
-                                    name=migration.name)
+                             exception=e,
+                             number=migration.number,
+                             name=migration.name)
                 logger.error(msg, exc_info=1)
                 operation_logger.error(msg)
                 break
@@ -966,6 +964,7 @@ def tools_migrations_migrate(target=None, skip=False, auto=False, accept_disclai
         state["last_run_migration"] = None
 
     write_to_json(MIGRATIONS_STATE_PATH, state)
+
 
 def tools_migrations_state():
     """
@@ -1009,7 +1008,7 @@ def _get_migrations_list():
     migrations = []
 
     try:
-        import data_migrations
+        from . import data_migrations
     except ImportError:
         # not data migrations present, return empty list
         return migrations
@@ -1032,7 +1031,7 @@ def _get_migration_by_name(migration_name):
     """
 
     try:
-        import data_migrations
+        from . import data_migrations
     except ImportError:
         raise AssertionError("Unable to find migration with name %s" % migration_name)
 
@@ -1051,7 +1050,7 @@ def _load_migration(migration_file):
     number, name = migration_id.split("_", 1)
 
     logger.debug(m18n.n('migrations_loading_migration',
-        number=number, name=name))
+                        number=number, name=name))
 
     try:
         # this is python builtin method to import a module using a name, we
@@ -1064,7 +1063,8 @@ def _load_migration(migration_file):
         traceback.print_exc()
 
         raise YunohostError('migrations_error_failed_to_load_migration',
-            number=number, name=name)
+                            number=number, name=name)
+
 
 def _skip_all_migrations():
     """
@@ -1115,4 +1115,3 @@ class Migration(object):
     @property
     def description(self):
         return m18n.n("migration_description_%s" % self.id)
-

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -40,6 +40,7 @@ from yunohost.log import is_unit_operation
 
 logger = getActionLogger('yunohost.user')
 
+
 def user_list(auth, fields=None):
     """
     List users
@@ -98,7 +99,7 @@ def user_list(auth, fields=None):
 
 @is_unit_operation([('username', 'user')])
 def user_create(operation_logger, auth, username, firstname, lastname, mail, password,
-        mailbox_quota="0"):
+                mailbox_quota="0"):
     """
     Create user
 
@@ -262,8 +263,8 @@ def user_delete(operation_logger, auth, username, purge=False):
 
 @is_unit_operation([('username', 'user')], exclude=['auth', 'change_password'])
 def user_update(operation_logger, auth, username, firstname=None, lastname=None, mail=None,
-        change_password=None, add_mailforward=None, remove_mailforward=None,
-        add_mailalias=None, remove_mailalias=None, mailbox_quota=None):
+                change_password=None, add_mailforward=None, remove_mailforward=None,
+                add_mailalias=None, remove_mailalias=None, mailbox_quota=None):
     """
     Update user informations
 
@@ -466,17 +467,22 @@ def user_info(auth, username):
 #
 import yunohost.ssh
 
+
 def user_ssh_allow(auth, username):
     return yunohost.ssh.user_ssh_allow(auth, username)
+
 
 def user_ssh_disallow(auth, username):
     return yunohost.ssh.user_ssh_disallow(auth, username)
 
+
 def user_ssh_list_keys(auth, username):
     return yunohost.ssh.user_ssh_list_keys(auth, username)
 
+
 def user_ssh_add_key(auth, username, key, comment):
     return yunohost.ssh.user_ssh_add_key(auth, username, key, comment)
+
 
 def user_ssh_remove_key(auth, username, key):
     return yunohost.ssh.user_ssh_remove_key(auth, username, key)
@@ -484,6 +490,7 @@ def user_ssh_remove_key(auth, username, key):
 #
 # End SSH subcategory
 #
+
 
 def _convertSize(num, suffix=''):
     for unit in ['K', 'M', 'G', 'T', 'P', 'E', 'Z']:
@@ -520,6 +527,3 @@ def _hash_user_password(password):
 
     salt = '$6$' + salt + '$'
     return '{CRYPT}' + crypt.crypt(str(password), salt)
-
-
-

--- a/src/yunohost/utils/error.py
+++ b/src/yunohost/utils/error.py
@@ -22,12 +22,14 @@
 from moulinette.core import MoulinetteError
 from moulinette import m18n
 
+
 class YunohostError(MoulinetteError):
+
     """Yunohost base exception"""
+
     def __init__(self, key, __raw_msg__=False, *args, **kwargs):
         if __raw_msg__:
             msg = key
         else:
             msg = m18n.n(key, *args, **kwargs)
         super(YunohostError, self).__init__(msg, __raw_msg__=True)
-

--- a/src/yunohost/utils/filesystem.py
+++ b/src/yunohost/utils/filesystem.py
@@ -20,9 +20,11 @@
 """
 import os
 
+
 def free_space_in_directory(dirpath):
     stat = os.statvfs(dirpath)
     return stat.f_frsize * stat.f_bavail
+
 
 def space_used_by_directory(dirpath):
     stat = os.statvfs(dirpath)

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -71,7 +71,7 @@ def get_gateway():
     return addr.popitem()[1] if len(addr) == 1 else None
 
 
-###############################################################################
+#
 
 
 def _extract_inet(string, skip_netmask=False, skip_loopback=True):

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -33,6 +33,7 @@ logger = logging.getLogger('yunohost.utils.packages')
 # Exceptions -----------------------------------------------------------------
 
 class PackageException(Exception):
+
     """Base exception related to a package
 
     Represent an exception related to the package named `pkgname`. If no
@@ -50,16 +51,19 @@ class PackageException(Exception):
 
 
 class UnknownPackage(PackageException):
+
     """The package is not found in the cache."""
     message_key = 'package_unknown'
 
 
 class UninstalledPackage(PackageException):
+
     """The package is not installed."""
     message_key = 'package_not_installed'
 
 
 class InvalidSpecifier(ValueError):
+
     """An invalid specifier was found."""
 
 
@@ -68,6 +72,7 @@ class InvalidSpecifier(ValueError):
 # See: https://github.com/pypa/packaging
 
 class Specifier(object):
+
     """Unique package version specifier
 
     Restrict a package version according to the `spec`. It must be a string
@@ -257,6 +262,7 @@ class Specifier(object):
 
 
 class SpecifierSet(object):
+
     """A set of package version specifiers
 
     Combine several Specifier separated by a comma. It allows to restrict

--- a/src/yunohost/utils/password.py
+++ b/src/yunohost/utils/password.py
@@ -38,8 +38,10 @@ STRENGTH_LEVELS = [
     (12, 1, 1, 1, 1),
 ]
 
+
 def assert_password_is_strong_enough(profile, password):
     PasswordValidator(profile).validate(password)
+
 
 class PasswordValidator(object):
 
@@ -157,7 +159,7 @@ class PasswordValidator(object):
             # and the strength of the password (e.g. [11, 2, 7, 2, 0])
             # and compare the values 1-by-1.
             # If one False is found, the password does not satisfy the level
-            if False in [s>=c for s, c in zip(strength, level_criterias)]:
+            if False in [s >= c for s, c in zip(strength, level_criterias)]:
                 break
             # Otherwise, the strength of the password is at least of the current level.
             strength_level = level + 1
@@ -186,7 +188,7 @@ if __name__ == '__main__':
     if len(sys.argv) < 2:
         import getpass
         pwd = getpass.getpass("")
-        #print("usage: password.py PASSWORD")
+        # print("usage: password.py PASSWORD")
     else:
         pwd = sys.argv[1]
     status, msg = PasswordValidator('user').validation_summary(pwd)

--- a/src/yunohost/utils/yunopaste.py
+++ b/src/yunohost/utils/yunopaste.py
@@ -5,6 +5,7 @@ import json
 
 from yunohost.utils.error import YunohostError
 
+
 def yunopaste(data):
 
     paste_server = "https://paste.yunohost.org"


### PR DESCRIPTION
## The problem

Pep8 complains about quite a lot of things

## Solution

Ran `autopep8 -i --ignore=E501 -a -a -a -a -a *.py */*.py`
(Made a few manual tweaks because a few changes were made which werent so logical o.O)

Turns out `autopep8` also makes some adjustements for Python3 compatibility which is nice :+1: 

N.B. : this PR is on top of https://github.com/YunoHost/yunohost/pull/574

## PR Status

Not tested but most of those are only whitespace changes

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
