### PR TITLE
[mod] don't truncate 'yunohost log display' log by default

### DIFF
--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -121,7 +121,7 @@ def log_list(category=[], limit=None, with_details=False):
     return result
 
 
-def log_display(path, number=50, share=False):
+def log_display(path, number=None, share=False):
     """
     Display a log file enriched with metadata if any.
 
@@ -201,7 +201,10 @@ def log_display(path, number=50, share=False):
     # Display logs if exist
     if os.path.exists(log_path):
         from yunohost.service import _tail
-        logs = _tail(log_path, int(number))
+        if number:
+            logs = _tail(log_path, int(number))
+        else:
+            logs = read_file(log_path)
         infos['log_path'] = log_path
         infos['logs'] = logs
 


### PR DESCRIPTION
## The problem

Having seen several situations of users working with logs the fact that logs are truncated by default is absolutely not obvious at all and very confusing, they just don't get it and I got trap myself several times.

## Solution

Remove the truncating by default as it actually really doesn't served that much purpose.

## PR Status

Test and works.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
