### PR TITLE
Persist cookies between multiple ynh_local_curl calls for the same app

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -198,6 +198,7 @@ ynh_setup_source () {
 }
 
 # Curl abstraction to help with POST requests to local pages (such as installation forms)
+# For multiple calls, cookies are persisted between each call for the same app
 #
 # $domain and $path_url should be defined externally (and correspond to the domain.tld and the /path (of the app?))
 #
@@ -238,7 +239,7 @@ ynh_local_curl () {
     sleep 2
 
     # Curl the URL
-    curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url"
+    curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar /tmp/ynh-$app-cookie.txt --cookie /tmp/ynh-$app-cookie.txt
 }
 
 # Render templates with Jinja2


### PR DESCRIPTION
## The problem

Some app installations require the use of multiple API calls through HTTP, keeping cookies along the way. Current `ynh_local_curl` implementation doesn't enable that behavior.

## Solution

Persist cookies in an app-dedicated `/tmp/ynh_$app_cookie.txt` file, in order to keep cookies for an app, and segregate the different apps installation.

## PR Status

Implemented in Piwigo package [here](https://github.com/YunoHost-Apps/piwigo_ynh/pull/45).

## How to test

Test manually or via the Piwigo example (the token retrieval wouldn't work without that change).

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
