### PR TITLE
[FIX] options in config panel

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1771,22 +1771,27 @@ def _get_app_config_panel(app_id):
                               value.items())
 
             for section_key, section_value in sections:
+                def parse_options(section, values):
+                    options = filter(lambda (k, v): k not in ("name",) and isinstance(v, OrderedDict),
+                                 values.items())
+                    for option_key, option_value in options:
+                        option = dict(option_value)
+                        if "ask" not in option:
+                            parse_options(section, option_value)
+                        else:
+                            option["name"] = option_key
+                            option["ask"] = {"en": option["ask"]}
+                            if "help" in option:
+                                option["help"] = {"en": option["help"]}
+                            section["options"].append(option)
+                        
                 section = {
                     "id": section_key,
                     "name": section_value["name"],
                     "options": [],
                 }
-
-                options = filter(lambda (k, v): k not in ("name",) and isinstance(v, OrderedDict),
-                                 section_value.items())
-
-                for option_key, option_value in options:
-                    option = dict(option_value)
-                    option["name"] = option_key
-                    option["ask"] = {"en": option["ask"]}
-                    if "help" in option:
-                        option["help"] = {"en": option["help"]}
-                    section["options"].append(option)
+                
+                parse_options(section, section_value)
 
                 panel["sections"].append(section)
 


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/issues-with-actions-and-config-panel-features/9773

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/api.py", line 439, in process
    ret = self.actionsmap.process(arguments, timeout=30, route=_route)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 527, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/log.py", line 287, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/app.py", line 1824, in app_config_show_panel
    config_panel = _get_app_config_panel(app)
  File "/usr/lib/moulinette/yunohost/app.py", line 2163, in _get_app_config_panel
    option["ask"] = {"en": option["ask"]}
KeyError: 'ask'
```

## Solution

...

## PR Status

...

## How to test

Use this config-panel:
https://github.com/YunoHost-Apps/fallback_ynh/blob/2-different-panels/config_panel.toml

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
