### PR TITLE
Add apache2 as conflicting package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Conflicts: iptables-persistent
  , yunohost-config-dovecot, yunohost-config-slapd
  , yunohost-config-nginx, yunohost-config-amavis
  , yunohost-config-mysql, yunohost-predepends
+ , apache2
 Replaces: moulinette-yunohost, yunohost-config
  , yunohost-config-others, yunohost-config-postfix
  , yunohost-config-dovecot, yunohost-config-slapd


### PR DESCRIPTION
## The problem

In various situation, we end up with people voluntarily installing apache2, or various dependency stuff in apt/dpkg ending up willing to install apache2 because some packages have it as recommended or whatever ...

This ends up breaking instances because once the server restarts, apache may start before nginx

## Solution

Add apache2 as a damn conflict to end this madness. YunoHost is a packaged flagged as "Essential" in Debian control file, so YunoHost should win in a fight against apache2 (or at least, even trying to install apache2 explicitly manually will result in a "Are you really sure?" question from apt)

## PR Status

Yolocommited, not really tested but meh

## How to test

Well eh find a way to properly update the control file of an existing install and try to install apache2...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
