### PR TITLE
[mod] more permissive email regex

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -104,7 +104,7 @@ user:
                         ask: ask_email
                         required: True
                         pattern: &pattern_email
-                            - !!str ^[\w.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+([^\W\d_]{2,})$
+                            - !!str ".+@.+"
                             - "pattern_email"
                 -p:
                     full: --password


### PR DESCRIPTION
## The problem

Email regex is way too restrictive, doesn't allow "+" stuff etc...

Extracted from
https://github.com/YunoHost/yunohost/pull/176/files#diff-85bc3950f9df27a6e9d05ea5ff3c82fbR129
by Julien Malik

## Solution

Make simpler stuff, email for regex is fucked up after all, we can only assume to have a "@" somewhere.

## PR Status

Not tested but looks fine.

**We probably need to check if this doesn't allow ldap query injection**

## How to test

Create a new user with a fucked up email address.
## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
