### PR TITLE
[mod] Remove those random sudo which are useless yet triggers LDAP warning when LDAP is in bad state

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -13,7 +13,7 @@ ynh_wait_dpkg_free() {
     for try in `seq 1 17`
     do
         # Check if /var/lib/dpkg/lock is used by another process
-        if sudo lsof /var/lib/dpkg/lock > /dev/null
+        if lsof /var/lib/dpkg/lock > /dev/null
         then
             echo "apt is already in use..."
             # Sleep an exponential time at each round

--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -179,7 +179,7 @@ ynh_restore () {
 # usage: _get_archive_path ORIGIN_PATH
 _get_archive_path () {
     # For security reasons we use csv python library to read the CSV
-    sudo python -c "
+    python -c "
 import sys
 import csv
 with open(sys.argv[1], 'r') as backup_file:
@@ -302,7 +302,7 @@ ynh_store_file_checksum () {
     ynh_handle_getopts_args "$@"
 
     local checksum_setting_name=checksum_${file//[\/ ]/_}    # Replace all '/' and ' ' by '_'
-    ynh_app_setting_set --app=$app --key=$checksum_setting_name --value=$(sudo md5sum "$file" | cut -d' ' -f1)
+    ynh_app_setting_set --app=$app --key=$checksum_setting_name --value=$(md5sum "$file" | cut -d' ' -f1)
 
     # If backup_file_checksum isn't empty, ynh_backup_if_checksum_is_different has made a backup
     if [ -n "${backup_file_checksum-}" ]
@@ -339,11 +339,11 @@ ynh_backup_if_checksum_is_different () {
     backup_file_checksum=""
     if [ -n "$checksum_value" ]
     then    # Proceed only if a value was stored into the app settings
-        if [ -e $file ] && ! echo "$checksum_value $file" | sudo md5sum -c --status
+        if [ -e $file ] && ! echo "$checksum_value $file" | md5sum -c --status
         then    # If the checksum is now different
             backup_file_checksum="/home/yunohost.conf/backup/$file.backup.$(date '+%Y%m%d.%H%M%S')"
-            sudo mkdir -p "$(dirname "$backup_file_checksum")"
-            sudo cp -a "$file" "$backup_file_checksum"    # Backup the current file
+            mkdir -p "$(dirname "$backup_file_checksum")"
+            cp -a "$file" "$backup_file_checksum"    # Backup the current file
             ynh_print_warn "File $file has been manually modified since the installation or last upgrade. So it has been duplicated in $backup_file_checksum"
             echo "$backup_file_checksum"    # Return the name of the backup file
         fi
@@ -394,7 +394,7 @@ ynh_backup_before_upgrade () {
     if [ "$NO_BACKUP_UPGRADE" -eq 0 ]
     then
         # Check if a backup already exists with the prefix 1
-        if sudo yunohost backup list | grep -q $app_bck-pre-upgrade1
+        if yunohost backup list | grep -q $app_bck-pre-upgrade1
         then
             # Prefix becomes 2 to preserve the previous backup
             backup_number=2
@@ -402,14 +402,14 @@ ynh_backup_before_upgrade () {
         fi
 
         # Create backup
-        sudo BACKUP_CORE_ONLY=1 yunohost backup create --apps $app --name $app_bck-pre-upgrade$backup_number --debug
+        BACKUP_CORE_ONLY=1 yunohost backup create --apps $app --name $app_bck-pre-upgrade$backup_number --debug
         if [ "$?" -eq 0 ]
         then
             # If the backup succeeded, remove the previous backup
-            if sudo yunohost backup list | grep -q $app_bck-pre-upgrade$old_backup_number
+            if yunohost backup list | grep -q $app_bck-pre-upgrade$old_backup_number
             then
                 # Remove the previous backup only if it exists
-                sudo yunohost backup delete $app_bck-pre-upgrade$old_backup_number > /dev/null
+                yunohost backup delete $app_bck-pre-upgrade$old_backup_number > /dev/null
             fi
         else
             ynh_die --message="Backup failed, the upgrade process was aborted."
@@ -438,12 +438,12 @@ ynh_restore_upgradebackup () {
     if [ "$NO_BACKUP_UPGRADE" -eq 0 ]
     then
         # Check if an existing backup can be found before removing and restoring the application.
-        if sudo yunohost backup list | grep -q $app_bck-pre-upgrade$backup_number
+        if yunohost backup list | grep -q $app_bck-pre-upgrade$backup_number
         then
             # Remove the application then restore it
-            sudo yunohost app remove $app
+            yunohost app remove $app
             # Restore the backup
-            sudo yunohost backup restore $app_bck-pre-upgrade$backup_number --apps $app --force --debug
+            yunohost backup restore $app_bck-pre-upgrade$backup_number --apps $app --force --debug
             ynh_die --message="The app was restored to the way it was before the failed upgrade."
         fi
     else

--- a/data/helpers.d/logging
+++ b/data/helpers.d/logging
@@ -46,10 +46,10 @@ ynh_print_info() {
 # Requires YunoHost version 2.6.4 or higher.
 ynh_no_log() {
   local ynh_cli_log=/var/log/yunohost/yunohost-cli.log
-  sudo cp -a ${ynh_cli_log} ${ynh_cli_log}-move
+  cp -a ${ynh_cli_log} ${ynh_cli_log}-move
   eval $@
   local exit_code=$?
-  sudo mv ${ynh_cli_log}-move ${ynh_cli_log}
+  mv ${ynh_cli_log}-move ${ynh_cli_log}
   return $?
 }
 

--- a/data/helpers.d/logrotate
+++ b/data/helpers.d/logrotate
@@ -90,8 +90,8 @@ $logfile {
 	$su_directive
 }
 EOF
-	sudo mkdir -p $(dirname "$logfile")	# Create the log directory, if not exist
-	cat ${app}-logrotate | sudo $customtee /etc/logrotate.d/$app > /dev/null	# Append this config to the existing config file, or replace the whole config file (depending on $customtee)
+	mkdir -p $(dirname "$logfile")	# Create the log directory, if not exist
+	cat ${app}-logrotate | $customtee /etc/logrotate.d/$app > /dev/null	# Append this config to the existing config file, or replace the whole config file (depending on $customtee)
 }
 
 # Remove the app's logrotate config.
@@ -101,6 +101,6 @@ EOF
 # Requires YunoHost version 2.6.4 or higher.
 ynh_remove_logrotate () {
 	if [ -e "/etc/logrotate.d/$app" ]; then
-		sudo rm "/etc/logrotate.d/$app"
+		rm "/etc/logrotate.d/$app"
 	fi
 }

--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -44,7 +44,7 @@ ynh_mysql_execute_as_root() {
     ynh_handle_getopts_args "$@"
     database="${database:-}"
 
-    ynh_mysql_connect_as --user="root" --password="$(sudo cat $MYSQL_ROOT_PWD_FILE)" \
+    ynh_mysql_connect_as --user="root" --password="$(cat $MYSQL_ROOT_PWD_FILE)" \
         --database="$database" <<< "$sql"
 }
 
@@ -65,7 +65,7 @@ ynh_mysql_execute_file_as_root() {
     ynh_handle_getopts_args "$@"
     database="${database:-}"
 
-    ynh_mysql_connect_as --user="root" --password="$(sudo cat $MYSQL_ROOT_PWD_FILE)" \
+    ynh_mysql_connect_as --user="root" --password="$(cat $MYSQL_ROOT_PWD_FILE)" \
         --database="$database" < "$file"
 }
 
@@ -126,7 +126,7 @@ ynh_mysql_dump_db() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    mysqldump -u "root" -p"$(sudo cat $MYSQL_ROOT_PWD_FILE)" --single-transaction --skip-dump-date "$database"
+    mysqldump -u "root" -p"$(cat $MYSQL_ROOT_PWD_FILE)" --single-transaction --skip-dump-date "$database"
 }
 
 # Create a user
@@ -223,7 +223,7 @@ ynh_mysql_remove_db () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	local mysql_root_password=$(sudo cat $MYSQL_ROOT_PWD_FILE)
+	local mysql_root_password=$(cat $MYSQL_ROOT_PWD_FILE)
 	if mysqlshow -u root -p$mysql_root_password | grep -q "^| $db_name"; then	# Check if the database exists
 		ynh_mysql_drop_db $db_name	# Remove the database	
 	else

--- a/data/helpers.d/nginx
+++ b/data/helpers.d/nginx
@@ -22,7 +22,7 @@ ynh_add_nginx_config () {
 	finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 	local others_var=${1:-}
 	ynh_backup_if_checksum_is_different --file="$finalnginxconf"
-	sudo cp ../conf/nginx.conf "$finalnginxconf"
+	cp ../conf/nginx.conf "$finalnginxconf"
 
 	# To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
 	# Substitute in a nginx config file only if the variable is not empty

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -28,12 +28,12 @@ ynh_add_fpm_config () {
 	ynh_app_setting_set --app=$app --key=fpm_service --value="$fpm_service"
 	finalphpconf="$fpm_config_dir/pool.d/$app.conf"
 	ynh_backup_if_checksum_is_different --file="$finalphpconf"
-	sudo cp ../conf/php-fpm.conf "$finalphpconf"
+	cp ../conf/php-fpm.conf "$finalphpconf"
 	ynh_replace_string --match_string="__NAMETOCHANGE__" --replace_string="$app" --target_file="$finalphpconf"
 	ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalphpconf"
 	ynh_replace_string --match_string="__USER__" --replace_string="$app" --target_file="$finalphpconf"
 	ynh_replace_string --match_string="__PHPVERSION__" --replace_string="$phpversion" --target_file="$finalphpconf"
-	sudo chown root: "$finalphpconf"
+	chown root: "$finalphpconf"
 	ynh_store_file_checksum --file="$finalphpconf"
 
 	if [ -e "../conf/php-fpm.ini" ]
@@ -41,8 +41,8 @@ ynh_add_fpm_config () {
 		echo "Packagers ! Please do not use a separate php ini file, merge your directives in the pool file instead." >&2
 		finalphpini="$fpm_config_dir/conf.d/20-$app.ini"
 		ynh_backup_if_checksum_is_different "$finalphpini"
-		sudo cp ../conf/php-fpm.ini "$finalphpini"
-		sudo chown root: "$finalphpini"
+		cp ../conf/php-fpm.ini "$finalphpini"
+		chown root: "$finalphpini"
 		ynh_store_file_checksum "$finalphpini"
 	fi
 	ynh_systemd_action --service_name=$fpm_service --action=reload

--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -45,7 +45,7 @@ ynh_psql_execute_as_root() {
 	ynh_handle_getopts_args "$@"
 	database="${database:-}"
 
-	ynh_psql_connect_as --user="postgres" --password="$(sudo cat $PSQL_ROOT_PWD_FILE)" \
+	ynh_psql_connect_as --user="postgres" --password="$(cat $PSQL_ROOT_PWD_FILE)" \
 		--database="$database" <<<"$sql"
 }
 
@@ -66,7 +66,7 @@ ynh_psql_execute_file_as_root() {
 	ynh_handle_getopts_args "$@"
 	database="${database:-}"
 
-	ynh_psql_connect_as --user="postgres" --password="$(sudo cat $PSQL_ROOT_PWD_FILE)" \
+	ynh_psql_connect_as --user="postgres" --password="$(cat $PSQL_ROOT_PWD_FILE)" \
 		--database="$database" <"$file"
 }
 
@@ -160,7 +160,7 @@ ynh_psql_user_exists() {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(sudo cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user" ; then
+	if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user" ; then
 		return 1
 	else
 		return 0
@@ -179,7 +179,7 @@ ynh_psql_database_exists() {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(sudo cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"; then
+	if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"; then
 		return 1
 	else
 		return 0
@@ -243,7 +243,7 @@ ynh_psql_remove_db() {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	local psql_root_password=$(sudo cat $PSQL_ROOT_PWD_FILE)
+	local psql_root_password=$(cat $PSQL_ROOT_PWD_FILE)
 	if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
 		ynh_psql_drop_db $db_name # Remove the database
 	else

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -211,7 +211,7 @@ ynh_webpath_available () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	sudo yunohost domain url-available $domain $path_url
+	yunohost domain url-available $domain $path_url
 }
 
 # Register/book a web path for an app
@@ -234,7 +234,7 @@ ynh_webpath_register () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	sudo yunohost app register-url $app $domain $path_url
+	yunohost app register-url $app $domain $path_url
 }
 
 # Create a new permission for the app

--- a/data/helpers.d/string
+++ b/data/helpers.d/string
@@ -49,7 +49,7 @@ ynh_replace_string () {
 	match_string=${match_string//${delimit}/"\\${delimit}"}
 	replace_string=${replace_string//${delimit}/"\\${delimit}"}
 
-	sudo sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$target_file"
+	sed --in-place "s${delimit}${match_string}${delimit}${replace_string}${delimit}g" "$target_file"
 }
 
 # Substitute/replace a special string by another in a file

--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -28,7 +28,7 @@ ynh_add_systemd_config () {
 
 	finalsystemdconf="/etc/systemd/system/$service.service"
 	ynh_backup_if_checksum_is_different --file="$finalsystemdconf"
-	sudo cp ../conf/$template "$finalsystemdconf"
+	cp ../conf/$template "$finalsystemdconf"
 
 	# To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
 	# Substitute in a nginx config file only if the variable is not empty
@@ -40,9 +40,9 @@ ynh_add_systemd_config () {
 	fi
 	ynh_store_file_checksum --file="$finalsystemdconf"
 
-	sudo chown root: "$finalsystemdconf"
-	sudo systemctl enable $service
-	sudo systemctl daemon-reload
+	chown root: "$finalsystemdconf"
+	systemctl enable $service
+	systemctl daemon-reload
 }
 
 # Remove the dedicated systemd config

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -16,7 +16,7 @@ ynh_user_exists() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo yunohost user list --output-as json | grep -q "\"username\": \"${username}\""
+    yunohost user list --output-as json | grep -q "\"username\": \"${username}\""
 }
 
 # Retrieve a YunoHost user information
@@ -38,7 +38,7 @@ ynh_user_get_info() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo yunohost user info "$username" --output-as plain | ynh_get_plain_key "$key"
+    yunohost user info "$username" --output-as plain | ynh_get_plain_key "$key"
 }
 
 # Get the list of YunoHost users
@@ -50,7 +50,7 @@ ynh_user_get_info() {
 #
 # Requires YunoHost version 2.4.0 or higher.
 ynh_user_list() {
-    sudo yunohost user list --output-as plain --quiet \
+    yunohost user list --output-as plain --quiet \
       | awk '/^##username$/{getline; print}'
 }
 

--- a/data/hooks/backup/05-conf_ldap
+++ b/data/hooks/backup/05-conf_ldap
@@ -11,7 +11,7 @@ backup_dir="${1}/conf/ldap"
 
 # Backup the configuration
 ynh_backup "/etc/ldap/slapd.conf" "${backup_dir}/slapd.conf"
-sudo slapcat -b cn=config -l "${backup_dir}/cn=config.master.ldif"
+slapcat -b cn=config -l "${backup_dir}/cn=config.master.ldif"
 
 # Backup the database
-sudo slapcat -b dc=yunohost,dc=org -l "${backup_dir}/dc=yunohost-dc=org.ldif"
+slapcat -b dc=yunohost,dc=org -l "${backup_dir}/dc=yunohost-dc=org.ldif"

--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -38,20 +38,20 @@ do_pre_regen() {
   if [[ -f $services_path ]]; then
       tmp_services_path="${services_path}-tmp"
       new_services_path="${services_path}-new"
-      sudo cp "$services_path" "$tmp_services_path"
+      cp "$services_path" "$tmp_services_path"
       _update_services "$new_services_path" || {
-        sudo mv "$tmp_services_path" "$services_path"
+        mv "$tmp_services_path" "$services_path"
         exit 1
       }
       if [[ -f $new_services_path ]]; then
           # replace services.yml with new one
-          sudo mv "$new_services_path" "$services_path"
-          sudo mv "$tmp_services_path" "${services_path}-old"
+          mv "$new_services_path" "$services_path"
+          mv "$tmp_services_path" "${services_path}-old"
       else
-          sudo rm -f "$tmp_services_path"
+          rm -f "$tmp_services_path"
       fi
   else
-      sudo cp services.yml /etc/yunohost/services.yml
+      cp services.yml /etc/yunohost/services.yml
   fi
 
   # add cron job for diagnosis to be ran at 7h and 19h + a random delay between
@@ -66,7 +66,7 @@ EOF
 }
 
 _update_services() {
-  sudo python2 - << EOF
+  python2 - << EOF
 import yaml
 
 

--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -99,13 +99,13 @@ do_post_regen() {
   [[ -f "${index_txt}" ]] || {
     if [[ -f "${index_txt}.saved" ]]; then
       # use saved database from 2.2
-      sudo cp "${index_txt}.saved" "${index_txt}"
+      cp "${index_txt}.saved" "${index_txt}"
     elif [[ -f "${index_txt}.old" ]]; then
       # ... or use the state-1 database
-      sudo cp "${index_txt}.old" "${index_txt}"
+      cp "${index_txt}.old" "${index_txt}"
     else
       # ... or create an empty one
-      sudo touch "${index_txt}"
+      touch "${index_txt}"
     fi
   }
 

--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -126,7 +126,7 @@ do_post_regen() {
   # wait a maximum time of 5 minutes
   # yes, force-reload behave like a restart
   number_of_wait=0
-  while ! sudo su admin -c '' && ((number_of_wait < 60))
+  while ! su admin -c '' && ((number_of_wait < 60))
   do
       sleep 5
       ((number_of_wait += 1))

--- a/data/hooks/conf_regen/09-nslcd
+++ b/data/hooks/conf_regen/09-nslcd
@@ -14,7 +14,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service nslcd restart
+    || service nslcd restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -14,7 +14,7 @@ do_pre_regen() {
 
   # retrieve variables
   main_domain=$(cat /etc/yunohost/current_host)
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # install main conf file
   cat metronome.cfg.lua \
@@ -42,19 +42,19 @@ do_post_regen() {
   regen_conf_files=$1
 
   # retrieve variables
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # create metronome directories for domains
   for domain in $domain_list; do
-    sudo mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
+    mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
   done
 
   # fix some permissions
-  sudo chown -R metronome: /var/lib/metronome/
-  sudo chown -R metronome: /etc/metronome/conf.d/
+  chown -R metronome: /var/lib/metronome/
+  chown -R metronome: /etc/metronome/conf.d/
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service metronome restart
+    || service metronome restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -45,7 +45,7 @@ do_pre_regen() {
 
   # retrieve variables
   main_domain=$(cat /etc/yunohost/current_host)
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # Support different strategy for security configurations
   export compatibility="$(yunohost settings get 'security.nginx.compatibility')"
@@ -102,15 +102,15 @@ do_post_regen() {
   [ -z "$regen_conf_files" ] && exit 0
 
   # retrieve variables
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # create NGINX conf directories for domains
   for domain in $domain_list; do
-    sudo mkdir -p "/etc/nginx/conf.d/${domain}.d"
+    mkdir -p "/etc/nginx/conf.d/${domain}.d"
   done
 
   # Reload nginx configuration
-  pgrep nginx && sudo service nginx reload
+  pgrep nginx && service nginx reload
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/19-postfix
+++ b/data/hooks/conf_regen/19-postfix
@@ -20,7 +20,7 @@ do_pre_regen() {
 
   # prepare main.cf conf file
   main_domain=$(cat /etc/yunohost/current_host)
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet | tr '\n' ' ')
+  domain_list=$(yunohost domain list --output-as plain --quiet | tr '\n' ' ')
 
   # Support different strategy for security configurations
   export compatibility="$(yunohost settings get 'security.postfix.compatibility')"
@@ -49,7 +49,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || { sudo service postfix restart && sudo service postsrsd restart; }
+    || { service postfix restart && service postsrsd restart; }
 
 }
 

--- a/data/hooks/conf_regen/25-dovecot
+++ b/data/hooks/conf_regen/25-dovecot
@@ -36,28 +36,28 @@ do_pre_regen() {
 do_post_regen() {
   regen_conf_files=$1
 
-  sudo mkdir -p "/etc/dovecot/yunohost.d/pre-ext.d"
-  sudo mkdir -p "/etc/dovecot/yunohost.d/post-ext.d"
+  mkdir -p "/etc/dovecot/yunohost.d/pre-ext.d"
+  mkdir -p "/etc/dovecot/yunohost.d/post-ext.d"
 
   # create vmail user
   id vmail > /dev/null 2>&1 \
-    || sudo adduser --system --ingroup mail --uid 500 vmail
+    || adduser --system --ingroup mail --uid 500 vmail
 
   # fix permissions
-  sudo chown -R vmail:mail /etc/dovecot/global_script
-  sudo chmod 770 /etc/dovecot/global_script
-  sudo chown root:mail /var/mail
-  sudo chmod 1775 /var/mail
+  chown -R vmail:mail /etc/dovecot/global_script
+  chmod 770 /etc/dovecot/global_script
+  chown root:mail /var/mail
+  chmod 1775 /var/mail
 
   [ -z "$regen_conf_files" ] && exit 0
 
   # compile sieve script
   [[ "$regen_conf_files" =~ dovecot\.sieve ]] && {
-    sudo sievec /etc/dovecot/global_script/dovecot.sieve
-    sudo chown -R vmail:mail /etc/dovecot/global_script
+    sievec /etc/dovecot/global_script/dovecot.sieve
+    chown -R vmail:mail /etc/dovecot/global_script
   }
 
-  sudo service dovecot restart
+  service dovecot restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/31-rspamd
+++ b/data/hooks/conf_regen/31-rspamd
@@ -22,11 +22,11 @@ do_post_regen() {
   ##
 
   # create DKIM directory with proper permission
-  sudo mkdir -p /etc/dkim
-  sudo chown _rspamd /etc/dkim
+  mkdir -p /etc/dkim
+  chown _rspamd /etc/dkim
 
   # retrieve domain list
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # create DKIM key for domains
   for domain in $domain_list; do
@@ -34,30 +34,30 @@ do_post_regen() {
     [ ! -f "$domain_key" ] && {
       # We use a 1024 bit size because nsupdate doesn't seem to be able to
       # handle 2048...
-      sudo opendkim-genkey --domain="$domain" \
+      opendkim-genkey --domain="$domain" \
           --selector=mail --directory=/etc/dkim -b 1024
-      sudo mv /etc/dkim/mail.private "$domain_key"
-      sudo mv /etc/dkim/mail.txt "/etc/dkim/${domain}.mail.txt"
+      mv /etc/dkim/mail.private "$domain_key"
+      mv /etc/dkim/mail.txt "/etc/dkim/${domain}.mail.txt"
     }
   done
 
   # fix DKIM keys permissions
-  sudo chown _rspamd /etc/dkim/*.mail.key
-  sudo chmod 400 /etc/dkim/*.mail.key
+  chown _rspamd /etc/dkim/*.mail.key
+  chmod 400 /etc/dkim/*.mail.key
 
   regen_conf_files=$1
   [ -z "$regen_conf_files" ] && exit 0
 
   # compile sieve script
   [[ "$regen_conf_files" =~ rspamd\.sieve ]] && {
-    sudo sievec /etc/dovecot/global_script/rspamd.sieve
-    sudo chown -R vmail:mail /etc/dovecot/global_script
-    sudo systemctl restart dovecot
+    sievec /etc/dovecot/global_script/rspamd.sieve
+    chown -R vmail:mail /etc/dovecot/global_script
+    systemctl restart dovecot
   }
 
   # Restart rspamd due to the upgrade
   # https://rspamd.com/announce/2016/08/01/rspamd-1.3.1.html 
-  sudo systemctl -q restart rspamd.service 
+  systemctl -q restart rspamd.service 
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -18,12 +18,12 @@ do_post_regen() {
   if [ ! -f /etc/yunohost/mysql ]; then
 
       # ensure that mysql is running
-      sudo systemctl -q is-active mysql.service \
-        || sudo service mysql start
+      systemctl -q is-active mysql.service \
+        || service mysql start
 
       # generate and set new root password
       mysql_password=$(ynh_string_random 10)
-      sudo mysqladmin -s -u root -pyunohost password "$mysql_password" || {
+      mysqladmin -s -u root -pyunohost password "$mysql_password" || {
         if [ $FORCE -eq 1 ]; then
             echo "It seems that you have already configured MySQL." \
               "YunoHost needs to have a root access to MySQL to runs its" \
@@ -31,13 +31,13 @@ do_post_regen() {
               "You can find this new password in /etc/yunohost/mysql." >&2
 
             # set new password with debconf
-            sudo debconf-set-selections << EOF
+            debconf-set-selections << EOF
 $MYSQL_PKG mysql-server/root_password password $mysql_password
 $MYSQL_PKG mysql-server/root_password_again password $mysql_password
 EOF
 
             # reconfigure Debian package
-            sudo dpkg-reconfigure -freadline -u "$MYSQL_PKG" 2>&1
+            dpkg-reconfigure -freadline -u "$MYSQL_PKG" 2>&1
         else
             echo "It seems that you have already configured MySQL." \
               "YunoHost needs to have a root access to MySQL to runs its" \
@@ -49,12 +49,12 @@ EOF
       }
 
       # store new root password
-      echo "$mysql_password" | sudo tee /etc/yunohost/mysql
-      sudo chmod 400 /etc/yunohost/mysql
+      echo "$mysql_password" | tee /etc/yunohost/mysql
+      chmod 400 /etc/yunohost/mysql
   fi
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service mysql restart
+    || service mysql restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/37-avahi-daemon
+++ b/data/hooks/conf_regen/37-avahi-daemon
@@ -15,7 +15,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service avahi-daemon restart
+    || service avahi-daemon restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/40-glances
+++ b/data/hooks/conf_regen/40-glances
@@ -14,7 +14,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service glances restart
+    || service glances restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -26,7 +26,7 @@ do_pre_regen() {
   ynh_validate_ip4 "$ipv4" || ipv4='127.0.0.1'
   ipv6=$(curl -s -6 https://ip6.yunohost.org 2>/dev/null || true)
   ynh_validate_ip6 "$ipv6" || ipv6=''
-  domain_list=$(sudo yunohost domain list --output-as plain --quiet)
+  domain_list=$(yunohost domain list --output-as plain --quiet)
 
   # add domain conf files
   for domain in $domain_list; do
@@ -51,7 +51,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service dnsmasq restart
+    || service dnsmasq restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/46-nsswitch
+++ b/data/hooks/conf_regen/46-nsswitch
@@ -14,7 +14,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service unscd restart
+    || service unscd restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/52-fail2ban
+++ b/data/hooks/conf_regen/52-fail2ban
@@ -20,7 +20,7 @@ do_post_regen() {
   regen_conf_files=$1
 
   [[ -z "$regen_conf_files" ]] \
-    || sudo service fail2ban restart
+    || service fail2ban restart
 }
 
 FORCE=${2:-0}

--- a/data/hooks/restore/05-conf_ldap
+++ b/data/hooks/restore/05-conf_ldap
@@ -5,7 +5,7 @@ if [[ $EUID -ne 0 ]]; then
     # We need to execute this script as root, since the ldap
     # service will be shut down during the operation (and sudo
     # won't be available)
-    sudo /bin/bash $(readlink -f $0) $1
+    /bin/bash $(readlink -f $0) $1
 
 else
 

--- a/data/hooks/restore/08-conf_ssh
+++ b/data/hooks/restore/08-conf_ssh
@@ -1,8 +1,8 @@
 backup_dir="$1/conf/ssh"
 
 if [ -d /etc/ssh/ ]; then
-    sudo cp -a $backup_dir/. /etc/ssh
-    sudo service ssh restart
+    cp -a $backup_dir/. /etc/ssh
+    service ssh restart
 else
     echo "SSH is not installed"
 fi

--- a/data/hooks/restore/11-conf_ynh_mysql
+++ b/data/hooks/restore/11-conf_ynh_mysql
@@ -9,15 +9,15 @@ service mysql status >/dev/null 2>&1 \
 
 # retrieve current and new password
 [ -f /etc/yunohost/mysql ] \
-  && curr_pwd=$(sudo cat /etc/yunohost/mysql)
-new_pwd=$(sudo cat "${backup_dir}/root_pwd" || sudo cat "${backup_dir}/mysql")
+  && curr_pwd=$(cat /etc/yunohost/mysql)
+new_pwd=$(cat "${backup_dir}/root_pwd" || cat "${backup_dir}/mysql")
 [ -z "$curr_pwd" ] && curr_pwd="yunohost"
 [ -z "$new_pwd" ] && {
     new_pwd=$(ynh_string_random 10)
 }
 
 # attempt to change it
-sudo mysqladmin -s -u root -p"$curr_pwd" password "$new_pwd" || {
+mysqladmin -s -u root -p"$curr_pwd" password "$new_pwd" || {
 
   echo "It seems that you have already configured MySQL." \
     "YunoHost needs to have a root access to MySQL to runs its" \
@@ -25,18 +25,18 @@ sudo mysqladmin -s -u root -p"$curr_pwd" password "$new_pwd" || {
     "You can find this new password in /etc/yunohost/mysql." >&2
 
   # set new password with debconf
-  sudo debconf-set-selections << EOF
+  debconf-set-selections << EOF
 $MYSQL_PKG mysql-server/root_password password $new_pwd
 $MYSQL_PKG mysql-server/root_password_again password $new_pwd
 EOF
 
   # reconfigure Debian package
-  sudo dpkg-reconfigure -freadline -u "$MYSQL_PKG" 2>&1
+  dpkg-reconfigure -freadline -u "$MYSQL_PKG" 2>&1
 }
 
 # store new root password
-echo "$new_pwd" | sudo tee /etc/yunohost/mysql
-sudo chmod 400 /etc/yunohost/mysql
+echo "$new_pwd" | tee /etc/yunohost/mysql
+chmod 400 /etc/yunohost/mysql
 
 # reload the grant tables
-sudo mysqladmin -s -u root -p"$new_pwd" reload
+mysqladmin -s -u root -p"$new_pwd" reload

--- a/data/hooks/restore/14-conf_ssowat
+++ b/data/hooks/restore/14-conf_ssowat
@@ -1,3 +1,3 @@
 backup_dir="$1/conf/ssowat"
 
-sudo cp -a $backup_dir/. /etc/ssowat
+cp -a $backup_dir/. /etc/ssowat

--- a/data/hooks/restore/17-data_home
+++ b/data/hooks/restore/17-data_home
@@ -1,3 +1,3 @@
 backup_dir="$1/data/home"
 
-sudo cp -a $backup_dir/. /home
+cp -a $backup_dir/. /home

--- a/data/hooks/restore/20-conf_ynh_firewall
+++ b/data/hooks/restore/20-conf_ynh_firewall
@@ -1,4 +1,4 @@
 backup_dir="$1/conf/ynh/firewall"
 
-sudo cp -a $backup_dir/. /etc/yunohost
-sudo yunohost firewall reload
+cp -a $backup_dir/. /etc/yunohost
+yunohost firewall reload

--- a/data/hooks/restore/21-conf_ynh_certs
+++ b/data/hooks/restore/21-conf_ynh_certs
@@ -1,7 +1,7 @@
 backup_dir="$1/conf/ynh/certs"
 
-sudo mkdir -p /etc/yunohost/certs/
+mkdir -p /etc/yunohost/certs/
 
-sudo cp -a $backup_dir/. /etc/yunohost/certs/
-sudo service nginx reload
-sudo service metronome reload
+cp -a $backup_dir/. /etc/yunohost/certs/
+service nginx reload
+service metronome reload

--- a/data/hooks/restore/23-data_mail
+++ b/data/hooks/restore/23-data_mail
@@ -1,8 +1,8 @@
 backup_dir="$1/data/mail"
 
-sudo cp -a $backup_dir/. /var/mail/ || echo 'No mail found'
-sudo chown -R vmail:mail /var/mail/
+cp -a $backup_dir/. /var/mail/ || echo 'No mail found'
+chown -R vmail:mail /var/mail/
 
 # Restart services to use migrated certs
-sudo service postfix restart
-sudo service dovecot restart
+service postfix restart
+service dovecot restart

--- a/data/hooks/restore/26-conf_xmpp
+++ b/data/hooks/restore/26-conf_xmpp
@@ -1,7 +1,7 @@
 backup_dir="$1/conf/xmpp"
 
-sudo cp -a $backup_dir/etc/. /etc/metronome
-sudo cp -a $backup_dir/var/. /var/lib/metronome
+cp -a $backup_dir/etc/. /etc/metronome
+cp -a $backup_dir/var/. /var/lib/metronome
 
 # Restart to apply new conf and certs
-sudo service metronome restart
+service metronome restart

--- a/data/hooks/restore/29-conf_nginx
+++ b/data/hooks/restore/29-conf_nginx
@@ -1,7 +1,7 @@
 backup_dir="$1/conf/nginx"
 
 # Copy all conf except apps specific conf located in DOMAIN.d
-sudo find $backup_dir/ -mindepth 1 -maxdepth 1 -name '*.d' -or -exec sudo cp -a {} /etc/nginx/conf.d/ \;
+find $backup_dir/ -mindepth 1 -maxdepth 1 -name '*.d' -or -exec cp -a {} /etc/nginx/conf.d/ \;
 
 # Restart to use new conf and certs
-sudo service nginx restart
+service nginx restart

--- a/data/hooks/restore/32-conf_cron
+++ b/data/hooks/restore/32-conf_cron
@@ -1,6 +1,6 @@
 backup_dir="$1/conf/cron"
 
-sudo cp -a $backup_dir/. /etc/cron.d
+cp -a $backup_dir/. /etc/cron.d
 
 # Restart just in case
-sudo service cron restart
+service cron restart

--- a/data/hooks/restore/40-conf_ynh_currenthost
+++ b/data/hooks/restore/40-conf_ynh_currenthost
@@ -1,3 +1,3 @@
 backup_dir="$1/conf/ynh"
 
-sudo cp -a "${backup_dir}/current_host" /etc/yunohost/current_host
+cp -a "${backup_dir}/current_host" /etc/yunohost/current_host

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -180,9 +180,9 @@ def _set_hostname(hostname, pretty_hostname=None):
 
     # Then call hostnamectl
     commands = [
-        "sudo hostnamectl --static    set-hostname".split() + [hostname],
-        "sudo hostnamectl --transient set-hostname".split() + [hostname],
-        "sudo hostnamectl --pretty    set-hostname".split() + [pretty_hostname]
+        "hostnamectl --static    set-hostname".split() + [hostname],
+        "hostnamectl --transient set-hostname".split() + [hostname],
+        "hostnamectl --pretty    set-hostname".split() + [pretty_hostname]
     ]
 
     for command in commands:


### PR DESCRIPTION
## The problem

If LDAP is down or kinda broken for some reason, these triggers a whole bunch of scary warning even for stuff unrelated to LDAP ... We don't need those sudo which were there for historical reason where scripts where ran as admin (or thought to be runable by non-root users)

## Solution

Remove those damn sudo

## PR Status

Done

## How to test

idk :| yolo commited lelz

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
