### PR TITLE
[fix] Admin password appearing in logs

### DIFF
--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -149,6 +149,11 @@ def _init_moulinette(use_websocket=True, debug=False, verbose=False):
                 'handlers': [],
                 'propagate': True,
             },
+            'gnupg': {
+                'level': 'INFO',
+                'handlers': [],
+                'propagate': False,
+            },
         },
         'root': {
             'level': level,


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1289

## Solution

Have a custom log level setting for gnupg

## PR Status

Tested and working

## How to test

Pull the branch, restart yunohost-api.
Check if 'gnupg' lines appear in `/var/log/yunohost/yunohost-api.log` while login into the admin interface

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
