### PR TITLE
[enh] Add the arch argument to ynh_install_nodejs

### DIFF
--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -69,6 +69,7 @@ ynh_install_nodejs () {
 	local arch
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
+	arch=${arch:-}
 
 	# Create $n_install_dir
 	mkdir -p "$n_install_dir"

--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -98,6 +98,7 @@ ynh_install_nodejs () {
 	test -x /usr/bin/npm_n && mv /usr/bin/npm_n /usr/bin/npm
 
 	# Install the requested version of nodejs
+	uname=$(uname -m)
 	if [[ $uname =~ aarch64 ||  $uname =~ arm64]]
 	then
 		n $nodejs_version --arch=arm64

--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -64,8 +64,9 @@ ynh_install_nodejs () {
 
 	# Declare an array to define the options of this helper.
 	local legacy_args=n
-	declare -Ar args_array=( [n]=nodejs_version= )
+	declare -Ar args_array=( [n]=nodejs_version= [a]=arch=)
 	local nodejs_version
+	local arch
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
@@ -98,7 +99,12 @@ ynh_install_nodejs () {
 	test -x /usr/bin/npm_n && mv /usr/bin/npm_n /usr/bin/npm
 
 	# Install the requested version of nodejs
-	n $nodejs_version
+	if [ -z "$arch" ]
+	then
+		n $nodejs_version
+	else
+		n $nodejs_version --arch=$arch
+	fi
 
 	# Find the last "real" version for this major version of node.
 	real_nodejs_version=$(find $node_version_path/$nodejs_version* -maxdepth 0 | sort --version-sort | tail --lines=1)

--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -64,12 +64,10 @@ ynh_install_nodejs () {
 
 	# Declare an array to define the options of this helper.
 	local legacy_args=n
-	declare -Ar args_array=( [n]=nodejs_version= [a]=arch=)
+	declare -Ar args_array=( [n]=nodejs_version= )
 	local nodejs_version
-	local arch
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
-	arch=${arch:-}
 
 	# Create $n_install_dir
 	mkdir -p "$n_install_dir"
@@ -100,11 +98,11 @@ ynh_install_nodejs () {
 	test -x /usr/bin/npm_n && mv /usr/bin/npm_n /usr/bin/npm
 
 	# Install the requested version of nodejs
-	if [ -z "$arch" ]
+	if [[ $uname =~ aarch64 ||  $uname =~ arm64]]
 	then
-		n $nodejs_version
+		n $nodejs_version --arch=arm64
 	else
-		n $nodejs_version --arch=$arch
+		n $nodejs_version
 	fi
 
 	# Find the last "real" version for this major version of node.


### PR DESCRIPTION
## The problem

When installing nodejs on arm64 and arch64, [N - Node.js version management](https://github.com/tj/n) handle the architecture as [AMD64](https://github.com/tj/n/pull/448) and the nodejs installation failed

## Solution

Use the N - Node.js version management argument --arch to specify an architecture

## PR Status

Done

## How to test

There is a package with the functionality setuped: `yunohost app install https://github.com/YunoHost-Apps/wikijs_ynh/tree/arm --debug`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
