### PR TITLE
[fix] adding a new test in case the info.json file exists but not the tar and vice versa

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2189,10 +2189,13 @@ def backup_info(name, with_details=False, human_readable=False):
 
     """
     archive_file = '%s/%s.tar.gz' % (ARCHIVES_PATH, name)
-
+    info_file = "%s/%s.info.json" % (ARCHIVES_PATH, name)
     # Check file exist (even if it's a broken symlink)
     if not os.path.lexists(archive_file):
         raise YunohostError('backup_archive_name_unknown', name=name)
+
+    if not (os.path.lexists(archive_file) and os.path.exists(info_file)):
+        raise YunohostError('backup_archive_missing', name=name)
 
     # If symlink, retrieve the real path
     if os.path.islink(archive_file):
@@ -2202,8 +2205,6 @@ def backup_info(name, with_details=False, human_readable=False):
         if not os.path.exists(archive_file):
             raise YunohostError('backup_archive_broken_link',
                                 path=archive_file)
-
-    info_file = "%s/%s.info.json" % (ARCHIVES_PATH, name)
 
     if not os.path.exists(info_file):
         tar = tarfile.open(archive_file, "r:gz")


### PR DESCRIPTION
## The problem

[this issue](https://github.com/YunoHost/issues/issues/1276)

## Solution

Adding one more test but it isn't the best one

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
