### PR TITLE
Use set +x / -x to hide the whole ynh_script_progression computation

### DIFF
--- a/data/helpers.d/logging
+++ b/data/helpers.d/logging
@@ -208,6 +208,7 @@ progress_string0="...................."
 # Define base_time when the file is sourced
 base_time=$(date +%s)
 ynh_script_progression () {
+	set +x
 	# Declare an array to define the options of this helper.
 	local legacy_args=mwtl
 	declare -Ar args_array=( [m]=message= [w]=weight= [t]=time [l]=last )
@@ -217,6 +218,7 @@ ynh_script_progression () {
 	local last
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
+	set +x
 	weight=${weight:-1}
 	time=${time:-0}
 	last=${last:-0}
@@ -280,6 +282,7 @@ ynh_script_progression () {
 	fi
 
 	ynh_print_info "[$progression_bar] > ${message}${print_exec_time}"
+	set -x
 }
 
 # Debugger for app packagers


### PR DESCRIPTION
## The problem

`ynh_script_progression` is awesome, but it fills the output log with a huge bunch of boring lines related to the computation of the progress bar :[ 

## Solution

Add some set +x / -x to hide this computation

## PR Status

Tested and working on my machine

## How to test

Run an app install like wordpress and compare the full output

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
