### PR TITLE
[FIX] Diagnosis bad response from the server

### DIFF
--- a/data/hooks/diagnosis/14-ports.py
+++ b/data/hooks/diagnosis/14-ports.py
@@ -26,16 +26,20 @@ class PortsDiagnoser(Diagnoser):
                 ports[port] = service
 
         try:
-            r = requests.post('https://diagnosis.yunohost.org/check-ports', json={'ports': ports.keys()}, timeout=30).json()
-            if "status" not in r.keys():
-                raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-            elif r["status"] == "error":
-                if "content" in r.keys():
-                    raise Exception(r["content"])
-                else:
+            r = requests.post('https://diagnosis.yunohost.org/check-ports', json={'ports': ports.keys()}, timeout=30)
+            if r.status_code == 200:
+                r = r.json()
+                if "status" not in r.keys():
                     raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-            elif r["status"] != "ok" or "ports" not in r.keys() or not isinstance(r["ports"], dict):
-                raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+                elif r["status"] == "error":
+                    if "content" in r.keys():
+                        raise Exception(r["content"])
+                    else:
+                        raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+                elif r["status"] != "ok" or "ports" not in r.keys() or not isinstance(r["ports"], dict):
+                    raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+            else:
+                raise Exception("Bad response from the server https://diagnosis.yunohost.org : %s" % str(r.status_code))
         except Exception as e:
             raise YunohostError("diagnosis_ports_could_not_diagnose", error=e)
 

--- a/data/hooks/diagnosis/14-ports.py
+++ b/data/hooks/diagnosis/14-ports.py
@@ -39,7 +39,7 @@ class PortsDiagnoser(Diagnoser):
                 elif r["status"] != "ok" or "ports" not in r.keys() or not isinstance(r["ports"], dict):
                     raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
             else:
-                raise Exception("Bad response from the server https://diagnosis.yunohost.org : %s" % str(r.status_code))
+                raise Exception("Bad response from the server https://diagnosis.yunohost.org/check-ports : %s - %s" % (str(r.status_code), r.content))
         except Exception as e:
             raise YunohostError("diagnosis_ports_could_not_diagnose", error=e)
 

--- a/data/hooks/diagnosis/14-ports.py
+++ b/data/hooks/diagnosis/14-ports.py
@@ -27,19 +27,18 @@ class PortsDiagnoser(Diagnoser):
 
         try:
             r = requests.post('https://diagnosis.yunohost.org/check-ports', json={'ports': ports.keys()}, timeout=30)
-            if r.status_code == 200:
-                r = r.json()
-                if "status" not in r.keys():
-                    raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-                elif r["status"] == "error":
-                    if "content" in r.keys():
-                        raise Exception(r["content"])
-                    else:
-                        raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-                elif r["status"] != "ok" or "ports" not in r.keys() or not isinstance(r["ports"], dict):
-                    raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-            else:
+            if r.status_code != 200:
                 raise Exception("Bad response from the server https://diagnosis.yunohost.org/check-ports : %s - %s" % (str(r.status_code), r.content))
+            r = r.json()
+            if "status" not in r.keys():
+                raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+            elif r["status"] == "error":
+                if "content" in r.keys():
+                    raise Exception(r["content"])
+                else:
+                    raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+            elif r["status"] != "ok" or "ports" not in r.keys() or not isinstance(r["ports"], dict):
+                raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
         except Exception as e:
             raise YunohostError("diagnosis_ports_could_not_diagnose", error=e)
 

--- a/data/hooks/diagnosis/16-http.py
+++ b/data/hooks/diagnosis/16-http.py
@@ -29,17 +29,16 @@ class HttpDiagnoser(Diagnoser):
 
             try:
                 r = requests.post('https://diagnosis.yunohost.org/check-http', json={'domain': domain, "nonce": nonce}, timeout=30)
-                if r.status_code == 200:
-                    r = r.json()
-                    if "status" not in r.keys():
-                        raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-                    elif r["status"] == "error" and ("code" not in r.keys() or not r["code"].startswith("error_http_check_")):
-                        if "content" in r.keys():
-                            raise Exception(r["content"])
-                        else:
-                            raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
-                else:
+                if r.status_code != 200:
                     raise Exception("Bad response from the server https://diagnosis.yunohost.org/check-http : %s - %s" % (str(r.status_code), r.content))
+                r = r.json()
+                if "status" not in r.keys():
+                    raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
+                elif r["status"] == "error" and ("code" not in r.keys() or not r["code"].startswith("error_http_check_")):
+                    if "content" in r.keys():
+                        raise Exception(r["content"])
+                    else:
+                        raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
             except Exception as e:
                 raise YunohostError("diagnosis_http_could_not_diagnose", error=e)
 

--- a/data/hooks/diagnosis/16-http.py
+++ b/data/hooks/diagnosis/16-http.py
@@ -39,7 +39,7 @@ class HttpDiagnoser(Diagnoser):
                         else:
                             raise Exception("Bad syntax for response ? Raw json: %s" % str(r))
                 else:
-                    raise Exception("Bad response from the server https://diagnosis.yunohost.org : %s" % str(r.status_code))
+                    raise Exception("Bad response from the server https://diagnosis.yunohost.org/check-http : %s - %s" % (str(r.status_code), r.content))
             except Exception as e:
                 raise YunohostError("diagnosis_http_could_not_diagnose", error=e)
 


### PR DESCRIPTION
## The problem

If the diagnosis.yunohost.org server crashes (omg, this NEVER happens ;-)), we're getting a strange error message like: "Impossible to parse json blablabla"

## Solution

Manage whether the answer is correct or not

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
