### PR TITLE
Set min version to 3.5.0 for helpers

### DIFF
--- a/data/helpers.d/fail2ban
+++ b/data/helpers.d/fail2ban
@@ -61,7 +61,7 @@
 # To validate your regex you can test with this command:
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_add_fail2ban_config () {
   # Declare an array to define the options of this helper.
   local legacy_args=lrmptv
@@ -143,7 +143,7 @@ EOF
 #
 # usage: ynh_remove_fail2ban_config
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_remove_fail2ban_config () {
   ynh_secure_remove "/etc/fail2ban/jail.d/$app.conf"
   ynh_secure_remove "/etc/fail2ban/filter.d/$app.conf"

--- a/data/helpers.d/logging
+++ b/data/helpers.d/logging
@@ -195,7 +195,7 @@ ynh_print_ON () {
 # The execution time is given for the duration since the previous call. So the weight should be applied to this previous call.
 # | arg: -l, --last=    - Use for the last call of the helper, to fill te progression bar.
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 increment_progression=0
 previous_weight=0
 # Define base_time when the file is sourced
@@ -284,7 +284,7 @@ ynh_script_progression () {
 # | arg: -m, --message= - The text to print
 # | arg: -t, --trace=   - Turn on or off the trace of the script. Usefull to trace nonly a small part of a script.
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_debug () {
 	# Disable set xtrace for the helper itself, to not pollute the debug log
 	set +x
@@ -339,7 +339,7 @@ ynh_debug () {
 #
 # | arg: command - command to execute
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_debug_exec () {
 	ynh_debug --message="$(eval $@)"
 }

--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -12,7 +12,7 @@ PSQL_ROOT_PWD_FILE=/etc/yunohost/psql
 # | arg: -p, --password - the user password
 # | arg: -d, --database - the database to connect to
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_connect_as() {
 	# Declare an array to define the options of this helper.
 	local legacy_args=upd
@@ -33,7 +33,7 @@ ynh_psql_connect_as() {
 # | arg: -s, --sql - the SQL command to execute
 # | arg: -d, --database - the database to connect to
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_execute_as_root() {
 	# Declare an array to define the options of this helper.
 	local legacy_args=sd
@@ -54,7 +54,7 @@ ynh_psql_execute_as_root() {
 # | arg: -f, --file - the file containing SQL commands
 # | arg: -d, --database - the database to connect to
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_execute_file_as_root() {
 	# Declare an array to define the options of this helper.
 	local legacy_args=fd
@@ -77,7 +77,7 @@ ynh_psql_execute_file_as_root() {
 # | arg: db - the database name to create
 # | arg: user - the user to grant privilegies
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_create_db() {
 	local db=$1
 	local user=${2:-}
@@ -102,7 +102,7 @@ ynh_psql_create_db() {
 # usage: ynh_psql_drop_db db
 # | arg: db - the database name to drop
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_drop_db() {
 	local db=$1
 	# First, force disconnection of all clients connected to the database
@@ -120,7 +120,7 @@ ynh_psql_drop_db() {
 # | arg: -d, --database - the database name to dump
 # | ret: the psqldump output
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_dump_db() {
 	# Declare an array to define the options of this helper.
 	local legacy_args=d
@@ -140,7 +140,7 @@ ynh_psql_dump_db() {
 # | arg: user - the user name to create
 # | arg: pwd - the password to identify user by
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_create_user() {
 	local user=$1
 	local pwd=$2
@@ -192,7 +192,7 @@ ynh_psql_database_exists() {
 # usage: ynh_psql_drop_user user
 # | arg: user - the user name to drop
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_psql_drop_user() {
 	ynh_psql_execute_as_root --sql="DROP USER ${1};"
 }

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -365,7 +365,7 @@ ynh_get_plain_key() {
 # | arg: -m, --manifest= - Path of the manifest to read
 # | arg: -k, --key= - Name of the key to find
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_read_manifest () {
 	# Declare an array to define the options of this helper.
         local legacy_args=mk
@@ -392,7 +392,7 @@ ynh_read_manifest () {
 # usage: ynh_app_upstream_version [-m manifest]
 # | arg: -m, --manifest= - Path of the manifest to read
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_app_upstream_version () {
     # Declare an array to define the options of this helper.
     local legacy_args=m
@@ -415,7 +415,7 @@ ynh_app_upstream_version () {
 # usage: ynh_app_package_version [-m manifest]
 # | arg: -m, --manifest= - Path of the manifest to read
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_app_package_version () {
     # Declare an array to define the options of this helper.
     local legacy_args=m
@@ -444,7 +444,7 @@ ynh_app_package_version () {
 #
 # usage: ynh_check_app_version_changed
 #
-# Requires YunoHost version 3.?.? or higher.
+# Requires YunoHost version 3.5.0 or higher.
 ynh_check_app_version_changed () {
   local force_upgrade=${YNH_FORCE_UPGRADE:-0}
   local package_check=${PACKAGE_CHECK_EXEC:-0}


### PR DESCRIPTION
## The problem

We forgot to set the minimum version required for helper during the last release.

## Solution

Set the last version to 3.5.0 for those helpers.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 