### PR TITLE
[enh] bash completion for yunohost cli

### DIFF
--- a/data/actionsmap/yunohost_completion.py
+++ b/data/actionsmap/yunohost_completion.py
@@ -1,0 +1,84 @@
+"""
+Simple automated generation of a bash_completion file
+for yunohost command from the actionsmap.
+
+Generates a bash completion file assuming the structure
+`yunohost domain action`
+adds `--help` at the end if one presses [tab] again.
+
+author: Christophe Vuillot
+"""
+import yaml
+
+ACTIONSMAP_FILE = 'yunohost.yml'
+BASH_COMPLETION_FILE = '../bash-completion.d/yunohost_completion'
+
+with open(ACTIONSMAP_FILE, 'r') as stream:
+
+    # Getting the dictionary containning what actions are possible per domain
+    OPTION_TREE = yaml.load(stream)
+    DOMAINS = [str for str in OPTION_TREE.keys() if not str.startswith('_')]
+    DOMAINS_STR = '"{}"'.format(' '.join(DOMAINS))
+    ACTIONS_DICT = {}
+    for domain in DOMAINS:
+        ACTIONS = [str for str in OPTION_TREE[domain]['actions'].keys()
+                   if not str.startswith('_')]
+        ACTIONS_STR = '"{}"'.format(' '.join(ACTIONS))
+        ACTIONS_DICT[domain] = ACTIONS_STR
+
+    with open(BASH_COMPLETION_FILE, 'w') as generated_file:
+
+        # header of the file
+        generated_file.write('#\n')
+        generated_file.write('# completion for yunohost\n')
+        generated_file.write('# automatically generated from the actionsmap\n')
+        generated_file.write('#\n\n')
+
+        # Start of the completion function
+        generated_file.write('_yunohost_completion()\n')
+        generated_file.write('{\n')
+
+        # Defining local variable for previously and currently typed words
+        generated_file.write('\tlocal cur prev opts narg\n')
+        generated_file.write('\tCOMPREPLY=()\n\n')
+        generated_file.write('\t# the number of words already typed\n')
+        generated_file.write('\tnarg=${#COMP_WORDS[@]}\n\n')
+        generated_file.write('\t# the current word being typed\n')
+        generated_file.write('\tcur="${COMP_WORDS[COMP_CWORD]}"\n\n')
+        generated_file.write('\t# the last typed word\n')
+        generated_file.write('\tprev="${COMP_WORDS[COMP_CWORD-1]}"\n\n')
+
+        # If one is currently typing a domain then match with the domain list
+        generated_file.write('\t# If one is currently typing a domain,\n')
+        generated_file.write('\t# match with domains\n')
+        generated_file.write('\tif [[ $narg == 2 ]]; then\n')
+        generated_file.write('\t\topts={}\n'.format(DOMAINS_STR))
+        generated_file.write('\tfi\n\n')
+
+        # If one is currently typing an action then match with the action list
+        # of the previously typed domain
+        generated_file.write('\t# If one already typed a domain,\n')
+        generated_file.write('\t# match the actions of that domain\n')
+        generated_file.write('\tif [[ $narg == 3 ]]; then\n')
+        for domain in DOMAINS:
+            generated_file.write('\t\tif [[ $prev == "{}" ]]; then\n'.format(domain))
+            generated_file.write('\t\t\topts={}\n'.format(ACTIONS_DICT[domain]))
+            generated_file.write('\t\tfi\n')
+        generated_file.write('\tfi\n\n')
+
+        # If both domain and action have been typed or the domain
+        # was not recognized propose --help (only once)
+        generated_file.write('\t# If no options were found propose --help\n')
+        generated_file.write('\tif [ -z "$opts" ]; then\n')
+        generated_file.write('\t\tif [[ $prev != "--help" ]]; then\n')
+        generated_file.write('\t\t\topts=( --help )\n')
+        generated_file.write('\t\tfi\n')
+        generated_file.write('\tfi\n')
+
+        # generate the completion list from the possible options
+        generated_file.write('\tCOMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )\n')
+        generated_file.write('\treturn 0\n')
+        generated_file.write('}\n\n')
+
+        # Add the function to bash completion
+        generated_file.write('complete -F _yunohost_completion yunohost')

--- a/data/bash-completion.d/yunohost_completion
+++ b/data/bash-completion.d/yunohost_completion
@@ -1,0 +1,74 @@
+#
+# completion for yunohost
+# automatically generated from the actionsmap
+#
+
+_yunohost_completion()
+{
+	local cur prev opts narg
+	COMPREPLY=()
+
+	# the number of words already typed
+	narg=${#COMP_WORDS[@]}
+
+	# the current word being typed
+	cur="${COMP_WORDS[COMP_CWORD]}"
+
+	# the last typed word
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+	# If one is currently typing a domain,
+	# match with domains
+	if [[ $narg == 2 ]]; then
+		opts="domain monitor service settings firewall backup app hook dyndns tools user"
+	fi
+
+	# If one already typed a domain,
+	# match the actions of that domain
+	if [[ $narg == 3 ]]; then
+		if [[ $prev == "domain" ]]; then
+			opts="cert-install cert-status list remove url-available add dns-conf cert-renew"
+		fi
+		if [[ $prev == "monitor" ]]; then
+			opts="enable network show-stats update-stats disk system disable"
+		fi
+		if [[ $prev == "service" ]]; then
+			opts="status enable regen-conf log stop remove start add disable"
+		fi
+		if [[ $prev == "settings" ]]; then
+			opts="reset set list reset-all get"
+		fi
+		if [[ $prev == "firewall" ]]; then
+			opts="reload allow stop list upnp disallow"
+		fi
+		if [[ $prev == "backup" ]]; then
+			opts="info restore create list delete"
+		fi
+		if [[ $prev == "app" ]]; then
+			opts="map checkurl install makedefault checkport listlists change-url removelist info change-label upgrade fetchlist clearaccess ssowatconf list remove register-url removeaccess setting initdb debug addaccess"
+		fi
+		if [[ $prev == "hook" ]]; then
+			opts="info callback add exec list remove"
+		fi
+		if [[ $prev == "dyndns" ]]; then
+			opts="subscribe update installcron removecron"
+		fi
+		if [[ $prev == "tools" ]]; then
+			opts="upgrade ldapinit postinstall maindomain update reboot shell adminpw shutdown diagnosis port-available"
+		fi
+		if [[ $prev == "user" ]]; then
+			opts="info create list update delete"
+		fi
+	fi
+
+	# If no options were found propose --help
+	if [ -z "$opts" ]; then
+		if [[ $prev != "--help" ]]; then
+			opts=( --help )
+		fi
+	fi
+	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+	return 0
+}
+
+complete -F _yunohost_completion yunohost


### PR DESCRIPTION
Added a python script (yunohost_completion.py) which generates a bash completion file for the yunohost command based on yunohost.yml, in data/actionsmap

Added the output of the script in data/bash-completion.d/yunohost_completion

This is probably not the correct place for the script and the generation should
be done at some other time and place also.

## The problem
missing bash completion for yunohost command

## Solution
a python script which generates the file from yunohost.yml

## PR Status
[WIP]

## How to test
At least test that the generated file is syntactically correct ?

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
