### PR TITLE
Fix backup tests

### DIFF
--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -42,7 +42,7 @@ def setup_function(function):
 
     assert len(backup_list()["archives"]) == 0
 
-    markers = function.__dict__.keys()
+    markers = [m.name for m in function.__dict__.get("pytestmark",[])]
 
     if "with_wordpress_archive_from_2p4" in markers:
         add_archive_wordpress_from_2p4()
@@ -82,7 +82,7 @@ def teardown_function(function):
     delete_all_backups()
     uninstall_test_apps_if_needed()
 
-    markers = function.__dict__.keys()
+    markers = [m.name for m in function.__dict__.get("pytestmark",[])]
 
     if "clean_opt_dir" in markers:
         shutil.rmtree("/opt/test_backup_output_directory")


### PR DESCRIPTION
## The problem

Backup tests failed for two different reason ...
- a weird edge case about link creation during the backup ... files were actually on different device but there seem to be no way to detect this ... I suspect this is because of running on a weird LXC setup with encrypted hard drive inside some /dev/mapper stuff such that the real "logical" (?) devices are hidden ...
- some changes in the pytest version or idk, such that the way to access function / tests markers broke

## Solution

Fix those

## PR Status

Tested on my machine

## How to test

Run the backup/restore tests

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
