### PR TITLE
[enh] Bind OpenLDAP socket on localhost

### DIFF
--- a/data/templates/slapd/slapd.default
+++ b/data/templates/slapd/slapd.default
@@ -21,7 +21,7 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
-SLAPD_SERVICES="ldap:/// ldapi:///"
+SLAPD_SERVICES="ldap://127.0.0.1:389/ ldap://[::1]:389/ ldapi:///"
 
 # If SLAPD_NO_START is set, the init script will not start or restart
 # slapd (but stop will still work).  Uncomment this if you are


### PR DESCRIPTION
## The problem

OpenLDAP service open its socket on every network interfaces. This is not usefull as services are only connected to localhost.

## Solution

Change default OpenLDAP configuration to only bind on localhost.

## PR Status



## How to test

This command 
```
lsof -i :389 | grep LISTEN
```

should display binding on localhost only

```
slapd    3559 openldap    8u  IPv4 34292432      0t0  TCP localhost:ldap (LISTEN)
slapd    3559 openldap    9u  IPv6 34292433      0t0  TCP localhost:ldap (LISTEN)
```


## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
