### PR TITLE
Fix several issues with bootprompt

### DIFF
--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Fetch ips
-ip=$(hostname --all-ip-address)
-
 # Fetch SSH fingerprints
 i=0
 for key in $(ls /etc/ssh/ssh_host_{ed25519,rsa,ecdsa}_key.pub 2> /dev/null) ; do 
@@ -32,11 +29,17 @@ EOF
 # Build the actual message
 #
 
+sleep 5
+# Get local IP
+# (we do this after the sleep 5 to have
+# better chances that the network is up)
+local_ip=$(hostname --all-ip-address | awk '{print $1}')
+
 LOGO_AND_FINGERPRINTS=$(cat << EOF
 
 $LOGO
 
- IP: ${ip}
+ IP: ${local_ip}
  SSH fingerprints:
  ${fingerprint[0]}
  ${fingerprint[1]}
@@ -51,17 +54,35 @@ if [[ -f /etc/yunohost/installed ]]
 then
     echo "$LOGO_AND_FINGERPRINTS" > /etc/issue
 else
-    sleep 5
     chvt 2
+
+    # Formatting
+    [[ -n "$local_ip" ]] && local_ip=$(echo -e "https://$local_ip/") || local_ip="(no ip detected?)"
+
     echo "$LOGO_AND_FINGERPRINTS"
-    echo -e "\e[m Post-installation \e[0m"
-    echo "Congratulations! YunoHost has been successfully installed.\nTwo more steps are required to activate the services of your server."
-    read -p "Proceed to post-installation? (y/n)\nAlternatively, you can proceed the post-installation on https://${ip}" -n 1
+    cat << EOF
+===============================================================================
+You should now proceed with Yunohost post-installation. This is where you will
+be asked for :
+  - the main domain of your server ;
+  - the administration password.
+
+You can perform this step :
+  - from your web browser, by accessing : ${local_ip}
+  - or in this terminal by answering 'yes' to the following question
+
+If this is your first time with YunoHost, it is strongly recommended to take
+time to read the administator documentation and in particular the sections
+'Finalizing your setup' and 'Getting to know YunoHost'. It is available at
+the following URL : https://yunohost.org/admindoc
+===============================================================================
+EOF
+
+    read -p "Proceed with post-installation? (y/n) "
     RESULT=1
     while [ $RESULT -gt 0 ]; do
         if [[ $REPLY =~ ^[Nn]$ ]]; then
-            chvt 1
-            exit 0
+            break
         fi
         echo -e "\n"
         /usr/bin/yunohost tools postinstall
@@ -71,4 +92,6 @@ else
             read -p "Retry? (y/n) " -n 1
         fi
     done
+    chvt 1
+    exit 0
 fi


### PR DESCRIPTION
## The problem

Currently there are several issues with the bootprompt, namely : 
- the IP field being empty (https://github.com/YunoHost/issues/issues/1248)
- some `\n` being displayed as literal `\n` (also mentionned in https://github.com/YunoHost/issues/issues/1248)
- after postinstall being successful, the bootprompt doesn't give back a working terminal hence users end up being stucked and have to reboot to get a working terminal (can't find the corresponding issue for this issue)

## Solution

I reworked and tweaked a few things : 
- fetch the ip after a sleep 5, which gives better changes that the network stack will be up
- add a message similar introducing the postinstall and other things in a similar way to what's done after the install script
- use `chvt 1` to switch to a fresh tty after postinstall is done.

## PR Status

Tested, ready for rewiews

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
