### PR TITLE
Add apt-transport-https to dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , moulinette (>= 2.7.1), ssowat (>= 2.7.1)
  , python-psutil, python-requests, python-dnspython, python-openssl
  , python-apt, python-miniupnpc, python-dbus, python-jinja2
- , glances
+ , glances, apt-transport-https
  , dnsutils, bind9utils, unzip, git, curl, cron, wget, jq
  , ca-certificates, netcat-openbsd, iproute
  , mariadb-server, php-mysql | php-mysqlnd


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1242

apt-transport-https is installed in many setups because it's installed via the install-script, but it's not in the yunohost dependencies so not installed on x86 ISO. Therefore, packagers don't realize this and this later breaks install for some user who don't have apt-transport-https installed.

From what I understand, this is related to the whole question of wether or not to add additional repo. Not sure what to do exactly but it sounds to me that sometimes it can't really be avoided ... Anyway this is kinda independent, and I think for the "additional repo" thing we could add a warning in package linter or something. (My opinion is that we should have helpers / core stuff to help integrating additional repos in a clean way)

## Solution

Add apt-transport-https to core dependencies

## PR Status

Yolocommited

## How to test

Uh compile the whole debian package and install it on a fresh debian but meh not sure we really need to test this

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
