### PR TITLE
[fix] moulinette logs were never displayed #lol

### DIFF
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -145,7 +145,7 @@ def _init_moulinette(debug=False, quiet=False):
             },
             'moulinette': {
                 'level': level,
-                'handlers': [],
+                'handlers': handlers,
                 'propagate': True,
             },
             'moulinette.interface': {


### PR DESCRIPTION
Needed for https://github.com/YunoHost/moulinette/pull/205

For some reason logs from core of the moulinette were never displayed at all since 4 years :man_shrugging: 