### PR TITLE
[enh] Don't add Strict-Transport-Security header in nginx conf if using a selfsigned cert

### DIFF
--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -51,7 +51,9 @@ server {
     # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
     # https://wiki.mozilla.org/Security/Guidelines/Web_Security
     # https://observatory.mozilla.org/ 
-    more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload"; 
+    {% if domain_cert_ca != "Self-signed" %}
+    more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
+    {% endif %}
     more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
     more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
     more_set_headers "X-Content-Type-Options : nosniff";


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1310 , Firefox and probably all decent browser ignore this header anyway

## Solution

Don't add the header if using a self-signed cert

## PR Status

Tested on my machine™

## How to test

Pull the branch, have a domain with self-signed certificate, regen nginx conf. Check a javascript console before and after on the SSO portal.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
