### PR TITLE
[enh] Add the current work to the progression bar

### DIFF
--- a/data/helpers.d/print
+++ b/data/helpers.d/print
@@ -243,8 +243,9 @@ ynh_script_progression () {
 
 	# Set the scale of the progression bar
 	local scale=20
-	# progress_string(1,2) should have the size of the scale.
-	local progress_string1="####################"
+	# progress_string(0,1,2) should have the size of the scale.
+	local progress_string2="####################"
+	local progress_string1="++++++++++++++++++++"
 	local progress_string0="...................."
 
 	# Reduce $increment_progression to the size of the scale
@@ -256,8 +257,13 @@ ynh_script_progression () {
 		local effective_progression=$scale
 	fi
 
-	# Build $progression_bar from progress_string(1,2) according to $effective_progression
-	local progression_bar="${progress_string1:0:$effective_progression}${progress_string0:0:$(( $scale - $effective_progression ))}"
+	# Build $progression_bar from progress_string(0,1,2) according to $effective_progression and the weight of the current task
+	# expected_progression is the progression expected after the current task
+	local expected_progression="$(( ( $increment_progression + $weight ) * $scale / $max_progression - $effective_progression ))"
+	# left_progression is the progression not yet done
+	local left_progression="$(( $scale - $effective_progression - $expected_progression ))"
+	# Build the progression bar with $effective_progression, work done, $expected_progression, current work and $left_progression, work to be done.
+	local progression_bar="${progress_string2:0:$effective_progression}${progress_string1:0:$expected_progression}${progress_string0:0:$left_progression}"
 
 	local print_exec_time=""
 	if [ $time -eq 1 ]

--- a/data/helpers.d/print
+++ b/data/helpers.d/print
@@ -260,6 +260,10 @@ ynh_script_progression () {
 	# Build $progression_bar from progress_string(0,1,2) according to $effective_progression and the weight of the current task
 	# expected_progression is the progression expected after the current task
 	local expected_progression="$(( ( $increment_progression + $weight ) * $scale / $max_progression - $effective_progression ))"
+	if [ $last -eq 1 ]
+	then
+		expected_progression=0
+	fi
 	# left_progression is the progression not yet done
 	local left_progression="$(( $scale - $effective_progression - $expected_progression ))"
 	# Build the progression bar with $effective_progression, work done, $expected_progression, current work and $left_progression, work to be done.


### PR DESCRIPTION
## The problem

I'd like to find a way to announce a long step during an app script, without having to say for all steps (it's going to be long !)
Also, watching the progression bar filling up, I thought it was too bad to know only after the job's done that it was actually a quick or a long step.

## Solution

Split the progression bar in 3 parts, work done, ongoing work, work not yet done.
A example with leed (which was my testing app).
```
Info: [+...................] > Validating installation parameters...
Info: [#+..................] > Storing installation settings...
Info: [##..................] > Creating a MySQL database...
Info: [##++................] > Setting up source files...
Info: [####+...............] > Configuring nginx web server...
Info: [#####+..............] > Configuring system user...
Info: [######+.............] > Configuring php-fpm...
Info: [#######+++..........] > Installing Leed with Curl...
Info: [##########+.........] > Setting up a cron file...
Info: [###########+++++....] > Configuring fail2ban...
Info: [################+...] > Configuring SSOwat...
Info: [#################+..] > Reloading nginx web server...
Info: [####################] > Installation of leed completed
```

## PR Status

Ready to be reviewed.
Tested with success on leed.

## How to test

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 