### PR TITLE
[enh] Check if dpkg is not broken when calling ynh_wait_dpkg_free

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -15,6 +15,21 @@ ynh_wait_dpkg_free() {
             # Sleep an exponential time at each round
             sleep $(( try * try ))
         else
+            # Check if dpkg hasn't been interrupted and is fully available.
+            # See this for more information: https://sources.debian.org/src/apt/1.4.9/apt-pkg/deb/debsystem.cc/#L141-L174
+            local dpkg_dir="/var/lib/dpkg/updates/"
+
+            # For each file in $dpkg_dir
+            while read dpkg_file <&9
+            do
+                # Check if the name of this file contains only numbers.
+                if echo "$dpkg_file" | grep -Pq "^[[:digit:]]*$"
+                then
+                    # If so, that a remaining of dpkg.
+                    ynh_print_err "E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem."
+                    return 1
+                fi
+            done 9<<< "$(ls -1 $dpkg_dir)"
             return 0
         fi
     done


### PR DESCRIPTION
## The problem

Fix https://github.com/YunoHost/issues/issues/1284

## Solution

Use the way apt check that dpkg is available to know if `dpkg --configure -a` is needed.

## PR Status

Ready to be reviewed.

## How to test

As Aleks told me, update metronome or any other package that will ask you to replace a config file. And kill the process without answering the question.
Then, remove the lock file and you'll have a broken dpkg

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 