### PR TITLE
[fix] permission change_url

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -336,6 +336,7 @@ def app_change_url(operation_logger, app, domain, path):
     """
     from yunohost.hook import hook_exec, hook_callback
     from yunohost.domain import _normalize_domain_path, _get_conflicting_apps
+    from yunohost.permission import permission_url
 
     installed = _is_installed(app)
     if not installed:
@@ -425,7 +426,7 @@ def app_change_url(operation_logger, app, domain, path):
     app_setting(app, 'domain', value=domain)
     app_setting(app, 'path', value=path)
 
-    permission_update(app, permission="main", add_url=[domain + path], remove_url=[old_domain + old_path], sync_perm=True)
+    permission_url(app + ".main", url=domain + path, sync_perm=True)
 
     # avoid common mistakes
     if _run_service_command("reload", "nginx") is False:


### PR DESCRIPTION
## The problem

When I try to change an url:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/api.py", line 439, in process
    ret = self.actionsmap.process(arguments, timeout=30, route=_route)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 527, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/log.py", line 287, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/app.py", line 441, in app_change_url
    permission_update(app, permission="main", add_url=[domain + path], remove_url=[old_domain + old_path], sync_perm=True)
NameError: global name 'permission_update' is not defined
```

## Solution

Import and use `permission_url`

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
