### PR TITLE
XMPP http upload

### DIFF
--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -47,6 +47,10 @@ do_post_regen() {
   # create metronome directories for domains
   for domain in $domain_list; do
     mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
+    # http_upload directory must be writable by metronome and readable by nginx
+    mkdir -p  "/var/www/xmpp-upload.${domain}/upload"
+    chmod g+s "/var/www/xmpp-upload.${domain}/upload"
+    chown -R metronome:www-data "/var/www/xmpp-upload.${domain}"
   done
 
   # fix some permissions

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -42,16 +42,18 @@ do_post_regen() {
   regen_conf_files=$1
 
   # retrieve variables
+  main_domain=$(cat /etc/yunohost/current_host)
   domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # create metronome directories for domains
   for domain in $domain_list; do
     mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
-    # http_upload directory must be writable by metronome and readable by nginx
-    mkdir -p  "/var/xmpp-upload/${domain}/upload"
-    chmod g+s "/var/xmpp-upload/${domain}/upload"
-    chown -R metronome:www-data "/var/xmpp-upload/${domain}"
   done
+  # http_upload directory must be writable by metronome and readable by nginx
+  mkdir -p  "/var/xmpp-upload/${main_domain}/upload"
+  chmod g+s "/var/xmpp-upload/${main_domain}/upload"
+  chown -R metronome:www-data "/var/xmpp-upload/${main_domain}"
+
 
   # fix some permissions
   chown -R metronome: /var/lib/metronome/

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -48,9 +48,9 @@ do_post_regen() {
   for domain in $domain_list; do
     mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
     # http_upload directory must be writable by metronome and readable by nginx
-    mkdir -p  "/var/www/xmpp-upload.${domain}/upload"
-    chmod g+s "/var/www/xmpp-upload.${domain}/upload"
-    chown -R metronome:www-data "/var/www/xmpp-upload.${domain}"
+    mkdir -p  "/var/xmpp-upload/${domain}/upload"
+    chmod g+s "/var/xmpp-upload/${domain}/upload"
+    chown -R metronome:www-data "/var/xmpp-upload/${domain}"
   done
 
   # fix some permissions

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -49,6 +49,7 @@ do_pre_regen() {
 
   # Support different strategy for security configurations
   export compatibility="$(yunohost settings get 'security.nginx.compatibility')"
+  ynh_render_template "security.conf.inc" "${nginx_conf_dir}/security.conf.inc"
 
   # add domain conf files
   for domain in $domain_list; do

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -85,7 +85,7 @@ use_ipv6 = true
 disco_items = {
 	{ "muc.{{ main_domain }}" },
 	{ "pubsub.{{ main_domain }}" },
-	{ "upload.{{ main_domain }}" },
+	{ "xmpp-upload.{{ main_domain }}" },
 	{ "vjud.{{ main_domain }}" }
 };
 
@@ -141,11 +141,16 @@ Component "pubsub.{{ main_domain }}" "pubsub"
 	unrestricted_node_creation = true -- Anyone can create a PubSub node (from any server)
 
 ---Set up a HTTP Upload service
-Component "upload.{{ main_domain }}" "http_upload"
+Component "xmpp-upload.{{ main_domain }}" "http_upload"
 	name = "{{ main_domain }} Sharing Service"
 
+	http_file_path = "/var/www/xmpp-upload.{{ main_domain }}/upload"
+	http_external_url = "https://xmpp-upload.{{ main_domain }}:443"
+	http_file_base_path = "/upload"
 	http_file_size_limit = 6*1024*1024
 	http_file_quota = 60*1024*1024
+	http_upload_file_size_limit = 100 * 1024 * 1024 -- bytes
+	http_upload_quota = 10 * 1024 * 1024 * 1024 -- bytes
 
 
 ---Set up a VJUD service

--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -144,7 +144,7 @@ Component "pubsub.{{ main_domain }}" "pubsub"
 Component "xmpp-upload.{{ main_domain }}" "http_upload"
 	name = "{{ main_domain }} Sharing Service"
 
-	http_file_path = "/var/www/xmpp-upload.{{ main_domain }}/upload"
+	http_file_path = "/var/xmpp-upload/{{ main_domain }}/upload"
 	http_external_url = "https://xmpp-upload.{{ main_domain }}:443"
 	http_file_base_path = "/upload"
 	http_file_size_limit = 6*1024*1024

--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -1,0 +1,33 @@
+{% if compatibility == "modern" %}
+# Ciphers with modern compatibility
+# https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=modern
+# The following configuration use modern ciphers, but remove compatibility with some old clients (android < 5.0, Internet Explorer < 10, ...)
+ssl_protocols TLSv1.2;
+ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+ssl_prefer_server_ciphers on;
+{% else %}
+# As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
+ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
+ssl_prefer_server_ciphers on;
+
+# Ciphers with intermediate compatibility
+# https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=intermediate
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+
+# Uncomment the following directive after DH generation
+# > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
+#ssl_dhparam /etc/ssl/private/dh2048.pem;
+{% endif %}
+
+more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
+more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
+more_set_headers "X-Content-Type-Options : nosniff";
+more_set_headers "X-XSS-Protection : 1; mode=block";
+more_set_headers "X-Download-Options : noopen";
+more_set_headers "X-Permitted-Cross-Domain-Policies : none";
+more_set_headers "X-Frame-Options : SAMEORIGIN";
+
+# Disable gzip to protect against BREACH
+# Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
+gzip off;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -68,8 +68,9 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name xmpp-upload.{{ domain }};
+    root /dev/null;
 
-    location /upload {
+    location /upload/ {
         alias /var/xmpp-upload/{{ domain }}/upload;
         # Pass all requests to metronome, except for GET and HEAD requests.
         limit_except GET HEAD {

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -6,7 +6,7 @@ map $http_upgrade $connection_upgrade {
 server {
     listen 80;
     listen [::]:80;
-    server_name {{ domain }};
+    server_name {{ domain }} xmpp-upload.{{ domain }};
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 
@@ -96,4 +96,85 @@ server {
 
     access_log /var/log/nginx/{{ domain }}-access.log;
     error_log /var/log/nginx/{{ domain }}-error.log;
+}
+
+# vhost dedicated to XMPP http_upload
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name xmpp-upload.{{ domain }};
+
+    location /upload {
+        alias /var/www/xmpp-upload.{{ domain }}/upload;
+        # Pass all requests to metronome, except for GET and HEAD requests.
+        limit_except GET HEAD {
+          proxy_pass http://localhost:5290;
+        }
+
+        include proxy_params;
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'HEAD, GET, PUT, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'Authorization';
+        add_header 'Access-Control-Allow-Credentials' 'true';
+        client_max_body_size 105M; # Choose a value a bit higher than the max upload configured in XMPP server
+    }
+
+    ssl_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
+    ssl_certificate_key /etc/yunohost/certs/{{ domain }}/key.pem;
+    ssl_session_timeout 5m;
+    ssl_session_cache shared:SSL:50m;
+
+    {% if compatibility == "modern" %}
+    # Ciphers with modern compatibility
+    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=modern
+    # The following configuration use modern ciphers, but remove compatibility with some old clients (android < 5.0, Internet Explorer < 10, ...)
+    ssl_protocols TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+    ssl_prefer_server_ciphers on;
+    {% else %}
+    # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
+    ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
+    ssl_prefer_server_ciphers on;
+
+    # Ciphers with intermediate compatibility
+    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=intermediate
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+
+    # Uncomment the following directive after DH generation
+    # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
+    #ssl_dhparam /etc/ssl/private/dh2048.pem;
+    {% endif %}
+
+    # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
+    # https://wiki.mozilla.org/Security/Guidelines/Web_Security
+    # https://observatory.mozilla.org/
+    {% if domain_cert_ca != "Self-signed" %}
+    more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
+    {% endif %}
+    more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
+    more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
+    more_set_headers "X-Content-Type-Options : nosniff";
+    more_set_headers "X-XSS-Protection : 1; mode=block";
+    more_set_headers "X-Download-Options : noopen";
+    more_set_headers "X-Permitted-Cross-Domain-Policies : none";
+    more_set_headers "X-Frame-Options : SAMEORIGIN";
+
+    {% if domain_cert_ca == "Let's Encrypt" %}
+    # OCSP settings
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
+    resolver 127.0.0.1 127.0.1.1 valid=300s;
+    resolver_timeout 5s;
+    {% endif %}
+
+    # Disable gzip to protect against BREACH
+    # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
+    gzip off;
+
+#    access_by_lua_file /usr/share/ssowat/access.lua;
+
+    access_log /var/log/nginx/xmpp-upload.{{ domain }}-access.log;
+    error_log /var/log/nginx/xmpp-upload.{{ domain }}-error.log;
 }

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -38,42 +38,11 @@ server {
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
 
-    {% if compatibility == "modern" %}
-    # Ciphers with modern compatibility
-    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=modern
-    # The following configuration use modern ciphers, but remove compatibility with some old clients (android < 5.0, Internet Explorer < 10, ...)
-    ssl_protocols TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-    ssl_prefer_server_ciphers on;
-    {% else %}
-    # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
-    ssl_prefer_server_ciphers on;
+    include /etc/nginx/conf.d/security.conf.inc;
 
-    # Ciphers with intermediate compatibility
-    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=intermediate
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-    # Uncomment the following directive after DH generation
-    # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
-    #ssl_dhparam /etc/ssl/private/dh2048.pem;
-    {% endif %}
-
-    # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
-    # https://wiki.mozilla.org/Security/Guidelines/Web_Security
-    # https://observatory.mozilla.org/ 
     {% if domain_cert_ca != "Self-signed" %}
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
     {% endif %}
-    more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-    more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
-    more_set_headers "X-Content-Type-Options : nosniff";
-    more_set_headers "X-XSS-Protection : 1; mode=block";
-    more_set_headers "X-Download-Options : noopen";
-    more_set_headers "X-Permitted-Cross-Domain-Policies : none";
-    more_set_headers "X-Frame-Options : SAMEORIGIN";
-
     {% if domain_cert_ca == "Let's Encrypt" %}
     # OCSP settings
     ssl_stapling on;
@@ -82,10 +51,6 @@ server {
     resolver 127.0.0.1 127.0.1.1 valid=300s;
     resolver_timeout 5s;
     {% endif %}
-
-    # Disable gzip to protect against BREACH
-    # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
-    gzip off;
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 
@@ -124,42 +89,11 @@ server {
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:50m;
 
-    {% if compatibility == "modern" %}
-    # Ciphers with modern compatibility
-    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=modern
-    # The following configuration use modern ciphers, but remove compatibility with some old clients (android < 5.0, Internet Explorer < 10, ...)
-    ssl_protocols TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-    ssl_prefer_server_ciphers on;
-    {% else %}
-    # As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-    ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
-    ssl_prefer_server_ciphers on;
+    include /etc/nginx/conf.d/security.conf.inc;
 
-    # Ciphers with intermediate compatibility
-    # https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=intermediate
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-    # Uncomment the following directive after DH generation
-    # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
-    #ssl_dhparam /etc/ssl/private/dh2048.pem;
-    {% endif %}
-
-    # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
-    # https://wiki.mozilla.org/Security/Guidelines/Web_Security
-    # https://observatory.mozilla.org/
     {% if domain_cert_ca != "Self-signed" %}
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
     {% endif %}
-    more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-    more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
-    more_set_headers "X-Content-Type-Options : nosniff";
-    more_set_headers "X-XSS-Protection : 1; mode=block";
-    more_set_headers "X-Download-Options : noopen";
-    more_set_headers "X-Permitted-Cross-Domain-Policies : none";
-    more_set_headers "X-Frame-Options : SAMEORIGIN";
-
     {% if domain_cert_ca == "Let's Encrypt" %}
     # OCSP settings
     ssl_stapling on;
@@ -168,12 +102,6 @@ server {
     resolver 127.0.0.1 127.0.1.1 valid=300s;
     resolver_timeout 5s;
     {% endif %}
-
-    # Disable gzip to protect against BREACH
-    # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
-    gzip off;
-
-#    access_by_lua_file /usr/share/ssowat/access.lua;
 
     access_log /var/log/nginx/xmpp-upload.{{ domain }}-access.log;
     error_log /var/log/nginx/xmpp-upload.{{ domain }}-error.log;

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -105,7 +105,7 @@ server {
     server_name xmpp-upload.{{ domain }};
 
     location /upload {
-        alias /var/www/xmpp-upload.{{ domain }}/upload;
+        alias /var/xmpp-upload/{{ domain }}/upload;
         # Pass all requests to metronome, except for GET and HEAD requests.
         limit_except GET HEAD {
           proxy_pass http://localhost:5290;

--- a/data/templates/ssl/openssl.cnf
+++ b/data/templates/ssl/openssl.cnf
@@ -192,7 +192,7 @@ authorityKeyIdentifier=keyid,issuer
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 
-subjectAltName=DNS:yunohost.org,DNS:www.yunohost.org,DNS:ns.yunohost.org
+subjectAltName=DNS:yunohost.org,DNS:www.yunohost.org,DNS:ns.yunohost.org,DNS:xmpp-upload.yunohost.org
 
 [ v3_ca ]
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -223,6 +223,7 @@
     "diagnosis_unknown_categories": "The following categories are unknown: {categories}",
     "diagnosis_never_ran_yet": "It looks like this server was setup recently and there's no diagnosis report to show yet. You should start by running a full diagnosis, either from the webadmin or using 'yunohost diagnosis run' from the command line.",
     "domain_cannot_remove_main": "You cannot remove '{domain:s}' since it's the main domain, you first need to set another domain as the main domain using 'yunohost domain main-domain -n <another-domain>'; here is the list of candidate domains: {other_domains:s}",
+    "domain_cannot_add_xmpp_upload": "You cannot add domains starting with 'xmpp-upload.'. This kind of name is reserved for the XMPP upload feature integrated in YunoHost.",
     "domain_cannot_remove_main_add_new_one": "You cannot remove '{domain:s}' since it's the main domain and your only domain, you need to first add another domain using 'yunohost domain add <another-domain.com>', then set is as the main domain using 'yunohost domain main-domain -n <another-domain.com>' and then you can remove the domain '{domain:s}' using 'yunohost domain remove {domain:s}'.'",
     "domain_cert_gen_failed": "Could not generate certificate",
     "domain_created": "Domain created",

--- a/locales/en.json
+++ b/locales/en.json
@@ -133,6 +133,7 @@
     "certmanager_domain_http_not_working": "It seems the domain {domain:s} cannot be accessed through HTTP. Check that your DNS and NGINX configuration is correct",
     "certmanager_domain_unknown": "Unknown domain '{domain:s}'",
     "certmanager_error_no_A_record": "No DNS 'A' record found for '{domain:s}'. You need to make your domain name point to your machine to be able to install a Let's Encrypt certificate. (If you know what you are doing, use '--no-checks' to turn off those checks.)",
+    "certmanager_warning_subdomain_dns_record": "Subdomain '{subdomain:s}' does not resolve to the same IP address as '{domain:s}'. Some features will not be available until you fix this and regenerate the certificate.",
     "certmanager_hit_rate_limit": "Too many certificates already issued for this exact set of domains {domain:s} recently. Please try again later. See https://letsencrypt.org/docs/rate-limits/ for more details",
     "certmanager_http_check_timeout": "Timed out when server tried to contact itself through HTTP using a public IP address (domain '{domain:s}' with IP '{ip:s}'). You may be experiencing a hairpinning issue, or the firewall/router ahead of your server is misconfigured.",
     "certmanager_no_cert_file": "Could not read the certificate file for the domain {domain:s} (file: {file:s})",

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -639,6 +639,9 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     # Set the domain
     csr.get_subject().CN = domain
 
+    # Include xmpp-upload subdomain as subject alternate names
+    csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:xmpp-upload." + domain)])
+
     # Set the key
     with open(key_file, 'rt') as f:
         key = crypto.load_privatekey(crypto.FILETYPE_PEM, f.read())

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -43,7 +43,6 @@ from yunohost.utils.network import get_public_ip
 
 from moulinette import m18n
 from yunohost.app import app_ssowatconf
-from yunohost.domain import _get_maindomain
 from yunohost.service import _run_service_command
 from yunohost.regenconf import regen_conf
 from yunohost.log import OperationLogger
@@ -640,6 +639,7 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     # Set the domain
     csr.get_subject().CN = domain
 
+    from yunohost.domain import _get_maindomain
     if domain == _get_maindomain():
         # Include xmpp-upload subdomain in subject alternate names
         subdomain="xmpp-upload." + domain

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -643,11 +643,10 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     if domain == _get_maindomain():
         # Include xmpp-upload subdomain in subject alternate names
         subdomain="xmpp-upload." + domain
-        try:
-            _check_domain_is_ready_for_ACME(subdomain)
+        if _dns_ip_match_public_ip(get_public_ip(), subdomain):
             logger.info("Subdmain {} is ready for ACME and will be included in the certificate.".format(subdomain))
             csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
-        except YunohostError:
+        else:
             logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
 
     # Set the key

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -639,8 +639,14 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     # Set the domain
     csr.get_subject().CN = domain
 
-    # Include xmpp-upload subdomain as subject alternate names
-    csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:xmpp-upload." + domain)])
+    # Include xmpp-upload subdomain in subject alternate names
+    subdomain="xmpp-upload." + domain
+    try:
+        _check_domain_is_ready_for_ACME(subdomain)
+        logger.info("Subdmain {} is ready for ACME and will be included in the certificate.".format(subdomain))
+        csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
+    except YunohostError:
+        logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
 
     # Set the key
     with open(key_file, 'rt') as f:

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -644,7 +644,6 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
         # Include xmpp-upload subdomain in subject alternate names
         subdomain="xmpp-upload." + domain
         if _dns_ip_match_public_ip(get_public_ip(), subdomain):
-            logger.info("Subdmain {} is ready for ACME and will be included in the certificate.".format(subdomain))
             csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
         else:
             logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -643,9 +643,10 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     if domain == _get_maindomain():
         # Include xmpp-upload subdomain in subject alternate names
         subdomain="xmpp-upload." + domain
-        if _dns_ip_match_public_ip(get_public_ip(), subdomain):
+        try:
+            _dns_ip_match_public_ip(get_public_ip(), subdomain)
             csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
-        else:
+        except YunohostError:
             logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
 
     # Set the key

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -43,6 +43,7 @@ from yunohost.utils.network import get_public_ip
 
 from moulinette import m18n
 from yunohost.app import app_ssowatconf
+from yunohost.domain import _get_maindomain
 from yunohost.service import _run_service_command
 from yunohost.regenconf import regen_conf
 from yunohost.log import OperationLogger
@@ -639,14 +640,15 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     # Set the domain
     csr.get_subject().CN = domain
 
-    # Include xmpp-upload subdomain in subject alternate names
-    subdomain="xmpp-upload." + domain
-    try:
-        _check_domain_is_ready_for_ACME(subdomain)
-        logger.info("Subdmain {} is ready for ACME and will be included in the certificate.".format(subdomain))
-        csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
-    except YunohostError:
-        logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
+    if domain == _get_maindomain():
+        # Include xmpp-upload subdomain in subject alternate names
+        subdomain="xmpp-upload." + domain
+        try:
+            _check_domain_is_ready_for_ACME(subdomain)
+            logger.info("Subdmain {} is ready for ACME and will be included in the certificate.".format(subdomain))
+            csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
+        except YunohostError:
+            logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
 
     # Set the key
     with open(key_file, 'rt') as f:

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -412,6 +412,7 @@ def _build_dns_conf(domain, ttl=3600):
             {"type": "CNAME", "name": "muc", "value": "@", "ttl": 3600},
             {"type": "CNAME", "name": "pubsub", "value": "@", "ttl": 3600},
             {"type": "CNAME", "name": "vjud", "value": "@", "ttl": 3600}
+            {"type": "CNAME", "name": "xmpp-upload", "value": "@", "ttl": 3600}
         ],
         "mail": [
             {"type": "MX", "name": "@", "value": "10 domain.tld.", "ttl": 3600},
@@ -453,6 +454,7 @@ def _build_dns_conf(domain, ttl=3600):
         ["muc", ttl, "CNAME", "@"],
         ["pubsub", ttl, "CNAME", "@"],
         ["vjud", ttl, "CNAME", "@"],
+        ["xmpp-upload", ttl, "CNAME", "@"],
     ]
 
     # SPF record

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -79,6 +79,9 @@ def domain_add(operation_logger, domain, dyndns=False):
     from yunohost.app import app_ssowatconf
     from yunohost.utils.ldap import _get_ldap_interface
 
+    if domain.startswith("xmpp-upload."):
+        raise YunohostError("domain_cannot_add_xmpp_upload")
+
     ldap = _get_ldap_interface()
 
     try:


### PR DESCRIPTION
## The problem

Sharing files with XMPP's http upload mechanism is currently impossible.
This PR is an attempt to address issue [#1278](https://github.com/YunoHost/issues/issues/1278 )

Metronome's configuration is ready for http upload but port 5290 is not reachable.

## Solution

http upload requires a dedicated subdomain (I have chosen *jabber.thedomain.net* instead of upload.thedomain.net to avoid possible conflicts with possible other "upload" things).

This subdomain should be reachable via HTTPS so we need:
- [X] add a DNS entry for that subdomain
- [X] transparently include *jabber.thedomain.net* as a SAN in the same certificate for *thedomain.net*
- [X] explicitly define the storage path in metronome's config (the same will be configured in nginx)
- [X] create an nginx config for that subdomain
- [x] silently recreate existing Letsencrypt certificates

## PR Status
The PR ready for review.

## How to test

Create 2 accounts : alice and bob
Install Dino and configure those accounts.
Happily share pictures between alice and bob.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
