### PR TITLE
[enh] Allow localhost ips to connect as root

### DIFF
--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -81,5 +81,5 @@ Match User sftpusers
 # user admin can't be used...
 # If the server is a VPS, it's expected that the owner of the
 # server has access to a web console through which to log in.
-Match Address 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,169.254.0.0/16,fe80::/10,fd00::/8
+Match Address 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,169.254.0.0/16,127.0.0.0/8,::1,fe80::/10,fd00::/8
         PermitRootLogin yes


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/cannot-edit-files-using-users-or-admin-account/8183

## Solution

I suggest to add authorization to connect to root user through ssh from 127.0.0.1/8 et ::1 (localhost) 

## PR Status

Need to be tested

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
