### PR TITLE
Allow system users to auth on the mail stack and send emails

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -44,20 +44,20 @@ passdb {
   driver = ldap
 }
 
-# Internally, allow authentication from system user
-# who might want to send emails (e.g. from apps)
+# Internally, allow authentication from apps system user who have "enable_email = true"
 passdb {
-  override_fields = allow_nets=127.0.0.1/32,::1/64
-  driver = pam
+  driver = passwd-file
+  args = /etc/dovecot/app-senders-passwd
 }
 
 userdb {
-  args = /etc/dovecot/dovecot-ldap.conf
   driver = ldap
+  args = /etc/dovecot/dovecot-ldap.conf
 }
 
 userdb {
-  driver = passwd
+  driver = passwd-file
+  args = /etc/dovecot/app-senders-passwd
 }
 
 protocol imap {

--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -38,14 +38,26 @@ ssl_prefer_server_ciphers = no
 ###############################################################################
 
 
+# Regular Yunohost accounts
 passdb {
   args = /etc/dovecot/dovecot-ldap.conf
   driver = ldap
 }
 
+# Internally, allow authentication from system user
+# who might want to send emails (e.g. from apps)
+passdb {
+  override_fields = allow_nets=127.0.0.1/32,::1/64
+  driver = pam
+}
+
 userdb {
   args = /etc/dovecot/dovecot-ldap.conf
   driver = ldap
+}
+
+userdb {
+  driver = passwd
 }
 
 protocol imap {

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -107,7 +107,10 @@ virtual_alias_domains =
 virtual_minimum_uid = 100
 virtual_uid_maps = static:vmail
 virtual_gid_maps = static:mail
-smtpd_sender_login_maps= ldap:/etc/postfix/ldap-accounts.cf
+smtpd_sender_login_maps=
+   ldap:/etc/postfix/ldap-accounts.cf, # Regular Yunohost accounts
+   hash:/etc/postfix/sender_login_maps # Extra maps for system users who need to send emails
+
 
 # Dovecot LDA
 virtual_transport = dovecot

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -108,8 +108,10 @@ virtual_minimum_uid = 100
 virtual_uid_maps = static:vmail
 virtual_gid_maps = static:mail
 smtpd_sender_login_maps=
-   ldap:/etc/postfix/ldap-accounts.cf, # Regular Yunohost accounts
-   hash:/etc/postfix/sender_login_maps # Extra maps for system users who need to send emails
+   # Regular Yunohost accounts
+   ldap:/etc/postfix/ldap-accounts.cf,
+   # Extra maps for app system users who need to send emails
+   hash:/etc/postfix/app_senders_login_maps
 
 
 # Dovecot LDA

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -80,6 +80,8 @@ do_post_regen() {
 
     postmap -F hash:/etc/postfix/sni
 
+    python3 -c 'from yunohost.app import regen_mail_app_user_config_for_dovecot_and_postfix as r; r(only="postfix")'
+
     [[ -z "$regen_conf_files" ]] \
         || { systemctl restart postfix && systemctl restart postsrsd; }
 

--- a/hooks/conf_regen/25-dovecot
+++ b/hooks/conf_regen/25-dovecot
@@ -53,6 +53,8 @@ do_post_regen() {
     chown root:mail /var/mail
     chmod 1775 /var/mail
 
+    python3 -c 'from yunohost.app import regen_mail_app_user_config_for_dovecot_and_postfix as r; r(only="dovecot")'
+
     [ -z "$regen_conf_files" ] && exit 0
 
     # compile sieve script

--- a/src/app.py
+++ b/src/app.py
@@ -3173,7 +3173,9 @@ def regen_mail_app_user_config_for_dovecot_and_postfix(only=None):
             hashed_password = _hash_user_password(settings["mail_pwd"])
             dovecot_passwd.append(f"{app}:{hashed_password}::::::allow_nets=127.0.0.1/24")
         if postfix:
-            postfix_map.append(f"{app}@{settings['domain']} {app}")
+            mail_user = settings.get("mail_user", app)
+            mail_domain = settings.get("mail_domain", settings["domain"])
+            postfix_map.append(f"{mail_user}@{mail_domain} {app}")
 
     if dovecot:
         app_senders_passwd = "/etc/dovecot/app-senders-passwd"

--- a/src/app.py
+++ b/src/app.py
@@ -1582,6 +1582,9 @@ def app_setting(app, key, value=None, delete=False):
     if delete:
         if key in app_settings:
             del app_settings[key]
+        else:
+            # Don't call _set_app_settings to avoid unecessary writes...
+            return
 
     # SET
     else:
@@ -3148,3 +3151,45 @@ def _ask_confirmation(
 
     if not answer:
         raise YunohostError("aborting")
+
+
+def regen_mail_app_user_config_for_dovecot_and_postfix(only=None):
+
+    dovecot = True if only in [None, "dovecot"] else False
+    postfix = True if only in [None, "postfix"] else False
+
+    from yunohost.user import _hash_user_password
+
+    postfix_map = []
+    dovecot_passwd = []
+    for app in _installed_apps():
+
+        settings = _get_app_settings(app)
+
+        if "domain" not in settings or "mail_pwd" not in settings:
+            continue
+
+        if dovecot:
+            hashed_password = _hash_user_password(settings["mail_pwd"])
+            dovecot_passwd.append(f"{app}:{hashed_password}::::::allow_nets=127.0.0.1/24")
+        if postfix:
+            postfix_map.append(f"{app}@{settings['domain']} {app}")
+
+    if dovecot:
+        app_senders_passwd = "/etc/dovecot/app-senders-passwd"
+        content = "# This file is regenerated automatically.\n# Please DO NOT edit manually ... changes will be overwritten!"
+        content += '\n' + '\n'.join(dovecot_passwd)
+        write_to_file(app_senders_passwd, content)
+        chmod(app_senders_passwd, 0o440)
+        chown(app_senders_passwd, "root", "dovecot")
+
+    if postfix:
+        app_senders_map = "/etc/postfix/app_senders_login_maps"
+        content = "# This file is regenerated automatically.\n# Please DO NOT edit manually ... changes will be overwritten!"
+        content += '\n' + '\n'.join(postfix_map)
+        write_to_file(app_senders_map, content)
+        chmod(app_senders_map, 0o440)
+        chown(app_senders_map, "postfix", "root")
+        os.system(f"postmap {app_senders_map} 2>/dev/null")
+        chmod(app_senders_map + ".db", 0o640)
+        chown(app_senders_map + ".db", "postfix", "root")

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -451,6 +451,7 @@ class SystemuserAppResource(AppResource):
     ##### Properties:
     - `allow_ssh`: (default: False) Adds the user to the ssh.app group, allowing SSH connection via this user
     - `allow_sftp`: (default: False) Adds the user to the sftp.app group, allowing SFTP connection via this user
+    - `allow_email`: (default: False) Enable authentication on the mail stack for the system user and send mail using `__APP__@__DOMAIN__`. A `mail_pwd` setting is automatically defined (similar to `db_pwd` for databases). You can then configure the app to use `__APP__` and `__MAIL_PWD__` as SMTP credentials (with host 127.0.0.1)
     - `home`: (default: `/var/www/__APP__`) Defines the home property for this user. NB: unfortunately you can't simply use `__INSTALL_DIR__` or `__DATA_DIR__` for now
 
     ##### Provision/Update:

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -451,7 +451,7 @@ class SystemuserAppResource(AppResource):
     ##### Properties:
     - `allow_ssh`: (default: False) Adds the user to the ssh.app group, allowing SSH connection via this user
     - `allow_sftp`: (default: False) Adds the user to the sftp.app group, allowing SFTP connection via this user
-    - `allow_email`: (default: False) Enable authentication on the mail stack for the system user and send mail using `__APP__@__DOMAIN__`. A `mail_pwd` setting is automatically defined (similar to `db_pwd` for databases). You can then configure the app to use `__APP__` and `__MAIL_PWD__` as SMTP credentials (with host 127.0.0.1)
+    - `allow_email`: (default: False) Enable authentication on the mail stack for the system user and send mail using `__APP__@__DOMAIN__`. A `mail_pwd` setting is automatically defined (similar to `db_pwd` for databases). You can then configure the app to use `__APP__` and `__MAIL_PWD__` as SMTP credentials (with host 127.0.0.1). You can also tweak the user-part of the domain-part of the email used by manually defining a custom setting `mail_user` or `mail_domain`
     - `home`: (default: `/var/www/__APP__`) Defines the home property for this user. NB: unfortunately you can't simply use `__INSTALL_DIR__` or `__DATA_DIR__` for now
 
     ##### Provision/Update:


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/947

This is not easy to configure an app to send emails. While packaging an app (transpay), it explicitly required to be able to auth on the mail server. I started creating a system user ... but realized it could not authenticated (because only LDAP accounts are able to with the current conf). 

## Solution

Thanks to the help of @taziden I was able to configure dovecot to accept system users to authenticate. For this, a new passwd-like file `/etc/postfix/app_senders_login_maps` is added and filled with the appropriate app users.

```
foobar:{CRYPT}$6$SivRDh9NDh3w5.zs$Flq1MfFWq/RfVq3VvssWPwR2pMDWlTN87hretdavCUZlTwkROY1vmpqPxdEpeVg8AafmpDrGfbnyEwe7/5NX1/::::::allow_nets=127.0.0.1/24
```

But postfix also needs to be tweak to allow `foobar` to send emails with From equal to `foobar@somedomain.tld`. For this, I added a new file `/etc/postfix/app_senders_login_maps` to the `smtpd_sender_login_maps`. It is automatically filled with the appropriate user map

```
foobar@somedomain.tld foobar
```


On the packaging side, one only need to have:

```toml
    [resources.system_user]
    allow_email = true
```

which will automatically provision a `mail_pwd` setting

Then configure the app to use the app id as login (NB: the app id, NOT appid@domain.tld) and `$mail_pwd`/`__MAIL_PWD__`  as password

## PR Status

Tested and working
