### PR TITLE
[fix] Detect and warn early about unavailable full domains...

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -19,6 +19,7 @@
     "app_change_url_no_script": "This application '{app_name:s}' doesn't support URL modification yet. Maybe you should upgrade it.",
     "app_change_url_success": "{app:s} URL is now {domain:s}{path:s}",
     "app_extraction_failed": "Could not extract the installation files",
+    "app_full_domain_unavailable": "Sorry, this application requires a full domain to be installed on, but some other apps are already installed on {domain}. One possible solution is to add a subdomain dedicated to this application.",
     "app_id_invalid": "Invalid app ID",
     "app_incompatible": "The app {app} is incompatible with your YunoHost version",
     "app_install_files_invalid": "These files cannot be installed",

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,7 +19,7 @@
     "app_change_url_no_script": "This application '{app_name:s}' doesn't support URL modification yet. Maybe you should upgrade it.",
     "app_change_url_success": "{app:s} URL is now {domain:s}{path:s}",
     "app_extraction_failed": "Could not extract the installation files",
-    "app_full_domain_unavailable": "Sorry, this application requires a full domain to be installed on, but some other apps are already installed on {domain}. One possible solution is to add a subdomain dedicated to this application.",
+    "app_full_domain_unavailable": "Sorry, this application requires a full domain to be installed on, but some other apps are already installed on domain '{domain}'. One possible solution is to add and use a subdomain dedicated to this application instead.",
     "app_id_invalid": "Invalid app ID",
     "app_incompatible": "The app {app} is incompatible with your YunoHost version",
     "app_install_files_invalid": "These files cannot be installed",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2717,13 +2717,14 @@ def _validate_and_normalize_webpath(manifest, args_dict, app_folder):
         # Full-domain apps typically declare something like path_url="/" or path=/
         # and use ynh_webpath_register or yunohost_app_checkurl inside the install script
         install_script_content = open(os.path.join(app_folder, 'scripts/install')).read()
+
         if re.search(r"\npath(_url)?=[\"']?/[\"']?\n", install_script_content) \
-           and re.search(r"(ynh_webpath_register|yunohost app checkurl)"):
+           and re.search(r"(ynh_webpath_register|yunohost app checkurl)", install_script_content):
 
             domain = domain_args[0][1]
             conflicts = _get_conflicting_apps(domain, "/")
 
-            raise YunohostError('app_full_domain_unavailable', domain)
+            raise YunohostError('app_full_domain_unavailable', domain=domain)
 
 
 def _make_environment_dict(args_dict, prefix="APP_ARG_"):

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -847,6 +847,9 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     args_list = [ value[0] for value in args_odict.values() ]
     args_list.append(app_instance_name)
 
+    # Validate domain / path availability for webapps
+    _validate_and_normalize_webpath(manifest, args_odict, extracted_app_folder)
+
     # Prepare env. var. to pass to script
     env_dict = _make_environment_dict(args_odict)
     env_dict["YNH_APP_ID"] = app_id
@@ -2547,8 +2550,7 @@ def _parse_args_for_action(action, args={}):
 def _parse_args_in_yunohost_format(args, action_args):
     """Parse arguments store in either manifest.json or actions.json
     """
-    from yunohost.domain import (domain_list, _get_maindomain,
-                                 _get_conflicting_apps, _normalize_domain_path)
+    from yunohost.domain import domain_list, _get_maindomain
     from yunohost.user import user_info, user_list
 
     args_dict = OrderedDict()
@@ -2666,13 +2668,18 @@ def _parse_args_in_yunohost_format(args, action_args):
             assert_password_is_strong_enough('user', arg_value)
         args_dict[arg_name] = (arg_value, arg_type)
 
-    # END loop over action_args...
+    return args_dict
+
+
+def _validate_and_normalize_webpath(manifest, args_dict, app_folder):
+
+    from yunohost.domain import _get_conflicting_apps, _normalize_domain_path
 
     # If there's only one "domain" and "path", validate that domain/path
     # is an available url and normalize the path.
 
-    domain_args = [ (name, value[0]) for name, value in args_dict.items() if value[1] == "domain" ]
-    path_args = [ (name, value[0]) for name, value in args_dict.items() if value[1] == "path" ]
+    domain_args = [(name, value[0]) for name, value in args_dict.items() if value[1] == "domain"]
+    path_args = [(name, value[0]) for name, value in args_dict.items() if value[1] == "path"]
 
     if len(domain_args) == 1 and len(path_args) == 1:
 
@@ -2698,7 +2705,25 @@ def _parse_args_in_yunohost_format(args, action_args):
         # standard path format to deal with no matter what the user inputted)
         args_dict[path_args[0][0]] = (path, "path")
 
-    return args_dict
+    # This is likely to be a full-domain app...
+    elif len(domain_args) == 1 and len(path_args) == 0:
+
+        # Confirm that this is a full-domain app This should cover most cases
+        # ...  though anyway the proper solution is to implement some mechanism
+        # in the manifest for app to declare that they require a full domain
+        # (among other thing) so that we can dynamically check/display this
+        # requirement on the webadmin form and not miserably fail at submit time
+
+        # Full-domain apps typically declare something like path_url="/" or path=/
+        # and use ynh_webpath_register or yunohost_app_checkurl inside the install script
+        install_script_content = open(os.path.join(app_folder, 'scripts/install')).read()
+        if re.search(r"\npath(_url)?=[\"']?/[\"']?\n", install_script_content) \
+           and re.search(r"(ynh_webpath_register|yunohost app checkurl)"):
+
+            domain = domain_args[0][1]
+            conflicts = _get_conflicting_apps(domain, "/")
+
+            raise YunohostError('app_full_domain_unavailable', domain)
 
 
 def _make_environment_dict(args_dict, prefix="APP_ARG_"):


### PR DESCRIPTION
## The problem

I got mad about seeing at least ~3 people every week reporting issues about [failed app install because the app requires a full domain but conflicts are not detected early...](https://forum.yunohost.org/t/install-homeassistant-failes/9031) (and the error is "hidden" in the log, as if the script crashed, and even then the error is not 100% friendly because the user only chose the domain and not the url ...)

## Solution

Ideally, the right solution should be to implement some general mechanism for app to declare requirements (so e.g. also for RAM, swap, arch, ...) and have dynamic check in the admin form before actually triggering `app_install` ... but fuck it I have no time for now to do it >.> ... So let's implement this damn dirty hack...

It uses the fact that full-domain apps will typically have something like `path_url='/'` and use `yunohost app checkurl` or `ynh_webpath_register` at some point. (Yes, that doesn't cover every full-domain apps, but at least 90% of them)


## PR Status

Not tested at all because yolo commit before bed

## How to test

Try to install an app that required a full-domain, but using a domain with already a 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
