### PR TITLE
[mod] BREAKING (but should be fine) apps without path aren't considering using the domain anymore

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -420,6 +420,9 @@ def app_map(app=None, raw=False, user=None):
             continue
         if 'domain' not in app_settings:
             continue
+        if 'path' not in app_settings:
+            # we assume that an app that doesn't have a path doesn't have an HTTP api
+            continue
         if 'no_sso' in app_settings:  # I don't think we need to check for the value here
             continue
         if user is not None:
@@ -430,7 +433,7 @@ def app_map(app=None, raw=False, user=None):
                 continue
 
         domain = app_settings['domain']
-        path = app_settings.get('path', '/')
+        path = app_settings['path']
 
         if raw:
             if domain not in result:


### PR DESCRIPTION
## The problem

Following https://github.com/YunoHost/issues/issues/1384#event-2490152235 we stop considering that an app that only has a domain but not (http) path is having an HTTP api.

That might breaks some app (but I'm really expecting not, that looks too much like a bad practice.)

## PR Status

Tested and working for me.

## How to test

Have some apps, edit the settings of one (`/etc/yunohost/$app/settings.yml`) to remove the path and launch `yunohost app map`.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
