### PR TITLE
Noauth

### DIFF
--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -207,7 +207,7 @@ else:
     elif action == "set":
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
-        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped", "noauth"]):
+        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
             sys.stderr.write("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.\n")
         settings[key] = value
     else:

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -208,7 +208,7 @@ else:
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
         if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
-            sys.stderr.write("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.\n")
+            sys.stderr.write("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.\n")
         settings[key] = value
     else:
         raise ValueError("action should either be get, set or delete")

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -90,6 +90,37 @@ ynh_add_skipped_uris() {
     ynh_app_setting_set --app=$appid --key=$key --value="$url"
 }
 
+# Add noauth_uris urls into the config
+#
+# usage: ynh_add_noauth_uris [--appid=app] --url=url1,url2 [--regex]
+# | arg: -a, --appid - the application id
+# | arg: -u, --url - the urls to add to the sso for this app
+# | arg: -r, --regex - Use the key 'noauth_regex' instead of 'noauth_uris'
+#
+# An URL set with 'noauth_uris' key will be totally ignored by the SSO,
+# which means that the access will be public and the logged-in user information will not be passed to the app.
+#
+# Requires YunoHost version 3.6.0 or higher.
+ynh_add_noauth_uris() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=aur
+    declare -Ar args_array=( [a]=appid= [u]=url= [r]=regex )
+    local appid
+    local url
+    local regex
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    appid={appid:-$app}
+    regex={regex:-0}
+
+    local key=noauth_uris
+    if [ $regex -eq 1 ]; then
+        key=noauth_regex
+    fi
+
+    ynh_app_setting_set --app=$appid --key=$key --value="$url"
+}
+
 # Add unprotected_uris urls into the config
 #
 # usage: ynh_add_unprotected_uris [--appid=app] --url=url1,url2 [--regex]
@@ -176,8 +207,8 @@ else:
     elif action == "set":
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
-        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
-            sys.stderr.write("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.\n")
+        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped", "noauth"]):
+            sys.stderr.write("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.\n")
         settings[key] = value
     else:
         raise ValueError("action should either be get, set or delete")

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1152,7 +1152,7 @@ def app_setting(app, key, value=None, delete=False):
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
         if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
-            logger.warning("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.")
+            logger.warning("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.")
 
         app_settings[key] = value
     _set_app_settings(app, app_settings)

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1151,7 +1151,7 @@ def app_setting(app, key, value=None, delete=False):
         # FIXME: Allow multiple values for some keys?
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
-        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped", "noauth"]):
+        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
             logger.warning("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.")
 
         app_settings[key] = value

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1151,8 +1151,8 @@ def app_setting(app, key, value=None, delete=False):
         # FIXME: Allow multiple values for some keys?
         if key in ['redirected_urls', 'redirected_regex']:
             value = yaml.load(value)
-        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped"]):
-            logger.warning("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.")
+        if any(key.startswith(word+"_") for word in ["unprotected", "protected", "skipped", "noauth"]):
+            logger.warning("/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex/noauth settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism.")
 
         app_settings[key] = value
     _set_app_settings(app, app_settings)
@@ -1222,6 +1222,7 @@ def app_ssowatconf():
 
     skipped_urls = []
     skipped_regex = []
+    noauth_urls = []
     unprotected_urls = []
     unprotected_regex = []
     protected_urls = []
@@ -1266,6 +1267,7 @@ def app_ssowatconf():
         # Skipped
         skipped_urls += [_sanitized_absolute_url(uri) for uri in _get_setting(app_settings, 'skipped_uris')]
         skipped_regex += _get_setting(app_settings, 'skipped_regex')
+        noauth_urls += [_sanitized_absolute_url(uri) for uri in _get_setting(app_settings, 'noauth_uris')]
 
         # Redirected
         redirected_urls.update(app_settings.get('redirected_urls', {}))
@@ -1298,9 +1300,10 @@ def app_ssowatconf():
                 if url not in protected_urls:
                     protected_urls.append(url)
 
-                # Legacy stuff : we remove now unprotected-urls / skipped-urls that might have been declared as protected earlier...
+                # Legacy stuff : we remove now unprotected-urls / skipped-urls / noauth-urls that might have been declared as protected earlier...
                 unprotected_urls = [u for u in unprotected_urls if u != url]
                 skipped_urls = [u for u in skipped_urls if u != url]
+                noauth_urls = [u for u in noauth_urls if u != url]
 
     for domain in domains:
         skipped_urls.extend([domain + '/yunohost/admin', domain + '/yunohost/api'])
@@ -1330,6 +1333,7 @@ def app_ssowatconf():
         },
         'domains': domains,
         'skipped_urls': skipped_urls,
+        'noauth_urls': noauth_urls,
         'unprotected_urls': unprotected_urls,
         'protected_urls': protected_urls,
         'skipped_regex': skipped_regex,

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1303,7 +1303,6 @@ def app_ssowatconf():
                 # Legacy stuff : we remove now unprotected-urls / skipped-urls / noauth-urls that might have been declared as protected earlier...
                 unprotected_urls = [u for u in unprotected_urls if u != url]
                 skipped_urls = [u for u in skipped_urls if u != url]
-                noauth_urls = [u for u in noauth_urls if u != url]
 
     for domain in domains:
         skipped_urls.extend([domain + '/yunohost/admin', domain + '/yunohost/api'])


### PR DESCRIPTION
## The problem

Fix https://github.com/YunoHost/issues/issues/1420

## Solution

Adding a noauth parameter.

Can be used during package install: `ynh_app_setting_set --app=$app --key=noauth_uris --value="/"`

It will add in /etc/ssowat/conf.json:
```
    "noauth_urls": [
        "url with auth disabled"
    ], 
```

## PR Status

Done and tested.
To be used with https://github.com/YunoHost/SSOwat/pull/155

## How to test

You can test it installing one of the apps as private app:
`yunohost app install https://github.com/YunoHost-Apps/mastodon_ynh/tree/noauth --debug`

`yunohost app install https://github.com/YunoHost-Apps/peertube_ynh/tree/noauth --debug`

`yunohost app install https://github.com/YunoHost-Apps/bitwarden_ynh/tree/noauth --debug`

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
