### PR TITLE
Improve protection against indexation from the robots.

### DIFF
--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -65,6 +65,10 @@ server {
 
     location /yunohost {
         # Block crawlers bot
+        if ($http_user_agent ~ (crawl|Googlebot|Slurp|spider|bingbot|tracker|click|parser|spider|facebookexternalhit) ) {
+            return 403;
+        }
+        # X-Robots-Tag to precise the rules applied.
         add_header  X-Robots-Tag "nofollow, noindex, noarchive, nosnippet";
         # Redirect most of 404 to maindomain.tld/yunohost/sso
         access_by_lua_file /usr/share/ssowat/access.lua;

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -68,7 +68,7 @@ server {
         if ($http_user_agent ~ (crawl|Googlebot|Slurp|spider|bingbot|tracker|click|parser|spider|facebookexternalhit) ) {
             return 403;
         }
-
+        add_header  X-Robots-Tag "nofollow, noindex, noarchive, nosnippet";
         # Redirect most of 404 to maindomain.tld/yunohost/sso
         access_by_lua_file /usr/share/ssowat/access.lua;
     }

--- a/data/templates/nginx/plain/yunohost_admin.conf
+++ b/data/templates/nginx/plain/yunohost_admin.conf
@@ -65,9 +65,6 @@ server {
 
     location /yunohost {
         # Block crawlers bot
-        if ($http_user_agent ~ (crawl|Googlebot|Slurp|spider|bingbot|tracker|click|parser|spider|facebookexternalhit) ) {
-            return 403;
-        }
         add_header  X-Robots-Tag "nofollow, noindex, noarchive, nosnippet";
         # Redirect most of 404 to maindomain.tld/yunohost/sso
         access_by_lua_file /usr/share/ssowat/access.lua;


### PR DESCRIPTION
## The problem

- $http_user_agent ne permet pas bloquer totalement tout, et sûrement ne bloque pas tous les robot.

## Solution

-  Ajouter une directive plus générale permettant de bloquer l'ensemble des contenu
- Code plus propre qu'une fonction nginx
- Évite de lister l'ensemble des User-Agent des robots d'indexation (ce qui est possible si c'est nécessaire)

## PR Status

Tested, but need test (I don't know how to test the effect of the header)

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 


Sources (because it's needed) : 
- https://developers.google.com/search/reference/robots_meta_tag
- http://robots-txt.com/x-robots-tag/