### PR TITLE
[enh] Add IPv6 nameserver to resolv.dnsmasq.conf from diyisp.org

### DIFF
--- a/data/templates/dnsmasq/plain/dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/dnsmasq.conf
@@ -2,6 +2,5 @@ domain-needed
 expand-hosts
 
 listen-address=127.0.0.1
-listen-address=::1
 resolv-file=/etc/resolv.dnsmasq.conf
 cache-size=256

--- a/data/templates/dnsmasq/plain/dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/dnsmasq.conf
@@ -2,5 +2,6 @@ domain-needed
 expand-hosts
 
 listen-address=127.0.0.1
+listen-address=::1
 resolv-file=/etc/resolv.dnsmasq.conf
 cache-size=256

--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -9,25 +9,37 @@
 
 # (FR) FDN
 nameserver 80.67.169.12
+nameserver 2001:910:800::12
 nameserver 80.67.169.40
+nameserver 2001:910:800::40
 # (FR) LDN
 nameserver 80.67.188.188
+nameserver 2001:913::8
 # (FR) ARN
 nameserver 89.234.141.66
+nameserver 2a00:5881:8100:1000::3
 # (FR) Aquilenet
 nameserver 185.233.100.100
+nameserver 2a0c:e300::100
 nameserver 185.233.100.101
+nameserver 2a0c:e300::101
 # (FR) gozmail / grifon
 nameserver 80.67.190.200
+nameserver 2a00:5884:8218::1
 # (DE) FoeBud / Digital Courage
 nameserver 85.214.20.141
 # (DE) CCC Berlin
 nameserver 195.160.173.53
 # (DE) AS250
 nameserver 194.150.168.168
+nameserver 2001:4ce8::53
 # (DE) Ideal-Hosting
 nameserver 84.200.69.80
+nameserver 2001:1608:10:25::1c04:b12f
 nameserver 84.200.70.40
+nameserver 2001:1608:10:25::9249:d69b
 # (DK) censurfridns
 nameserver 91.239.100.100
+nameserver 2001:67c:28a4::
 nameserver 89.233.43.71
+nameserver 2002:d596:2a92:1:71:53::


### PR DESCRIPTION
## The problem

No DNS query to IPv6 servers available.

## Solution

Add IPv6 nameserver from http://diyisp.org/dokuwiki/doku.php?id=technical:dnsresolver

## PR Status

Manually changed list tested on a server.

## How to test

Update the list, regen dnsmasq conf, check if domain name resolution

## Validation

- [x] Principle agreement 0/2 : 
- [x] Quick review 0/1 : 
- [x] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
