### PR TITLE
Optimize ynh_script_progression

### DIFF
--- a/data/helpers.d/logging
+++ b/data/helpers.d/logging
@@ -198,6 +198,13 @@ ynh_print_ON () {
 # Requires YunoHost version 3.?.? or higher.
 increment_progression=0
 previous_weight=0
+max_progression=-1
+# Set the scale of the progression bar
+# progress_string(0,1,2) should have the size of the scale.
+progress_scale=20
+progress_string2="####################"
+progress_string1="++++++++++++++++++++"
+progress_string0="...................."
 # Define base_time when the file is sourced
 base_time=$(date +%s)
 ynh_script_progression () {
@@ -218,54 +225,51 @@ ynh_script_progression () {
 	local exec_time=$(( $(date +%s) - $base_time ))
 	base_time=$(date +%s)
 
-	# Get the number of occurrences of 'ynh_script_progression' in the script. Except those are commented.
-	local helper_calls="$(grep --count "^[^#]*ynh_script_progression" $0)"
-	# Get the number of call with a weight value
-	local weight_calls=$(grep --perl-regexp --count "^[^#]*ynh_script_progression.*(--weight|-w )" $0)
+	# Compute $max_progression (if we didn't already)
+	if [ "$max_progression" = -1 ]
+	then
+		# Get the number of occurrences of 'ynh_script_progression' in the script. Except those are commented.
+		local helper_calls="$(grep --count "^[^#]*ynh_script_progression" $0)"
+		# Get the number of call with a weight value
+		local weight_calls=$(grep --perl-regexp --count "^[^#]*ynh_script_progression.*(--weight|-w )" $0)
 
-	# Get the weight of each occurrences of 'ynh_script_progression' in the script using --weight
-        local weight_valuesA="$(grep --perl-regexp "^[^#]*ynh_script_progression.*--weight" $0 | sed 's/.*--weight[= ]\([[:digit:]]*\).*/\1/g')"
-        # Get the weight of each occurrences of 'ynh_script_progression' in the script using -w
-        local weight_valuesB="$(grep --perl-regexp "^[^#]*ynh_script_progression.*-w " $0 | sed 's/.*-w[= ]\([[:digit:]]*\).*/\1/g')"
-	# Each value will be on a different line.
-	# Remove each 'end of line' and replace it by a '+' to sum the values.
-	local weight_values=$(( $(echo "$weight_valuesA" | tr '\n' '+') + $(echo "$weight_valuesB" | tr '\n' '+') 0 ))
+		# Get the weight of each occurrences of 'ynh_script_progression' in the script using --weight
+		local weight_valuesA="$(grep --perl-regexp "^[^#]*ynh_script_progression.*--weight" $0 | sed 's/.*--weight[= ]\([[:digit:]]*\).*/\1/g')"
+		# Get the weight of each occurrences of 'ynh_script_progression' in the script using -w
+		local weight_valuesB="$(grep --perl-regexp "^[^#]*ynh_script_progression.*-w " $0 | sed 's/.*-w[= ]\([[:digit:]]*\).*/\1/g')"
+		# Each value will be on a different line.
+		# Remove each 'end of line' and replace it by a '+' to sum the values.
+		local weight_values=$(( $(echo "$weight_valuesA" | tr '\n' '+') + $(echo "$weight_valuesB" | tr '\n' '+') 0 ))
 
-	# max_progression is a total number of calls to this helper.
-	#    Less the number of calls with a weight value.
-	#    Plus the total of weight values
-	local max_progression=$(( $helper_calls - $weight_calls + $weight_values ))
+		# max_progression is a total number of calls to this helper.
+		# 	Less the number of calls with a weight value.
+		# 	Plus the total of weight values
+		max_progression=$(( $helper_calls - $weight_calls + $weight_values ))
+	fi
 
 	# Increment each execution of ynh_script_progression in this script by the weight of the previous call.
 	increment_progression=$(( $increment_progression + $previous_weight ))
 	# Store the weight of the current call in $previous_weight for next call
 	previous_weight=$weight
 
-	# Set the scale of the progression bar
-	local scale=20
-	# progress_string(0,1,2) should have the size of the scale.
-	local progress_string2="####################"
-	local progress_string1="++++++++++++++++++++"
-	local progress_string0="...................."
-
 	# Reduce $increment_progression to the size of the scale
 	if [ $last -eq 0 ]
 	then
-		local effective_progression=$(( $increment_progression * $scale / $max_progression ))
+		local effective_progression=$(( $increment_progression * $progress_scale / $max_progression ))
 	# If last is specified, fill immediately the progression_bar
 	else
-		local effective_progression=$scale
+		local effective_progression=$progress_scale
 	fi
 
 	# Build $progression_bar from progress_string(0,1,2) according to $effective_progression and the weight of the current task
 	# expected_progression is the progression expected after the current task
-	local expected_progression="$(( ( $increment_progression + $weight ) * $scale / $max_progression - $effective_progression ))"
+	local expected_progression="$(( ( $increment_progression + $weight ) * $progress_scale / $max_progression - $effective_progression ))"
 	if [ $last -eq 1 ]
 	then
 		expected_progression=0
 	fi
 	# left_progression is the progression not yet done
-	local left_progression="$(( $scale - $effective_progression - $expected_progression ))"
+	local left_progression="$(( $progress_scale - $effective_progression - $expected_progression ))"
 	# Build the progression bar with $effective_progression, work done, $expected_progression, current work and $left_progression, work to be done.
 	local progression_bar="${progress_string2:0:$effective_progression}${progress_string1:0:$expected_progression}${progress_string0:0:$left_progression}"
 


### PR DESCRIPTION
## The problem

`ynh_script_progression` is awesome but I noticed that app logs are filled with hundreds of lines related to the computation of the progress bar. But some parts of it could be factorized to be only done once so that'll slightly simplify the debug logs

## Solution

Compute the stuff we can only once using "global"(?) variables

## PR Status

Tested and seems to be working, but I'm not an expert of this helper ;)

## How to test

Run an app install and check the detailed log

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
