### PR TITLE
[fix] Loading only one helper file leads to errors because missing getopts

### DIFF
--- a/data/hooks/backup/05-conf_ldap
+++ b/data/hooks/backup/05-conf_ldap
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ldap"

--- a/data/hooks/backup/08-conf_ssh
+++ b/data/hooks/backup/08-conf_ssh
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ssh"

--- a/data/hooks/backup/11-conf_ynh_mysql
+++ b/data/hooks/backup/11-conf_ynh_mysql
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ynh/mysql"

--- a/data/hooks/backup/14-conf_ssowat
+++ b/data/hooks/backup/14-conf_ssowat
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ssowat"

--- a/data/hooks/backup/17-data_home
+++ b/data/hooks/backup/17-data_home
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/data/home"

--- a/data/hooks/backup/20-conf_ynh_firewall
+++ b/data/hooks/backup/20-conf_ynh_firewall
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ynh/firewall"

--- a/data/hooks/backup/21-conf_ynh_certs
+++ b/data/hooks/backup/21-conf_ynh_certs
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ynh/certs"

--- a/data/hooks/backup/23-data_mail
+++ b/data/hooks/backup/23-data_mail
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/data/mail"

--- a/data/hooks/backup/26-conf_xmpp
+++ b/data/hooks/backup/26-conf_xmpp
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/xmpp"

--- a/data/hooks/backup/29-conf_nginx
+++ b/data/hooks/backup/29-conf_nginx
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/nginx"

--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/cron"

--- a/data/hooks/backup/40-conf_ynh_currenthost
+++ b/data/hooks/backup/40-conf_ynh_currenthost
@@ -4,7 +4,7 @@
 set -eu
 
 # Source YNH helpers
-source /usr/share/yunohost/helpers.d/filesystem
+source /usr/share/yunohost/helpers
 
 # Backup destination
 backup_dir="${1}/conf/ynh"

--- a/data/hooks/conf_regen/03-ssh
+++ b/data/hooks/conf_regen/03-ssh
@@ -2,7 +2,7 @@
 
 set -e
 
-. /usr/share/yunohost/helpers.d/utils
+. /usr/share/yunohost/helpers
 
 do_pre_regen() {
     pending_dir=$1

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -2,7 +2,7 @@
 
 set -e
 
-. /usr/share/yunohost/helpers.d/utils
+. /usr/share/yunohost/helpers
 
 do_init_regen() {
   if [[ $EUID -ne 0 ]]; then

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -2,6 +2,7 @@
 
 set -e
 MYSQL_PKG="mariadb-server-10.1"
+. /usr/share/yunohost/helpers
 
 do_pre_regen() {
   pending_dir=$1
@@ -15,7 +16,6 @@ do_post_regen() {
   regen_conf_files=$1
 
   if [ ! -f /etc/yunohost/mysql ]; then
-      . /usr/share/yunohost/helpers.d/string
 
       # ensure that mysql is running
       sudo systemctl -q is-active mysql.service \
@@ -25,8 +25,6 @@ do_post_regen() {
       mysql_password=$(ynh_string_random 10)
       sudo mysqladmin -s -u root -pyunohost password "$mysql_password" || {
         if [ $FORCE -eq 1 ]; then
-            . /usr/share/yunohost/helpers.d/package
-
             echo "It seems that you have already configured MySQL." \
               "YunoHost needs to have a root access to MySQL to runs its" \
               "applications, and is going to reset the MySQL root password." \

--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -1,12 +1,10 @@
 #!/bin/bash
 
 set -e
+. /usr/share/yunohost/helpers
 
 do_pre_regen() {
   pending_dir=$1
-
-  # source ip helpers
-  . /usr/share/yunohost/helpers.d/ip
 
   cd /usr/share/yunohost/templates/dnsmasq
 

--- a/data/hooks/restore/11-conf_ynh_mysql
+++ b/data/hooks/restore/11-conf_ynh_mysql
@@ -1,6 +1,8 @@
 backup_dir="$1/conf/ynh/mysql"
 MYSQL_PKG="mariadb-server-10.1"
 
+. /usr/share/yunohost/helpers
+
 # ensure that mysql is running
 service mysql status >/dev/null 2>&1 \
   || service mysql start
@@ -11,13 +13,11 @@ service mysql status >/dev/null 2>&1 \
 new_pwd=$(sudo cat "${backup_dir}/root_pwd" || sudo cat "${backup_dir}/mysql")
 [ -z "$curr_pwd" ] && curr_pwd="yunohost"
 [ -z "$new_pwd" ] && {
-    . /usr/share/yunohost/helpers.d/string
     new_pwd=$(ynh_string_random 10)
 }
 
 # attempt to change it
 sudo mysqladmin -s -u root -p"$curr_pwd" password "$new_pwd" || {
-  . /usr/share/yunohost/helpers.d/package
 
   echo "It seems that you have already configured MySQL." \
     "YunoHost needs to have a root access to MySQL to runs its" \


### PR DESCRIPTION
## The problem

Ran a postinstall on unstable and realized that some regenconf hooks were broken because they use a helper, and getopts wasn't sourced...

## Solution

Well that's a solution where I just load all helpers instead as in apps. Dunno that's what we want, maybe there's a significant overhead compared to sourcing getopts in each file ?

## PR Status

Not tested

## How to test

Run a postinstall with and without this branch

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
