### PR TITLE
[fix] Reject app password if they contains { or }

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -380,6 +380,7 @@
     "pattern_port_or_range": "Must be a valid port number (i.e. 0-65535) or range of ports (e.g. 100:200)",
     "pattern_positive_number": "Must be a positive number",
     "pattern_username": "Must be lower-case alphanumeric and underscore characters only",
+    "pattern_password_app": "Sorry, passwords should not contain the following characters: {forbidden_chars}",
     "port_already_closed": "Port {port:d} is already closed for {ip_version:s} connections",
     "port_already_opened": "Port {port:d} is already opened for {ip_version:s} connections",
     "port_available": "Port {port:d} is available",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2287,6 +2287,9 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
                 else:
                     raise YunohostError('app_argument_choice_invalid', name=arg_name, choices='yes, no, y, n, 1, 0')
         elif arg_type == 'password':
+            forbidden_chars = "{}"
+            if any(char in arg_value for char in forbidden_chars):
+                raise YunohostError('pattern_password_app', forbidden_chars=forbidden_chars)
             from yunohost.utils.password import assert_password_is_strong_enough
             assert_password_is_strong_enough('user', arg_value)
         args_dict[arg_name] = arg_value


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1319

## Solution

Reject app passwords that contain { or } ...

## PR Status

Tested and working

## How to test

Try to install for example lstu_ynh and put { or } in password

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
