### PR TITLE
Python hooks reloaded

### DIFF
--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -462,7 +462,13 @@ def _hook_exec_python(path, args, env, loggers):
 
     # TODO : We might want to check here that it's a tuple
     # containing an int + a dict ?
-    return module.main(args, env, loggers)
+    ret = module.main(args, env, loggers)
+    assert isinstance(ret, tuple) \
+            and len(ret) == 2 \
+            and isinstance(ret[0],int) \
+            and isinstance(ret[1],dict), \
+            "Module %s did not return a (int, dict) tuple !" % module
+    return ret
 
 
 def _extract_filename_parts(filename):

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -460,9 +460,8 @@ def _hook_exec_python(path, args, env, loggers):
         sys.path = [dir_] + sys.path
     module = import_module(name)
 
-    # TODO : We might want to check here that it's a tuple
-    # containing an int + a dict ?
     ret = module.main(args, env, loggers)
+    # # Assert that the return is a (int, dict) tuple
     assert isinstance(ret, tuple) \
             and len(ret) == 2 \
             and isinstance(ret[0],int) \

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -329,7 +329,7 @@ def hook_exec(path, args=None, raise_on_error=False, no_trace=False,
     else:
         # TODO / FIXME : if needed in the future, implement support for other
         # languages...
-        assert hook_ext == "", "hook_exec only supports bash and python hooks for now"
+        assert hook_ext in ["", ".sh"], "hook_exec only supports bash and python hooks for now"
 
     # Define output loggers and call command
     loggers = (


### PR DESCRIPTION
## The problem

This is a rewrite of https://github.com/YunoHost/yunohost/pull/535 because there were too many changes ... : 

Python hooks are required for the new diagnosis system modularity / extendability, and more generally if we want to implement some hooks in python for some reason. This could be the case for example of the famous `app ssowatconf` command which should be a classical regen-conf thing but can't be so far because it has too many python calls and json stuff to be implemented in bash.

## Solution

Split the behavior of the `hook_exec` function depending on the nature of the hook. Python hooks are to be modules loaded by yunohost and expected to have a `main` function.

## PR Status

Tested and working

## How to test

Create some hook with a main function (e.g. just displaying `hello world`) and call `yunohost hook list your_hook_type` and `yunohost diagnosis callback your_hook_type`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
