### PR TITLE
Remove nistpxxx curve

### DIFF
--- a/data/hooks/conf_regen/03-ssh
+++ b/data/hooks/conf_regen/03-ssh
@@ -16,7 +16,7 @@ do_pre_regen() {
     # do not listen to IPv6 if unavailable
     [[ -f /proc/net/if_inet6 ]] && ipv6_enabled=true || ipv6_enabled=false
 
-    ssh_keys=$(ls /etc/ssh/ssh_host_{ed25519,rsa,ecdsa}_key 2>/dev/null || true)
+    ssh_keys=$(ls /etc/ssh/ssh_host_{ed25519,rsa}_key 2>/dev/null || true)
 
     # Support legacy setting (this setting might be disabled by a user during a migration)
     if [[ "$(yunohost settings get 'service.ssh.allow_deprecated_dsa_hostkey')" == "True" ]]; then

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -16,7 +16,7 @@ HostKey {{ key }}{% endfor %}
 # ##############################################
 
 # Keys, ciphers and MACS
-KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 


### PR DESCRIPTION
## The problem

The website https://safecurves.cr.yp.to/ say that the curve nistp256, and nistp384 is not secure. 

From some source, the NSA had backdoored Dual the curve NIST P-256.

## Solution

Remove all of theses curves

## PR Status

Not tested, but should work, with some other curves

## How to test

Just update your ssh config

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
