### PR TITLE
Escape $ in getopts

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -203,7 +203,7 @@ ynh_handle_getopts_args () {
 				# Escape double quote to prevent any interpretation during the eval
 				arguments[$i]="${arguments[$i]//\"/\\\"}"
 				# Escape $ as well to prevent the string following it to be seen as a variable.
-				all_args[$i]="${all_args[$i]//$/\\\$}"
+				arguments[$i]="${arguments[$i]//$/\\\$}"
 
 				# Store each value given as argument in the corresponding variable
 				# The values will be stored in the same order than $args_array

--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -152,6 +152,8 @@ ynh_handle_getopts_args () {
 								fi
 								# Escape double quote to prevent any interpretation during the eval
 								all_args[$i]="${all_args[$i]//\"/\\\"}"
+								# Escape $ as well to prevent the string following it to be seen as a variable.
+								all_args[$i]="${all_args[$i]//$/\\\$}"
 
 								eval ${option_var}+=\"${all_args[$i]}\"
 								shift_value=$(( shift_value + 1 ))
@@ -193,6 +195,8 @@ ynh_handle_getopts_args () {
 
 				# Escape double quote to prevent any interpretation during the eval
 				arguments[$i]="${arguments[$i]//\"/\\\"}"
+				# Escape $ as well to prevent the string following it to be seen as a variable.
+				all_args[$i]="${all_args[$i]//$/\\\$}"
 
 				# Store each value given as argument in the corresponding variable
 				# The values will be stored in the same order than $args_array

--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -155,6 +155,13 @@ ynh_handle_getopts_args () {
 								# Escape $ as well to prevent the string following it to be seen as a variable.
 								all_args[$i]="${all_args[$i]//$/\\\$}"
 
+								# For the record.
+								# We're using eval here to get the content of the variable stored itself as simple text in $option_var...
+								# Other ways to get that content would be to use either ${!option_var} or declare -g ${option_var}
+								# But... ${!option_var} can't be used as left part of an assignation.
+								# declare -g ${option_var} will create a local variable (despite -g !) and will not be available for the helper itself.
+								# So... Stop fucking arguing each time that eval is evil... Go find an other working solution if you can find one!
+
 								eval ${option_var}+=\"${all_args[$i]}\"
 								shift_value=$(( shift_value + 1 ))
 							fi


### PR DESCRIPTION
## The problem

As found by JimboJoe here, https://github.com/YunoHost/yunohost/pull/646#issuecomment-473448470, $ have to be escaped as well as double quotes.

## Solution

## PR Status

Ready to be review

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 