### PR TITLE
[fix] Disable gzip entirely

### DIFF
--- a/data/templates/nginx/plain/global.conf
+++ b/data/templates/nginx/plain/global.conf
@@ -1,2 +1,2 @@
 server_tokens off;
-gzip_types text/css text/javascript application/javascript;
+gzip off;


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1315

And in particular : 

The reason is that, currently, **text/html is always included in the
gzipped MIME types whatever you do** [1, 2]:

    Syntax: gzip_types mime-type ...;
    [...]
    Enables gzipping of responses for the specified MIME types
    in addition to “text/html”.


## Solution

Disable gzip entirely to protect against BREACH

## PR Status

Not tested but this is a simple change, should be working ...

## How to test

Uh I guess go on a webpage and check the headers or something

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
