### PR TITLE
Allow dots in application name (fix #1525)

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -67,7 +67,7 @@ re_github_repo = re.compile(
 )
 
 re_app_instance_name = re.compile(
-    r'^(?P<appid>[\w-]+?)(__(?P<appinstancenb>[1-9][0-9]*))?$'
+    r'^(?P<appid>[\w\.-]+?)(__(?P<appinstancenb>[1-9][0-9]*))?$'
 )
 
 
@@ -2543,6 +2543,12 @@ def _parse_app_instance_name(app_instance_name):
     >>> _parse_app_instance_name('yolo__23qdqsd') == ('yolo__23qdqsd', 1)
     True
     >>> _parse_app_instance_name('yolo__23qdqsd56') == ('yolo__23qdqsd56', 1)
+    True
+    >>> _parse_app_instance_name('yolo.net') == ('yolo.net', 1)
+    True
+    >>> _parse_app_instance_name('yolo.net__2') == ('yolo.net', 2)
+    True
+    >>> _parse_app_instance_name('yolo.net__1312louise_michel') == ('yolo.net__1312louise_michel', 1)
     True
     """
     match = re_app_instance_name.match(app_instance_name)


### PR DESCRIPTION
## The problem

Described in [#1525](https://github.com/YunoHost/issues/issues/1525)

## Solution

Add a literal dot in the regex to validate application names.

## PR Status

Tested by @Gofannon. Seems to fix the issue for them.

Doctests were not run due to my failure at setting up the dev environment. I'll come back to you when i succeed

## How to test

Installing and removing an app with a dot in the name should not fail. This can be tried with the `diagrams.net` application.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
