### PR TITLE
[enh] Iteration on sanity / anomaly checks for app operations

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -409,6 +409,7 @@
     "no_ipv6_connectivity": "IPv6 connectivity is not available",
     "no_restore_script": "No restore script found for the app '{app:s}'",
     "not_enough_disk_space": "Not enough free disk space on '{path:s}'",
+    "operation_interrupted": "The operation was manually interrupted?",
     "package_not_installed": "Package '{pkgname}' is not installed",
     "package_unexpected_error": "An unexpected error occurred processing the package '{pkgname}'",
     "package_unknown": "Unknown package '{pkgname}'",

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,6 +7,7 @@
     "admin_password_too_long": "Please choose a password shorter than 127 characters",
     "already_up_to_date": "Nothing to do! Everything is already up to date!",
     "app_action_cannot_be_ran_because_required_services_down": "This app requires some services which are currently down. Before continuing, you should try to restart the following services (and possibly investigate why they are down) : {services}",
+    "app_action_broke_system": "This action seem to have broke these important services: {services}",
     "app_already_installed": "{app:s} is already installed",
     "app_already_installed_cant_change_url": "This app is already installed. The url cannot be changed just by this function. Look into `app changeurl` if it's available.",
     "app_already_up_to_date": "{app:s} is already up to date",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -679,7 +679,10 @@ def app_upgrade(app=[], url=None, file=None):
         finally:
 
             # Did the script succeed ?
-            if upgrade_retcode != 0:
+            if upgrade_retcode == -1:
+                error_msg = m18n.n('operation_interrupted')
+                operation_logger.error(error_msg)
+            elif upgrade_retcode != 0:
                 error_msg = m18n.n('app_upgrade_failed', app=app_instance_name)
                 operation_logger.error(error_msg)
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -666,56 +666,81 @@ def app_upgrade(app=[], url=None, file=None):
 
         # Execute App upgrade script
         os.system('chown -hR admin: %s' % INSTALL_TMP)
-        if hook_exec(extracted_app_folder + '/scripts/upgrade',
-                     args=args_list, env=env_dict)[0] != 0:
-            msg = m18n.n('app_upgrade_failed', app=app_instance_name)
-            operation_logger.error(msg)
 
-            # display this if there are remaining apps
-            if apps[number + 1:]:
-                logger.error(m18n.n('app_upgrade_stopped'))
-                not_upgraded_apps = apps[number:]
-                # we don't want to continue upgrading apps here in case that breaks
-                # everything
-                raise YunohostError('app_not_upgraded',
-                                    failed_app=app_instance_name,
-                                    apps=', '.join(not_upgraded_apps))
+
+        try:
+            upgrade_retcode = hook_exec(extracted_app_folder + '/scripts/upgrade',
+                                        args=args_list, env=env_dict)[0]
+        except (KeyboardInterrupt, EOFError):
+            upgrade_retcode = -1
+        except Exception:
+            import traceback
+            logger.exception(m18n.n('unexpected_error', error=u"\n" + traceback.format_exc()))
+        finally:
+
+            # Did the script succeed ?
+            if upgrade_retcode != 0:
+                error_msg = m18n.n('app_upgrade_failed', app=app_instance_name)
+                operation_logger.error(error_msg)
+
+            # Did it broke the system ?
+            try:
+                broke_the_system = False
+                _assert_system_is_sane_for_app(manifest, "post")
+            except Exception as e:
+                broke_the_system = True
+                error_msg = operation_logger.error(str(e))
+
+            # If upgrade failed or broke the system,
+            # raise an error and interrupt all other pending upgrades
+            if upgrade_retcode != 0 or broke_the_system:
+
+                # display this if there are remaining apps
+                if apps[number + 1:]:
+                    logger.error(m18n.n('app_upgrade_stopped'))
+                    not_upgraded_apps = apps[number:]
+                    # we don't want to continue upgrading apps here in case that breaks
+                    # everything
+                    raise YunohostError('app_not_upgraded',
+                                        failed_app=app_instance_name,
+                                        apps=', '.join(not_upgraded_apps))
+                else:
+                    raise YunohostError(error_msg, raw_msg=True)
+
+            # Otherwise we're good and keep going !
             else:
-                raise YunohostError(msg)
-        else:
-            now = int(time.time())
-            # TODO: Move install_time away from app_setting
-            app_setting(app_instance_name, 'update_time', now)
-            status['upgraded_at'] = now
+                now = int(time.time())
+                # TODO: Move install_time away from app_setting
+                app_setting(app_instance_name, 'update_time', now)
+                status['upgraded_at'] = now
 
-            # Clean hooks and add new ones
-            hook_remove(app_instance_name)
-            if 'hooks' in os.listdir(extracted_app_folder):
-                for hook in os.listdir(extracted_app_folder + '/hooks'):
-                    hook_add(app_instance_name, extracted_app_folder + '/hooks/' + hook)
+                # Clean hooks and add new ones
+                hook_remove(app_instance_name)
+                if 'hooks' in os.listdir(extracted_app_folder):
+                    for hook in os.listdir(extracted_app_folder + '/hooks'):
+                        hook_add(app_instance_name, extracted_app_folder + '/hooks/' + hook)
 
-            # Store app status
-            with open(app_setting_path + '/status.json', 'w+') as f:
-                json.dump(status, f)
+                # Store app status
+                with open(app_setting_path + '/status.json', 'w+') as f:
+                    json.dump(status, f)
 
-            # Replace scripts and manifest and conf (if exists)
-            os.system('rm -rf "%s/scripts" "%s/manifest.toml %s/manifest.json %s/conf"' % (app_setting_path, app_setting_path, app_setting_path, app_setting_path))
+                # Replace scripts and manifest and conf (if exists)
+                os.system('rm -rf "%s/scripts" "%s/manifest.toml %s/manifest.json %s/conf"' % (app_setting_path, app_setting_path, app_setting_path, app_setting_path))
 
-            if os.path.exists(os.path.join(extracted_app_folder, "manifest.json")):
-                os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
-            if os.path.exists(os.path.join(extracted_app_folder, "manifest.toml")):
-                os.system('mv "%s/manifest.toml" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
+                if os.path.exists(os.path.join(extracted_app_folder, "manifest.json")):
+                    os.system('mv "%s/manifest.json" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
+                if os.path.exists(os.path.join(extracted_app_folder, "manifest.toml")):
+                    os.system('mv "%s/manifest.toml" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
-            for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf"]:
-                if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
-                    os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
+                for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf"]:
+                    if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
+                        os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 
-            # So much win
-            logger.success(m18n.n('app_upgraded', app=app_instance_name))
+                # So much win
+                logger.success(m18n.n('app_upgraded', app=app_instance_name))
 
-            _assert_system_is_sane_for_app(manifest, "post")
-            hook_callback('post_app_upgrade', args=args_list, env=env_dict)
-            operation_logger.success()
+                hook_callback('post_app_upgrade', args=args_list, env=env_dict)
+                operation_logger.success()
 
     permission_sync_to_user()
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -931,8 +931,12 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
                     logger.warning(msg)
                     operation_logger_remove.error(msg)
                 else:
-                    _assert_system_is_sane_for_app(manifest, "post")
-                    operation_logger_remove.success()
+                    try:
+                        _assert_system_is_sane_for_app(manifest, "post")
+                    except Exception as e:
+                        operation_logger_remove.error(e)
+                    else:
+                        operation_logger_remove.success()
 
             # Clean tmp folders
             shutil.rmtree(app_setting_path)


### PR DESCRIPTION
## The problem

Currently we now do some checks that services requested by an app are up and running (and other anomaly checks) before some operations like install and upgrade ...Which is cool, but we can do better : 
- checking *before* and *after* the operations
- check nginx and fail2ban all the time even if not explicitly required by the app, because those are related to regular issues
- combine this with the dpkg check (and in the future we can add other basic sanity checks in that vein)

## Solution

Rework a few things to implement this

## PR Status

Tested and working using the PR about app unit tests ... Though maybe still need some work because not all tests are implemented and there are still weird issues in the test

## How to test

Eeeeh using the app unit test, or manually run stuff like app install with nginx down. Or try to install an app that break nginx or fail2ban.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
