### PR TITLE
Fix ynh_print_OFF when set -x is used in other helpers

### DIFF
--- a/data/helpers.d/logging
+++ b/data/helpers.d/logging
@@ -172,7 +172,7 @@ ynh_exec_fully_quiet () {
 #
 # Requires YunoHost version 3.2.0 or higher.
 ynh_print_OFF () {
-	set +x
+	exec {BASH_XTRACEFD}>/dev/null
 }
 
 # Restore the logging after ynh_print_OFF
@@ -181,7 +181,7 @@ ynh_print_OFF () {
 #
 # Requires YunoHost version 3.2.0 or higher.
 ynh_print_ON () {
-	set -x
+	exec {BASH_XTRACEFD}>&1
 	# Print an echo only for the log, to be able to know that ynh_print_ON has been called.
 	echo ynh_print_ON > /dev/null
 }


### PR DESCRIPTION
## The problem

As reported by @Josue-T, ynh_print_OFF doesn't work when used before a helper using getopts, because the helper getopts use set -x.

## Solution

Redirect BASH_XTRACEFD, the file descriptor for xtrace, to /dev/null to get rid of the trace.
Then redirect back to stdout.

## PR Status

Tested on leed.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 