### PR TITLE
Fix #635 on ynh_secure_remove

### DIFF
--- a/data/helpers.d/filesystem
+++ b/data/helpers.d/filesystem
@@ -392,10 +392,10 @@ ynh_secure_remove () {
 	/var/www \
 	/home/yunohost.app"
 
-    if [[ -n "$2" ]]
-    then
-		echo "/!\ Packager ! You provided a second argument to ynh_secure_remove but it will be ignored... Use this helper with one argument at time." >&2
-    fi
+	if [ $# -ge 2 ]
+	then
+		echo "/!\ Packager ! You provided more than one argument to ynh_secure_remove but it will be ignored... Use this helper with one argument at time." >&2
+	fi
 
 	if [[ "$forbidden_path" =~ "$file" \
 		# Match all paths or subpaths in $forbidden_path


### PR DESCRIPTION
## The problem

#635 has added a regression by using $2 directly, which fails if there's only one argument.
`/usr/share/yunohost/helpers.d/filesystem: line 351: $2: unbound variable`

## Solution

Use the number of args instead of testing $2
Anyway, by using getopts, we will already have a message like: `Attention : [WARN] Too many arguments ! /my/path will be ignored.`

## PR Status

Tested with my new "personal" ynh-dev ;)

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 