### PR TITLE
change maxretry of fail2ban from 6 to 10

### DIFF
--- a/data/templates/fail2ban/yunohost-jails.conf
+++ b/data/templates/fail2ban/yunohost-jails.conf
@@ -29,4 +29,4 @@ protocol = tcp
 filter   = yunohost
 logpath  = /var/log/nginx/*error.log
            /var/log/nginx/*access.log
-maxretry = 6
+maxretry = 10


### PR DESCRIPTION
## The problem

Fail2ban failt count is way too harsh as exposed in https://github.com/YunoHost/issues/issues/1437

## Solution
Should make it at least 10 instead of 6

## PR Status
Open

## How to test
Put 10 erroneous passwords in Ynh admin login form over HTTPS port.

## Validation

- [x] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
