### PR TITLE
[fix] metronome domain folder permissions

### DIFF
--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -51,6 +51,7 @@ do_post_regen() {
   # create metronome directories for domains
   for domain in $domain_list; do
     sudo mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
+    sudo chown -R metronome: /var/lib/metronome/${domain//./%2e}/
   done
 
   [[ -z "$regen_conf_files" ]] \

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -41,18 +41,17 @@ do_pre_regen() {
 do_post_regen() {
   regen_conf_files=$1
 
-  # fix some permissions
-  sudo chown -R metronome: /var/lib/metronome/
-  sudo chown -R metronome: /etc/metronome/conf.d/
-
   # retrieve variables
   domain_list=$(sudo yunohost domain list --output-as plain --quiet)
 
   # create metronome directories for domains
   for domain in $domain_list; do
     sudo mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
-    sudo chown -R metronome: /var/lib/metronome/${domain//./%2e}/
   done
+
+  # fix some permissions
+  sudo chown -R metronome: /var/lib/metronome/
+  sudo chown -R metronome: /etc/metronome/conf.d/
 
   [[ -z "$regen_conf_files" ]] \
     || sudo service metronome restart


### PR DESCRIPTION
## The problem

When adding new domains to Yunohost a directory for each newly added domain is created in `/var/lib/metronome` unfortunately since the directory is created with `sudo mkdir` that means `root:root` owns the directory. Metronome will now fail to write to the directory.

## Solution

After creating the directory `chown` it.

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
