### PR TITLE
[mod] use ask key for display_text instead and support i18n

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2204,7 +2204,7 @@ def _parse_action_args_in_yunohost_format(args, action_args, auth=None):
 
         # do not print for webadmin
         if arg_type == 'display_text' and msettings.get('interface') != 'api':
-            print(arg["text"])
+            print(_value_for_locale(arg['ask']))
             continue
 
         # Attempt to retrieve argument value


### PR DESCRIPTION
## The problem

While working on the admin integration I realized that uniformizing the behavior with other key and using "ask" instead of "text" was way simpler for the whole code (despite not making that much sens for "display_text" field) and annex tool (i18n integration for example).

I also added i18n support.

## PR Status

Ready to merge.

## How to test

Use this app and try to install it https://github.com/Psycojoker/display_text_ynh

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
