### PR TITLE
[fix] Fix extraction of weight value for ynh_script_progression

### DIFF
--- a/data/helpers.d/print
+++ b/data/helpers.d/print
@@ -223,9 +223,9 @@ ynh_script_progression () {
 	local weight_calls=$(grep --perl-regexp --count "^[^#]*ynh_script_progression.*(--weight|-w )" $0)
 
 	# Get the weight of each occurrences of 'ynh_script_progression' in the script using --weight
-	local weight_valuesA="$(grep --perl-regexp "^[^#]*ynh_script_progression.*--weight" $0 | sed 's/.*--weight[= ]\([[:digit:]].*\)/\1/g')"
-	# Get the weight of each occurrences of 'ynh_script_progression' in the script using -w
-	local weight_valuesB="$(grep --perl-regexp "^[^#]*ynh_script_progression.*-w " $0 | sed 's/.*-w[= ]\([[:digit:]].*\)/\1/g')"
+        local weight_valuesA="$(grep --perl-regexp "^[^#]*ynh_script_progression.*--weight" $0 | sed 's/.*--weight[= ]\([[:digit:]]*\).*/\1/g')"
+        # Get the weight of each occurrences of 'ynh_script_progression' in the script using -w
+        local weight_valuesB="$(grep --perl-regexp "^[^#]*ynh_script_progression.*-w " $0 | sed 's/.*-w[= ]\([[:digit:]]*\).*/\1/g')"
 	# Each value will be on a different line.
 	# Remove each 'end of line' and replace it by a '+' to sum the values.
 	local weight_values=$(( $(echo "$weight_valuesA" | tr '\n' '+') + $(echo "$weight_valuesB" | tr '\n' '+') 0 ))

--- a/data/helpers.d/print
+++ b/data/helpers.d/print
@@ -192,6 +192,7 @@ ynh_print_ON () {
 # | arg: -m, --message= - The text to print
 # | arg: -w, --weight=  - The weight for this progression. This value is 1 by default. Use a bigger value for a longer part of the script.
 # | arg: -t, --time=    - Print the execution time since the last call to this helper. Especially usefull to define weights.
+# The execution time is given for the duration since the previous call. So the weight should be applied to this previous call.
 # | arg: -l, --last=    - Use for the last call of the helper, to fill te progression bar.
 #
 # Requires YunoHost version 3.?.? or higher.


### PR DESCRIPTION
## The problem

The weight value will take everything after --weight=, especially --time or --last

## Solution

Fix the regex

## PR Status

Ready to be reviewed.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 