### PR TITLE
Enforce --force-confold during apt upgrade

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -563,6 +563,7 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
 
             operation_logger.start()
             try:
+                os.environ["DEBIAN_FRONTEND"] = "noninteractive"
                 # Apply APT changes
                 # TODO: Logs output for the API
                 cache.commit(apt.progress.text.AcquireProgress(),
@@ -575,6 +576,8 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
             else:
                 logger.info(m18n.n('done'))
                 operation_logger.success()
+            finally:
+                del os.environ["DEBIAN_FRONTEND"]
         else:
             logger.info(m18n.n('packages_no_upgrade'))
 

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -531,7 +531,7 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
 
     if not ignore_packages:
 
-        apt.apt_pkg.config.init()
+        apt.apt_pkg.init()
         apt.apt_pkg.config.set("DPkg::Options::", "--force-confold")
 
         cache = apt.Cache()

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -530,6 +530,10 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
     is_api = True if msettings.get('interface') == 'api' else False
 
     if not ignore_packages:
+
+        apt.apt_pkg.config.init()
+        apt.apt_pkg.config.set("DPkg::Options::", "--force-confold")
+
         cache = apt.Cache()
         cache.open(None)
         cache.upgrade(True)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -532,6 +532,7 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
     if not ignore_packages:
 
         apt.apt_pkg.init()
+        apt.apt_pkg.config.set("DPkg::Options::", "--force-confdef")
         apt.apt_pkg.config.set("DPkg::Options::", "--force-confold")
 
         cache = apt.Cache()


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1232

## Solution

Bram digged into the madness of `python-apt` and its (lack of) documentation to find that we could use some magic stuff to change the configuration supposedly being used during the actual upgrade...

This is not tested yet tho.

## PR Status

Ready ? But not tested ...

## How to test

Launch a `yunohost tools upgrade` and somehow try to detect if the option is correctly being used :/ 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
