### PR TITLE
Remove unecessary log messages

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -225,7 +225,6 @@ ynh_mysql_remove_db () {
 
 	local mysql_root_password=$(sudo cat $MYSQL_ROOT_PWD_FILE)
 	if mysqlshow -u root -p$mysql_root_password | grep -q "^| $db_name"; then	# Check if the database exists
-		ynh_print_info --message="Removing database $db_name"
 		ynh_mysql_drop_db $db_name	# Remove the database	
 	else
 		ynh_print_warn --message="Database $db_name not found"

--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -244,7 +244,6 @@ ynh_psql_remove_db() {
 
 	local psql_root_password=$(sudo cat $PSQL_ROOT_PWD_FILE)
 	if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
-		ynh_print_info --message="Removing database $db_name"
 		ynh_psql_drop_db $db_name # Remove the database
 	else
 		ynh_print_warn --message="Database $db_name not found"
@@ -252,7 +251,6 @@ ynh_psql_remove_db() {
 
 	# Remove psql user if it exists
 	if ynh_psql_user_exists --user=$db_user; then
-		ynh_print_info --message="Removing user $db_user"
 		ynh_psql_drop_user $db_user
 	else
 		ynh_print_warn --message="User $db_user not found"

--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -120,8 +120,6 @@ ynh_systemd_action() {
         fi
     fi
 
-    ynh_print_info --message="${action^} the service $service_name"
-
     # Use reload-or-restart instead of reload. So it wouldn't fail if the service isn't running.
     if [ "$action" == "reload" ]; then
         action="reload-or-restart"

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -145,7 +145,6 @@ ynh_system_user_delete () {
     # Check if the user exists on the system
     if ynh_system_user_exists "$username"
     then
-		ynh_print_info --message="Remove the user $username"
 		deluser $username
 	else
 		ynh_print_warn --message="The user $username was not found"
@@ -154,7 +153,6 @@ ynh_system_user_delete () {
     # Check if the group exists on the system
     if ynh_system_group_exists "$username"
     then
-		ynh_print_info --message="Remove the group $username"
 		delgroup $username
     fi
 }


### PR DESCRIPTION
## The problem

`ynh_script_progression` is awesome, but the info logging channel (what the regular user sees) is often kinda polluted with low-level technical messages, typically saying that `service X` is being reloaded...

E.g. :  

```text
$ yunohost app remove wordpress
Info: Removing application wordpress…
Info: [+...................] > Load settings
Info: [#+++++++............] > Remove dependencies
Info: [########+...........] > Remove the mysql database
Info: Removing database wordpress
Info: [#########+..........] > Remove app main directory
Info: [##########..........] > Remove nginx configuration
Info: Reload the service nginx
Info: [##########++........] > Remove php-fpm configuration
Info: /etc/php/7.0/fpm/conf.d/20-wordpress.ini wasn't deleted because it doesn't exist.
Info: Reload the service php7.0-fpm
Info: [############+++++...] > Remove fail2ban configuration
Info: Reload the service fail2ban
Info: [#################++.] > Remove the dedicated user
Info: Remove the user wordpress
Info: [####################] > Deletion completed
```

Imho those are duplicated / not necessary and the packager can see the detailed log if needed...

## Solution

Remove those info messages

## PR Status

Tested and working

## How to test

Install / remove wordpress for example

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
