### PR TITLE
[fix] Set owner of archives folder to 'admin'

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -40,7 +40,7 @@ from moulinette import msignals, m18n
 from yunohost.utils.error import YunohostError
 from moulinette.utils import filesystem
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_file
+from moulinette.utils.filesystem import read_file, mkdir
 
 from yunohost.app import (
     app_info, _is_installed, _parse_app_instance_name, _patch_php5
@@ -2295,7 +2295,9 @@ def _create_archive_dir():
         if os.path.lexists(ARCHIVES_PATH):
             raise YunohostError('backup_output_symlink_dir_broken', path=ARCHIVES_PATH)
 
-        os.mkdir(ARCHIVES_PATH, 0o750)
+        # Create the archive folder, with 'admin' as owner, such that
+        # people can scp archives out of the server
+        mkdir(ARCHIVES_PATH, mode=0o750, parents=True, uid="admin", gid="root")
 
 
 def _call_for_each_path(self, callback, csv_path=None):

--- a/src/yunohost/data_migrations/0008_ssh_conf_managed_by_yunohost_step2.py
+++ b/src/yunohost/data_migrations/0008_ssh_conf_managed_by_yunohost_step2.py
@@ -2,6 +2,7 @@ import re
 
 from moulinette import m18n
 from moulinette.utils.log import getActionLogger
+from moulinette.utils.filesystem import chown
 
 from yunohost.tools import Migration
 from yunohost.service import service_regen_conf, \
@@ -9,6 +10,8 @@ from yunohost.service import service_regen_conf, \
                              _calculate_hash
 from yunohost.settings import settings_set, settings_get
 from yunohost.utils.error import YunohostError
+from yunohost.backup import ARCHIVES_PATH
+
 
 logger = getActionLogger('yunohost.migration')
 
@@ -33,6 +36,10 @@ class MyMigration(Migration):
     def migrate(self):
         settings_set("service.ssh.allow_deprecated_dsa_hostkey", False)
         service_regen_conf(names=['ssh'], force=True)
+
+        # Update local archives folder permissions, so that
+        # admin can scp archives out of the server
+        chown(ARCHIVES_PATH, uid="admin", gid="root")
 
     def backward(self):
 


### PR DESCRIPTION
## The problem

c.f. this issue https://github.com/YunoHost/issues/issues/1266

Currently, `admin` cannot access files in the archive folder, `/home/yunohost.backup/archives`. This is not such a big deal for now because I guess most people still log as root. But with 3.4 coming where we really discourage root login and encourage admin login, this prevent people from scp-ing backup archives out of their server.

## Solution

When creating the folder, set `admin` as the owner of the folder. + Add a thing in migration n°8 to change the permission for already existing instances 

## PR Status

Not tested x_x

## How to test

Test on a fresh instance, and on a migrated instance that admin can indeed access those files

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
