### PR TITLE
[fix] Do not log migration to stretch in /tmp/. Issue #1280

### DIFF
--- a/src/yunohost/data_migrations/0003_migrate_to_stretch.py
+++ b/src/yunohost/data_migrations/0003_migrate_to_stretch.py
@@ -35,7 +35,7 @@ class MyMigration(Migration):
 
     def migrate(self):
 
-        self.logfile = "/tmp/{}.log".format(self.name)
+        self.logfile = "/var/log/yunohost/{}.log".format(self.name)
 
         self.check_assertions()
 


### PR DESCRIPTION
## The problem

Log file will be erased at reboot. Sometimes the dist-upgrade process goes bad, and the server need a manual (and forced) reboot. 

## Solution

Use the /var/log/yunohost folder, which already exists.

## How to test

Take a jessie server, install yunohost 2.x, launch the migration, crash your machine during migration, hard-reboot and see if a log file exists in /var/log/yunohost.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
