### PR TITLE
[fix] Fix the way change_url updates the domain/path

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -606,14 +606,14 @@ app:
                     full: --domain
                     help: New app domain on which the application will be moved
                     extra:
-                        ask: ask_main_domain
+                        ask: ask_new_domain
                         pattern: *pattern_domain
                         required: True
                 -p:
                     full: --path
                     help: New path at which the application will be moved
                     extra:
-                        ask: ask_path
+                        ask: ask_new_path
                         required: True
 
         ### app_setting()

--- a/locales/en.json
+++ b/locales/en.json
@@ -57,6 +57,8 @@
     "ask_list_to_remove": "List to remove",
     "ask_main_domain": "Main domain",
     "ask_new_admin_password": "New administration password",
+    "ask_new_domain": "New domain",
+    "ask_new_path": "New path",
     "ask_password": "Password",
     "ask_path": "Path",
     "backup_abstract_method": "This backup method hasn't yet been implemented",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1284,7 +1284,7 @@ def app_checkurl(auth, url, app=None):
 
     logger.error("Packagers /!\\ : 'app checkurl' is deprecated ! Please use the helper 'ynh_webpath_register' instead !")
 
-    from yunohost.domain import domain_list
+    from yunohost.domain import domain_list, _normalize_domain_path
 
     if "https://" == url[:8]:
         url = url[8:]
@@ -1298,8 +1298,7 @@ def app_checkurl(auth, url, app=None):
     path = url[url.index('/'):]
     installed = False
 
-    if path[-1:] != '/':
-        path = path + '/'
+    domain, path = _normalize_domain_path(domain, path)
 
     apps_map = app_map(raw=True)
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -445,6 +445,7 @@ def app_change_url(operation_logger, auth, app, domain, path):
 
     """
     from yunohost.hook import hook_exec, hook_callback
+    from yunohost.domain import _normalize_domain_path, _get_conflicting_apps
 
     installed = _is_installed(app)
     if not installed:
@@ -457,18 +458,13 @@ def app_change_url(operation_logger, auth, app, domain, path):
     old_path = app_setting(app, "path")
 
     # Normalize path and domain format
-    domain = domain.strip().lower()
-
-    old_path = normalize_url_path(old_path)
-    path = normalize_url_path(path)
+    old_domain, old_path = _normalize_domain_path(old_domain, old_path)
+    domain, path = _normalize_domain_path(domain, path)
 
     if (domain, path) == (old_domain, old_path):
         raise YunohostError("app_change_url_identical_domains", domain=domain, path=path)
 
-    # WARNING / FIXME : checkurl will modify the settings
-    # (this is a non intuitive behavior that should be changed)
-    # (or checkurl renamed in reserve_url)
-    app_checkurl(auth, '%s%s' % (domain, path), app)
+    _get_conflicting_apps(auth, domain, path)
 
     manifest = json.load(open(os.path.join(APPS_SETTING_PATH, app, "manifest.json")))
 
@@ -486,9 +482,9 @@ def app_change_url(operation_logger, auth, app, domain, path):
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
 
     env_dict["YNH_APP_OLD_DOMAIN"] = old_domain
-    env_dict["YNH_APP_OLD_PATH"] = old_path.rstrip("/")
+    env_dict["YNH_APP_OLD_PATH"] = old_path
     env_dict["YNH_APP_NEW_DOMAIN"] = domain
-    env_dict["YNH_APP_NEW_PATH"] = path.rstrip("/")
+    env_dict["YNH_APP_NEW_PATH"] = path
 
     if domain != old_domain:
         operation_logger.related_to.append(('domain', old_domain))
@@ -1251,7 +1247,6 @@ def app_register_url(auth, app, domain, path):
 
     # We cannot change the url of an app already installed simply by changing
     # the settings...
-    # FIXME should look into change_url once it's merged
 
     installed = app in app_list(installed=True, raw=True).keys()
     if installed:
@@ -2527,13 +2522,6 @@ def random_password(length=8):
 
     char_set = string.ascii_uppercase + string.digits + string.ascii_lowercase
     return ''.join([random.SystemRandom().choice(char_set) for x in range(length)])
-
-
-def normalize_url_path(url_path):
-    if url_path.strip("/").strip():
-        return '/' + url_path.strip("/").strip() + '/'
-
-    return "/"
 
 
 def unstable_apps():

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -464,7 +464,18 @@ def app_change_url(operation_logger, auth, app, domain, path):
     if (domain, path) == (old_domain, old_path):
         raise YunohostError("app_change_url_identical_domains", domain=domain, path=path)
 
-    _get_conflicting_apps(auth, domain, path)
+    # Check the url is available
+    conflicts = _get_conflicting_apps(auth, domain, path)
+    if conflicts:
+        apps = []
+        for path, app_id, app_label in conflicts:
+            apps.append(" * {domain:s}{path:s} → {app_label:s} ({app_id:s})".format(
+                domain=domain,
+                path=path,
+                app_id=app_id,
+                app_label=app_label,
+            ))
+        raise YunohostError('app_location_unavailable', apps="\n".join(apps))
 
     manifest = json.load(open(os.path.join(APPS_SETTING_PATH, app, "manifest.json")))
 

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -298,7 +298,7 @@ def _normalize_domain_path(domain, path):
         domain = domain[len("http://"):]
 
     # Remove trailing slashes
-    domain = domain.rstrip("/")
+    domain = domain.rstrip("/").lower()
     path = "/" + path.strip("/")
 
     return domain, path

--- a/src/yunohost/tests/test_changeurl.py
+++ b/src/yunohost/tests/test_changeurl.py
@@ -34,9 +34,9 @@ def install_changeurl_app(path):
 def check_changeurl_app(path):
     appmap = app_map(raw=True)
 
-    assert path + "/" in appmap[maindomain].keys()
+    assert path in appmap[maindomain].keys()
 
-    assert appmap[maindomain][path + "/"]["id"] == "change_url_app"
+    assert appmap[maindomain][path]["id"] == "change_url_app"
 
     r = requests.get("https://127.0.0.1%s/" % path, headers={"domain": maindomain}, verify=False)
     assert r.status_code == 200


### PR DESCRIPTION
## The problem

- In the `change-url` function we use a old function `check_url`.
- The change-url function call the change-url script with variable with empty value (`$YNH_APP_OLD_PATH`, `$YNH_APP_NEW_PATH
`) when the path is the root path. By this we need write a code like that : https://github.com/YunoHost-Apps/wordpress_ynh/blob/master/scripts/change_url#L41-L44 . In the same time we have in the core a function which do that : `_normalize_domain_path`.

## Solution

- Replace the `check_url` by `_get_conflicting_apps`.
- Give the argument about the url as same as in the install.

## PR Status

Tested. Work on my side.

Note that this PR should also fix https://github.com/YunoHost/yunohost/pull/376

## How to test

Test with an app which has a change-url script.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
