### PR TITLE
Pave the way to migration to php7.3 and following

### DIFF
--- a/data/helpers.d/nginx
+++ b/data/helpers.d/nginx
@@ -12,6 +12,7 @@
 #   __PORT__      by  $port
 #   __NAME__      by  $app
 #   __FINALPATH__ by  $final_path
+#   __PHPVERSION__ by  $YNH_PHP_VERSION ($YNH_PHP_VERSION is either the default php version or the version defined for the app)
 #
 #  And dynamic variables (from the last example) :
 #   __PATH_2__    by $path_2
@@ -44,6 +45,7 @@ ynh_add_nginx_config () {
 	if test -n "${final_path:-}"; then
 		ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalnginxconf"
 	fi
+	ynh_replace_string --match_string="__PHPVERSION__" --replace_string="$YNH_PHP_VERSION" --target_file="$finalnginxconf"
 
 	# Replace all other variable given as arguments
 	for var_to_replace in $others_var

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Declare the actual php version to use.
+# A packager willing to use another version of php can override the variable into its _common.sh.
+YNH_PHP_VERSION=${YNH_PHP_VERSION:-$YNH_DEFAULT_PHP_VERSION}
+
 # Create a dedicated php-fpm config
 #
 # usage: ynh_add_fpm_config [--phpversion=7.X]
@@ -14,8 +18,8 @@ ynh_add_fpm_config () {
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 
-	# Configure PHP-FPM 7.0 by default
-	phpversion="${phpversion:-7.0}"
+	# Set the default PHP-FPM version by default
+	phpversion="${phpversion:-$YNH_PHP_VERSION}"
 
 	local fpm_config_dir="/etc/php/$phpversion/fpm"
 	local fpm_service="php${phpversion}-fpm"
@@ -26,6 +30,7 @@ ynh_add_fpm_config () {
 	fi
 	ynh_app_setting_set --app=$app --key=fpm_config_dir --value="$fpm_config_dir"
 	ynh_app_setting_set --app=$app --key=fpm_service --value="$fpm_service"
+	ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion
 	finalphpconf="$fpm_config_dir/pool.d/$app.conf"
 	ynh_backup_if_checksum_is_different --file="$finalphpconf"
 	cp ../conf/php-fpm.conf "$finalphpconf"
@@ -56,10 +61,10 @@ ynh_add_fpm_config () {
 ynh_remove_fpm_config () {
 	local fpm_config_dir=$(ynh_app_setting_get --app=$app --key=fpm_config_dir)
 	local fpm_service=$(ynh_app_setting_get --app=$app --key=fpm_service)
-	# Assume php version 7 if not set
+	# Assume default php version if not set
 	if [ -z "$fpm_config_dir" ]; then
-		fpm_config_dir="/etc/php/7.0/fpm"
-		fpm_service="php7.0-fpm"
+		fpm_config_dir="/etc/php/$YNH_DEFAULT_PHP_VERSION/fpm"
+		fpm_service="php$YNH_DEFAULT_PHP_VERSION-fpm"
 	fi
 	ynh_secure_remove --file="$fpm_config_dir/pool.d/$app.conf"
 	ynh_secure_remove --file="$fpm_config_dir/conf.d/20-$app.ini" 2>&1

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -59,6 +59,7 @@ APPS_CATALOG_CONF = '/etc/yunohost/apps_catalog.yml'
 APPS_CATALOG_CRON_PATH = "/etc/cron.daily/yunohost-fetch-apps-catalog"
 APPS_CATALOG_API_VERSION = 2
 APPS_CATALOG_DEFAULT_URL = "https://app.yunohost.org/default"
+APPS_DEFAULT_PHP_VERSION = "7.0"
 
 re_github_repo = re.compile(
     r'^(http[s]?://|git@)github.com[/:]'
@@ -347,6 +348,7 @@ def app_change_url(operation_logger, app, domain, path):
     env_dict["YNH_APP_ID"] = app_id
     env_dict["YNH_APP_INSTANCE_NAME"] = app
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+    env_dict["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
 
     env_dict["YNH_APP_OLD_DOMAIN"] = old_domain
     env_dict["YNH_APP_OLD_PATH"] = old_path
@@ -483,6 +485,7 @@ def app_upgrade(app=[], url=None, file=None):
         env_dict["YNH_APP_ID"] = app_id
         env_dict["YNH_APP_INSTANCE_NAME"] = app_instance_name
         env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+        env_dict["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
 
         # Start register change on system
         related_to = [('app', app_instance_name)]
@@ -695,6 +698,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     env_dict["YNH_APP_ID"] = app_id
     env_dict["YNH_APP_INSTANCE_NAME"] = app_instance_name
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(instance_number)
+    env_dict["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
 
     # Start register change on system
     operation_logger.extra.update({'env': env_dict})
@@ -803,6 +807,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
             env_dict_remove["YNH_APP_ID"] = app_id
             env_dict_remove["YNH_APP_INSTANCE_NAME"] = app_instance_name
             env_dict_remove["YNH_APP_INSTANCE_NUMBER"] = str(instance_number)
+            env_dict_remove["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
 
             # Execute remove script
             operation_logger_remove = OperationLogger('remove_on_failed_install',
@@ -980,6 +985,7 @@ def app_remove(operation_logger, app):
     env_dict["YNH_APP_ID"] = app_id
     env_dict["YNH_APP_INSTANCE_NAME"] = app
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+    env_dict["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
     operation_logger.extra.update({'env': env_dict})
     operation_logger.flush()
 
@@ -1403,6 +1409,7 @@ def app_action_run(operation_logger, app, action, args=None):
     env_dict["YNH_APP_ID"] = app_id
     env_dict["YNH_APP_INSTANCE_NAME"] = app
     env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+    env_dict["YNH_DEFAULT_PHP_VERSION"] = APPS_DEFAULT_PHP_VERSION
     env_dict["YNH_ACTION"] = action
 
     _, path = tempfile.mkstemp()
@@ -1466,6 +1473,7 @@ def app_config_show_panel(operation_logger, app):
         "YNH_APP_ID": app_id,
         "YNH_APP_INSTANCE_NAME": app,
         "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb),
+        "YNH_DEFAULT_PHP_VERSION": APPS_DEFAULT_PHP_VERSION,
     }
 
     return_code, parsed_values = hook_exec(config_script,
@@ -1539,6 +1547,7 @@ def app_config_apply(operation_logger, app, args):
         "YNH_APP_ID": app_id,
         "YNH_APP_INSTANCE_NAME": app,
         "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb),
+        "YNH_DEFAULT_PHP_VERSION": APPS_DEFAULT_PHP_VERSION,
     }
     args = dict(urlparse.parse_qsl(args, keep_blank_values=True)) if args else {}
 


### PR DESCRIPTION
## The problem

Php version will change for buster, and so on for next debian release.

## Solution

Following https://github.com/YunoHost/yunohost/pull/879, prepare the migration by not using a fixed version of php into apps, but the default version set by $YNH_DEFAULT_PHP_VERSION 

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
