### PR TITLE
New way to prevent Robot from watching files on the server + ECDH Curve upgrade (same goal as #618)

### DIFF
--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -50,6 +50,13 @@ do_init_regen() {
       update-ca-certificates
   fi
 
+  if [[ ! -e "/etc/ssl/private/dh2048.pem" ]]; then
+    echo -e "\n# Creating the dh_params \n" >>$LOGFILE
+    (openssl dhparam -out /tmp/dhparam.pem 2048 -dsaparam > /dev/null 2>&1 &)
+  else
+    echo -e "\n# A dh_params file already exists \n" >>$LOGFILE
+  fi
+  
   if [[ ! -f "$ynh_crt" ]]; then
       echo -e "\n# Creating initial key and certificate (?)\n" >>$LOGFILE
 

--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -50,13 +50,6 @@ do_init_regen() {
       update-ca-certificates
   fi
 
-  if [[ ! -e "/etc/ssl/private/dh2048.pem" ]]; then
-    echo -e "\n# Creating the dh_params \n" >>$LOGFILE
-    (openssl dhparam -out /tmp/dhparam.pem 2048 -dsaparam > /dev/null 2>&1 &)
-  else
-    echo -e "\n# A dh_params file already exists \n" >>$LOGFILE
-  fi
-  
   if [[ ! -f "$ynh_crt" ]]; then
       echo -e "\n# Creating initial key and certificate (?)\n" >>$LOGFILE
 

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -68,7 +68,7 @@ server {
         if ($http_user_agent ~ (crawl|Googlebot|Slurp|spider|bingbot|tracker|click|parser|spider|facebookexternalhit) ) {
             return 403;
         }
-
+        add_header  X-Robots-Tag "nofollow, noindex, noarchive, nosnippet";
         # Redirect most of 404 to maindomain.tld/yunohost/sso
         access_by_lua_file /usr/share/ssowat/access.lua;
     }

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -13,10 +13,8 @@ server {
 
 server {
     # Disabling http2 for now as it's causing weird issues with curl
-    #listen 443 ssl http2 default_server;
-    #listen [::]:443 ssl http2 default_server;
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
 
     ssl_certificate /etc/yunohost/certs/yunohost.org/crt.pem;
     ssl_certificate_key /etc/yunohost/certs/yunohost.org/key.pem;
@@ -24,12 +22,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    # (this doesn't work on jessie though ...?)
-    # ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
-
-    # As suggested by https://cipherli.st/
-    ssl_ecdh_curve secp384r1;
-
+    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -22,7 +22,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1;
+    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1:prime256v1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -22,7 +22,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1:prime256v1;
+    ssl_ecdh_curve X25519:secp521r1:secp384r1:prime256v1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -30,7 +30,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1:prime256v1;
+    ssl_ecdh_curve X25519:secp521r1:secp384r1:prime256v1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -30,7 +30,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1;
+    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1:prime256v1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -30,7 +30,7 @@ server {
     ssl_session_cache shared:SSL:50m;
 
     # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
+    ssl_ecdh_curve X25519:sect571r1:secp521r1:secp384r1;
     ssl_prefer_server_ciphers on;
 
     # Ciphers with intermediate compatibility


### PR DESCRIPTION
## The problem

- No precise problem, just a clean way to replace one day User-Agent
- ECDH upgrade (same goal as in the #618)

## Solution

- Add the dedicated nginx header
- Change ECDH (for more secure one)

## PR Status

Work. Tested (but difficult to know if it works, that's the reason, I set to one day the definitive replacement)

## How to test

Install Yunohost

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
