### PR TITLE
[enh] Specify -a parameter on dovecot lda for Sieve

### DIFF
--- a/data/templates/postfix/plain/master.cf
+++ b/data/templates/postfix/plain/master.cf
@@ -122,6 +122,6 @@ mailman   unix  -       n       n       -       -       pipe
   flags=FR user=list argv=/usr/lib/mailman/bin/postfix-to-mailman.py
   ${nexthop} ${user}
 
-# Dovecot LDA 
-dovecot    unix  -       n       n       -       -       pipe 
-    flags=DRhu user=vmail:mail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${user}@${nexthop} -m ${extension}
+# Dovecot LDA
+dovecot    unix  -       n       n       -       -       pipe
+    flags=DRhu user=vmail:mail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${user}@${nexthop} -m ${extension} -a ${recipient}


### PR DESCRIPTION
## The problem

If you want to use Sieve filter with subaddress it doesn't work unless you change postfix lda configuration.

## Solution

This change in /etc/postfix/master.cf will fix the problem

```
-# Dovecot LDA
-dovecot    unix  -       n       n       -       -       pipe
-    flags=DRhu user=vmail:mail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${user}@${nexthop} -m ${extension}
+# Dovecot LDA
+dovecot    unix  -       n       n       -       -       pipe
+    flags=DRhu user=vmail:mail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${user}@${nexthop} -m ${extension} -a ${recipient}
```

## PR Status


## How to test

Update file /etc/postfix/master.cf to mirrot this line

```
dovecot    unix  -       n       n       -       -       pipe
    flags=DRhu user=vmail:mail argv=/usr/lib/dovecot/deliver -f ${sender} -d ${user}@${nexthop} -m ${extension} -a ${recipient}
```
Reload postfix
```
sudo postfix reload
```

Edit your sieve script to use subadress

```
require ["variables", "envelope", "fileinto", "subaddress"];

if envelope :is :user "to" "exploit" {
  if envelope :matches :detail "to" "*" {
    /* Save name in ${name} in all lowercase except for the first letter.
     * Joe, joe, jOe thus all become 'Joe'.
     */
    set :lower "name" "${1}";
  }

  if string :is "${name}" "" {
    /* Default case if no detail is specified */
    fileinto "INBOX";
  } else {
    /* For exploit+joe@ this will become exploit/joe */
    fileinto "exploit.${name}";
  }
}
```

Now send an email
```
mail -s "Check subaddress"
To: exploit+log@<your domain>
Cc:
Check mail in subfolder log !
```


## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [X] Simple test 1/1 : 
- [ ] Deep review 0/1 : 
