### PR TITLE
Add basic Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: python
-install: "pip install pytest pyyaml"
-python:
-    - "2.7"
-script: "py.test tests"
+
+matrix:
+  allow_failures:
+    - env: TOXENV=lint
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=lint
+
+install:
+  - pip install tox
+
+script:
+  - tox

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/YunoHost/yunohost.svg?branch=stretch-unstable)](https://travis-ci.org/YunoHost/yunohost)
+[![GitHub license](https://img.shields.io/github/license/YunoHost/yunohost)](https://github.com/YunoHost/yunohost/blob/stretch-unstable/LICENSE)
+
 # YunoHost core
 
 This repository is the core of YunoHost code.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -s -v
+norecursedirs = dist doc build .tox .eggs
+testpaths = tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501,E128,E731,E722

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = 
+  py27
+  lint
+skipdist = True
+
+[testenv]
+skip_install=True
+deps =
+  pytest >= 4.6.3, < 5.0
+  pyyaml >= 5.1.2, < 6.0
+commands =
+    pytest {posargs}
+
+[testenv:lint]
+skip_install=True
+commands = flake8 src doc data tests
+deps = flake8


### PR DESCRIPTION
## The problem

The Travis Ci configuration should match our work on Moulinette.

## Solution

We copy/pasta it to match here.

## PR Status

Ready to review and merge if we agree that the 1,0000+ flake8 errors can be fixed another time (put in "allowed failures" on Travis for now). I would recommend that we just run [Black](https://github.com/ambv/black) over the source at some point and that will resolve it. For another day, I guess. 

## How to test

```
$ pip install tox
$ tox
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
