### PR TITLE
[FIX] Hook backup warning message

### DIFF
--- a/data/hooks/backup/32-conf_cron
+++ b/data/hooks/backup/32-conf_cron
@@ -10,6 +10,6 @@ source /usr/share/yunohost/helpers
 backup_dir="${1}/conf/cron"
 
 # Backup the configuration
-for f in $(ls -1B /etc/cron.d/yunohost*); do
+for f in $(ls -1B /etc/cron.d/yunohost* 2> /dev/null); do
   ynh_backup "$f" "${backup_dir}/${f##*/}"
 done


### PR DESCRIPTION
## The problem

`Warning: yunohost.hook <lambda> - [965.1] ls: cannot access '/etc/cron.d/yunohost*': No such file or directory`

## Solution

Redirect stderr into /dev/null

## PR Status

Do a backup

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
