### PR TITLE
Fix getops again

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -81,9 +81,9 @@ ynh_handle_getopts_args () {
 				# And replace long option (value of the option_flag) by the short option, the option_flag itself
 				# (e.g. for [u]=user, --user will be -u)
 				# Replace long option with = (match the beginning of the argument)
-				arguments[arg]="$(echo ${arguments[arg]} | sed "s/^--${args_array[$option_flag]}/-${option_flag} /")"
+				arguments[arg]="$(echo "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]}/-${option_flag} /")"
 				# And long option without = (match the whole line)
-				arguments[arg]="$(echo ${arguments[arg]} | sed "s/^--${args_array[$option_flag]%=}$/-${option_flag} /")"
+				arguments[arg]="$(echo "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]%=}$/-${option_flag} /")"
 			done
 		done
 


### PR DESCRIPTION
## The problem

`echo` may interpret arguments during substitution :

https://paste.yunohost.org/inalofovev.bash

In this example, `--db_name=bar` is replaced by `-n bar` here

https://github.com/YunoHost/yunohost/blob/cd0b0c8892cdd5c25b2a2458806dd4a20dbd088d/data/helpers.d/getopts#L84

and one the next line: 
https://github.com/YunoHost/yunohost/blob/cd0b0c8892cdd5c25b2a2458806dd4a20dbd088d/data/helpers.d/getopts#L86

`echo` see the -n argument.

## Solution

double quote `${arguments[arg]}`

Con:
Empty arguments is no longer detected as an issue (for example: `ynh_mysql_connect_as --user=root --password=toto --database=`, more info [here](https://github.com/YunoHost/yunohost/pull/885#issuecomment-596228521) on the previous discussion)



## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
