### PR TITLE
Allow to display logs when postinstall fails

### DIFF
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -195,7 +195,8 @@ if __name__ == '__main__':
     # Check that YunoHost is installed
     if not os.path.isfile('/etc/yunohost/installed') and \
        (len(args) < 2 or (args[0] +' '+ args[1] != 'tools postinstall' and \
-                          args[0] +' '+ args[1] != 'backup restore')):
+                          args[0] +' '+ args[1] != 'backup restore' and \
+                          args[0] +' '+ args[1] != 'log display')):
 
         from moulinette import m18n
         # Init i18n


### PR DESCRIPTION
## The problem

> on failed postinstall, yunohost suggest to uses "yunohost log" but it's can't be used since postinstall hasn't run

See https://github.com/YunoHost/issues/issues/1345.

## Solution

Make a special case inside `bin/yunohost` to allow `log display` command to run.

Closes https://github.com/YunoHost/issues/issues/1345.

## PR Status

Ready for review.

## How to test

```
root@yunohostdev:/ynh-dev/yunohost# yunohost
Error: YunoHost is not or not correctly installed. Please execute 'yunohost tools postinstall'
root@yunohostdev:/ynh-dev/yunohost# yunohost log display
usage: yunohost log display path [-h] [-n NUMBER] [--share]
yunohost log display: error: too few arguments
root@yunohostdev:/ynh-dev/yunohost# git diff
diff --git a/bin/yunohost b/bin/yunohost
index fd9c2dbf..10a21a9d 100755
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -195,7 +195,8 @@ if __name__ == '__main__':
     # Check that YunoHost is installed
     if not os.path.isfile('/etc/yunohost/installed') and \
        (len(args) < 2 or (args[0] +' '+ args[1] != 'tools postinstall' and \
-                          args[0] +' '+ args[1] != 'backup restore')):
+                          args[0] +' '+ args[1] != 'backup restore' and \
+                          args[0] +' '+ args[1] != 'log display')):
 
         from moulinette import m18n
         # Init i18n
root@yunohostdev:/ynh-dev/yunohost# git checkout .
root@yunohostdev:/ynh-dev/yunohost# yunohost log display
Error: YunoHost is not or not correctly installed. Please execute 'yunohost tools postinstall'
root@yunohostdev:/ynh-dev/yunohost# touch /etc/yunohost/installed
root@yunohostdev:/ynh-dev/yunohost# yunohost log display
usage: yunohost log display path [-h] [-n NUMBER] [--share]
yunohost log display: error: too few arguments
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
