### PR TITLE
Add a --with-details option for log list

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1802,6 +1802,10 @@ log:
                     full: --limit
                     help: Maximum number of logs
                     type: int
+                -d:
+                    full: --with-details
+                    help: Show additional infos (e.g. operation success) but may significantly increase command time. Consider using --limit in combination with this.
+                    action: store_true
 
         ### log_display()
         display:

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -47,12 +47,13 @@ RELATED_CATEGORIES = ['app', 'domain', 'service', 'user']
 logger = getActionLogger('yunohost.log')
 
 
-def log_list(category=[], limit=None):
+def log_list(category=[], limit=None, with_details=False):
     """
     List available logs
 
     Keyword argument:
         limit -- Maximum number of logs
+        with_details -- Include details (e.g. if the operation was a success). Likely to increase the command time as it needs to open and parse the metadata file for each log... So try to use this in combination with --limit.
     """
 
     categories = category
@@ -69,12 +70,11 @@ def log_list(category=[], limit=None):
         category_path = os.path.join(CATEGORIES_PATH, category)
         if not os.path.exists(category_path):
             logger.debug(m18n.n('log_category_404', category=category))
-
             continue
 
         logs = filter(lambda x: x.endswith(METADATA_FILE_EXT),
                       os.listdir(category_path))
-        logs = reversed(sorted(logs))
+        logs = list(reversed(sorted(logs)))
 
         if limit is not None:
             logs = logs[:limit]
@@ -99,6 +99,15 @@ def log_list(category=[], limit=None):
                 pass
             else:
                 entry["started_at"] = log_datetime
+
+            if with_details:
+                with open(md_path, "r") as md_file:
+                    try:
+                        metadata = yaml.safe_load(md_file)
+                    except yaml.YAMLError:
+                        logger.warning(m18n.n('log_corrupted_md_file', file=md_path))
+
+                    entry["success"] = metadata.get("success", "?")
 
             result[category].append(entry)
 
@@ -317,6 +326,20 @@ class OperationLogger(object):
             self.started_at = datetime.utcnow()
             self.flush()
             self._register_log()
+
+    @property
+    def md_path(self):
+        """
+        Metadata path file
+        """
+        return os.path.join(self.path, self.name + METADATA_FILE_EXT)
+
+    @property
+    def log_path(self):
+        """
+        Log path file
+        """
+        return os.path.join(self.path, self.name + LOG_FILE_EXT)
 
     def _register_log(self):
         """


### PR DESCRIPTION
## The problem

Needed for https://github.com/YunoHost/yunohost-admin/pull/241

## Solution

Add a --with-details option for `yunohost log list`

## PR Status

Tested and working

## How to test

Run `yunohost log list` and see if there's a `success` key

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
