### PR TITLE
Remove app_debug, unused stuff / not really relevant

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -754,14 +754,6 @@ app:
                     full: --sql
                     help: Initial SQL file
 
-        ### app_debug()
-        debug:
-            action_help: Display all debug informations for an application
-            api: GET /apps/<app>/debug
-            arguments:
-                app:
-                    help: App name
-
         ### app_makedefault()
         makedefault:
             action_help: Redirect domain root to an app

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1253,28 +1253,6 @@ def app_clearaccess(apps):
     return {'allowed_users': output}
 
 
-def app_debug(app):
-    """
-    Display debug informations for an app
-
-    Keyword argument:
-        app
-    """
-    manifest = _get_manifest_of_app(os.path.join(APPS_SETTING_PATH, app))
-
-    return {
-        'name': manifest['id'],
-        'label': manifest['name'],
-        'services': [{
-            "name": x,
-            "logs": [{
-                "file_name": y,
-                "file_content": "\n".join(z),
-            } for (y, z) in sorted(service_log(x).items(), key=lambda x: x[0])],
-        } for x in sorted(manifest.get("services", []))]
-    }
-
-
 @is_unit_operation()
 def app_makedefault(operation_logger, app, domain=None):
     """


### PR DESCRIPTION
## The problem

Imho that's not really used, or does not display relevant information. Most of the time issues are related to installations which is handled by the log system from 3.2. And typically in other cases `app_debug` very rarely display the useful piece of log.

## Solution

Remove it, kill legacy unused features @_@. This contribute to simplify `yunohost app --help` along with other PRs.

## PR Status

Yolo commited

TODO : remove the corresponding button in the app view in the webadmin

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
