### PR TITLE
[enh] Refactor app_list and app_info, + add support for app categories

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -543,35 +543,41 @@ app:
     category_help: Manage apps
     actions:
 
+        catalog:
+            action_help: Show the catalog of installable application
+            api: GET /appscatalog
+            arguments:
+                -f:
+                    full: --full
+                    help: Display all details, including the app manifest and various other infos
+                    action: store_true
+
+
         ### app_list()
         list:
-            action_help: List apps
+            action_help: List installed apps
             api: GET /apps
             arguments:
-                -r:
-                    full: --raw
-                    help: Return the full app_dict
-                    action: store_true
-                -i:
-                    full: --installed
-                    help: Return only installed apps
+                -f:
+                    full: --full
+                    help: Display all details, including the app manifest and various other infos
                     action: store_true
 
         ### app_info()
         info:
-            action_help: Get information about an installed app
+            action_help: Show infos about a specific installed app
             api: GET /apps/<app>
             arguments:
                 app:
                     help: Specific app ID
-                -r:
-                    full: --raw
-                    help: Return the full app_dict
+                -f:
+                    full: --full
+                    help: Display all details, including the app manifest and various other infos
                     action: store_true
 
         ### app_map()
         map:
-            action_help: List apps by domain
+            action_help: Show the mapping between urls and apps
             api: GET /appsmap
             arguments:
                 -a:

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -548,9 +548,6 @@ app:
             action_help: List apps
             api: GET /apps
             arguments:
-                -f:
-                    full: --filter
-                    help: Name filter of app_id or app_name
                 -r:
                     full: --raw
                     help: Return the full app_dict
@@ -558,10 +555,6 @@ app:
                 -i:
                     full: --installed
                     help: Return only installed apps
-                    action: store_true
-                -b:
-                    full: --with-backup
-                    help: Return only apps with backup feature (force --installed filter)
                     action: store_true
 
         ### app_info()

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -551,7 +551,10 @@ app:
                     full: --full
                     help: Display all details, including the app manifest and various other infos
                     action: store_true
-
+                -c:
+                    full: --with-categories
+                    help: Also return a list of app categories
+                    action: store_true
 
         ### app_list()
         list:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -96,6 +96,8 @@ def app_catalog(full=False, with_categories=False):
     for category in catalog["categories"]:
         category["title"] = _value_for_locale(category["title"])
         category["description"] = _value_for_locale(category["description"])
+        for subtags in category.get("subtags", []):
+            subtags["title"] = _value_for_locale(subtags["title"])
 
     if not full:
         catalog["categories"] = [{"id": c["id"],

--- a/src/yunohost/tests/test_appscatalog.py
+++ b/src/yunohost/tests/test_appscatalog.py
@@ -14,6 +14,7 @@ from yunohost.app import (_initialize_apps_catalog_system,
                           _update_apps_catalog,
                           _actual_apps_catalog_api_url,
                           _load_apps_catalog,
+                          app_catalog,
                           logger,
                           APPS_CATALOG_CACHE,
                           APPS_CATALOG_CONF,
@@ -25,8 +26,14 @@ APPS_CATALOG_DEFAULT_URL_FULL = _actual_apps_catalog_api_url(APPS_CATALOG_DEFAUL
 CRON_FOLDER, CRON_NAME = APPS_CATALOG_CRON_PATH.rsplit("/", 1)
 
 DUMMY_APP_CATALOG = """{
-   "foo": {"id": "foo", "level": 4},
-   "bar": {"id": "bar", "level": 7}
+   "apps": {
+       "foo": {"id": "foo", "level": 4, "category": "yolo", "manifest":{"description": "Foo"}},
+       "bar": {"id": "bar", "level": 7, "category": "swag", "manifest":{"description": "Bar"}}
+   },
+   "categories": [
+       {"id": "yolo", "description": "YoLo"},
+       {"id": "swag", "description": "sWaG"}
+   ]
 }
 """
 
@@ -107,7 +114,7 @@ def test_apps_catalog_emptylist():
     assert not len(apps_catalog_list)
 
 
-def test_apps_catalog_update_success(mocker):
+def test_apps_catalog_update_nominal(mocker):
 
     # Initialize ...
     _initialize_apps_catalog_system()
@@ -130,9 +137,16 @@ def test_apps_catalog_update_success(mocker):
     # Cache shouldn't be empty anymore empty
     assert glob.glob(APPS_CATALOG_CACHE + "/*")
 
-    app_dict = _load_apps_catalog()
-    assert "foo" in app_dict.keys()
-    assert "bar" in app_dict.keys()
+    # And if we load the catalog, we sould find
+    # - foo and bar as apps (unordered),
+    # - yolo and swag as categories (ordered)
+    catalog = app_catalog(with_categories=True)
+
+    assert "apps" in catalog
+    assert set(catalog["apps"].keys()) == set(["foo", "bar"])
+
+    assert "categories" in catalog
+    assert [c["id"] for c in catalog["categories"]] == ["yolo", "swag"]
 
 
 def test_apps_catalog_update_404(mocker):
@@ -219,7 +233,7 @@ def test_apps_catalog_load_with_empty_cache(mocker):
         # Try to load the apps catalog
         # This should implicitly trigger an update in the background
         mocker.spy(m18n, "n")
-        app_dict = _load_apps_catalog()
+        app_dict = _load_apps_catalog()["apps"]
         m18n.n.assert_any_call("apps_catalog_obsolete_cache")
         m18n.n.assert_any_call("apps_catalog_update_success")
 
@@ -252,7 +266,7 @@ def test_apps_catalog_load_with_conflicts_between_lists(mocker):
         # Try to load the apps catalog
         # This should implicitly trigger an update in the background
         mocker.spy(logger, "warning")
-        app_dict = _load_apps_catalog()
+        app_dict = _load_apps_catalog()["apps"]
         logger.warning.assert_any_call(AnyStringWith("Duplicate"))
 
     # Cache shouldn't be empty anymore empty
@@ -291,7 +305,7 @@ def test_apps_catalog_load_with_oudated_api_version(mocker):
         m.register_uri("GET", APPS_CATALOG_DEFAULT_URL_FULL, text=DUMMY_APP_CATALOG)
 
         mocker.spy(m18n, "n")
-        app_dict = _load_apps_catalog()
+        app_dict = _load_apps_catalog()["apps"]
         m18n.n.assert_any_call("apps_catalog_update_success")
 
     assert "foo" in app_dict.keys()
@@ -329,7 +343,7 @@ def test_apps_catalog_migrate_legacy_explicitly():
     assert cron_job_is_there()
 
     # Reading the apps_catalog should work
-    app_dict = _load_apps_catalog()
+    app_dict = _load_apps_catalog()["apps"]
     assert "foo" in app_dict.keys()
     assert "bar" in app_dict.keys()
 
@@ -343,7 +357,7 @@ def test_apps_catalog_migrate_legacy_implicitly():
 
     with requests_mock.Mocker() as m:
         m.register_uri("GET", APPS_CATALOG_DEFAULT_URL_FULL, text=DUMMY_APP_CATALOG)
-        app_dict = _load_apps_catalog()
+        app_dict = _load_apps_catalog()["apps"]
 
     assert "foo" in app_dict.keys()
     assert "bar" in app_dict.keys()

--- a/src/yunohost/tests/test_permission.py
+++ b/src/yunohost/tests/test_permission.py
@@ -3,7 +3,7 @@ import pytest
 
 from conftest import message, raiseYunohostError
 
-from yunohost.app import app_install, app_remove, app_change_url, app_list, app_map
+from yunohost.app import app_install, app_remove, app_change_url, app_list, app_map, _installed_apps
 from yunohost.user import user_list, user_create, user_delete, \
                           user_group_list, user_group_delete
 from yunohost.permission import user_permission_update, user_permission_list, user_permission_reset, \
@@ -163,9 +163,7 @@ def check_permission_for_apps():
 
     app_perms_prefix = set(p.split(".")[0] for p in app_perms)
 
-    installed_apps = {app['id'] for app in app_list(installed=True)['apps']}
-
-    assert installed_apps == app_perms_prefix
+    assert set(_installed_apps()) == app_perms_prefix
 
 
 def can_access_webpage(webpath, logged_as=None):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -470,17 +470,17 @@ def _list_upgradable_apps():
     app_list_installed = os.listdir(APPS_SETTING_PATH)
     for app_id in app_list_installed:
 
-        app_dict = app_info(app_id, raw=True)
+        app_dict = app_info(app_id, full=True)
 
         if app_dict["upgradable"] == "yes":
 
             # FIXME : would make more sense for these infos to be computed
             # directly in app_info and used to check the upgradability of
             # the app...
-            current_version = app_dict.get("version", "?")
+            current_version = app_dict.get("manifest", {}).get("version", "?")
             current_commit = app_dict.get("settings", {}).get("current_revision", "?")[:7]
-            new_version = app_dict.get("manifest",{}).get("version","?")
-            new_commit = app_dict.get("git", {}).get("revision", "?")[:7]
+            new_version = app_dict.get("from_catalog", {}).get("manifest", {}).get("version", "?")
+            new_commit = app_dict.get("from_catalog", {}).get("git", {}).get("revision", "?")[:7]
 
             if current_version == new_version:
                 current_version += " (" + current_commit + ")"


### PR DESCRIPTION
## The problem

App categoriez bruh, we need them

Also `app_list` and `app_info` are complete madness so fuck these, refactored them. (The main point being the constant confusion between local info and info from the app catalog)

## Solution

The app category thing can easily be introduced thanks to https://github.com/YunoHost/yunohost/pull/778 . It is based on an evolution of the app list format, available here : https://app.yunohost.org/default/v2/apps.json (c.f. also the PR on the apps repo : https://github.com/YunoHost/apps/pull/828 )

`app_list` and `app_info` got changed a lot : 
- `app_info` returns info about a single installed app.  `--full` can be added to fetch all the info (useful for other part of the code + the admin). The info from the catalog is separated from the local info in an obvious way (there's a `from_catalog` entry)
- `app_list` will now only list *installed* apps. Its code is pretty simple and just returns the `app_info` for all installed apps.
- and then we have a new `app_catalog` meant to display ... the application catalog and that's it (not mixed with local info about locally installed apps, except maybe a flag saying if the app is already installed). It's also meant to expose the categories information.

## PR Status

Still WIP, working on integration in the webadmin

## How to test

Run `yunohost app info`, `app list` and `app catalog`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
