### PR TITLE
[fix] Nodejs helpers : use YNH_APP_INSTANCE_NAME instead of YNH_APP_ID

### DIFF
--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -123,7 +123,7 @@ ynh_install_nodejs () {
 	fi
 
 	# Store the ID of this app and the version of node requested for it
-	echo "$YNH_APP_ID:$nodejs_version" | tee --append "$n_install_dir/ynh_app_version"
+	echo "$YNH_APP_INSTANCE_NAME:$nodejs_version" | tee --append "$n_install_dir/ynh_app_version"
 
 	# Store nodejs_version into the config of this app
 	ynh_app_setting_set --app=$app --key=nodejs_version --value=$nodejs_version
@@ -147,7 +147,7 @@ ynh_remove_nodejs () {
 	nodejs_version=$(ynh_app_setting_get --app=$app --key=nodejs_version)
 
 	# Remove the line for this app
-	sed --in-place "/$YNH_APP_ID:$nodejs_version/d" "$n_install_dir/ynh_app_version"
+	sed --in-place "/$YNH_APP_INSTANCE_NAME:$nodejs_version/d" "$n_install_dir/ynh_app_version"
 
 	# If no other app uses this version of nodejs, remove it.
 	if ! grep --quiet "$nodejs_version" "$n_install_dir/ynh_app_version"


### PR DESCRIPTION
## The problem

f you install two time the same application, when removing one of them, nodejs is uninstalled

## Solution

YNH_APP_INSTANCE_NAME instead of YNH_APP_ID

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
