### PR TITLE
[fix] Backup delete should delete symlink target

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2322,8 +2322,8 @@ def backup_delete(name):
     files_to_delete = [archive_file, info_file]
 
     # To handle the case where archive_file is in fact a symlink
-    actual_archive = os.path.realpath(archive_file)
-    if actual_archive != archive_file:
+    if os.islink(archive_file):
+        actual_archive = os.path.realpath(archive_file)
         files_to_delete.append(actual_archive)
 
     for backup_file in files_to_delete:

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2319,7 +2319,14 @@ def backup_delete(name):
     archive_file = '%s/%s.tar.gz' % (ARCHIVES_PATH, name)
     info_file = "%s/%s.info.json" % (ARCHIVES_PATH, name)
 
-    for backup_file in [archive_file, info_file]:
+    files_to_delete = [archive_file, info_file]
+
+    # To handle the case where archive_file is in fact a symlink
+    actual_archive = os.path.realpath(archive_file)
+    if actual_archive != archive_file:
+        files_to_delete.append(actual_archive)
+
+    for backup_file in files_to_delete:
         try:
             os.remove(backup_file)
         except:


### PR DESCRIPTION
## The problem

Today a user on the chat pointed out that, when creating backups in a custom output directory (e.g. `/tmp/backups/`) then deleting the backup using `yunohost backup delete`, the .tar.gz file is still in `/tmp/backups/`

## Solution

That's because `backup_delete()` naively deletes `/home/yunohost.backup/archives/thebackup.tar.gz`, which turns out to exist and is a symlink to the actual archive in `/tmp/backups/`. So the solution is to also delete the target of the symlink (if the path is a symlink).

## PR Status

Tested on my machine and working

## How to test

```
yunohost backup create foo -o /tmp/backups/
ls /tmp/backups/  # Should display an archive for foo
yunohost backup delete foo
ls /tmp/backups/  # foo shouldn't be there anymore with this fix
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
