### PR TITLE
Reload fail2ban instead of restart

### DIFF
--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -195,6 +195,7 @@ def firewall_reload(skip_upnp=False):
 
     """
     from yunohost.hook import hook_callback
+    from yunohost.service import _run_service_command
 
     reloaded = False
     errors = False
@@ -276,8 +277,7 @@ def firewall_reload(skip_upnp=False):
         # Refresh port forwarding with UPnP
         firewall_upnp(no_refresh=False)
 
-    # TODO: Use service_restart
-    os.system("service fail2ban restart")
+    _run_service_command("reload", "fail2ban")
 
     if errors:
         logger.warning(m18n.n('firewall_rules_cmd_failed'))


### PR DESCRIPTION
## The problem

Restarting fail2ban is really slow on ARM architecture.
Reload should be enough.

## Solution

Reload fail2ban when we reload the firewall

## PR Status

Tested that when we reload fail2ban all iptables rules are created a new time.

## How to test

Checkout the branch.
Reload the firewall and check that the fail2ban rules are restored.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
