### PR TITLE
Add support in restore script of ynh_setup_source

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -166,15 +166,22 @@ ynh_setup_source () {
     ynh_handle_getopts_args "$@"
     source_id="${source_id:-app}" # If the argument is not given, source_id equals "app"
 
+    local src_file_path="$YNH_CWD/../conf/${src_id}.src"
+    # In case of restore script the src file is in an other path.
+    # So try to use the restore path if the general path point to no file.
+    if [[ ! -e "$src_file_path" ]]; then
+        src_file_path="$YNH_CWD/../settings/conf/${src_id}.src"
+    fi
+
     # Load value from configuration file (see above for a small doc about this file
     # format)
-    local src_url=$(grep 'SOURCE_URL=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_sum=$(grep 'SOURCE_SUM=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_sumprg=$(grep 'SOURCE_SUM_PRG=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_format=$(grep 'SOURCE_FORMAT=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_extract=$(grep 'SOURCE_EXTRACT=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_in_subdir=$(grep 'SOURCE_IN_SUBDIR=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
-    local src_filename=$(grep 'SOURCE_FILENAME=' "$YNH_CWD/../conf/${source_id}.src" | cut -d= -f2-)
+    local src_url=$(grep 'SOURCE_URL=' "$src_file_path" | cut -d= -f2-)
+    local src_sum=$(grep 'SOURCE_SUM=' "$src_file_path" | cut -d= -f2-)
+    local src_sumprg=$(grep 'SOURCE_SUM_PRG=' "$src_file_path" | cut -d= -f2-)
+    local src_format=$(grep 'SOURCE_FORMAT=' "$src_file_path" | cut -d= -f2-)
+    local src_extract=$(grep 'SOURCE_EXTRACT=' "$src_file_path" | cut -d= -f2-)
+    local src_in_subdir=$(grep 'SOURCE_IN_SUBDIR=' "$src_file_path" | cut -d= -f2-)
+    local src_filename=$(grep 'SOURCE_FILENAME=' "$src_file_path" | cut -d= -f2-)
 
     # Default value
     src_sumprg=${src_sumprg:-sha256sum}

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -166,11 +166,11 @@ ynh_setup_source () {
     ynh_handle_getopts_args "$@"
     source_id="${source_id:-app}" # If the argument is not given, source_id equals "app"
 
-    local src_file_path="$YNH_CWD/../conf/${src_id}.src"
+    local src_file_path="$YNH_CWD/../conf/${source_id}.src"
     # In case of restore script the src file is in an other path.
     # So try to use the restore path if the general path point to no file.
     if [[ ! -e "$src_file_path" ]]; then
-        src_file_path="$YNH_CWD/../settings/conf/${src_id}.src"
+        src_file_path="$YNH_CWD/../settings/conf/${source_id}.src"
     fi
 
     # Load value from configuration file (see above for a small doc about this file

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -169,7 +169,7 @@ ynh_setup_source () {
     local src_file_path="$YNH_CWD/../conf/${source_id}.src"
     # In case of restore script the src file is in an other path.
     # So try to use the restore path if the general path point to no file.
-    if [[ ! -e "$src_file_path" ]]; then
+    if [ ! -e "$src_file_path" ]; then
         src_file_path="$YNH_CWD/../settings/conf/${source_id}.src"
     fi
 


### PR DESCRIPTION
## The problem

Actually the path to the app.src file in the helper ynh_setup_source work only in install and upgrade script.

## Solution

Add the support for restore script by adding a specific path if the general path is not available.

## PR Status

Tested work on monitorix.

## How to test

Use the helper in a restore script of an app.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
