### PR TITLE
[fix] Optimize dyndns requests

### DIFF
--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -157,12 +157,12 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
     try:
         r = requests.post('https://%s/key/%s?key_algo=hmac-sha512' % (subscribe_host, base64.b64encode(key)), data={'subdomain': domain}, timeout=30)
     except requests.ConnectionError:
-        os.system("rm %s" % private_file)
-        os.system("rm %s" % key_file)
+        os.system("rm -f %s" % private_file)
+        os.system("rm -f %s" % key_file)
         raise YunohostError('no_internet_connection')
     if r.status_code != 201:
-        os.system("rm %s" % private_file)
-        os.system("rm %s" % key_file)
+        os.system("rm -f %s" % private_file)
+        os.system("rm -f %s" % key_file)
         try:
             error = json.loads(r.text)['error']
         except:

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -333,7 +333,8 @@ def _guess_current_dyndns_domain(dyn_host):
     """
 
     # Retrieve the first registered domain
-    for path in glob.iglob('/etc/yunohost/dyndns/K*.private'):
+    paths = list(glob.iglob('/etc/yunohost/dyndns/K*.private'))
+    for path in paths:
         match = RE_DYNDNS_PRIVATE_KEY_MD5.match(path)
         if not match:
             match = RE_DYNDNS_PRIVATE_KEY_SHA512.match(path)
@@ -343,7 +344,9 @@ def _guess_current_dyndns_domain(dyn_host):
 
         # Verify if domain is registered (i.e., if it's available, skip
         # current domain beause that's not the one we want to update..)
-        if _dyndns_available(dyn_host, _domain):
+        # If there's only 1 such key found, then avoid doing the request
+        # for nothing (that's very probably the one we want to find ...)
+        if len(paths) > 1 and _dyndns_available(dyn_host, _domain):
             continue
         else:
             return (_domain, path)

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -156,10 +156,10 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
     # Send subscription
     try:
         r = requests.post('https://%s/key/%s?key_algo=hmac-sha512' % (subscribe_host, base64.b64encode(key)), data={'subdomain': domain}, timeout=30)
-    except requests.ConnectionError:
+    except Exception as e:
         os.system("rm -f %s" % private_file)
         os.system("rm -f %s" % key_file)
-        raise YunohostError('no_internet_connection')
+        raise YunohostError('dyndns_registration_failed', error=str(e))
     if r.status_code != 201:
         os.system("rm -f %s" % private_file)
         os.system("rm -f %s" % key_file)

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -119,6 +119,9 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
         subscribe_host -- Dynette HTTP API to subscribe to
 
     """
+    if len(glob.glob('/etc/yunohost/dyndns/*.key')) != 0 or os.path.exists('/etc/cron.d/yunohost-dyndns'):
+        raise YunohostError('domain_dyndns_already_subscribed')
+
     if domain is None:
         domain = _get_maindomain()
         operation_logger.related_to.append(('domain', domain))


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1300 - unecessary madness which makes everything slower (dyndns update taking the lock every 2 minutes to do a full HTTPS request for nothing and therefore dynette is bombarded with those and sometimes aint able to answer)

## Solution

Don't make all those crazy request, not really necessary ... Also add some constrains to try to remove ambiguities

## PR Status

Yolocommited, not tested :|

## How to test

Try this on a server with a registered nohost.me/noho.st/... Try to subscribe multiple time. Try a case where subscribing failed to see if keys are indeed removed.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
