### PR TITLE
[enh] Be able to define hook to trigger when changing a setting

### DIFF
--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -264,7 +264,7 @@ def trigger_post_change_hook(setting_name, old_value, new_value):
         return
 
     f = post_change_hooks[setting_name]
-    f(old_value, new_value)
+    f(setting_name, old_value, new_value)
 
 
 # ===========================================
@@ -273,14 +273,15 @@ def trigger_post_change_hook(setting_name, old_value, new_value):
 # You can define such an action with :
 #
 # @post_change_hook("your.setting.name")
-# def some_function_name(old_value, new_value):
+# def some_function_name(setting_name, old_value, new_value):
 #     # Do some stuff
 #
 # ===========================================
 
 
 #@post_change_hook("example.int")
-#def myfunc(old_value, new_value):
+#def myfunc(setting_name, old_value, new_value):
 #    print("In hook")
+#    print(setting_name)
 #    print(old_value)
 #    print(new_value)

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -115,9 +115,17 @@ def settings_set(key, value):
         raise YunohostError('global_settings_unknown_type', setting=key,
                             unknown_type=key_type)
 
+    old_value = settings[key].get("value")
     settings[key]["value"] = value
-
     _save_settings(settings)
+
+    # TODO : whatdo if the old value is the same as
+    # the new value...
+    try:
+        trigger_post_change_hook(key, old_value, value)
+    except Exception as e:
+        logger.error("Post-change hook for setting %s failed : %s" % (key, e))
+        raise
 
 
 def settings_reset(key):
@@ -235,3 +243,44 @@ def _save_settings(settings, location=SETTINGS_PATH):
             settings_fd.write(result)
     except Exception as e:
         raise YunohostError('global_settings_cant_write_settings', reason=e)
+
+
+# Meant to be a dict of setting_name -> function to call
+post_change_hooks = {}
+
+
+def post_change_hook(setting_name):
+    def decorator(func):
+        assert setting_name in DEFAULTS.keys(), "The setting %s does not exists" % setting_name
+        assert setting_name not in post_change_hooks, "You can only register one post change hook per setting (in particular for %s)" % setting_name
+        post_change_hooks[setting_name] = func
+        return func
+    return decorator
+
+
+def trigger_post_change_hook(setting_name, old_value, new_value):
+    if setting_name not in post_change_hooks:
+        logger.debug("Nothing to do after changing setting %s" % setting_name)
+        return
+
+    f = post_change_hooks[setting_name]
+    f(old_value, new_value)
+
+
+# ===========================================
+#
+# Actions to trigger when changing a setting
+# You can define such an action with :
+#
+# @post_change_hook("your.setting.name")
+# def some_function_name(old_value, new_value):
+#     # Do some stuff
+#
+# ===========================================
+
+
+#@post_change_hook("example.int")
+#def myfunc(old_value, new_value):
+#    print("In hook")
+#    print(old_value)
+#    print(new_value)


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/yunohost/pull/640 and other similar use case : we need to be able to trigger specific code when updating a setting value. For instance, to trigger a regenconf of nginx or ssh or whatever.

## Solution

Introduce a decorator `@post_change_hook("your.setting.name")` to define what code to trigger after the setting is changed. A dummy example is : 

```python
@post_change_hook("example.int")
def myfunc(old_value, new_value):
    print("In hook")
    print(old_value)
    print(new_value) 
```


## PR Status

Tested, ready for review

## How to test

Uncomment the example at the end and try to run for instance `yunohost settings set example.int -v 1664`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
