### PR TITLE
Disable VRFY command in Postfix command

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -154,3 +154,9 @@ smtpd_milters = inet:localhost:11332
 
 # Skip email without checking if milter has died
 milter_default_action = accept
+
+# Avoid email adress scanning
+# By default it's possible to detect if the email adress exist
+# So it's easly possible to scan a server to know which email adress is valid
+# and after to send spam
+disable_vrfy_command = yes


### PR DESCRIPTION
## The problem

Some server scan on internet each mail server and try to detect the email adress. After the email adress is found some spam are send.

The result is by example this : https://forum.yunohost.org/t/usage-frauduleux-de-ma-boite-mail/7540/4

## Solution

Block the VRFY command in Postfix wich give the possibility to do that on the server.

## PR Status

Tested and it work. But need to be tested more deeply. By example if it break something.

## How to test

Enable the option `disable_vrfy_command` in the main postfix config.
Launch this: 
```
# nc localhost 25
220 domain.tld Service ready
VRFY email@domain.tld
502 5.5.1 VRFY command is disabled
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
