### PR TITLE
[fix] app conflicting with itself during change_url

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -465,7 +465,7 @@ def app_change_url(operation_logger, auth, app, domain, path):
         raise YunohostError("app_change_url_identical_domains", domain=domain, path=path)
 
     # Check the url is available
-    conflicts = _get_conflicting_apps(auth, domain, path)
+    conflicts = _get_conflicting_apps(auth, domain, path, ignore_app=app)
     if conflicts:
         apps = []
         for path, app_id, app_label in conflicts:

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -226,13 +226,14 @@ def domain_cert_renew(auth, domain_list, force=False, no_checks=False, email=Fal
     return yunohost.certificate.certificate_renew(auth, domain_list, force, no_checks, email, staging)
 
 
-def _get_conflicting_apps(auth, domain, path):
+def _get_conflicting_apps(auth, domain, path, ignore_app=None):
     """
     Return a list of all conflicting apps with a domain/path (it can be empty)
 
     Keyword argument:
         domain -- The domain for the web path (e.g. your.domain.tld)
         path -- The path to check (e.g. /coffee)
+        ignore_app -- An optional app id to ignore (c.f. the change_url usecase)
     """
 
     domain, path = _normalize_domain_path(domain, path)
@@ -253,6 +254,8 @@ def _get_conflicting_apps(auth, domain, path):
     if domain in apps_map:
         # Loop through apps
         for p, a in apps_map[domain].items():
+            if a["id"] == ignore_app:
+                continue
             if path == p:
                 conflicts.append((p, a["id"], a["label"]))
             # We also don't want conflicts with other apps starting with


### PR DESCRIPTION
## The problem

As reported by @maniackcrudelis, apps might conflict with themselves when change_url is used : 

```
Change the url from sous.domain.tld/path to sous.domain.tld/...
[...]
 yunohost cli - This url is not available or conflicts with the already installed app(s):
 * sous.domain.tld/path → WordPress (wordpress)
```

## Solution

Add an optional `ignore_app` argument to `_get_conflicting_apps` for the change_url usecase.

## PR Status

Not tested :s 

## How to test

Pull the branch and test to change the url of an app from `/path` to `/` for instance ... or `/path` to `/path2`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
