### PR TITLE
Support logfiles not ending with .log in logrotate ...

### DIFF
--- a/data/helpers.d/logrotate
+++ b/data/helpers.d/logrotate
@@ -40,10 +40,13 @@ ynh_use_logrotate () {
 	fi
 
 	if [ $# -gt 0 ] && [ "$(echo ${1:0:1})" != "-" ]; then
-		if [ "$(echo ${1##*.})" == "log" ]; then	# Keep only the extension to check if it's a logfile
-			local logfile=$1	# In this case, focus logrotate on the logfile
+		# If the given logfile parameter already exists as a file, or if it ends up with ".log",
+		# we just want to manage a single file
+		if [ -f "$1" ] || [ "$(echo ${1##*.})" == "log" ]; then
+			local logfile=$1
+		# Otherwise we assume we want to manage a directory and all its .log file inside
 		else
-			local logfile=$1/*.log	# Else, uses the directory and all logfile into it.
+			local logfile=$1/*.log
 		fi
 	fi
 	# LEGACY CODE
@@ -54,7 +57,7 @@ ynh_use_logrotate () {
 	fi
 	if [ -n "$logfile" ]
 	then
-		if [ "$(echo ${logfile##*.})" != "log" ]; then	# Keep only the extension to check if it's a logfile
+		if [ ! -f "$1" ] && [ "$(echo ${logfile##*.})" != "log" ]; then	# Keep only the extension to check if it's a logfile
 			local logfile="$logfile/*.log"	# Else, uses the directory and all logfile into it.
 		fi
 	else


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1390 and https://github.com/YunoHost-Apps/shaarli_ynh/issues/45 and I'm getting fucking mad of seeing people encountering this issue every two days

## Solution

Support logfile which does not end up with `.log` and that already exists (c.f. this fix in shaarli app : https://github.com/YunoHost-Apps/shaarli_ynh/compare/fix-the-damn-log-issue ) 

## PR Status

Tested and working

## How to test

Try to install shaarli with [this branch](https://github.com/YunoHost-Apps/shaarli_ynh/compare/fix-the-damn-log-issue)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
