### PR TITLE
[enh] Dpkg vendor set to YunoHost

### DIFF
--- a/data/other/dpkg-origins
+++ b/data/other/dpkg-origins
@@ -1,0 +1,4 @@
+Vendor: YunoHost
+Vendor-URL: https://yunohost.org/
+Bugs: https://github.com/YunoHost/issues/
+Parent: Debian

--- a/debian/install
+++ b/debian/install
@@ -6,6 +6,7 @@ data/actionsmap/* /usr/share/moulinette/actionsmap/
 data/hooks/* /usr/share/yunohost/hooks/
 data/other/yunoprompt.service /etc/systemd/system/
 data/other/password/* /usr/share/yunohost/other/password/
+data/other/dpkg-origins /etc/dpkg/origins/yunohost
 data/other/* /usr/share/yunohost/yunohost-config/moulinette/
 data/templates/* /usr/share/yunohost/templates/
 data/helpers /usr/share/yunohost/

--- a/debian/postinst
+++ b/debian/postinst
@@ -23,6 +23,12 @@ do_configure() {
         || echo "yunohost-firewall service is not running, you should " \
             "consider to start it by doing 'service yunohost-firewall start'."
   fi
+  
+  # Change dpkg vendor 
+  # see https://wiki.debian.org/Derivatives/Guidelines#Vendor
+  readlink -f /etc/dpkg/origins/default | grep -q debian \
+    && rm -f /etc/dpkg/origins/default \
+    && ln -s /etc/dpkg/origins/yunohost /etc/dpkg/origins/default
 
   # Yunoprompt
   systemctl enable yunoprompt.service

--- a/debian/postrm
+++ b/debian/postrm
@@ -14,6 +14,10 @@ if [ "$1" = "remove" ]; then
    rm -f /etc/yunohost/installed
 fi
 
+# Reset dpkg vendor to debian
+# see https://wiki.debian.org/Derivatives/Guidelines#Vendor
+rm -f /etc/dpkg/origins/default
+ln -s /etc/dpkg/origins/debian /etc/dpkg/origins/default
 
 #DEBHELPER#
 


### PR DESCRIPTION
## The problem

`dpkg-vendor --query Vendor` returns "debian"
see https://wiki.debian.org/Derivatives/Guidelines#Vendor

## Solution

Create /etc/dpkg/origins/yunohost and add a symlink on /etc/dpkg/origins/default

## PR Status

Ready (tested by putting file and symlink by hand on a yunohost instance)

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
