### PR TITLE
[enh] allow 'display_text' ~fake~ argument in manifest.json

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2202,6 +2202,11 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
         if arg_type == 'boolean':
             arg_default = 1 if arg_default else 0
 
+        # do not print for webadmin
+        if arg_type == 'display_text' and msettings.get('interface') != 'api':
+            print(arg["text"])
+            continue
+
         # Attempt to retrieve argument value
         if arg_name in args:
             arg_value = args[arg_name]


### PR DESCRIPTION
## The problem

A very simple idea I had since quite some time: allow to add a way in the argument list of an app to have an argument that simply display text and fetch no value as way to allow app packagers to display information for the user.

The usage is very simple, simply had this kind of argument in your manifest:

```json
            {
                "name": "some_text",
                "type": "display_text",
                "text": "This is some text that is going to be displayed.\n\nAnother line."
            },
```

## PR Status

Working. Need the equivalent for the admin UI once it's agreed on principle.

## How to test

Create an empty app and had this kind of argument to the manifest and had an empty shell script and run the installation.

Example:

![2019-03-04-031132_714x243_escrotum](https://user-images.githubusercontent.com/41827/53706562-4265e280-3e2b-11e9-8d4c-b4eaeac150cb.png)


## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
