### PR TITLE
[fix] DEBUG-level messages not appearing in actions performed via the API

### DIFF
--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -13,7 +13,8 @@ DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 6787
 
 # Level for which loggers will log
-LOGGERS_LEVEL = 'INFO'
+LOGGERS_LEVEL = 'DEBUG'
+API_LOGGER_LEVEL = 'INFO'
 
 # Handlers that will be used by loggers
 #  - file: log to the file LOG_DIR/LOG_FILE
@@ -97,8 +98,10 @@ def _init_moulinette(use_websocket=True, debug=False, verbose=False):
 
     # Define loggers level
     level = LOGGERS_LEVEL
+    api_level = API_LOGGER_LEVEL
     if debug:
         level = 'DEBUG'
+        api_level = 'DEBUG'
 
     # Custom logging configuration
     logging = {
@@ -119,6 +122,7 @@ def _init_moulinette(use_websocket=True, debug=False, verbose=False):
         },
         'handlers': {
             'api': {
+                'level': api_level,
                 'class': 'moulinette.interfaces.api.APIQueueHandler',
             },
             'file': {


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1251 : this is annoying as fuck that people show logs from failed app install without the DEBUG-level messages, which defeats the purpose of log feature from 3.2 x_x ...

## Solution

Fix the loggers/handlers log level such that it's consistent with what was expected ...

## PR Status

Tested and working

## How to test

Launch an app install that will fail (or any action that shall add DEBUG stuff in the logs) and check the produced logs in /var/log/yunohost/categories/operations with and without this.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
