### PR TITLE
[mod] on reset ldap password temp password display is not needed anymore

### DIFF
--- a/sbin/yunohost-reset-ldap-password
+++ b/sbin/yunohost-reset-ldap-password
@@ -40,13 +40,6 @@ service slapd start
 #   Properly set new admin password   #
 #######################################
 
-# Display tmp password to user
-# NB : we do NOT pass it as a command line argument for "yunohost tools adminpw"
-# as a malicious user could run a script in background waiting for this command
-# to pop in ps -ef and automatically do nasty stuff in the ldap database
-# meanwhile.
-echo "Use this temporary password when asked for the administration password : $TMP_LDAPROOT_PASSWORD"
-
 # Call yunohost tools adminpw for user to set new password
 yunohost tools adminpw
 


### PR DESCRIPTION
## The problem

Tested the command, it's not needed anymore to enter the password by hand. 

This also means that this script is not needed anymore in shell since "yunohost tools adminpw" don't ask for the password anymore, but in case someone still use it let's clean it.

@alexAubin I'm not micromerging because I want your validation but I think we can directly do it (and simplify much more this script but who knows we might need it?)

## PR Status

Working.

## How to test

Launch the script.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
