### PR TITLE
[enh] add systemd logs

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1150,7 +1150,7 @@ service:
                     full: --description
                     help: Description of the service
                 -t:
-                    full: --type_log
+                    full: --log_type
                     help: Type of the log (file or systemd)
                     nargs: "+"
                     choices:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1149,6 +1149,14 @@ service:
                 -d:
                     full: --description
                     help: Description of the service
+                -t:
+                    full: --type_log
+                    help: Type of the log (file or systemd)
+                    nargs: "+"
+                    choices:
+                        - file
+                        - systemd
+                    default: file
 
         ### service_remove()
         remove:

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -375,7 +375,10 @@ def service_log(name, number=50):
 
     for log_path in log_list:
         # log is a file, read it
-        if not os.path.isdir(log_path):
+        if log_path == "systemd":
+            result[log_path] = _get_journalctl_logs(name)
+            continue
+        elif not os.path.isdir(log_path):
             result[log_path] = _tail(log_path, int(number)) if os.path.exists(log_path) else []
             continue
 

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -392,8 +392,7 @@ def service_log(name, number=50):
 
     result = {}
 
-    for index in range(len(log_list)):
-        log_path = log_list[index]
+    for index, log_path in enumerate(log_list):
         log_type = log_type_list[index]
 
         if log_type == "file":

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -376,7 +376,7 @@ def service_log(name, number=50):
     for log_path in log_list:
         # log is a file, read it
         if log_path == "systemd":
-            result[log_path] = _get_journalctl_logs(name, int(number))
+            result[log_path] = _get_journalctl_logs(name, int(number)).splitlines()
             continue
         elif not os.path.isdir(log_path):
             result[log_path] = _tail(log_path, int(number)) if os.path.exists(log_path) else []

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -376,7 +376,7 @@ def service_log(name, number=50):
     for log_path in log_list:
         # log is a file, read it
         if log_path == "systemd":
-            result[log_path] = _get_journalctl_logs(name)
+            result[log_path] = _get_journalctl_logs(name, int(number))
             continue
         elif not os.path.isdir(log_path):
             result[log_path] = _tail(log_path, int(number)) if os.path.exists(log_path) else []
@@ -1050,9 +1050,9 @@ def manually_modified_files():
     return output
 
 
-def _get_journalctl_logs(service):
+def _get_journalctl_logs(service, number="all"):
     try:
-        return subprocess.check_output("journalctl -xn -u %s" % service, shell=True)
+        return subprocess.check_output("journalctl -xn -u {0} -n{1}".format(service, number), shell=True)
     except:
         import traceback
         return "error while get services logs from journalctl:\n%s" % traceback.format_exc()

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -49,7 +49,7 @@ MOULINETTE_LOCK = "/var/run/moulinette_yunohost.lock"
 logger = log.getActionLogger('yunohost.service')
 
 
-def service_add(name, status=None, log=None, runlevel=None, need_lock=False, description=None, type_log="file"):
+def service_add(name, status=None, log=None, runlevel=None, need_lock=False, description=None, log_type="file"):
     """
     Add a custom service
 
@@ -60,7 +60,7 @@ def service_add(name, status=None, log=None, runlevel=None, need_lock=False, des
         runlevel -- Runlevel priority of the service
         need_lock -- Use this option to prevent deadlocks if the service does invoke yunohost commands.
         description -- description of the service
-        type_log -- Precise if the corresponding log is a file or a systemd log
+        log_type -- Precise if the corresponding log is a file or a systemd log
     """
     services = _get_services()
 
@@ -75,14 +75,14 @@ def service_add(name, status=None, log=None, runlevel=None, need_lock=False, des
         
         services[name]['log'] = log
 
-        if not isinstance(type_log, list):
-            type_log = [type_log]
+        if not isinstance(log_type, list):
+            log_type = [log_type]
 
-        if len(type_log) < len(log):
-            type_log.extend([type_log[-1]] * (len(log) - len(type_log))) # extend list to have the same size as log
+        if len(log_type) < len(log):
+            log_type.extend([log_type[-1]] * (len(log) - len(log_type))) # extend list to have the same size as log
 
-        if len(type_log) == len(log):
-            services[name]['type_log'] = type_log
+        if len(log_type) == len(log):
+            services[name]['log_type'] = log_type
         else:
             raise YunohostError('service_add_failed', service=name)
                 
@@ -383,13 +383,13 @@ def service_log(name, number=50):
         raise YunohostError('service_no_log', service=name)
 
     log_list = services[name]['log']
-    type_log_list = services[name]['type_log']
+    log_type_list = services[name]['log_type']
 
     result = {}
 
     for index in range(len(log_list)):
         log_path = log_list[index]
-        log_type = type_log_list[index]
+        log_type = log_type_list[index]
 
         if log_type == "file":
             # log is a file, read it

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -72,7 +72,7 @@ def service_add(name, status=None, log=None, runlevel=None, need_lock=False, des
     if log is not None:
         if not isinstance(log, list):
             log = [log]
-        
+
         services[name]['log'] = log
 
         if not isinstance(log_type, list):
@@ -85,8 +85,8 @@ def service_add(name, status=None, log=None, runlevel=None, need_lock=False, des
             services[name]['log_type'] = log_type
         else:
             raise YunohostError('service_add_failed', service=name)
-                
-        
+
+
     if runlevel is not None:
         services[name]['runlevel'] = runlevel
 
@@ -383,7 +383,12 @@ def service_log(name, number=50):
         raise YunohostError('service_no_log', service=name)
 
     log_list = services[name]['log']
-    log_type_list = services[name]['log_type']
+    log_type_list = services[name].get('log_type', [])
+
+    if not isinstance(log_list, list):
+        log_list = [log_list]
+    if len(log_type_list) < len(log_list):
+        log_type_list.extend(["file"] * (len(log_list)-len(log_type_list)))
 
     result = {}
 


### PR DESCRIPTION
## The problem

Some apps don't provide log files.

## Solution

I have added the possibility to use systemd log (with journalctl)

## PR Status

I either have to create a migration file to update the file `/etc/yunohost/services.yml` or check if `log_type` is defined, and if not, I'm considering that the log is a file (as old method)

## How to test

#### Old method:
 - `yunohost service log service_name --log /var/log/service_name/service_name.log`
 - `yunohost service log service_name --log /var/log/service_name/service_name.log /var/log/service_name/service_name2.log`

#### New method:

1. The old one is still compatible:
 - `yunohost service log service_name --log /var/log/service_name/service_name.log`
 - `yunohost service log service_name --log /var/log/service_name/service_name.log /var/log/service_name/service_name2.log`

2. The new:
 - for a file: `yunohost service log service_name --log /var/log/service_name/service_name.log --log_type file`
 - for several files: `yunohost service log service_name --log /var/log/service_name/service_name.log /var/log/service_name/service_name2.log --log_type file`
 - for a systemd log: `yunohost service log service_name --log service_name --log_type systemd`
 - for both: `yunohost service log service_name --log /var/log/service_name/service_name.log service_name --log_type file systemd`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
