### PR TITLE
[fix] `_run_service_command` not properly returning False if command fails

### DIFF
--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -609,7 +609,7 @@ def _run_service_command(action, service):
     try:
         # Launch the command
         logger.debug("Running '%s'" % cmd)
-        p = subprocess.Popen(cmd.split(), stderr=subprocess.STDOUT)
+        p = subprocess.check_call(cmd.split(), stderr=subprocess.STDOUT)
         # If this command needs a lock (because the service uses yunohost
         # commands inside), find the PID and add a lock for it
         if need_lock:


### PR DESCRIPTION
## The problem

Not sure why we did not notice this before, but `_run_service_command` which is a low-level function behind `yunohost service start|stop|...` will show a Success even if the command failed ...

## Solution

This is because `subprocess.Popen` won't raise a `subprocess.CalledProcessError` like the code expects ... `check_call` should be used instead.

## PR Status

Tested and working

## How to test

Make a dummy breaking change to nginx conf file and try to stop/start it.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
