### PR TITLE
[fix] ynh_app_setting_get and ynh_app_setting_delete don't have a fou…

### DIFF
--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -60,7 +60,7 @@ ynh_app_setting_delete() {
 #
 ynh_app_setting()
 {
-    ACTION="$1" APP="$2" KEY="$3" VALUE="$4" python - <<EOF
+    ACTION="$1" APP="$2" KEY="$3" VALUE="${4:-}" python - <<EOF
 import os, yaml
 app, action = os.environ['APP'], os.environ['ACTION'].lower()
 key, value = os.environ['KEY'], os.environ.get('VALUE', None)


### PR DESCRIPTION
## The problem

ynh_app_setting_get and ynh_app_setting_delete don't have a fourth argument.
/usr/share/yunohost/helpers.d/setting: line 63: $4: unbound variable

## Solution

Init $4 with a blank value if unset.

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
