### PR TITLE
Check that  exist before the calculate the checksum

### DIFF
--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -339,7 +339,7 @@ ynh_backup_if_checksum_is_different () {
     backup_file_checksum=""
     if [ -n "$checksum_value" ]
     then    # Proceed only if a value was stored into the app settings
-        if ! echo "$checksum_value $file" | sudo md5sum -c --status
+        if [ -e $file ] && ! echo "$checksum_value $file" | sudo md5sum -c --status
         then    # If the checksum is now different
             backup_file_checksum="/home/yunohost.conf/backup/$file.backup.$(date '+%Y%m%d.%H%M%S')"
             sudo mkdir -p "$(dirname "$backup_file_checksum")"


### PR DESCRIPTION
## The problem

If we try to use the helper `ynh_add_fail2ban_config` in the restore script we have a problem with the helper `ynh_backup_if_checksum_is_different` because we have the checksum in the settings but the file is not installed.

## Solution

Check that the file exist before to calculate the checksum

## PR Status

Tested and it work

## How to test

- Checkout the branch.
- Try to use the helper `ynh_add_fail2ban_config` in a restore script

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
