### PR TITLE
[fix] Path not displayed in log_corrupted_md_file

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -252,7 +252,7 @@
     "invalid_url_format": "Invalid URL format",
     "ip6tables_unavailable": "You cannot play with ip6tables here. You are either in a container or your kernel does not support it",
     "iptables_unavailable": "You cannot play with iptables here. You are either in a container or your kernel does not support it",
-    "log_corrupted_md_file": "The yaml metadata file associated with logs is corrupted: '{md_file}'",
+    "log_corrupted_md_file": "The yaml metadata file associated with logs is corrupted: '{md_file}\nError: {error}'",
     "log_category_404": "The log category '{category}' does not exist",
     "log_link_to_log": "Full log of this operation: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
     "log_help_to_get_log": "To view the log of the operation '{desc}', use the command 'yunohost log display {name}'",

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -106,7 +106,7 @@ def log_list(category=[], limit=None, with_details=False):
                     try:
                         metadata = yaml.safe_load(md_file)
                     except yaml.YAMLError:
-                        logger.warning(m18n.n('log_corrupted_md_file', file=md_path))
+                        logger.warning(m18n.n('log_corrupted_md_file', md_file=md_path))
 
                     entry["success"] = metadata.get("success", "?") if metadata else "?"
 
@@ -192,7 +192,7 @@ def log_display(path, number=50, share=False):
                 if 'log_path' in metadata:
                     log_path = metadata['log_path']
             except yaml.YAMLError:
-                error = m18n.n('log_corrupted_md_file', file=md_path)
+                error = m18n.n('log_corrupted_md_file', md_file=md_path)
                 if os.path.exists(log_path):
                     logger.warning(error)
                 else:

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -35,7 +35,7 @@ from logging import FileHandler, getLogger, Formatter
 from moulinette import m18n, msettings
 from yunohost.utils.error import YunohostError
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_file
+from moulinette.utils.filesystem import read_file, read_yaml
 
 CATEGORIES_PATH = '/var/log/yunohost/categories/'
 OPERATIONS_PATH = '/var/log/yunohost/categories/operation/'
@@ -102,13 +102,8 @@ def log_list(category=[], limit=None, with_details=False):
                 entry["started_at"] = log_datetime
 
             if with_details:
-                with open(md_path, "r") as md_file:
-                    try:
-                        metadata = yaml.safe_load(md_file)
-                    except yaml.YAMLError:
-                        logger.warning(m18n.n('log_corrupted_md_file', md_file=md_path))
-
-                    entry["success"] = metadata.get("success", "?") if metadata else "?"
+                metadata = read_yaml(md_path)
+                entry["success"] = metadata.get("success", "?") if metadata else "?"
 
             result[category].append(entry)
 


### PR DESCRIPTION
## The problem
An error is displayed without md_file var

"Le fichier yaml de metadata associé aux logs est corrompu : '{md_file}'"

## Solution

Use read_yaml moulinette helper to let us know on which file and error of yaml loading is triggered

## PR Status

Ready

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
