### PR TITLE
Avoid having to shell-escape arguments in ynh_handle_getopts_args

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -152,19 +152,8 @@ ynh_handle_getopts_args () {
 									# If there's already another value for this option, add a ; before adding the new value
 									eval ${option_var}+="\;"
 								fi
-								# Escape double quote to prevent any interpretation during the eval
-								all_args[$i]="${all_args[$i]//\"/\\\"}"
-								# Escape $ as well to prevent the string following it to be seen as a variable.
-								all_args[$i]="${all_args[$i]//$/\\\$}"
 
-								# For the record.
-								# We're using eval here to get the content of the variable stored itself as simple text in $option_var...
-								# Other ways to get that content would be to use either ${!option_var} or declare -g ${option_var}
-								# But... ${!option_var} can't be used as left part of an assignation.
-								# declare -g ${option_var} will create a local variable (despite -g !) and will not be available for the helper itself.
-								# So... Stop fucking arguing each time that eval is evil... Go find an other working solution if you can find one!
-
-								eval ${option_var}+=\"${all_args[$i]}\"
+								eval ${option_var}+='"${all_args[$i]}"'
 								shift_value=$(( shift_value + 1 ))
 							fi
 						done
@@ -202,14 +191,7 @@ ynh_handle_getopts_args () {
 				# The variable name will be stored in 'option_var'
 				local option_var="${args_array[$option_flag]%=}"
 
-				# Escape double quote to prevent any interpretation during the eval
-				arguments[$i]="${arguments[$i]//\"/\\\"}"
-				# Escape $ as well to prevent the string following it to be seen as a variable.
-				arguments[$i]="${arguments[$i]//$/\\\$}"
-
-				# Store each value given as argument in the corresponding variable
-				# The values will be stored in the same order than $args_array
-				eval ${option_var}+=\"${arguments[$i]}\"
+				eval ${option_var}+='"${arguments[$i]}"'
 			done
 			unset legacy_args
 		else

--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -153,6 +153,13 @@ ynh_handle_getopts_args () {
 									eval ${option_var}+="\;"
 								fi
 
+								# For the record.
+								# We're using eval here to get the content of the variable stored itself as simple text in $option_var...
+								# Other ways to get that content would be to use either ${!option_var} or declare -g ${option_var}
+								# But... ${!option_var} can't be used as left part of an assignation.
+								# declare -g ${option_var} will create a local variable (despite -g !) and will not be available for the helper itself.
+								# So... Stop fucking arguing each time that eval is evil... Go find an other working solution if you can find one!
+
 								eval ${option_var}+='"${all_args[$i]}"'
 								shift_value=$(( shift_value + 1 ))
 							fi
@@ -191,6 +198,8 @@ ynh_handle_getopts_args () {
 				# The variable name will be stored in 'option_var'
 				local option_var="${args_array[$option_flag]%=}"
 
+				# Store each value given as argument in the corresponding variable
+				# The values will be stored in the same order than $args_array
 				eval ${option_var}+='"${arguments[$i]}"'
 			done
 			unset legacy_args


### PR DESCRIPTION
## The problem

Shell characters are not all escaped in `eval` call.

## Solution

Escape shell metacharacters with a dedicated function.

Alternative to #683.

## PR Status

...

## How to test

```sh
#!/bin/sh

. ./getopts

function my_helper()
{
    declare -Ar args_array=( [a]=arg1= [b]=arg2= [c]=arg3 )
    local arg1
    local arg2
    local arg3
    ynh_handle_getopts_args "$@"

    echo "Inner"
    echo arg1=$arg1
    echo arg2=$arg2
    echo arg2=$arg3
    echo
}

my_helper --arg1 '$toto`ls`' -b "'" -c
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
