### PR TITLE
[enh] Add OpenLDAP TLS support

### DIFF
--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -31,7 +31,7 @@ do_init_regen() {
 do_pre_regen() {
   pending_dir=$1
 
-  # Add openldap user in the ssl-cert group to let it access the ceriticate for TLS
+  # Add openldap user in the ssl-cert group to let it access the certificate for TLS
   sudo usermod -aG ssl-cert openldap
 
   cd /usr/share/yunohost/templates/slapd

--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -31,9 +31,6 @@ do_init_regen() {
 do_pre_regen() {
   pending_dir=$1
 
-  # Add openldap user in the ssl-cert group to let it access the certificate for TLS
-  sudo usermod -aG ssl-cert openldap
-
   cd /usr/share/yunohost/templates/slapd
 
   # create needed directories
@@ -78,6 +75,9 @@ do_post_regen() {
   sudo chown root:openldap /etc/ldap/slapd.conf
   sudo chown -R openldap:openldap /etc/ldap/schema/
   sudo chown -R openldap:openldap /etc/ldap/slapd.d/
+
+  # Add openldap user in the ssl-cert group to let it access the certificate for TLS
+  sudo usermod -aG ssl-cert openldap
 
   [ -z "$regen_conf_files" ] && exit 0
 

--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -31,6 +31,9 @@ do_init_regen() {
 do_pre_regen() {
   pending_dir=$1
 
+  # Add openldap user in the ssl-cert group to let it access the ceriticate for TLS
+  sudo usermod -aG ssl-cert openldap
+
   cd /usr/share/yunohost/templates/slapd
 
   # create needed directories

--- a/data/templates/slapd/slapd.conf
+++ b/data/templates/slapd/slapd.conf
@@ -41,6 +41,10 @@ sizelimit 500
 # for indexing.
 tool-threads 1
 
+# TLS Support
+TLSCertificateFile /etc/ssl/private/yunohost_crt.pem
+TLSCertificateKeyFile /etc/ssl/private/yunohost_key.pem
+
 #######################################################################
 # Specific Backend Directives for mdb:
 # Backend specific directives apply to this backend until another


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1379

## Solution

Implement TLS Certificate : https://www.openldap.org/doc/admin24/tls.html

## PR Status

...

## How to test

- Apply the patch
- Execute `yunohost tools regen-conf`
- Test using `openssl s_client -connect localhost:636 -showcerts`

Tested with Mastodon LDAP authentication: https://github.com/YunoHost-Apps/mastodon_ynh/pull/165

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
