### PR TITLE
[fix] Backup fails because output directory not empty

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -326,10 +326,19 @@ class BackupManager():
         if not os.path.isdir(self.work_dir):
             filesystem.mkdir(self.work_dir, 0o750, parents=True, uid='admin')
         elif self.is_tmp_work_dir:
-            logger.debug("temporary directory for backup '%s' already exists",
+
+            logger.debug("temporary directory for backup '%s' already exists... attempting to clean it",
                          self.work_dir)
-            # FIXME May be we should clean the workdir here
-            raise YunohostError('backup_output_directory_not_empty')
+
+            # Try to recursively unmount stuff (from a previously failed backup ?)
+            if _recursive_umount(self.work_dir) > 0:
+                raise YunohostError('backup_output_directory_not_empty')
+            else:
+                # If umount succeeded, remove the directory (we checked that
+                # we're in /home/yunohost.backup/tmp so that should be okay...
+                # c.f. method clean() which also does this)
+                filesystem.rm(self.work_dir, True, True)
+                filesystem.mkdir(self.work_dir, 0o750, parents=True, uid='admin')
 
     #
     # Backup target management                                              #
@@ -1514,33 +1523,11 @@ class BackupMethod(object):
                                   directories of the working directories
         """
         if self.need_mount():
-            if self._recursive_umount(self.work_dir) > 0:
+            if _recursive_umount(self.work_dir) > 0:
                 raise YunohostError('backup_cleaning_failed')
 
         if self.manager.is_tmp_work_dir:
             filesystem.rm(self.work_dir, True, True)
-
-    def _recursive_umount(self, directory):
-        """
-        Recursively umount sub directories of a directory
-
-        Args:
-            directory -- a directory path
-        """
-        mount_lines = subprocess.check_output("mount").split("\n")
-
-        points_to_umount = [line.split(" ")[2]
-                            for line in mount_lines
-                            if len(line) >= 3 and line.split(" ")[2].startswith(directory)]
-        ret = 0
-        for point in reversed(points_to_umount):
-            ret = subprocess.call(["umount", point])
-            if ret != 0:
-                ret = 1
-                logger.warning(m18n.n('backup_cleaning_failed', point))
-                continue
-
-        return ret
 
     def _check_is_enough_free_space(self):
         """
@@ -2011,6 +1998,7 @@ def backup_create(name=None, description=None, methods=[],
         # Check that output directory is empty
         if os.path.isdir(output_directory) and no_compress and \
                 os.listdir(output_directory):
+
             raise YunohostError('backup_output_directory_not_empty')
     elif no_compress:
         raise YunohostError('backup_output_directory_required')
@@ -2313,6 +2301,30 @@ def _call_for_each_path(self, callback, csv_path=None):
         backup_csv = csv.DictReader(backup_file, fieldnames=['source', 'dest'])
         for row in backup_csv:
             callback(self, row['source'], row['dest'])
+
+
+def _recursive_umount(directory):
+    """
+    Recursively umount sub directories of a directory
+
+    Args:
+        directory -- a directory path
+    """
+    mount_lines = subprocess.check_output("mount").split("\n")
+
+    points_to_umount = [line.split(" ")[2]
+                        for line in mount_lines
+                        if len(line) >= 3 and line.split(" ")[2].startswith(directory)]
+
+    ret = 0
+    for point in reversed(points_to_umount):
+        ret = subprocess.call(["umount", point])
+        if ret != 0:
+            ret = 1
+            logger.warning(m18n.n('backup_cleaning_failed', point))
+            continue
+
+    return ret
 
 
 def free_space_in_directory(dirpath):

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -337,7 +337,7 @@ class BackupManager():
                 # If umount succeeded, remove the directory (we checked that
                 # we're in /home/yunohost.backup/tmp so that should be okay...
                 # c.f. method clean() which also does this)
-                filesystem.rm(self.work_dir, True, True)
+                filesystem.rm(self.work_dir, recursive=True, force=True)
                 filesystem.mkdir(self.work_dir, 0o750, parents=True, uid='admin')
 
     #
@@ -913,7 +913,7 @@ class RestoreManager():
             ret = subprocess.call(["umount", self.work_dir])
             if ret != 0:
                 logger.warning(m18n.n('restore_cleaning_failed'))
-        filesystem.rm(self.work_dir, True, True)
+        filesystem.rm(self.work_dir, recursive=True, force=True)
 
     #
     # Restore target manangement                                            #

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -331,7 +331,7 @@ class BackupManager():
                          self.work_dir)
 
             # Try to recursively unmount stuff (from a previously failed backup ?)
-            if _recursive_umount(self.work_dir) > 0:
+            if not _recursive_umount(self.work_dir):
                 raise YunohostError('backup_output_directory_not_empty')
             else:
                 # If umount succeeded, remove the directory (we checked that
@@ -1523,7 +1523,7 @@ class BackupMethod(object):
                                   directories of the working directories
         """
         if self.need_mount():
-            if _recursive_umount(self.work_dir) > 0:
+            if not _recursive_umount(self.work_dir):
                 raise YunohostError('backup_cleaning_failed')
 
         if self.manager.is_tmp_work_dir:
@@ -2316,15 +2316,15 @@ def _recursive_umount(directory):
                         for line in mount_lines
                         if len(line) >= 3 and line.split(" ")[2].startswith(directory)]
 
-    ret = 0
+    everything_went_fine = True
     for point in reversed(points_to_umount):
         ret = subprocess.call(["umount", point])
         if ret != 0:
-            ret = 1
+            everything_went_fine = False
             logger.warning(m18n.n('backup_cleaning_failed', point))
             continue
 
-    return ret
+    return everything_went_fine
 
 
 def free_space_in_directory(dirpath):

--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -571,7 +571,7 @@ def test_backup_binds_are_readonly(monkeypatch):
 
         assert "Read-only file system" in output
 
-        if self._recursive_umount(self.work_dir) > 0:
+        if not _recursive_umount(self.work_dir):
             raise Exception("Backup cleaning failed !")
 
         self.clean()

--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -10,7 +10,7 @@ from moulinette import m18n
 from moulinette.core import init_authenticator
 from yunohost.app import app_install, app_remove, app_ssowatconf
 from yunohost.app import _is_installed
-from yunohost.backup import backup_create, backup_restore, backup_list, backup_info, backup_delete
+from yunohost.backup import backup_create, backup_restore, backup_list, backup_info, backup_delete, _recursive_umount
 from yunohost.domain import _get_maindomain
 from yunohost.utils.error import YunohostError
 


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1308 which sometime breaks upgrade for silly reasons

## Solution

Implement the 'FIXME' by attempting to unmount / clean the directory.

While fixing this, I realized that the function `_recursive_umount` probably had a buggy behavior / return value ... Dunno if that explains why the original issue happened in the first place, but could be related.

## PR Status

Tested and works okay

## How to test

```bash
# Initialize dummy file
mkdir /var/toto
echo "toto" > /var/toto/toto

# Initialize dummy tmp directory
cd /home/yunohost.backup/tmp
mkdir yoloswag; cd yoloswag

# Mount dummy stuff in the tmp directory
mkdir toto
mount -o ro,bind /var/toto ./toto

# Try to create a backup
cd
yunohost backup create -n yoloswag --debug
```

Should see in the debug output (at the beginning) that it complains the directory ain't empty and attempts to clean it

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
