### PR TITLE
Use apps.json as default list

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -415,10 +415,10 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
     # Enable UPnP silently and reload firewall
     firewall_upnp('enable', no_refresh=True)
 
-    # Setup the default official app list with cron job
+    # Setup the default apps list with cron job
     try:
         app_fetchlist(name="yunohost",
-                      url="https://app.yunohost.org/official.json")
+                      url="https://app.yunohost.org/apps.json")
     except Exception as e:
         logger.warning(str(e))
 


### PR DESCRIPTION
## The problem

Follow the decision about merging community and official into one list.

## Solution

Use apps.json as the default list.

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

**This PR should be merged after https://github.com/YunoHost/apps/pull/694**