### PR TITLE
Reorder smtpd_sender_restrictions

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -124,8 +124,8 @@ smtpd_helo_restrictions =
 
 # Requirements for the sender address
 smtpd_sender_restrictions =
-    reject_sender_login_mismatch,
     permit_mynetworks,
+    reject_sender_login_mismatch,
     permit_sasl_authenticated,
     reject_non_fqdn_sender,
     reject_unknown_sender_domain,


### PR DESCRIPTION
To let send without login when coming from localhost

## The problem

When trying to send mail from apps on Yunohost, for now the app need to first authenticate, which means: have to create a dedicated user for the app

## Solution

Reorder smtpd_sender_restrictions to allow to send mail without login from mynetworks

## PR Status

Ready

## How to test

For example, install mobilizon_ynh and try to register a user. Without this patch, you will find in `/var/log/mail.info` something like `NOQUEUE: reject: RCPT from localhost[127.0.0.1]: 553 5.7.1 <xxx@xxxx.xxx>: Sender address rejected: not logged in;`

With the patch, all goes well, mail sent and received

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
