### PR TITLE
[fix] prevent firefox to mix CA and server certificate

### DIFF
--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -321,7 +321,7 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
         'touch %s/index.txt' % ssl_dir,
         'cp %s/openssl.cnf %s/openssl.ca.cnf' % (ssl_dir, ssl_dir),
         'sed -i s/yunohost.org/%s/g %s/openssl.ca.cnf ' % (domain, ssl_dir),
-        'openssl req -x509 -new -config %s/openssl.ca.cnf -days 3650 -out %s/ca/cacert.pem -keyout %s/ca/cakey.pem -nodes -batch' % (ssl_dir, ssl_dir, ssl_dir),
+        'openssl req -x509 -new -config %s/openssl.ca.cnf -days 3650 -out %s/ca/cacert.pem -keyout %s/ca/cakey.pem -nodes -batch -subj /CN=%s/O=%s' % (ssl_dir, ssl_dir, ssl_dir, domain, os.path.splitext(domain)[0]),
         'cp %s/ca/cacert.pem /etc/ssl/certs/ca-yunohost_crt.pem' % ssl_dir,
         'update-ca-certificates'
     ]


### PR DESCRIPTION
Fixes https://github.com/YunoHost/issues/issues/1479: 

## The problem

yunohost was using the exact same Distinguished Name for
the CA certificate and the main domain server certificate. When creating
alternate domain name, firefox thought the CA for this second domain was
the server certificate for the first domain. As the key mismatches,
Firefox raised a bad key usage error, which is not bypassable.

## Solution

To fix this, we "simply" need to make sure the DN for the CA is
distinct for any other DN. I did so by adding a Organization to it, and
I decided to just remove the last part of the domain and use that as an
organization name. It is certainly possible to do something else, as
long as we end up having a distinct DN. So yolo.test gives a yolo
organization for instance.

More info here https://bugzilla.mozilla.org/show_bug.cgi?id=1590217

## PR Status


## How to test

Run postinstall with yolo.test, create a new domain with yolo2.test and install an app in it. Before the fix, yolo2.test was in error, after the fix, we can make firefox accept the certificate.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
