### PR TITLE
[enh] Add current and new version for apps in tools_update output

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -534,9 +534,21 @@ def _list_upgradable_apps():
         app_dict = app_info(app_id, raw=True)
 
         if app_dict["upgradable"] == "yes":
+
+            current_version = app_dict.get("version", "?")
+            current_commit = app_dict.get("status", {}).get("remote", {}).get("revision", "?")[:7]
+            new_version = app_dict.get("manifest",{}).get("version","?")
+            new_commit = app_dict.get("git", {}).get("revision", "?")[:7]
+
+            if current_version == new_version:
+                current_version += " (" + current_commit + ")"
+                new_version += " (" + new_commit + ")"
+
             yield {
                 'id': app_id,
-                'label': app_dict['settings']['label']
+                'label': app_dict['settings']['label'],
+                'current_version': current_version,
+                'new_version': new_version
             }
 
 


### PR DESCRIPTION
## The problem

The update/upgrade view in yunohost-admin doesn't show what's the current app version and next version

## Solution

Add current and next version of the apps in `tools_update` output. This is kind of a follow-up of https://github.com/YunoHost/yunohost/pull/730

## PR Status

Tested and working

## How to test

Install an app (make it so that it's not up to date) and run `yunohost tools update --apps`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
