### PR TITLE
Fix wrong usage of ynh_mysql_user_exists

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -231,7 +231,7 @@ ynh_mysql_remove_db () {
 	fi
 
 	# Remove mysql user if it exists
-        if $(ynh_mysql_user_exists --user=$db_user); then
+	if ynh_mysql_user_exists --user=$db_user; then
 		ynh_mysql_drop_user $db_user
 	fi
 }


### PR DESCRIPTION
## The problem

`ynh_mysql_user_exists` returns 1 or 0 as error code ...  but is used with `if $(ynh_mysql_user_exists)` instead of `if ynh_mysql_user_exists` ... Dunno if that's really troublesome since apparently that never caused any issue, but at least that's unconsistent and confusing ...

## Solution

Fix it eh

## PR Status

Done, but untested :/ 

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
