### PR TITLE
[fix] Can't delete a system backup with webadmin

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2380,7 +2380,7 @@ def backup_info(name, with_details=False, human_readable=False):
                     if name in info["size_details"][category].keys():
                         key_info["size"] = info["size_details"][category][name]
                         if human_readable:
-                            key_info["size"] = binary_to_human(key_info['size']) + 'B'
+                            key_info["size"] = binary_to_human(key_info["size"]) + 'B'
                     else:
                         key_info["size"] = -1
                         if human_readable:

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2372,13 +2372,18 @@ def backup_info(name, with_details=False, human_readable=False):
             for category in ["apps", "system"]:
                 for name, key_info in info[category].items():
                     if name in info["size_details"][category].keys():
-                        key_info["size"] = info["size_details"][category][name]
+                        size = info["size_details"][category][name]
                         if human_readable:
-                            key_info["size"] = binary_to_human(key_info["size"]) + 'B'
+                            size = binary_to_human(size) + 'B'
                     else:
-                        key_info["size"] = -1
+                        size = -1
                         if human_readable:
-                            key_info["size"] = "?"
+                            size = "?"
+
+                    if category == "system":
+                        info[category][name] = {'hooks': info[category][name], 'size': size}
+                    else:
+                        key_info['size'] = size
 
         result["apps"] = info["apps"]
         result["system"] = info[system_key]

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2372,7 +2372,7 @@ def backup_info(name, with_details=False, human_readable=False):
             for category in ["apps", "system"]:
                 for name, key_info in info[category].items():
                     # Retrocompatibility with archives produced 
-                    # around january 2019
+                    # until 3.5.x
                     if not isinstance(key_info, dict):
                         key_info = {x: 'succeed' for x in key_info}
                         info[category][name] = key_info

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2371,19 +2371,20 @@ def backup_info(name, with_details=False, human_readable=False):
         if "size_details" in info.keys():
             for category in ["apps", "system"]:
                 for name, key_info in info[category].items():
+                    # Retrocompatibility with archives produced 
+                    # around january 2019
+                    if not isinstance(key_info, dict):
+                        key_info = {x: 'succeed' for x in key_info}
+                        info[category][name] = key_info
+                        
                     if name in info["size_details"][category].keys():
-                        size = info["size_details"][category][name]
+                        key_info['size'] = info["size_details"][category][name]
                         if human_readable:
-                            size = binary_to_human(size) + 'B'
+                            key_info['size'] = binary_to_human(key_info['size']) + 'B'
                     else:
-                        size = -1
+                        key_info['size'] = -1
                         if human_readable:
-                            size = "?"
-
-                    if category == "system":
-                        info[category][name] = {'hooks': info[category][name], 'size': size}
-                    else:
-                        key_info['size'] = size
+                            key_info['size'] = "?"
 
         result["apps"] = info["apps"]
         result["system"] = info[system_key]

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2378,13 +2378,13 @@ def backup_info(name, with_details=False, human_readable=False):
                         info[category][name] = key_info
                         
                     if name in info["size_details"][category].keys():
-                        key_info['size'] = info["size_details"][category][name]
+                        key_info["size"] = info["size_details"][category][name]
                         if human_readable:
-                            key_info['size'] = binary_to_human(key_info['size']) + 'B'
+                            key_info["size"] = binary_to_human(key_info['size']) + 'B'
                     else:
-                        key_info['size'] = -1
+                        key_info["size"] = -1
                         if human_readable:
-                            key_info['size'] = "?"
+                            key_info["size"] = "?"
 
         result["apps"] = info["apps"]
         result["system"] = info[system_key]


### PR DESCRIPTION
## The problem

Backup info fails to display system backup. So the user can't delete it in Webadmin.
```
Traceback (most recent call last):
File “/usr/lib/python2.7/dist-packages/moulinette/interfaces/api.py”, line 439, in process
ret = self.actionsmap.process(arguments, timeout=30, route=_route)
File “/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py”, line 523, in process
return func(**arguments)
File “/usr/lib/moulinette/yunohost/backup.py”, line 2292, in backup_info
key_info[“size”] = info[“size_details”][category][name]
TypeError: list indices must be integers, not str
```

https://forum.yunohost.org/t/impossible-de-supprimer-une-archive-de-sauvegarde/8393

## Solution

Transform the list of string of hook by an object like: 
```
{ 'hooks': ["..."], 'size': 542}
```

## PR Status
Ready
Tested on a yunohost with same bug by running `yunohost backup info`

## How to test

Try to get info on old backup with system hook include (not only with apps)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
