### PR TITLE
fix legacy permission management

### DIFF
--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -158,6 +158,11 @@ ynh_add_protected_uris() {
 #
 ynh_app_setting()
 {
+    if [[ "$1" == "delete" ]] && [[ "$3" =~ ^(unprotected|skipped)_ ]] 
+    then
+        current_value=$(ynh_app_setting_get --app=$app --key=$3)
+    fi
+
     ACTION="$1" APP="$2" KEY="$3" VALUE="${4:-}" python2.7 - <<EOF
 import os, yaml, sys
 app, action = os.environ['APP'], os.environ['ACTION'].lower()
@@ -192,7 +197,7 @@ EOF
         if [[ "$1" == "set" ]] && [[ "${4:-}" == "/" ]]
         then
             ynh_permission_update --permission "main" --add "visitors"
-        elif [[ "$1" == "delete" ]]
+        elif [[ "$1" == "delete" ]] && [[ "${current_value:-}" == "/" ]]
         then
             ynh_permission_update --permission "main" --remove "visitors"
         fi

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -187,9 +187,15 @@ EOF
 
     # Fucking legacy permission management.
     # We need this because app temporarily set the app as unprotected to configure it with curl...
-    if [[ "$3" =~ ^(unprotected|skipped)_ ]] && [[ "${4:-}" == "/" ]]
+    if [[ "$3" =~ ^(unprotected|skipped)_ ]]
     then
-        ynh_permission_update --permission "main" --add "visitors"
+        if [[ "$1" == "set" ]] && [[ "${4:-}" == "/" ]]
+        then
+            ynh_permission_update --permission "main" --add "visitors"
+        elif [[ "$1" == "delete" ]]
+        then
+            ynh_permission_update --permission "main" --remove "visitors"
+        fi
     fi
 }
 


### PR DESCRIPTION
## The problem

The variable `unprotected_url` or `skipped_url` used by all our apps will be deprecated after the 3.7. We don't want kill all our apps after the 3.7 upgrade.

## Solution

`add` or `remove` `visitors` to mirror what those variables did before 3.7

## PR Status

...

## How to test

Install an app with a `config` script that can change the `is_public` variable ([leed](https://github.com/YunoHost-Apps/leed_ynh) for example), and play with the config panel/actions to change the value of `is_public`:
```bash
yunohost app action run leed public_private
```

Then check permissions with:
```bash
yunohost user permission list
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
