### PR TITLE
[FIX] config panel ask and actions description

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1779,7 +1779,7 @@ def _get_app_actions(app_id):
 
             arguments = []
             
-            if not isinstance(action["description"], list) or "en" not in action["description"]:
+            if "description" in action and (not isinstance(action["description"], list) or "en" not in action["description"]):
                 action["description"] = {"en": action["description"]}
 
             for argument_name, argument in value.get("arguments", {}).items():

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1778,6 +1778,10 @@ def _get_app_actions(app_id):
             action["id"] = key
 
             arguments = []
+            
+            if not isinstance(action["description"], list) or "en" not in action["description"]:
+                action["description"] = {"en": action["description"]}
+
             for argument_name, argument in value.get("arguments", {}).items():
                 argument = dict(**argument)
                 argument["name"] = argument_name
@@ -1901,8 +1905,9 @@ def _get_app_config_panel(app_id):
                 for option_key, option_value in options:
                     option = dict(option_value)
                     option["name"] = option_key
-                    option["ask"] = {"en": option["ask"]}
-                    if "help" in option:
+                    if not isinstance(option["ask"], list) or "en" not in option["ask"]:
+                        option["ask"] = {"en": option["ask"]}
+                    if "help" in option and (not isinstance(option["help"], list) or "en" not in option["help"]):
                         option["help"] = {"en": option["help"]}
                     section["options"].append(option)
 


### PR DESCRIPTION
## The problem

The description in actions could be not displayed if we define `description` but not `description.en`
Same for config panel: `ask` and `help`

## Solution

...

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
