### PR TITLE
[enh] Assert dpkg is not broken before app install

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -146,6 +146,7 @@
     "diagnosis_monitor_network_error": "Can't monitor network: {error}",
     "diagnosis_monitor_system_error": "Can't monitor system: {error}",
     "diagnosis_no_apps": "No installed application",
+    "dpkg_is_broken": "You cannot do this right now because dpkg/apt (the system package managers) seems to be in a broken state... You can try to solve this issue by connecting through SSH and running `sudo dpkg --configure -a`.",
     "dnsmasq_isnt_installed": "dnsmasq does not seem to be installed, please run 'apt-get remove bind9 && apt-get install dnsmasq'",
     "domain_cannot_remove_main": "Cannot remove main domain. Set a new main domain first",
     "domain_cert_gen_failed": "Unable to generate certificate",

--- a/locales/en.json
+++ b/locales/en.json
@@ -464,6 +464,7 @@
     "ssowat_persistent_conf_write_error": "Error while saving SSOwat persistent configuration: {error:s}. Edit /etc/ssowat/conf.json.persistent file to fix the JSON syntax",
     "system_upgraded": "The system has been upgraded",
     "system_username_exists": "Username already exists in the system users",
+    "this_action_broke_dpkg": "This action broke dpkg/apt (the system package managers)... You can try to solve this issue by connecting through SSH and running `sudo dpkg --configure -a`.",
     "unbackup_app": "App '{app:s}' will not be saved",
     "unexpected_error": "An unexpected error occured: {error}",
     "unit_unknown": "Unknown unit '{unit:s}'",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -722,6 +722,9 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
         },
     }
 
+    if packages.dpkg_is_broken():
+        raise YunohostError(m18n.n("dpkg_is_broken"))
+
     def confirm_install(confirm):
 
         # Ignore if there's nothing for confirm (good quality app), if --force is used

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -565,7 +565,7 @@ def app_upgrade(auth, app=[], url=None, file=None):
 
     """
     if packages.dpkg_is_broken():
-        raise YunohostError(m18n.n("dpkg_is_broken"))
+        raise YunohostError("dpkg_is_broken")
 
     from yunohost.hook import hook_add, hook_remove, hook_exec, hook_callback
 
@@ -709,7 +709,7 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
         force -- Do not ask for confirmation when installing experimental / low-quality apps
     """
     if packages.dpkg_is_broken():
-        raise YunohostError(m18n.n("dpkg_is_broken"))
+        raise YunohostError("dpkg_is_broken")
 
     from yunohost.hook import hook_add, hook_remove, hook_exec, hook_callback
     from yunohost.log import OperationLogger
@@ -966,7 +966,7 @@ def app_remove(operation_logger, auth, app):
     app_ssowatconf(auth)
 
     if packages.dpkg_is_broken():
-        raise YunohostError(m18n.n("this_action_broke_dpkg"))
+        raise YunohostError("this_action_broke_dpkg")
 
 
 def app_addaccess(auth, apps, users=[]):

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -564,6 +564,9 @@ def app_upgrade(auth, app=[], url=None, file=None):
         url -- Git url to fetch for upgrade
 
     """
+    if packages.dpkg_is_broken():
+        raise YunohostError(m18n.n("dpkg_is_broken"))
+
     from yunohost.hook import hook_add, hook_remove, hook_exec, hook_callback
 
     # Retrieve interface

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -708,6 +708,9 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
         no_remove_on_failure -- Debug option to avoid removing the app on a failed installation
         force -- Do not ask for confirmation when installing experimental / low-quality apps
     """
+    if packages.dpkg_is_broken():
+        raise YunohostError(m18n.n("dpkg_is_broken"))
+
     from yunohost.hook import hook_add, hook_remove, hook_exec, hook_callback
     from yunohost.log import OperationLogger
 
@@ -724,9 +727,6 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
             'type': None,
         },
     }
-
-    if packages.dpkg_is_broken():
-        raise YunohostError(m18n.n("dpkg_is_broken"))
 
     def confirm_install(confirm):
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -880,6 +880,9 @@ def app_install(operation_logger, auth, app, label=None, args=None, no_remove_on
 
             app_ssowatconf(auth)
 
+            if packages.dpkg_is_broken():
+                logger.error(m18n.n("this_action_broke_dpkg"))
+
             if install_retcode == -1:
                 msg = m18n.n('operation_interrupted') + " " + error_msg
                 raise YunohostError(msg, raw_msg=True)
@@ -961,6 +964,9 @@ def app_remove(operation_logger, auth, app):
     shutil.rmtree('/tmp/yunohost_remove')
     hook_remove(app)
     app_ssowatconf(auth)
+
+    if packages.dpkg_is_broken():
+        raise YunohostError(m18n.n("this_action_broke_dpkg"))
 
 
 def app_addaccess(auth, apps, users=[]):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -526,7 +526,7 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
     """
     from yunohost.utils import packages
     if packages.dpkg_is_broken():
-        raise YunohostError(m18n.n("dpkg_is_broken"))
+        raise YunohostError("dpkg_is_broken")
 
     failure = False
 

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -524,6 +524,10 @@ def tools_upgrade(operation_logger, auth, ignore_apps=False, ignore_packages=Fal
         ignore_packages -- Ignore APT packages upgrade
 
     """
+    from yunohost.utils import packages
+    if packages.dpkg_is_broken():
+        raise YunohostError(m18n.n("dpkg_is_broken"))
+
     failure = False
 
     # Retrieve interface

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -477,5 +477,7 @@ def dpkg_is_broken():
     # If dpkg is broken, /var/lib/dpkg/updates
     # will contains files like 0001, 0002, ...
     # ref: https://sources.debian.org/src/apt/1.4.9/apt-pkg/deb/debsystem.cc/#L141-L174
+    if not os.path.isdir("/var/lib/dpkg/updates/"):
+        return False
     return any(re.match("^[0-9]+$", f)
                for f in os.listdir("/var/lib/dpkg/updates/"))

--- a/src/yunohost/utils/packages.py
+++ b/src/yunohost/utils/packages.py
@@ -19,6 +19,7 @@
 
 """
 import re
+import os
 import logging
 from collections import OrderedDict
 
@@ -470,3 +471,11 @@ def ynh_packages_version(*args, **kwargs):
         'yunohost', 'yunohost-admin', 'moulinette', 'ssowat',
         with_repo=True
     )
+
+
+def dpkg_is_broken():
+    # If dpkg is broken, /var/lib/dpkg/updates
+    # will contains files like 0001, 0002, ...
+    # ref: https://sources.debian.org/src/apt/1.4.9/apt-pkg/deb/debsystem.cc/#L141-L174
+    return any(re.match("^[0-9]+$", f)
+               for f in os.listdir("/var/lib/dpkg/updates/"))


### PR DESCRIPTION
## The problem

Follow-up of https://github.com/YunoHost/issues/issues/1284 and https://github.com/YunoHost/yunohost/pull/638.

## Solution

Make sure that dpkg/apt ain't broken before starting to install an app. This could also be done for other scripts which are quite likely to rely on apt : upgrade, remove and restore. I don't know if that's relevant though ... e.g. maybe we want people (or yunohost) to trigger removals even if dpkg/apt is broken ? I dunno ...

Note that the plan is anyway to add this check in ynh_apt though https://github.com/YunoHost/yunohost/pull/638 but the plan is to, where relevant, avoid starting to run a whole script if we can know it's gonna fail anyway.

## PR Status

Tested and working

## How to test

c.f. https://github.com/YunoHost/issues/issues/1284#issuecomment-459375469

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
