### PR TITLE
[enh] Upgrade n version (also for compatibility with arm64)

### DIFF
--- a/data/helpers.d/nodejs
+++ b/data/helpers.d/nodejs
@@ -16,8 +16,8 @@ ynh_install_n () {
 	ynh_print_info --message="Installation of N - Node.js version management"
 	# Build an app.src for n
 	mkdir -p "../conf"
-	echo "SOURCE_URL=https://github.com/tj/n/archive/v2.1.7.tar.gz
-SOURCE_SUM=2ba3c9d4dd3c7e38885b37e02337906a1ee91febe6d5c9159d89a9050f2eea8f" > "../conf/n.src"
+	echo "SOURCE_URL=https://github.com/tj/n/archive/v4.1.0.tar.gz
+SOURCE_SUM=3983fa3f00d4bf85ba8e21f1a590f6e28938093abe0bb950aeea52b1717471fc" > "../conf/n.src"
 	# Download and extract n
 	ynh_setup_source --dest_dir="$n_install_dir/git" --source_id=n
 	# Install n


### PR DESCRIPTION
## The problem

1. When installing node js using ynh_install_nodejs on aarch64, it's the x86-64 version of nodejs that is installed
2. N - Node.js version management included in YunoHost is version 2.1.7, one year old

## Solution

Updating N - Node.js version management version
since N version 3.0.0 aarch64 and arm64 are detected

## PR Status

Done

## How to test

Have and aarch64 or arm64 YunoHost, install a package that request nodejs like wekan: yunohost app install https://github.com/yalh76/wekan_ynh/tree/2.98 --debug

After the installation, just test someting like: `/opt/node_n/bin/node --version`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
