### PR TITLE
Cache results from meltdown checker

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -724,7 +724,6 @@ def _check_if_vulnerable_to_meltdown():
     # (e.g. from yunohost)
     cache_file = "/tmp/yunohost-meltdown-diagnosis"
     dpkg_log = "/var/log/dpkg.log"
-    print(os.path.exists(cache_file))
     if os.path.exists(cache_file):
         if not os.path.exists(dpkg_log) or os.path.getmtime(cache_file) > os.path.getmtime(dpkg_log):
             logger.debug("Using cached results for meltdown checker, from %s" % cache_file)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -713,6 +713,23 @@ def tools_diagnosis(auth, private=False):
 def _check_if_vulnerable_to_meltdown():
     # meltdown CVE: https://security-tracker.debian.org/tracker/CVE-2017-5754
 
+    # We use a cache file to avoid re-running the script so many times,
+    # which can be expensive (up to around 5 seconds on ARM)
+    # and make the admin appear to be slow (c.f. the calls to diagnosis
+    # from the webadmin)
+    #
+    # The cache is in /tmp and shall disappear upon reboot
+    # *or* we compare it to dpkg.log modification time
+    # such that it's re-ran if there was package upgrades
+    # (e.g. from yunohost)
+    cache_file = "/tmp/yunohost-meltdown-diagnosis"
+    dpkg_log = "/var/log/dpkg.log"
+    print(os.path.exists(cache_file))
+    if os.path.exists(cache_file):
+        if not os.path.exists(dpkg_log) or os.path.getmtime(cache_file) > os.path.getmtime(dpkg_log):
+            logger.debug("Using cached results for meltdown checker, from %s" % cache_file)
+            return read_json(cache_file)[0]["VULNERABLE"]
+
     # script taken from https://github.com/speed47/spectre-meltdown-checker
     # script commit id is store directly in the script
     file_dir = os.path.split(__file__)[0]
@@ -722,6 +739,7 @@ def _check_if_vulnerable_to_meltdown():
     # example output from the script:
     # [{"NAME":"MELTDOWN","CVE":"CVE-2017-5754","VULNERABLE":false,"INFOS":"PTI mitigates the vulnerability"}]
     try:
+        logger.debug("Running meltdown vulnerability checker")
         call = subprocess.Popen("bash %s --batch json --variant 3" %
                                 SCRIPT_PATH, shell=True,
                                 stdout=subprocess.PIPE,
@@ -752,6 +770,8 @@ def _check_if_vulnerable_to_meltdown():
         logger.warning("Something wrong happened when trying to diagnose Meltdown vunerability, exception: %s" % e)
         raise Exception("Command output for failed meltdown check: '%s'" % output)
 
+    logger.debug("Writing results from meltdown checker to cache file, %s" % cache_file)
+    write_to_json(cache_file, CVEs)
     return CVEs[0]["VULNERABLE"]
 
 


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1304

## Solution

Cache the results from meltdown checker instead of re-running the script everytime a diagnosis is done...

The cache is stored in `/tmp/` with the idea that it shall be cleared upon a reboot (which might change the result from the script). Also since we might want to change what we do with this diagnosis, I check the modification time of the cached file against `/var/log/dpkg.log` such that the diagnosis is re-ran if there was an upgrade (of yunohost for example)

## PR Status

Tested and working

## How to test

Run `yunohost tools diagnosis --debug` a few time, you should see a message indicating the result is write to / read from the cached file

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
