### PR TITLE
[enh] support config_panel in TOML format

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Depends: ${python:Depends}, ${misc:Depends}
  , moulinette (>= 2.7.1), ssowat (>= 2.7.1)
  , python-psutil, python-requests, python-dnspython, python-openssl
  , python-apt, python-miniupnpc, python-dbus, python-jinja2
+ , python-toml
  , glances, apt-transport-https
  , dnsutils, bind9utils, unzip, git, curl, cron, wget, jq
  , ca-certificates, netcat-openbsd, iproute

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -24,6 +24,7 @@
     Manage apps
 """
 import os
+import toml
 import json
 import shutil
 import yaml
@@ -680,7 +681,7 @@ def app_upgrade(app=[], url=None, file=None):
             os.system('rm -rf "%s/scripts" "%s/manifest.json %s/conf"' % (app_setting_path, app_setting_path, app_setting_path))
             os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
-            for file_to_copy in ["actions.json", "config_panel.json", "conf"]:
+            for file_to_copy in ["actions.json", "config_panel.json", "config_panel.toml", "conf"]:
                 if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
                     os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 
@@ -835,7 +836,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     os.system('cp %s/manifest.json %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
 
-    for file_to_copy in ["actions.json", "config_panel.json", "conf"]:
+    for file_to_copy in ["actions.json", "config_panel.json", "config_panel.toml", "conf"]:
         if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
             os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 
@@ -1581,20 +1582,18 @@ def app_config_show_panel(app):
     # this will take care of checking if the app is installed
     app_info_dict = app_info(app)
 
-    config_panel = os.path.join(APPS_SETTING_PATH, app, 'config_panel.json')
+    config_panel = _get_app_config_panel(app)
     config_script = os.path.join(APPS_SETTING_PATH, app, 'scripts', 'config')
 
     app_id, app_instance_nb = _parse_app_instance_name(app)
 
-    if not os.path.exists(config_panel) or not os.path.exists(config_script):
+    if not config_panel or not os.path.exists(config_script):
         return {
             "app_id": app_id,
             "app": app,
             "app_name": app_info_dict["name"],
             "config_panel": [],
         }
-
-    config_panel = read_json(config_panel)
 
     env = {
         "YNH_APP_ID": app_id,
@@ -1672,14 +1671,12 @@ def app_config_apply(app, args):
     if not installed:
         raise YunohostError('app_not_installed', app=app)
 
-    config_panel = os.path.join(APPS_SETTING_PATH, app, 'config_panel.json')
+    config_panel = _get_app_config_panel(app)
     config_script = os.path.join(APPS_SETTING_PATH, app, 'scripts', 'config')
 
-    if not os.path.exists(config_panel) or not os.path.exists(config_script):
+    if not config_panel or not os.path.exists(config_script):
         # XXX real exception
         raise Exception("Not config-panel.json nor scripts/config")
-
-    config_panel = read_json(config_panel)
 
     app_id, app_instance_nb = _parse_app_instance_name(app)
     env = {
@@ -1717,6 +1714,129 @@ def app_config_apply(app, args):
         raise Exception("'script/config apply' return value code: %s (considered as an error)", return_code)
 
     logger.success("Config updated as expected")
+
+
+def _get_app_config_panel(app_id):
+    "Get app config panel stored in json or in toml"
+    config_panel_toml_path = os.path.join(APPS_SETTING_PATH, app_id, 'config_panel.toml')
+    config_panel_json_path = os.path.join(APPS_SETTING_PATH, app_id, 'config_panel.json')
+
+    # sample data to get an idea of what is going on
+    # this toml extract:
+    #
+    # version = "0.1"
+    # name = "Unattended-upgrades configuration panel"
+    #
+    # [main]
+    # name = "Unattended-upgrades configuration"
+    #
+    #     [main.unattended_configuration]
+    #     name = "50unattended-upgrades configuration file"
+    #
+    #         [main.unattended_configuration.upgrade_level]
+    #         name = "Choose the sources of packages to automatically upgrade."
+    #         default = "Security only"
+    #         type = "text"
+    #         help = "We can't use a choices field for now. In the meantime please choose between one of this values:<br>Security only, Security and updates."
+    #         # choices = ["Security only", "Security and updates"]
+
+    #         [main.unattended_configuration.ynh_update]
+    #         name = "Would you like to update YunoHost packages automatically ?"
+    #         type = "bool"
+    #         default = true
+    #
+    # will be parsed into this:
+    #
+    # OrderedDict([(u'version', u'0.1'),
+    #              (u'name', u'Unattended-upgrades configuration panel'),
+    #              (u'main',
+    #               OrderedDict([(u'name', u'Unattended-upgrades configuration'),
+    #                            (u'unattended_configuration',
+    #                             OrderedDict([(u'name',
+    #                                           u'50unattended-upgrades configuration file'),
+    #                                          (u'upgrade_level',
+    #                                           OrderedDict([(u'name',
+    #                                                         u'Choose the sources of packages to automatically upgrade.'),
+    #                                                        (u'default',
+    #                                                         u'Security only'),
+    #                                                        (u'type', u'text'),
+    #                                                        (u'help',
+    #                                                         u"We can't use a choices field for now. In the meantime please choose between one of this values:<br>Security only, Security and updates.")])),
+    #                                          (u'ynh_update',
+    #                                           OrderedDict([(u'name',
+    #                                                         u'Would you like to update YunoHost packages automatically ?'),
+    #                                                        (u'type', u'bool'),
+    #                                                        (u'default', True)])),
+    #
+    # and needs to be converted into this:
+    #
+    # {u'name': u'Unattended-upgrades configuration panel',
+    #  u'panel': [{u'id': u'main',
+    #    u'name': u'Unattended-upgrades configuration',
+    #    u'sections': [{u'id': u'unattended_configuration',
+    #      u'name': u'50unattended-upgrades configuration file',
+    #      u'options': [{u'//': u'"choices" : ["Security only", "Security and updates"]',
+    #        u'default': u'Security only',
+    #        u'help': u"We can't use a choices field for now. In the meantime please choose between one of this values:<br>Security only, Security and updates.",
+    #        u'id': u'upgrade_level',
+    #        u'name': u'Choose the sources of packages to automatically upgrade.',
+    #        u'type': u'text'},
+    #       {u'default': True,
+    #        u'id': u'ynh_update',
+    #        u'name': u'Would you like to update YunoHost packages automatically ?',
+    #        u'type': u'bool'},
+
+    if os.path.exists(config_panel_toml_path):
+        toml_config_panel = toml.load(open(config_panel_toml_path, "r"), _dict=OrderedDict)
+
+        # transform toml format into json format
+        config_panel = {
+            "name": toml_config_panel["name"],
+            "version": toml_config_panel["version"],
+            "panel": [],
+        }
+
+        panels = filter(lambda (key, value): key not in ("name", "version")
+                                             and isinstance(value, OrderedDict),
+                        toml_config_panel.items())
+
+        for key, value in panels:
+            panel = {
+                "id": key,
+                "name": value["name"],
+                "sections": [],
+            }
+
+            sections = filter(lambda (k, v): k not in ("name",)
+                                             and isinstance(v, OrderedDict),
+                              value.items())
+
+            for section_key, section_value in sections:
+                section = {
+                    "id": section_key,
+                    "name": section_value["name"],
+                    "options": [],
+                }
+
+                options = filter(lambda (k, v): k not in ("name",)
+                                                and isinstance(v, OrderedDict),
+                                 section_value.items())
+
+                for option_key, option_value in options:
+                    option = dict(option_value)
+                    option["id"] = option_key
+                    section["options"].append(option)
+
+                panel["sections"].append(section)
+
+            config_panel["panel"].append(panel)
+
+        return config_panel
+
+    elif os.path.exists(config_panel_json_path):
+        return json.load(open(config_panel_json_path))
+
+    return None
 
 
 def _get_app_settings(app_id):


### PR DESCRIPTION
## The problem

Writting a config_panel in json turns out to be unecessary complicated and error prone.

## Solution

After looking at a lot of different formats, toml turns out to be the most intuitive one and less error prone to use for not super-turbo-nerdy people which most app devs are (and even for turbo-nerdy writting json by hand sucks). App group people confirmed that it really looks like an improvement other json.

The solution to limit the modification of the code is to transform this new toml format in the current json format internally on load (which is easier to use for code)

Sidenode: I'm considering introducing support for `manifest.toml` and will certainly do `actions.toml` as it also really looks like an improvment: https://gist.github.com/Psycojoker/71aca1767738c4b254b6cd74e09c28e1#file-manifest-toml

In json it looks like that:

```json
{
	"name": "Unattended-upgrades configuration panel",
	"version": "0.1",
	"panel": [{
		"name": "Unattended-upgrades configuration",
		"id": "main",
		"sections": [{
			"name": "50unattended-upgrades configuration file",
			"id": "unattended_configuration",
			"options": [{
				"name": "Choose the sources of packages to automatically upgrade.",
				"help": "We can't use a choices field for now. In the meantime please choose between one of this values:<br>Security only, Security and updates.",
				"id": "upgrade_level",
				"type": "text",
				"//": "\"choices\" : [\"Security only\", \"Security and updates\"]",
				"default" : "Security only"
			},
			{
				"name": "Would you like to update YunoHost packages automatically ?",
				"id": "ynh_update",
				"type": "bool",
				"default": true
			},
			{
				"name": "Would you like to receive an email from Unattended-Upgrades ?",
				"help": "We can't use a choices field for now. In the meantime please choose between one of this values:<br>If an upgrade has been done, Only if there was an error, Never.",
				"id": "unattended_mail",
				"type": "text",
				"//": "\"choices\" : [\"If an upgrade has been done\", \"Only if there was an error\", \"Never\"]",
				"default" : "If an upgrade has been done"
			}]
		},
		{
			"name": "apticron cron file",
			"id": "apticron_configuration",
			"options": [{
				"name": "Would you like to receive an email to inform which upgrades need to be done ?",
				"id": "previous_apticron",
				"type": "bool",
				"default": true
			},
			{
				"name": "When do you want to receive this email ?",
				"help": "Choose an hour between 12 and 23.<br>",
				"id": "previous_apticron_hour",
				"type": "number",
				"default": 20
			},
			{
				"name": "Would you like to receive an email to verify if there any upgrades left after each auto upgrade ?",
				"id": "after_apticron",
				"type": "bool",
				"default": true
			},
			{
				"name": "When do you want to receive this email ?",
				"help": "Choose an hour between 0 and 10.",
				"id": "after_apticron_hour",
				"type": "number",
				"default": 2
			}]
		},
		{
			"name": "02periodic apt config file",
			"id": "periodic_configuration",
			"options": [{
				"name": "Choose the level of verbosity of Unattended-Upgrades mail",
				"help": "We can't use a choices field for now. In the meantime please choose between one of this values:<br>1, 2, 3.",
				"help": "1: Progress report only.<br>2: Progress report and command outputs.<br>3: Progress report and command outputs and trace.",
				"id": "unattended_verbosity",
				"type": "text",
				"//": "\"choices\" : [\"1\", \"2\", \"3\"]",
				"default" : "1"
			}]
		},
		{
			"name": "Overwriting config files",
			"id": "overwrite_files",
			"options": [{
				"name": "Overwrite the config file 02periodic ?",
				"help": "If the file is overwritten, a backup will be created.",
				"id": "overwrite_periodic",
				"type": "bool",
				"default": true
			}]
		},
		{
			"name": "Global configuration",
			"id": "global_config",
			"options": [{
				"name": "Send HTML email to admin ?",
				"help": "Allow app scripts to send HTML mails instead of plain text.",
				"id": "email_type",
				"type": "bool",
				"default": true
			}]
		}]
	}
]
}
```

In TOML like that:

```toml
version = "0.1"
name = "Unattended-upgrades configuration panel"

[main]
name = "Unattended-upgrades configuration"

    [main.unattended_configuration]
    name = "50unattended-upgrades configuration file"

        [main.unattended_configuration.upgrade_level]
        name = "Choose the sources of packages to automatically upgrade."
        default = "Security only"
        type = "text"
        help = "We can't use a choices field for now. In the meantime please choose between one of this values:<br>Security only, Security and updates."
        # choices = ["Security only", "Security and updates"]

        [main.unattended_configuration.ynh_update]
        name = "Would you like to update YunoHost packages automatically ?"
        type = "bool"
        default = true

        [main.unattended_configuration.unattended_mail]
        name = "Would you like to receive an email from Unattended-Upgrades ?"
        default = "If an upgrade has been done"
        type = "text"
        help = "We can't use a choices field for now. In the meantime please choose between one of this values:<br>If an upgrade has been done, Only if there was an error, Never."
        # choices = ["If an upgrade has been done", "Only if there was an error", "Never"]


    [main.apticron_configuration]
    name = "apticron cron file"

        [main.apticron_configuration.previous_apticron]
        name = "Would you like to receive an email to inform which upgrades need to be done ?"
        type = "bool"
        default = true

        [main.apticron_configuration.previous_apticron_hours]
        name = "When do you want to receive this email ?"
        type = "number"
        default = 20
        help = "Choose an hour between 12 and 23.<br>"

        [main.apticron_configuration.after_apticron]
        name = "Would you like to receive an email to verify if there any upgrades left after each auto upgrade ?"
        type = "bool"
        default = true

        [main.apticron_configuration.after_apticron_hour]
        name = "When do you want to receive this email ?"
        type = "number"
        default = 2
        help = "Choose an hour between 0 and 10."


    [main.periodic_configuration]
    name = "02periodic apt config file"

        [main.periodic_configuration.unattended_verbosity]
        name = "Choose the level of verbosity of Unattended-Upgrades mail"
        default = "1"
        type = "text"
        # choices = ["1", "2", "3"]
        help = "1: Progress report only.<br>2: Progress report and command outputs.<br>3: Progress report and command outputs and trace."


    [main.overwrite_files]
    name = "Overwriting config files"

        [main.overwrite_files.overwrite_periodic]
        name = "Overwrite the config file 02periodic ?"
        type = "bool"
        default = true
        help = "If the file is overwritten, a backup will be created."


    [main.global_config]
    name = "Global configuration"

        [main.global_config.email_type]
        name = "Send HTML email to admin ?"
        default = true
        type = "bool"
        help = "Allow app scripts to send HTML mails instead of plain text."
```

## PR Status

Tested by me and working.

## How to test

Install an app in which you have put a "config_panel.toml" file like in the example.

## Validation

- [ ] Principle agreement 0/2 : ljf
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
