### PR TITLE
Better error message for invalid email domain.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -286,7 +286,7 @@
     "ldap_initialized": "LDAP initialized",
     "license_undefined": "undefined",
     "mail_alias_remove_failed": "Could not remove e-mail alias '{mail:s}'",
-    "mail_domain_unknown": "Unknown e-mail address for domain '{domain:s}'",
+    "mail_domain_unknown": "Invalid e-mail address for domain '{domain:s}'. Please, use a domain administrated by this server.",
     "mail_forward_remove_failed": "Could not remove e-mail forwarding '{mail:s}'",
     "mailbox_disabled": "E-mail turned off for user {user:s}",
     "mailbox_used_space_dovecot_down": "The Dovecot mailbox service needs to be up, if you want to fetch used mailbox space",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -120,7 +120,7 @@
     "ldap_initialized": "L’annuaire LDAP initialisé",
     "license_undefined": "indéfinie",
     "mail_alias_remove_failed": "Impossible de supprimer l’alias de courriel '{mail:s}'",
-    "mail_domain_unknown": "Le domaine '{domain:s}' pour l'adresse de courriel est inconnu",
+    "mail_domain_unknown": "Le domaine '{domain:s}' de cette adress de courriel n'est pas valide. Merci d'utiliser un domain administré par ce serveur.",
     "mail_forward_remove_failed": "Impossible de supprimer le courriel de transfert '{mail:s}'",
     "maindomain_change_failed": "Impossible de modifier le domaine principal",
     "maindomain_changed": "Le domaine principal modifié",

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -72,7 +72,7 @@
     "ldap_initialized": "LDAP inicializada com êxito",
     "license_undefined": "indefinido",
     "mail_alias_remove_failed": "Não foi possível remover a etiqueta de correio '{mail:s}'",
-    "mail_domain_unknown": "Domínio de endereço de correio desconhecido '{domain:s}'",
+    "mail_domain_unknown": "Domínio de endereço de correio '{domain:s}' inválido. Por favor, usa um domínio administrado per esse servidor.",
     "mail_forward_remove_failed": "Não foi possível remover o reencaminhamento de correio '{mail:s}'",
     "maindomain_change_failed": "Incapaz alterar o domínio raiz",
     "maindomain_changed": "Domínio raiz alterado com êxito",


### PR DESCRIPTION
## The problem

Fix https://github.com/YunoHost/issues/issues/1365.

## Solution

Message more explicit.

## PR Status

Ready. Translated in English, French and Portuguese.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
