### PR TITLE
[fix] Get rid of annoying 'unable to initialize frontend' messages

### DIFF
--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -71,7 +71,7 @@ ynh_package_version() {
 # usage: ynh_apt update
 ynh_apt() {
     ynh_wait_dpkg_free
-    DEBIAN_FRONTEND=noninteractive sudo apt-get -y $@
+    DEBIAN_FRONTEND=noninteractive apt-get -y $@
 }
 
 # Update package index files
@@ -150,7 +150,7 @@ ynh_package_install_from_equivs () {
     cp "$controlfile" "${TMPDIR}/control"
     (cd "$TMPDIR"
     equivs-build ./control 1> /dev/null
-    DEBIAN_FRONTEND=noninteractive dpkg --force-depends -i "./${pkgname}_${pkgversion}_all.deb" 2>&1)
+    dpkg --force-depends -i "./${pkgname}_${pkgversion}_all.deb" 2>&1)
     ynh_package_install -f || ynh_die --message="Unable to install dependencies"
     [[ -n "$TMPDIR" ]] && rm -rf $TMPDIR	# Remove the temp dir.
 

--- a/data/helpers.d/package
+++ b/data/helpers.d/package
@@ -150,7 +150,7 @@ ynh_package_install_from_equivs () {
     cp "$controlfile" "${TMPDIR}/control"
     (cd "$TMPDIR"
     equivs-build ./control 1> /dev/null
-    dpkg --force-depends -i "./${pkgname}_${pkgversion}_all.deb" 2>&1)
+    DEBIAN_FRONTEND=noninteractive dpkg --force-depends -i "./${pkgname}_${pkgversion}_all.deb" 2>&1)
     ynh_package_install -f || ynh_die --message="Unable to install dependencies"
     [[ -n "$TMPDIR" ]] && rm -rf $TMPDIR	# Remove the temp dir.
 


### PR DESCRIPTION
## The problem

In some situation, e.g. installing an app from the webadmin, the install dump some warnings : 

```text
dpkg-preconfigure: unable to re-open stdin:
debconf: falling back to frontend: Teletype
debconf: (This frontend requires a controlling tty.)
debconf: unable to initialize frontend: Readline
debconf: falling back to frontend: Readline
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: unable to initialize frontend: Dialog
```

Those are pretty annoying and technical, would be nice to get rid of them ...

## Solution

My guess is that it's related to the use of dpkg inside `ynh_package_install_from_equivs` but I'm not that sure ... So tried to add `DEBIAN_FRONTEND=noninteractive` but not sure that's the issue / fix :wink: Mainly creating this PR to not forget about it later.

## PR Status

Not tested

## How to test

Pull the branch, try to install an app from the webadmin (e.g. Nextcloud). (Don't forget to restart yunohost-api)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
