### PR TITLE
"yunohost dyndns update" "--force" and "--dry-run"

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1533,6 +1533,10 @@ dyndns:
                 -i:
                     full: --ipv4
                     help: IP address to send
+                -f:
+                    full: --force
+                    help: Force the update (for debugging only)
+                    action: store_true
                 -6:
                     full: --ipv6
                     help: IPv6 address to send

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1537,6 +1537,10 @@ dyndns:
                     full: --force
                     help: Force the update (for debugging only)
                     action: store_true
+                -D:
+                    full: --dry-run
+                    help: Only display the generated zone
+                    action: store_true
                 -6:
                     full: --ipv6
                     help: IPv6 address to send

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -33,7 +33,7 @@ import subprocess
 from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import write_to_file
+from moulinette.utils.filesystem import write_to_file, read_file
 from moulinette.utils.network import download_json
 from moulinette.utils.process import check_output
 
@@ -176,7 +176,7 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
 
 @is_unit_operation()
 def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None, key=None,
-                  ipv4=None, ipv6=None, force=False):
+                  ipv4=None, ipv6=None, force=False, dry_run=False):
     """
     Update IP on DynDNS platform
 
@@ -249,7 +249,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
     logger.debug("Requested IPv4/v6 are (%s, %s)" % (ipv4, ipv6))
 
     # no need to update
-    if not force and (old_ipv4 == ipv4 and old_ipv6 == ipv6):
+    if (not force and not dry_run) and (old_ipv4 == ipv4 and old_ipv6 == ipv6):
         logger.info("No updated needed.")
         return
     else:
@@ -296,13 +296,18 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
 
     logger.debug("Now pushing new conf to DynDNS host...")
 
-    try:
-        command = ["/usr/bin/nsupdate", "-k", key, DYNDNS_ZONE]
-        subprocess.check_call(command)
-    except subprocess.CalledProcessError:
-        raise YunohostError('dyndns_ip_update_failed')
+    if not dry_run:
+        try:
+            command = ["/usr/bin/nsupdate", "-k", key, DYNDNS_ZONE]
+            subprocess.check_call(command)
+        except subprocess.CalledProcessError:
+            raise YunohostError('dyndns_ip_update_failed')
 
-    logger.success(m18n.n('dyndns_ip_updated'))
+        logger.success(m18n.n('dyndns_ip_updated'))
+    else:
+        print(read_file(DYNDNS_ZONE))
+        print("")
+        print("Warning: dry run, this is only the generated config, it won't be applied")
 
 
 def dyndns_installcron():

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -279,7 +279,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
             # should be muc.the.domain.tld. or the.domain.tld
             if record["value"] == "@":
                 record["value"] = domain
-            record["value"] = record["value"].replace(";", "\;")
+            record["value"] = record["value"].replace(";", r"\;")
 
             action = "update add {name}.{domain}. {ttl} {type} {value}".format(domain=domain, **record)
             action = action.replace(" @.", " ")

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -176,7 +176,7 @@ def dyndns_subscribe(operation_logger, subscribe_host="dyndns.yunohost.org", dom
 
 @is_unit_operation()
 def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None, key=None,
-                  ipv4=None, ipv6=None):
+                  ipv4=None, ipv6=None, force=False):
     """
     Update IP on DynDNS platform
 
@@ -249,7 +249,7 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
     logger.debug("Requested IPv4/v6 are (%s, %s)" % (ipv4, ipv6))
 
     # no need to update
-    if old_ipv4 == ipv4 and old_ipv6 == ipv6:
+    if not force and (old_ipv4 == ipv4 and old_ipv6 == ipv6):
         logger.info("No updated needed.")
         return
     else:


### PR DESCRIPTION
## The problem

Some you need to force the update of dyndns to check if the DKIM key is sent and you generally want to be able to have those feature for debugging (--dry-run).

## Solution

Add:

* `--force` the force update
* `--dry-run` that display the generated dns config that will be send but isn't

## PR Status

Tested and working, quite minor.

## How to test

Just do a "dyndns update" with the options, simple.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
