### PR TITLE
[enh] Redact secrets from logs

### DIFF
--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -266,7 +266,7 @@ ynh_psql_test_if_first_run() {
 		echo "PostgreSQL is already installed, no need to create master password"
 	else
 		local pgsql="$(ynh_string_random)"
-		echo "$pgsql" >/etc/yunohost/psql
+		echo "$pgsql" >$PSQL_ROOT_PWD_FILE
 
 		if [ -e /etc/postgresql/9.4/ ]; then
 			local pg_hba=/etc/postgresql/9.4/main/pg_hba.conf

--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -265,8 +265,8 @@ ynh_psql_test_if_first_run() {
 	if [ -f "$PSQL_ROOT_PWD_FILE" ]; then
 		echo "PostgreSQL is already installed, no need to create master password"
 	else
-		local pgsql="$(ynh_string_random)"
-		echo "$pgsql" >$PSQL_ROOT_PWD_FILE
+		local psql_root_password="$(ynh_string_random)"
+		echo "$psql_root_password" >$PSQL_ROOT_PWD_FILE
 
 		if [ -e /etc/postgresql/9.4/ ]; then
 			local pg_hba=/etc/postgresql/9.4/main/pg_hba.conf
@@ -280,7 +280,7 @@ ynh_psql_test_if_first_run() {
 
 		ynh_systemd_action --service_name=postgresql --action=start
 
-		sudo --login --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$pgsql'" postgres
+		sudo --login --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$psql_root_password'" postgres
 
 		# force all user to connect to local database using passwords
 		# https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html#EXAMPLE-PG-HBA.CONF

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -808,6 +808,9 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
 
     # Start register change on system
     operation_logger.extra.update({'env': env_dict})
+    # Tell the operation_logger to redact all password-type args
+    data_to_redact = [ value[0] for value in args_odict.values() if value[1] == "password" ]
+    operation_logger.data_to_redact.extend(data_to_redact)
     operation_logger.related_to = [s for s in operation_logger.related_to if s[0] != "app"]
     operation_logger.related_to.append(("app", app_id))
     operation_logger.start()

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -362,10 +362,10 @@ def app_info(app, show_status=False, raw=False):
 
         ret['upgradable'] = upgradable
         ret['change_url'] = os.path.exists(os.path.join(app_setting_path, "scripts", "change_url"))
-        
+
         with open(os.path.join(APPS_SETTING_PATH, app, 'manifest.json')) as json_manifest:
             manifest = json.load(json_manifest)
-        
+
         ret['version'] = manifest.get('version', '-')
 
         return ret
@@ -490,7 +490,7 @@ def app_change_url(operation_logger, app, domain, path):
     # Retrieve arguments list for change_url script
     # TODO: Allow to specify arguments
     args_odict = _parse_args_from_manifest(manifest, 'change_url')
-    args_list = args_odict.values()
+    args_list = [ value[0] for value in args_odict.values() ]
     args_list.append(app)
 
     # Prepare env. var. to pass to script
@@ -639,7 +639,7 @@ def app_upgrade(app=[], url=None, file=None):
         # Retrieve arguments list for upgrade script
         # TODO: Allow to specify arguments
         args_odict = _parse_args_from_manifest(manifest, 'upgrade')
-        args_list = args_odict.values()
+        args_list = [ value[0] for value in args_odict.values() ]
         args_list.append(app_instance_name)
 
         # Prepare env. var. to pass to script
@@ -797,7 +797,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     args_dict = {} if not args else \
         dict(urlparse.parse_qsl(args, keep_blank_values=True))
     args_odict = _parse_args_from_manifest(manifest, 'install', args=args_dict)
-    args_list = args_odict.values()
+    args_list = [ value[0] for value in args_odict.values() ]
     args_list.append(app_instance_name)
 
     # Prepare env. var. to pass to script
@@ -1537,7 +1537,7 @@ def app_action_run(app, action, args=None):
     # Retrieve arguments list for install script
     args_dict = dict(urlparse.parse_qsl(args, keep_blank_values=True)) if args else {}
     args_odict = _parse_args_for_action(actions[action], args=args_dict)
-    args_list = args_odict.values()
+    args_list = [ value[0] for value in args_odict.values() ]
 
     app_id, app_instance_nb = _parse_app_instance_name(app)
 
@@ -2272,7 +2272,7 @@ def _parse_action_args_in_yunohost_format(args, action_args):
             if arg.get("optional", False):
                 # Argument is optional, keep an empty value
                 # and that's all for this arg !
-                args_dict[arg_name] = ''
+                args_dict[arg_name] = ('', arg_type)
                 continue
             else:
                 # The argument is required !
@@ -2310,22 +2310,20 @@ def _parse_action_args_in_yunohost_format(args, action_args):
                 raise YunohostError('pattern_password_app', forbidden_chars=forbidden_chars)
             from yunohost.utils.password import assert_password_is_strong_enough
             assert_password_is_strong_enough('user', arg_value)
-        args_dict[arg_name] = arg_value
+        args_dict[arg_name] = (arg_value, arg_type)
 
     # END loop over action_args...
 
     # If there's only one "domain" and "path", validate that domain/path
     # is an available url and normalize the path.
 
-    domain_args = [arg["name"] for arg in action_args
-                   if arg.get("type", "string") == "domain"]
-    path_args = [arg["name"] for arg in action_args
-                 if arg.get("type", "string") == "path"]
+    domain_args = [ (name, value[0]) for name, value in args_dict.items() if value[1] == "domain" ]
+    path_args = [ (name, value[0]) for name, value in args_dict.items() if value[1] == "path" ]
 
     if len(domain_args) == 1 and len(path_args) == 1:
 
-        domain = args_dict[domain_args[0]]
-        path = args_dict[path_args[0]]
+        domain = domain_args[0][1]
+        path = path_args[0][1]
         domain, path = _normalize_domain_path(domain, path)
 
         # Check the url is available
@@ -2344,7 +2342,7 @@ def _parse_action_args_in_yunohost_format(args, action_args):
 
         # (We save this normalized path so that the install script have a
         # standard path format to deal with no matter what the user inputted)
-        args_dict[path_args[0]] = path
+        args_dict[path_args[0][0]] = (path, "path")
 
     return args_dict
 
@@ -2359,8 +2357,8 @@ def _make_environment_dict(args_dict, prefix="APP_ARG_"):
 
     """
     env_dict = {}
-    for arg_name, arg_value in args_dict.items():
-        env_dict["YNH_%s%s" % (prefix, arg_name.upper())] = arg_value
+    for arg_name, arg_value_and_type in args_dict.items():
+        env_dict["YNH_%s%s" % (prefix, arg_name.upper())] = arg_value_and_type[0]
     return env_dict
 
 

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -375,8 +375,11 @@ class OperationLogger(object):
         Write or rewrite the metadata file with all metadata known
         """
 
+        dump = yaml.safe_dump(self.metadata, default_flow_style=False)
+        for data in self.data_to_redact:
+            dump = dump.replace(data, "**********")
         with open(self.md_path, 'w') as outfile:
-            yaml.safe_dump(self.metadata, outfile, default_flow_style=False)
+            outfile.write(dump)
 
     @property
     def name(self):

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -308,7 +308,9 @@ class RedactingFormatter(Formatter):
         # Wrapping this in a try/except because we don't want this to
         # break everything in case it fails miserably for some reason :s
         try:
-            match = re.search(r'(db_pwd|password)=(\S{3,})$', record.strip())
+            # This matches stuff like db_pwd=the_secret or admin_password=other_secret
+            # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
+            match = re.search(r'(pwd|pass|password)=(\S{3,})$', record.strip())
             if match and match.group(2) not in self.data_to_redact:
                 self.data_to_redact.append(match.group(2))
         except Exception as e:

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -377,7 +377,7 @@ class OperationLogger(object):
 
         self.file_handler = FileHandler(self.log_path)
         # We use a custom formatter that's able to redact all stuff in self.data_to_redact
-        # N.B. : the stubtle thing here is that the class will remember a pointer to the list,
+        # N.B. : the subtle thing here is that the class will remember a pointer to the list,
         # so we can directly append stuff to self.data_to_redact and that'll be automatically
         # propagated to the RedactingFormatter
         self.file_handler.formatter = RedactingFormatter('%(asctime)s: %(levelname)s - %(message)s', self.data_to_redact)

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -323,6 +323,7 @@ class OperationLogger(object):
         self.logger = None
         self._name = None
         self.data_to_redact = []
+        self.data_to_redact.append(open("/etc/yunohost/mysql", "r").read().strip())
 
         self.path = OPERATIONS_PATH
 

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -338,7 +338,10 @@ class OperationLogger(object):
         self.logger = None
         self._name = None
         self.data_to_redact = []
-        self.data_to_redact.append(open("/etc/yunohost/mysql", "r").read().strip())
+
+        for filename in ["/etc/yunohost/mysql", "/etc/yunohost/psql"]:
+            if os.path.exists(filename):
+                self.data_to_redact.append(read_file(filename).strip())
 
         self.path = OPERATIONS_PATH
 


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1363

Note when working on this, I realized that the "python argument" case is already covered, c.f. these : 
https://github.com/YunoHost/yunohost/blob/stretch-testing/src/yunohost/log.py#L224
https://github.com/YunoHost/yunohost/blob/stretch-testing/src/yunohost/user.py#L274

## Solution

So here's an attempt to redact at least *most* of the sensitive / secret data in the logs. So far I was able to cover : 
- "static" secrets like `/etc/yunohost/mysql`
- secrets provided through the install form (password-type args)
- secrets generated or fetched(!) during the script execution, like mysql db password.

The last item is the least easiest and least "clean" one. It's all built on the way bash logs or not information ... So for example, we are somewhat lucky that [this line](https://github.com/YunoHost/yunohost/blob/stretch-unstable/data/helpers.d/mysql#L202) only results in showing the secret for the first time as : 

```
local new_db_pwd=the_super_secret
```

(and there's no weird intermediate output already showing the secret). Otherwise, it would be much more difficult to catch and we might end up having to *rewrite already written stuff in the file* which would complicates stuff (though not impossible but ugh)

So the current mechanism relies on catching matches for this regex : `(db_pwd|password)=(\S{3,})$`

So for example : `+ local new_db_pwd=pT0QepguMxajbmQE5Ad4ZPgd`

and therefore covers mysql and postgresql dbs created with the standard helpers. This also covers *getting* passwords from the setting file, as done with e.g. `upload_password=$(ynh_app_setting_get --app=$app --key=upload_password)` (as long as the variable name ends with `password` ...). So there are corner cases that might not be covered like if the variable is instead named `admin_pass`... To be discussed.

Hopefully that's a relatively understandable explanation :sweat_smile: 

## PR Status

Tested on the app install of my_webapp on my side ... seems to be kinda working

## How to test

Run some app install (and also remove, upgrade, ... any special case that could show a password or other info we would want to redact)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
