### PR TITLE
Use str instead of strerror

### DIFF
--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -199,7 +199,7 @@ def user_create(operation_logger, username, firstname, lastname, mail, password,
             with open('/etc/ssowat/conf.json.persistent') as json_conf:
                 ssowat_conf = json.loads(str(json_conf.read()))
         except ValueError as e:
-            raise YunohostError('ssowat_persistent_conf_read_error', error=e.strerror)
+            raise YunohostError('ssowat_persistent_conf_read_error', error=str(e))
         except IOError:
             ssowat_conf = {}
 
@@ -209,7 +209,7 @@ def user_create(operation_logger, username, firstname, lastname, mail, password,
                 with open('/etc/ssowat/conf.json.persistent', 'w+') as f:
                     json.dump(ssowat_conf, f, sort_keys=True, indent=4)
             except IOError as e:
-                raise YunohostError('ssowat_persistent_conf_write_error', error=e.strerror)
+                raise YunohostError('ssowat_persistent_conf_write_error', error=str(e))
 
     try:
         ldap.add('uid=%s,ou=users' % username, attr_dict)


### PR DESCRIPTION
See https://forum.yunohost.org/t/cant-create-a-user-after-post-intsallation/9190.

## The problem

https://forum.yunohost.org/t/cant-create-a-user-after-post-intsallation/9190

## Solution

Use `str`.

## PR Status

Untested.

## How to test

Do something weird in your `/etc/ssowat/conf.json.persistent` file and see that this error is reported.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
