### PR TITLE
[Fix] permission create

### DIFF
--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -267,16 +267,7 @@ def permission_create(operation_logger, permission, url=None, allowed=None, sync
     except Exception as e:
         raise YunohostError('permission_creation_failed', permission=permission, error=e)
 
-    to_add = None
-
-    # If who should be allowed is explicitly provided, use this info
-    if allowed:
-        if not isinstance(allowed, list):
-            to_add = [allowed]
-        else:
-            to_add = allowed
-
-    new_permission = _update_ldap_group_permission(permission=permission, allowed=to_add, sync_perm=sync_perm)
+    new_permission = _update_ldap_group_permission(permission=permission, allowed=allowed, sync_perm=sync_perm)
 
     logger.debug(m18n.n('permission_created', permission=permission))
     return new_permission

--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -273,9 +273,8 @@ def permission_create(operation_logger, permission, url=None, allowed=None, sync
     if allowed:
         if not isinstance(allowed, list):
             to_add = [allowed]
-    # For main permission, we add all users by default
-    elif permission.endswith(".main"):
-        to_add = "all_users"
+        else:
+            to_add = allowed
 
     new_permission = _update_ldap_group_permission(permission=permission, allowed=to_add, sync_perm=sync_perm)
 
@@ -294,6 +293,10 @@ def permission_url(operation_logger, permission, url=None, sync_perm=True):
     """
     from yunohost.utils.ldap import _get_ldap_interface
     ldap = _get_ldap_interface()
+
+    # By default, manipulate main permission
+    if "." not in permission:
+        permission = permission + ".main"
 
     # Fetch existing permission
 


### PR DESCRIPTION
## The problem

"All_user" was not added on the creation of new ".main" permission

## Solution

- *Fix it!*
- *No need to check `permission.endswith(".main")`: https://github.com/YunoHost/yunohost/blob/67816ad18ec82fe3ffdc234bdd6536844a872582/src/yunohost/app.py#L791*

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
