### PR TITLE
Add exception for data backup

### DIFF
--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -59,12 +59,18 @@ ynh_backup() {
     local not_mandatory="${not_mandatory:-0}"
 
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
+    test -n "${app:-}" && do_not_backup_data=$(ynh_app_setting_get $app do_not_backup_data)
 
     # If backing up core only (used by ynh_backup_before_upgrade),
     # don't backup big data items
-    if [ "$is_big" == "1" ] && [ "$BACKUP_CORE_ONLY" == "1" ] ; then
-      ynh_print_info --message="$src_path will not be saved, because backup_core_only is set."
-      return 0
+    if [ $is_big -eq 1 ] && ( [ ${do_not_backup_data:-0} -eq 1 ] || [ $BACKUP_CORE_ONLY -eq 1 ] ) 
+    then
+        if [ $BACKUP_CORE_ONLY -eq 1 ]; then
+            ynh_print_warn --message="$src_path will not be saved, because 'BACKUP_CORE_ONLY' is set."
+        else
+            ynh_print_warn --message="$src_path will not be saved, because 'do_not_backup_data' is set."
+        fi
+        return 0
     fi
 
     # ==============================================================================

--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -59,7 +59,7 @@ ynh_backup() {
     local not_mandatory="${not_mandatory:-0}"
 
     BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
-    test -n "${app:-}" && do_not_backup_data=$(ynh_app_setting_get $app do_not_backup_data)
+    test -n "${app:-}" && do_not_backup_data=$(ynh_app_setting_get --app=$app --key=do_not_backup_data)
 
     # If backing up core only (used by ynh_backup_before_upgrade),
     # don't backup big data items


### PR DESCRIPTION
## The problem

Some users were using the setting `backup_only_core` to not backup data during their backup.
As this setting wasn't meant to be used this way, I didn't care when changing the way it was handled.
https://forum.yunohost.org/t/yunohost-backup-create-ko/7688

## Solution

Implement a new setting `do_not_backup_data` to add to an app setting to avoid data backup.
This setting, as it's not part of the upgrade process, will not be removed by any script. So it could be used by an user to avoid to backup data for all backup script.

## PR Status

Ready to be reviewed.

## How to test

Set the setting for an app, `ynh_app_setting_set $app do_not_backup_data 1`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 