### PR TITLE
[FIX] find udp port

### DIFF
--- a/data/helpers.d/network
+++ b/data/helpers.d/network
@@ -17,7 +17,7 @@ ynh_find_port () {
 	ynh_handle_getopts_args "$@"
 
 	test -n "$port" || ynh_die --message="The argument of ynh_find_port must be a valid port."
-	while netstat -ltu | grep -q -w :$port       # Check if the port is free
+	while netstat -nltu | grep -q -w :$port       # Check if the port is free
 	do
 		port=$((port+1))	# Else, pass to next port
 	done

--- a/data/helpers.d/network
+++ b/data/helpers.d/network
@@ -17,7 +17,7 @@ ynh_find_port () {
 	ynh_handle_getopts_args "$@"
 
 	test -n "$port" || ynh_die --message="The argument of ynh_find_port must be a valid port."
-	while netcat -z 127.0.0.1 $port       # Check if the port is free
+	while netstat -ltu | grep -q -w :$port       # Check if the port is free
 	do
 		port=$((port+1))	# Else, pass to next port
 	done

--- a/locales/en.json
+++ b/locales/en.json
@@ -414,7 +414,7 @@
     "pattern_positive_number": "Must be a positive number",
     "pattern_username": "Must be lower-case alphanumeric and underscore characters only",
     "pattern_password_app": "Sorry, passwords can not contain the following characters: {forbidden_chars}",
-    "permission_already_allowed": "Group '{group}' already has permission '{permission}' enabled'",
+    "permission_already_allowed": "Group '{group}' already has permission '{permission}' enabled",
     "permission_already_disallowed": "Group '{group}' already has permission '{permission}' disabled'",
     "permission_already_exist": "Permission '{permission}' already exists",
     "permission_already_up_to_date": "The permission was not updated because the addition/removal requests already match the current state.",


### PR DESCRIPTION
## The problem

- *The actual helper don't catch the use of udp port*

## Solution

- *Use netstat instead of netcat*

The current way is to try to open this port, if it fail inc the port and try again...

My way just checks if it used, if it is inc the port and try again.

## PR Status

I can add arguments to this helper to force the check in ipv4 or ipv6 if needed (check both by default)

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
