### PR TITLE
[fix] add all users in visitors

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -379,6 +379,7 @@
     "migration_description_0012_postgresql_password_to_md5_authentication": "Force PostgreSQL authentication to use MD5 for local connections",
     "migration_description_0013_futureproof_apps_catalog_system": "Migrate to the new future-proof apps catalog system",
     "migration_description_0014_remove_app_status_json": "Remove legacy status.json app files",
+    "migration_description_0015_add_all_users_in_visitors": "Add all users in visitors group",
     "migration_0003_start": "Starting migration to Stretch. The logs will be available in {logfile}.",
     "migration_0003_patching_sources_list": "Patching the sources.lists…",
     "migration_0003_main_upgrade": "Starting main upgrade…",

--- a/src/yunohost/data_migrations/0011_setup_group_permission.py
+++ b/src/yunohost/data_migrations/0011_setup_group_permission.py
@@ -122,8 +122,6 @@ class MyMigration(Migration):
             if app_setting(app, "unprotected_uris") == "/" or app_setting(app, "skipped_uris") == "/":
                 user_permission_update(app+".main", remove="all_users", add="visitors", sync_perm=False)
 
-        permission_sync_to_user()
-
     def run(self):
 
         # FIXME : what do we really want to do here ...

--- a/src/yunohost/data_migrations/0011_setup_group_permission.py
+++ b/src/yunohost/data_migrations/0011_setup_group_permission.py
@@ -92,6 +92,7 @@ class MyMigration(Migration):
                         {'objectClass': ['mailAccount', 'inetOrgPerson', 'posixAccount', 'userPermissionYnh']})
             user_group_create(username, gid=user_info['uidNumber'][0], primary_group=True, sync_perm=False)
             user_group_update(groupname='all_users', add=username, force=True, sync_perm=False)
+            user_group_update(groupname='visitors', add=username, force=True, sync_perm=False)
 
     def migrate_app_permission(self, app=None):
         logger.info(m18n.n("migration_0011_migrate_permission"))

--- a/src/yunohost/data_migrations/0015_add_all_users_in_visitors.py
+++ b/src/yunohost/data_migrations/0015_add_all_users_in_visitors.py
@@ -1,0 +1,31 @@
+import os
+
+from moulinette.utils.log import getActionLogger
+
+from yunohost.tools import Migration
+from yunohost.user import user_group_update
+from yunohost.permission import permission_sync_to_user
+
+
+logger = getActionLogger('yunohost.migration')
+
+class MyMigration(Migration):
+
+    """Fix ldap access for visitors group"""
+
+    def run(self):
+
+        from yunohost.utils.ldap import _get_ldap_interface
+        ldap = _get_ldap_interface()
+
+        # Create a group for each yunohost user
+        user_list = ldap.search('ou=users,dc=yunohost,dc=org',
+                                '(&(objectclass=person)(!(uid=root))(!(uid=nobody)))',
+                                ['uid', 'uidNumber'])
+        for user_info in user_list:
+            username = user_info['uid'][0]
+            user_group_update(groupname='visitors', add=username, force=True, sync_perm=False)
+        
+        permission_sync_to_user()
+
+

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -227,7 +227,8 @@ def user_create(operation_logger, username, firstname, lastname, mail, password,
 
     # Create group for user and add to group 'all_users'
     user_group_create(groupname=username, gid=uid, primary_group=True, sync_perm=False)
-    user_group_update(groupname='all_users', add=username, force=True, sync_perm=True)
+    user_group_update(groupname='all_users', add=username, force=True, sync_perm=False)
+    user_group_update(groupname='visitors', add=username, force=True, sync_perm=True)
 
     # TODO: Send a welcome mail to user
     logger.success(m18n.n('user_created'))
@@ -258,6 +259,8 @@ def user_delete(operation_logger, username, purge=False):
     operation_logger.start()
 
     user_group_update("all_users", remove=username, force=True, sync_perm=False)
+    user_group_update("visitors", remove=username, force=True, sync_perm=False)
+
     for group, infos in user_group_list()["groups"].items():
         if group == "all_users":
             continue


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1485
https://github.com/YunoHost/issues/issues/1484

## Solution

Add all users in the visitors group (Should I create a new migration?)

## PR Status

- Install nextcloud with new permission system:
```
yunohost app install https://github.com/YunoHost-Apps/nextcloud_ynh/tree/new-permissions-system
```
- Add `visitors` permission.
- Try to login
 
## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [x] Quick review 0/1 : Josué
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
