### PR TITLE
[fix] Remove old SMTP port (465) from Fail2ban jail.conf

### DIFF
--- a/data/templates/fail2ban/jail.conf
+++ b/data/templates/fail2ban/jail.conf
@@ -513,27 +513,27 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 
-port     = smtp,465,submission
+port     = smtp,submission
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 
-port     = smtp,465,submission
+port     = smtp,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [postfix]
 
-port     = smtp,465,submission
+port     = smtp,submission
 logpath  = %(postfix_log)s
 backend  = %(postfix_backend)s
 
 
 [postfix-rbl]
 
-port     = smtp,465,submission
+port     = smtp,submission
 logpath  = %(postfix_log)s
 backend  = %(postfix_backend)s
 maxretry = 1
@@ -541,14 +541,14 @@ maxretry = 1
 
 [sendmail-auth]
 
-port    = submission,465,smtp
+port    = submission,smtp
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
 
 [sendmail-reject]
 
-port     = smtp,465,submission
+port     = smtp,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
@@ -556,7 +556,7 @@ backend  = %(syslog_backend)s
 [qmail-rbl]
 
 filter  = qmail
-port    = smtp,465,submission
+port    = smtp,submission
 logpath = /service/qmail/log/main/current
 
 
@@ -564,14 +564,14 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 
-port    = pop3,pop3s,imap,imaps,submission,465,sieve
+port    = pop3,pop3s,imap,imaps,submission,sieve
 logpath = %(dovecot_log)s
 backend = %(dovecot_backend)s
 
 
 [sieve]
 
-port   = smtp,465,submission
+port   = smtp,submission
 logpath = %(dovecot_log)s
 backend = %(dovecot_backend)s
 
@@ -584,19 +584,19 @@ logpath = %(solidpop3d_log)s
 
 [exim]
 
-port   = smtp,465,submission
+port   = smtp,submission
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 
-port   = smtp,465,submission
+port   = smtp,submission
 logpath = %(exim_main_log)s
 
 
 [kerio]
 
-port    = imap,smtp,imaps,465
+port    = imap,smtp,imaps
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -607,14 +607,14 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 
-port     = smtp,465,submission,imaps,pop3,pop3s
+port     = smtp,submission,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [postfix-sasl]
 
-port     = smtp,465,submission,imap,imaps,pop3,pop3s
+port     = smtp,submission,imap,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -631,7 +631,7 @@ backend = %(syslog_backend)s
 
 [squirrelmail]
 
-port = smtp,465,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
+port = smtp,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 


### PR DESCRIPTION
Issue #1283