### PR TITLE
Add pop3.enabled setting

### DIFF
--- a/data/hooks/conf_regen/25-dovecot
+++ b/data/hooks/conf_regen/25-dovecot
@@ -2,6 +2,8 @@
 
 set -e
 
+. /usr/share/yunohost/helpers
+
 do_pre_regen() {
   pending_dir=$1
 
@@ -14,11 +16,10 @@ do_pre_regen() {
   cp dovecot-ldap.conf "${dovecot_dir}/dovecot-ldap.conf"
   cp dovecot.sieve "${dovecot_dir}/global_script/dovecot.sieve"
 
-  # prepare dovecot.conf conf file
-  main_domain=$(cat /etc/yunohost/current_host)
-  cat dovecot.conf \
-    | sed "s/{{ main_domain }}/${main_domain}/g" \
-    > "${dovecot_dir}/dovecot.conf"
+  export pop3_enabled="$(yunohost settings get 'pop3.enabled')"
+  export main_domain=$(cat /etc/yunohost/current_host)
+
+  ynh_render_template "dovecot.conf" "${dovecot_dir}/dovecot.conf"
 
   # adapt it for IPv4-only hosts
   if [ ! -f /proc/net/if_inet6 ]; then

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -8,10 +8,9 @@ mail_home = /var/mail/%n
 mail_location = maildir:/var/mail/%n
 mail_uid = 500
 
-protocols = imap sieve
+protocols = imap sieve {% if pop3_enabled == "True" %}pop3{% endif %}
 
 mail_plugins = $mail_plugins quota
-
 
 ssl = yes
 ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem

--- a/locales/en.json
+++ b/locales/en.json
@@ -263,6 +263,7 @@
     "global_settings_cant_write_settings": "Could not save settings file, reason: {reason:s}",
     "global_settings_key_doesnt_exists": "The key '{settings_key:s}' does not exist in the global settings, you can see all the available keys by running 'yunohost settings list'",
     "global_settings_reset_success": "Previous settings now backed up to {path:s}",
+    "global_settings_setting_pop3_enabled": "Enable the POP3 protocol for the mail server",
     "global_settings_setting_example_bool": "Example boolean option",
     "global_settings_setting_example_enum": "Example enum option",
     "global_settings_setting_example_int": "Example int option",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2903,11 +2903,7 @@ def is_true(arg):
     if isinstance(arg, bool):
         return arg
     elif isinstance(arg, basestring):
-        true_list = ['yes', 'true', 'on']
-        for string in true_list:
-            if arg.lower() == string:
-                return True
-        return False
+        return arg.lower() in ['yes', 'true', 'on']
     else:
         logger.debug('arg should be a boolean or a string, got %r', arg)
         return True if arg else False

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2903,9 +2903,9 @@ def is_true(arg):
     if isinstance(arg, bool):
         return arg
     elif isinstance(arg, basestring):
-        true_list = ['yes', 'Yes', 'true', 'True']
+        true_list = ['yes', 'true', 'on']
         for string in true_list:
-            if arg == string:
+            if arg.lower() == string:
                 return True
         return False
     else:

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -15,6 +15,25 @@ logger = getActionLogger('yunohost.settings')
 SETTINGS_PATH = "/etc/yunohost/settings.json"
 SETTINGS_PATH_OTHER_LOCATION = "/etc/yunohost/settings-%s.json"
 
+def is_boolean(value):
+    """
+    Ensure a string value is intended as a boolean
+
+    Keyword arguments:
+        arg -- The string to check
+
+    Returns:
+        Boolean
+
+    """
+    if isinstance(value, bool):
+        return True
+    elif isinstance(value, basestring):
+        return str(value).lower() in ['true', 'on', 'yes', 'false', 'off', 'no']
+    else:
+        return False
+
+
 # a settings entry is in the form of:
 # namespace.subnamespace.name: {type, value, default, description, [choices]}
 # choices is only for enum
@@ -95,7 +114,7 @@ def settings_set(key, value):
     key_type = settings[key]["type"]
 
     if key_type == "bool":
-        if not isinstance(value, bool):
+        if not is_boolean(value):
             raise YunohostError('global_settings_bad_type_for_setting', setting=key,
                                 received_type=type(value).__name__, expected_type=key_type)
     elif key_type == "int":

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -28,7 +28,7 @@ SETTINGS_PATH_OTHER_LOCATION = "/etc/yunohost/settings-%s.json"
 # * bool
 # * int
 # * string
-# * enum (in form a python list)
+# * enum (in the form of a python list)
 
 DEFAULTS = OrderedDict([
     ("example.bool", {"type": "bool", "default": True}),

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -315,7 +315,7 @@ def reconfigure_ssh(setting_name, old_value, new_value):
         service_regen_conf(names=['ssh'])
 
 @post_change_hook("security.postfix.compatibility")
-def reconfigure_ssh(setting_name, old_value, new_value):
+def reconfigure_postfix(setting_name, old_value, new_value):
     if old_value != new_value:
         service_regen_conf(names=['postfix'])
 

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -147,8 +147,6 @@ def settings_set(key, value):
     settings[key]["value"] = value
     _save_settings(settings)
 
-    # TODO : whatdo if the old value is the same as
-    # the new value...
     try:
         trigger_post_change_hook(key, old_value, value)
     except Exception as e:

--- a/src/yunohost/tests/test_settings.py
+++ b/src/yunohost/tests/test_settings.py
@@ -62,6 +62,8 @@ def test_settings_set():
     settings_set("example.bool", False)
     assert settings_get("example.bool") == False
 
+    settings_set("example.bool", "on")
+    assert settings_get("example.bool") == True
 
 def test_settings_set_int():
     settings_set("example.int", 21)


### PR DESCRIPTION
## The problem

Using a non-default configuration is needed to setup pop3.

See https://github.com/YunoHost/issues/issues/1393.

## Solution

Allow to configure pop3 through a setting.

Following approach in https://github.com/YunoHost/yunohost/pull/773.

## PR Status

![](https://i.giphy.com/media/dIxkmtCuuBQuM9Ux1E/giphy.webp)

## How to test

```
$ yunohost settings set pop3.enabled -v True
$ yunohost settings set pop3.enabled -v False
```

Then have a look at your `/etc/dovecot/dovecot.conf` and check the "protocols = ..." line.

Also check that `dpkg -l` reports that `dovecot-pop3d` is installed.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
