### PR TITLE
[enh] Mark YunoHost as essential to avoid removing it inadvertenly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,7 @@
 Source: yunohost
 Section: utils
 Priority: extra
+Essential: yes
 Maintainer: YunoHost Contributors <contrib@yunohost.org>
 Build-Depends: debhelper (>=9), dh-systemd, dh-python, python-all (>= 2.7)
 Standards-Version: 3.9.6

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,6 @@
 Source: yunohost
 Section: utils
 Priority: extra
-Essential: yes
 Maintainer: YunoHost Contributors <contrib@yunohost.org>
 Build-Depends: debhelper (>=9), dh-systemd, dh-python, python-all (>= 2.7)
 Standards-Version: 3.9.6
@@ -9,6 +8,7 @@ X-Python-Version: >= 2.7
 Homepage: https://yunohost.org/
 
 Package: yunohost
+Essential: yes
 Architecture: all
 Depends: ${python:Depends}, ${misc:Depends}
  , moulinette (>= 2.7.1), ssowat (>= 2.7.1)


### PR DESCRIPTION
## The problem

Users might remove YunoHost inadvertenly ... c.f. some cases on the forum

## Solution

I randomly came accross this option in debian packages which allow to mark some package as essential - which is different from "held" package in that you can upgrade the package but not remove it.

For example, try to remove `bash` and it will complain : 

```
The following packages will be REMOVED:
  bash bash-completion
WARNING: The following essential packages will be removed.
This should NOT be done unless you know exactly what you are doing!
  bash
0 upgraded, 0 newly installed, 2 to remove and 0 not upgraded.
After this operation, 7,186 kB disk space will be freed.
You are about to do something potentially harmful.
To continue type in the phrase 'Yes, do as I say!'
 ?]
```

## PR Status

Not tested, just doing this quick PR before I forget about it ...

## How to test

Install YunoHost will this option enabled in the package somehow

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
