### PR TITLE
[enh] Ensure the tar file is closed during the backup

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -75,7 +75,7 @@
     "backup_archive_name_unknown": "Unknown local backup archive named '{name:s}'",
     "backup_archive_open_failed": "Unable to open the backup archive",
     "backup_archive_system_part_not_available": "System part '{part:s}' not available in this backup",
-    "backup_archive_writing_error": "Unable to add files to backup into the compressed archive",
+    "backup_archive_writing_error": "Unable to add files '{source:s}' (named in the archive: '{dest:s}') to backup into the compressed archive '{archive:s}'",
     "backup_ask_for_copying_if_needed": "Some files couldn't be prepared to be backuped using the method that avoid to temporarily waste space on the system. To perform the backup, {size:s}MB should be used temporarily. Do you agree?",
     "backup_borg_not_implemented": "Borg backup method is not yet implemented",
     "backup_cant_mount_uncompress_archive": "Unable to mount in readonly mode the uncompress archive directory",

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1803,7 +1803,7 @@ class TarBackupMethod(BackupMethod):
                 # "dest"
                 tar.add(path['source'], arcname=path['dest'])
         except IOError:
-            logger.error(m18n.n('backup_archive_writing_error'), exc_info=1)
+            logger.error(m18n.n('backup_archive_writing_error', source=path['source'], archive=self._archive_file, dest=path['dest']), exc_info=1)
             raise YunohostError('backup_creation_failed')
         finally:
             tar.close()

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1802,10 +1802,11 @@ class TarBackupMethod(BackupMethod):
                 # Add the "source" into the archive and transform the path into
                 # "dest"
                 tar.add(path['source'], arcname=path['dest'])
-            tar.close()
         except IOError:
             logger.error(m18n.n('backup_archive_writing_error'), exc_info=1)
             raise YunohostError('backup_creation_failed')
+        finally:
+            tar.close()
 
         # Move info file
         shutil.copy(os.path.join(self.work_dir, 'info.json'),


### PR DESCRIPTION
## The problem

In some conditions during a backup, the tar file is not closed.

## Solution

Ensure the tar file is closed

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
