### PR TITLE
[fix] Fix values starting by - in getopts

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -76,6 +76,8 @@ ynh_handle_getopts_args () {
 			# ${#arguments[@]} is the size of the array
 			for arg in `seq 0 $(( ${#arguments[@]} - 1 ))`
 			do
+				# Escape options' values starting with -. Otherwise the - will be considered as another option.
+				arguments[arg]="${arguments[arg]//--${args_array[$option_flag]}-/--${args_array[$option_flag]}\\-}"
 				# And replace long option (value of the option_flag) by the short option, the option_flag itself
 				# (e.g. for [u]=user, --user will be -u)
 				# Replace long option with =

--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -77,7 +77,7 @@ ynh_handle_getopts_args () {
 			for arg in `seq 0 $(( ${#arguments[@]} - 1 ))`
 			do
 				# Escape options' values starting with -. Otherwise the - will be considered as another option.
-				arguments[arg]="${arguments[arg]//--${args_array[$option_flag]}-/--${args_array[$option_flag]}\\-}"
+				arguments[arg]="${arguments[arg]//--${args_array[$option_flag]}-/--${args_array[$option_flag]}\\TOBEREMOVED\\-}"
 				# And replace long option (value of the option_flag) by the short option, the option_flag itself
 				# (e.g. for [u]=user, --user will be -u)
 				# Replace long option with =
@@ -154,6 +154,9 @@ ynh_handle_getopts_args () {
 									# If there's already another value for this option, add a ; before adding the new value
 									eval ${option_var}+="\;"
 								fi
+
+								# Remove the \ that escape - at beginning of values.
+								all_args[i]="${all_args[i]//\\TOBEREMOVED\\/}"
 
 								# For the record.
 								# We're using eval here to get the content of the variable stored itself as simple text in $option_var...


### PR DESCRIPTION
## The problem

Getopts fails to parse a value if it's start by -. It's misread as another option in the argument list.
https://github.com/YunoHost-Apps/rainloop_ynh/issues/58

## Solution

Escape - if it's a value of an option.

## PR Status

Tested on rainloop.

## How to test

Try an value starting by -.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 