### PR TITLE
[fix] Delete properly group as well as user

### DIFF
--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -145,7 +145,5 @@ ynh_system_user_delete () {
     then
 		echo "Remove the group $username" >&2
 		delgroup $username
-	else
-		echo "The group $username was not found" >&2
     fi
 }

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -63,6 +63,21 @@ ynh_system_user_exists() {
     getent passwd "$username" &>/dev/null
 }
 
+# Check if a group exists on the system
+#
+# usage: ynh_system_group_exists --group=group
+# | arg: -g, --group - the group to check
+ynh_system_group_exists() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=g
+    declare -Ar args_array=( [g]=group= )
+    local group
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+
+    getent group "$group" &>/dev/null
+}
+
 # Create a system user
 #
 # examples:
@@ -116,11 +131,21 @@ ynh_system_user_delete () {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    if ynh_system_user_exists "$username"	# Check if the user exists on the system
+    # Check if the user exists on the system
+    if ynh_system_user_exists "$username"
     then
 		echo "Remove the user $username" >&2
-		sudo userdel $username
+		deluser $username
 	else
 		echo "The user $username was not found" >&2
+    fi
+
+    # Check if the group exists on the system
+    if ynh_system_group_exists "$username"
+    then
+		echo "Remove the group $username" >&2
+		delgroup $username
+	else
+		echo "The group $username was not found" >&2
     fi
 }


### PR DESCRIPTION
## The problem

https://github.com/YunoHost-Apps/wordpress_ynh/issues/57
That's not the first time we have this problem, a group isn't deleted because there's other users in that group.

## Solution

`delgroup` will remove a group, even if not empty. Also, having it's own condition, running the helper will remove the group even if the user doesn't exist anymore.

## PR Status

~Need to be tested...~ Tested.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 