### PR TITLE
[enh] allow to have arguments in manifest for the remove script

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -684,6 +684,9 @@ app:
             arguments:
                 app:
                     help: App(s) to delete
+                -a:
+                    full: --args
+                    help: Serialized arguments for app remove script (i.e. "domain=domain.tld&path=/path")
 
         ### app_upgrade()
         upgrade:


### PR DESCRIPTION
## The problem

It's not possible to ask questions to user during the removal of an app, this cause problem for undefined behavior where we aren't sure what is the best course of action. The most common case is: should we keep nextcloud data?

## Solution

Allow to ask questions to user.

A serie of personal suggestions:

- I think that all apps should provide default value for all remove arguments
- the app groupe should discuss the general question of "should we keep app data?" default answer to uniformize this behavior amongs all apps, I'm expecting this to be the number of question that is going to pop out

## PR Status

Tested on my installation, works as excepted.

THE ADMIN INTERFACE PART IS NOT DONE. Mostly because bower fails without any reason for me x(

## How to test

You simply need to add a "remove" section in "arguments" exactely the same one than "install" in a random app.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
