### PR TITLE
Warn the user that ynh_secure_remove should be used with only one arg…

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -348,6 +348,11 @@ ynh_secure_remove () {
 	/var/www \
 	/home/yunohost.app"
 
+    if [[ -n "$2" ]]
+    then
+		echo "/!\ Packager ! You provided a second argument to ynh_secure_remove but it will be ignored... Use this helper with one argument at time." >&2
+    fi
+
 	if [[ "$forbidden_path" =~ "$path_to_remove" \
 		# Match all paths or subpaths in $forbidden_path
 		|| "$path_to_remove" =~ ^/[[:alnum:]]+$ \


### PR DESCRIPTION
## The problem

This is a silly detail, but the mistake of calling `ynh_secure_remove` with more than one arg comes quickly ... Either because you transform a `rm -rf /foo/*` to `ynh_secure_remove /foo/*`, or `rm foo bar` into `ynh_secure_remove foo bar`

## Solution

Add a small warning for the packager to tell that other arguments given will be ignored

## PR Status

Not tested because laziness @.@

## How to test

Try to run `ynh_secure_remove` with multiple args

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
