### PR TITLE
[fix] Update censurfridns ipv6

### DIFF
--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -42,4 +42,4 @@ nameserver 2001:1608:10:25::9249:d69b
 nameserver 91.239.100.100
 nameserver 2001:67c:28a4::
 nameserver 89.233.43.71
-nameserver 2002:d596:2a92:1:71:53::
+nameserver 2a01:3a0:53:53::


### PR DESCRIPTION
Previous Unicast IPV6 for censurfridns,dk was out of date

## The problem

One of the ip listed in the resolv.dnsmasq.conf was dead

## Solution

I've replaced the IP by the right one taken from https://blog.uncensoreddns.org/

## PR Status

Tested the IP on my yunohost instance and it respond properly

## How to test

Ping the old IP, it's dead, ping the new one, it answer.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
