### PR TITLE
[fix] Missing internetcube list

### DIFF
--- a/src/yunohost/data_migrations/0010_migrate_to_apps_json.py
+++ b/src/yunohost/data_migrations/0010_migrate_to_apps_json.py
@@ -25,7 +25,8 @@ class MyMigration(Migration):
             "app.yunohost.org/list.json",       # Old list on old installs, alias to official.json
             "app.yunohost.org/official.json",
             "app.yunohost.org/community.json",
-            "labriqueinter.net/apps/labriqueinternet.json"
+            "labriqueinter.net/apps/labriqueinternet.json",
+            "labriqueinter.net/internetcube.json"
         ]
 
         appslists = _read_appslist_list()


### PR DESCRIPTION
## The problem

With 3.6.2 my internetcube list was not removed. My internetcube is one of the first installed (installed by kload himself...).

## Solution

Add the missing list

## PR Status

Ready

## How to test



## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
