### PR TITLE
[enh] Propose a setting to remove support for TLSv1 and TLSv1.1 in Postfix

### DIFF
--- a/data/hooks/conf_regen/19-postfix
+++ b/data/hooks/conf_regen/19-postfix
@@ -2,6 +2,8 @@
 
 set -e
 
+. /usr/share/yunohost/helpers
+
 do_pre_regen() {
   pending_dir=$1
 
@@ -20,9 +22,12 @@ do_pre_regen() {
   main_domain=$(cat /etc/yunohost/current_host)
   domain_list=$(sudo yunohost domain list --output-as plain --quiet | tr '\n' ' ')
 
-  cat main.cf \
-    | sed "s/{{ main_domain }}/${main_domain}/g" \
-    > "${postfix_dir}/main.cf"
+  # Support different strategy for security configurations
+  export compatibility="$(yunohost settings get 'security.postfix.compatibility')"
+
+  export main_domain
+  export domain_list
+  ynh_render_template "main.cf" "${postfix_dir}/main.cf"
 
   cat postsrsd \
     | sed "s/{{ main_domain }}/${main_domain}/g" \

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -33,7 +33,11 @@ smtpd_tls_key_file = /etc/yunohost/certs/{{ main_domain }}/key.pem
 smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH, RC4, 3DES
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_loglevel=1
+{% if compatibility == "intermediate" %}
 smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
+{% else %}
+smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3,!TLSv1,!TLSv1.1
+{% endif %}
 smtpd_tls_mandatory_ciphers=high
 smtpd_tls_eecdh_grade = ultra
 
@@ -58,7 +62,7 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 mydomain = {{ main_domain }}
 mydestination = localhost
-relayhost = 
+relayhost =
 mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
 mailbox_command = procmail -a "$EXTENSION"
 mailbox_size_limit = 0
@@ -68,71 +72,71 @@ inet_interfaces = all
 #### Fit to the maximum message size to 30mb, more than allowed by GMail or Yahoo ####
 message_size_limit = 31457280
 
-# Virtual Domains Control 
-virtual_mailbox_domains = ldap:/etc/postfix/ldap-domains.cf 
-virtual_mailbox_maps = ldap:/etc/postfix/ldap-accounts.cf 
-virtual_mailbox_base = 
-virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf 
-virtual_alias_domains = 
-virtual_minimum_uid = 100 
-virtual_uid_maps = static:vmail 
+# Virtual Domains Control
+virtual_mailbox_domains = ldap:/etc/postfix/ldap-domains.cf
+virtual_mailbox_maps = ldap:/etc/postfix/ldap-accounts.cf
+virtual_mailbox_base =
+virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf
+virtual_alias_domains =
+virtual_minimum_uid = 100
+virtual_uid_maps = static:vmail
 virtual_gid_maps = static:mail
 smtpd_sender_login_maps= ldap:/etc/postfix/ldap-accounts.cf
 
-# Dovecot LDA 
-virtual_transport = dovecot 
+# Dovecot LDA
+virtual_transport = dovecot
 dovecot_destination_recipient_limit = 1
 
-# Enable SASL authentication for the smtpd daemon 
-smtpd_sasl_auth_enable = yes 
-smtpd_sasl_type = dovecot 
-smtpd_sasl_path = private/auth 
-# Fix some outlook's bugs 
-broken_sasl_auth_clients = yes 
-# Reject anonymous connections 
-smtpd_sasl_security_options = noanonymous 
+# Enable SASL authentication for the smtpd daemon
+smtpd_sasl_auth_enable = yes
+smtpd_sasl_type = dovecot
+smtpd_sasl_path = private/auth
+# Fix some outlook's bugs
+broken_sasl_auth_clients = yes
+# Reject anonymous connections
+smtpd_sasl_security_options = noanonymous
 smtpd_sasl_local_domain =
 
 
-# Wait until the RCPT TO command before evaluating restrictions 
-smtpd_delay_reject = yes 
- 
-# Basics Restrictions 
-smtpd_helo_required = yes 
-strict_rfc821_envelopes = yes 
- 
-# Requirements for the connecting server 
-smtpd_client_restrictions = 
-    permit_mynetworks, 
-    permit_sasl_authenticated, 
-    reject_rbl_client bl.spamcop.net, 
-    reject_rbl_client cbl.abuseat.org, 
-    reject_rbl_client zen.spamhaus.org, 
-    permit 
- 
-# Requirements for the HELO statement 
-smtpd_helo_restrictions = 
-    permit_mynetworks, 
-    permit_sasl_authenticated, 
-    reject_non_fqdn_hostname, 
-    reject_invalid_hostname, 
-    permit 
- 
-# Requirements for the sender address 
+# Wait until the RCPT TO command before evaluating restrictions
+smtpd_delay_reject = yes
+
+# Basics Restrictions
+smtpd_helo_required = yes
+strict_rfc821_envelopes = yes
+
+# Requirements for the connecting server
+smtpd_client_restrictions =
+    permit_mynetworks,
+    permit_sasl_authenticated,
+    reject_rbl_client bl.spamcop.net,
+    reject_rbl_client cbl.abuseat.org,
+    reject_rbl_client zen.spamhaus.org,
+    permit
+
+# Requirements for the HELO statement
+smtpd_helo_restrictions =
+    permit_mynetworks,
+    permit_sasl_authenticated,
+    reject_non_fqdn_hostname,
+    reject_invalid_hostname,
+    permit
+
+# Requirements for the sender address
 smtpd_sender_restrictions =
-    reject_sender_login_mismatch, 
-    permit_mynetworks, 
-    permit_sasl_authenticated, 
-    reject_non_fqdn_sender, 
+    reject_sender_login_mismatch,
+    permit_mynetworks,
+    permit_sasl_authenticated,
+    reject_non_fqdn_sender,
     reject_unknown_sender_domain,
-    permit 
- 
-# Requirement for the recipient address 
-smtpd_recipient_restrictions = 
-    permit_mynetworks, 
-    permit_sasl_authenticated, 
-    reject_non_fqdn_recipient, 
-    reject_unknown_recipient_domain, 
+    permit
+
+# Requirement for the recipient address
+smtpd_recipient_restrictions =
+    permit_mynetworks,
+    permit_sasl_authenticated,
+    reject_non_fqdn_recipient,
+    reject_unknown_recipient_domain,
     reject_unauth_destination,
     permit
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -215,6 +215,7 @@
     "global_settings_setting_security_password_admin_strength": "Admin password strength",
     "global_settings_setting_security_password_user_strength": "User password strength",
     "global_settings_setting_security_ssh_compatibility": "Compatibility vs. security tradeoff for the SSH server. Affects the ciphers (and other security-related aspects)",
+    "global_settings_setting_security_postfix_compatibility": "Compatibility vs. security tradeoff for the Postfix server. Affects the ciphers (and other security-related aspects)",
     "global_settings_unknown_setting_from_settings_file": "Unknown key in settings: '{setting_key:s}', discarding it and save it in /etc/yunohost/settings-unknown.json",
     "global_settings_setting_service_ssh_allow_deprecated_dsa_hostkey": "Allow the use of (deprecated) DSA hostkey for the SSH daemon configuration",
     "global_settings_unknown_type": "Unexpected situation, the setting {setting:s} appears to have the type {unknown_type:s} but it's not a type supported by the system.",

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -44,6 +44,8 @@ DEFAULTS = OrderedDict([
         "choices": ["intermediate", "modern"]}),
     ("security.nginx.compatibility", {"type": "enum", "default": "intermediate",
         "choices": ["intermediate", "modern"]}),
+    ("security.postfix.compatibility", {"type": "enum", "default": "intermediate",
+        "choices": ["intermediate", "modern"]}),
 ])
 
 
@@ -292,3 +294,8 @@ def reconfigure_nginx(setting_name, old_value, new_value):
 def reconfigure_ssh(setting_name, old_value, new_value):
     if old_value != new_value:
         service_regen_conf(names=['ssh'])
+
+@post_change_hook("security.postfix.compatibility")
+def reconfigure_ssh(setting_name, old_value, new_value):
+    if old_value != new_value:
+        service_regen_conf(names=['postfix'])


### PR DESCRIPTION
## The problem

TLSv1 and TLSV1.1 are unsecure protocols.

## Solution

Remove support for TLSv1 and TLSv1.1 from postfix config

## PR Status



## How to test

````
yunohost settings set security.postfix.compatibility -v modern
````

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
