### PR TITLE
Manifest in toml

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -730,10 +730,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     from yunohost.permission import permission_add, permission_update, permission_remove, permission_sync_to_user
     ldap = _get_ldap_interface()
 
-    # Fetch or extract sources
-    try:
-        os.listdir(INSTALL_TMP)
-    except OSError:
+    if not os.path.exists(INSTALL_TMP):
         os.makedirs(INSTALL_TMP)
 
     status = {


### PR DESCRIPTION
## The problem

Like every other PR, json sucks at writing, toml is better, allow to use toml instead, this time for manifest.

## PR Status

Tested what I could test but that's used a bit everywhere so ... meh :/

Would be really great in a test, bugs will be easy to fix if present.

Also, should we consider this feature to be experimental too?

Here is a `manifest.toml` for reference:

```toml
license = "free"
url = "https://example.com"
multi_instance = true
version = "1.0~ynh1"
packaging_format = 1
services = ["nginx", "php7.0-fpm", "mysql"]
id = "ynhexample"
name = "YunoHost example app"

[requirements]
yunohost = ">= 3.5"

[maintainer]
url = "http://example.com"
name = "John doe"
email = "john.doe@example.com"

[description]
fr = "Exemple de package d'application pour YunoHost."
en = "Example package for YunoHost application."

[arguments]
    [arguments.install.domain]
    type = "domain"
    example = "example.com"
        [arguments.install.domain.ask]
        fr = "Choisissez un nom de domaine pour ynhexample"
        en = "Choose a domain name for ynhexample"

    [arguments.install.path]
    default = "/example"
    type = "path"
    example = "/example"
        [arguments.install.path.ask]
        fr = "Choisissez un chemin pour ynhexample"
        en = "Choose a path for ynhexample"

    [arguments.install.admin]
    type = "user"
    example = "johndoe"
        [arguments.install.admin.ask]
        fr = "Choisissez l'administrateur"
        en = "Choose an admin user"

    [arguments.install.is_public]
    default = true
    type = "boolean"
    name = "is_public"
        [arguments.install.is_public.ask]
        fr = "Est-ce une application publique ?"
        en = "Is it a public application?"

    [arguments.install.language]
    default = "fr"
    type = "string"
    choices = ["fr", "en"]
        [arguments.install.language.ask]
        fr = "Choisissez la langue de l'application"
        en = "Choose the application language"

    [arguments.install.password]
    example = "Choose a password"
    type = "password"
        [arguments.install.password.ask]
        fr = "Dxe9finissez le mot de passe administrateur"
        en = "Set the administrator password"
        [arguments.install.password.help]
        fr = "Utilisez le champ aide pour ajouter une information xe0 l'intention de l'administrateur xe0 propos de cette question."
        en = "Use the help field to add an information for the admin about this question."
```

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
