### PR TITLE
Add indexes for fields listed by slapd in the logs

### DIFF
--- a/data/templates/slapd/slapd.conf
+++ b/data/templates/slapd/slapd.conf
@@ -63,9 +63,13 @@ suffix          "dc=yunohost,dc=org"
 directory       "/var/lib/ldap"
 
 # Indexing options for database #1
-index  objectClass         eq
-index  uid                 eq,sub
-index  entryCSN,entryUUID  eq
+index  objectClass                   eq
+index  uid,sudoUser                  eq,sub
+index  entryCSN,entryUUID            eq
+index  cn,mail                       eq
+index  gidNumber,uidNumber           eq
+index  member,memberUid,uniqueMember eq
+index  virtualdomain                 eq
 
 # Save the time that the entry gets modified, for database #1
 lastmod         on


### PR DESCRIPTION
I get lots of suggestion of indexes by slapd in my logs:

 <= mdb_equality_candidates: (cn) not indexed
 <= mdb_equality_candidates: (gidNumber) not indexed
 <= mdb_equality_candidates: (mail) not indexed
 <= mdb_equality_candidates: (member) not indexed
 <= mdb_equality_candidates: (memberUid) not indexed
 <= mdb_equality_candidates: (sudoUser) not indexed
 <= mdb_equality_candidates: (uidNumber) not indexed
 <= mdb_equality_candidates: (uniqueMember) not indexed
 <= mdb_equality_candidates: (virtualdomain) not indexed
 <= mdb_substring_candidates: (sudoUser) not indexed

Since Yunohost makes it hard to edit LDAP server configuration (see https://github.com/YunoHost/issues/issues/1350), the default configuration should contain indexes for the fields used by Yunohost a lot.

## The problem

...

## Solution

...

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
