### PR TITLE
[fix] test_backup_and_restore_permission_app

### DIFF
--- a/src/yunohost/tests/test_backuprestore.py
+++ b/src/yunohost/tests/test_backuprestore.py
@@ -500,7 +500,7 @@ def test_backup_and_restore_with_ynh_restore(mocker):
     _test_backup_and_restore_app(mocker, "backup_recommended_app")
 
 @pytest.mark.with_permission_app_installed
-def test_backup_and_restore_permission_app():
+def test_backup_and_restore_permission_app(mocker):
 
     res = user_permission_list(full=True)['permissions']
     assert "permissions_app.main" in res
@@ -514,7 +514,7 @@ def test_backup_and_restore_permission_app():
     assert res['permissions_app.admin']['allowed'] == ["alice"]
     assert res['permissions_app.dev']['allowed'] == []
 
-    _test_backup_and_restore_app("permissions_app")
+    _test_backup_and_restore_app(mocker, "permissions_app")
 
     res = user_permission_list(full=True)['permissions']
     assert "permissions_app.main" in res


### PR DESCRIPTION
## The problem

`TypeError: _test_backup_and_restore_app() takes exactly 2 arguments (1 given)`

## Solution

Add mocker in parameter (is it the right thing to do?)

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
