### PR TITLE
Fix permission sychronization

### DIFF
--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -484,8 +484,9 @@ def permission_sync_to_user(force=False):
     for per in ldap.search('ou=permission,dc=yunohost,dc=org',
                            '(objectclass=permissionYnh)',
                            ['cn', 'inheritPermission', 'groupPermission', 'memberUid']):
+        print(per)
         if 'groupPermission' not in per:
-            continue
+            per['groupPermission'] = []
         user_permission = set()
         for group in per['groupPermission']:
             group = group.split("=")[1].split(",")[0]

--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -484,7 +484,7 @@ def permission_sync_to_user(force=False):
     for per in ldap.search('ou=permission,dc=yunohost,dc=org',
                            '(objectclass=permissionYnh)',
                            ['cn', 'inheritPermission', 'groupPermission', 'memberUid']):
-        print(per)
+
         if 'groupPermission' not in per:
             per['groupPermission'] = []
         user_permission = set()


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1427

## Solution

Just consider that if the key `groupPermission` it's equivalent to en empty list. It avoid to do anything when we remove the last permission.

## PR Status

Tested and it work

## How to test

Just 
```
yunohost user permission clear mail
yunohost user permission add mail -u test toto
yunohost user permission remove mail -u test
yunohost user permission remove mail -u toto
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
