### PR TITLE
[enh] Optimize app setting helpers

### DIFF
--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -75,9 +75,11 @@ else:
     if action == "delete":
         if key in settings:
             del settings[key]
-    else:
+    elif action == "get":
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
+    else:
+        raise ValueError("action should either be get, set or delete")
     settings[key] = value
     with open(setting_file, "w") as f:
         yaml.safe_dump(settings, f, default_flow_style=False)

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -75,12 +75,12 @@ else:
     if action == "delete":
         if key in settings:
             del settings[key]
-    elif action == "get":
+    elif action == "set":
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
+        settings[key] = value
     else:
         raise ValueError("action should either be get, set or delete")
-    settings[key] = value
     with open(setting_file, "w") as f:
         yaml.safe_dump(settings, f, default_flow_style=False)
 EOF

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -14,7 +14,7 @@ ynh_app_setting_get() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo yunohost app setting "$app" "$key" --output-as plain --quiet
+    ynh_app_setting "get" "$app" "$key"
 }
 
 # Set an application setting
@@ -33,7 +33,7 @@ ynh_app_setting_set() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo yunohost app setting "$app" "$key" --value="$value" --quiet
+    ynh_app_setting "set" "$app" "$key" "$value"
 }
 
 # Delete an application setting
@@ -50,5 +50,36 @@ ynh_app_setting_delete() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo yunohost app setting -d "$app" "$key" --quiet
+    ynh_app_setting "delete" "$app" "$key"
+}
+
+# Small "hard-coded" interface to avoid calling "yunohost app" directly each
+# time dealing with a setting is needed (which may be so slow on ARM boards)
+#
+# [internal]
+#
+ynh_app_setting()
+{
+    ACTION="$1" APP="$2" KEY="$3" VALUE="$4" python - <<EOF
+import os, yaml
+app, action = os.environ['APP'], os.environ['ACTION'].lower()
+key, value = os.environ['KEY'], os.environ.get('VALUE', None)
+setting_file = "/etc/yunohost/apps/%s/settings.yml" % app
+assert os.path.exists(setting_file), "Setting file %s does not exists ?" % setting_file
+with open(setting_file) as f:
+    settings = yaml.load(f)
+if action == "get":
+    if key in settings:
+        print(settings[key])
+else:
+    if action == "delete":
+        if key in settings:
+            del settings[key]
+    else:
+        if key in ['redirected_urls', 'redirected_regex']:
+            value = yaml.load(value)
+    settings[key] = value
+    with open(setting_file, "w") as f:
+        yaml.safe_dump(settings, f, default_flow_style=False)
+EOF
 }


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1299

On an ARM board like RPi2, `yunohost app setting` takes 6\~7 second to complete... Considering that an app usually interacts with 5\~10 settings during an install, you may loose a whole damn minute just getting or setting settings... 

Instead, doing this with a "small" python snippet can divide this time by ~10.

## Solution

Have a small helper to manipulate the setting yaml files. Turns out it's not straightforward as there are some special cases (c.f. `redirected_urls` and `redirected_regex`) to handle to truly reproduce the `yunohost app setting` behavior.

## PR Status

Partially tested on my machine

## How to test...

Load and use the `ynh_app_setting_{get,set,delete}` in various case ;)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
