### PR TITLE
[fix] Fix home_dir unset in ynh_system_user_create

### DIFF
--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -61,7 +61,8 @@ ynh_system_user_create () {
 	local use_shell
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
- 	local use_shell="${use_shell:-0}"
+ 	use_shell="${use_shell:-0}"
+ 	home_dir="${home_dir:-}"
 
 	if ! ynh_system_user_exists "$username"	# Check if the user exists on the system
 	then	# If the user doesn't exist


### PR DESCRIPTION
## The problem

ynh_system_user_create is failing with the error `home_dir: unbound variable`

## Solution

Set `home_dir` if not used.

## PR Status

Ready to be reviewed.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
