### PR TITLE
[fix] Make sure the group permission update contains unique elements

### DIFF
--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -452,6 +452,9 @@ def _update_ldap_group_permission(permission, allowed, sync_perm=True):
         return existing_permission
 
     allowed = [allowed] if not isinstance(allowed, list) else allowed
+    
+    # Guarantee uniqueness of values in allowed, which would otherwise make ldap.update angry.
+    allowed = set(allowed)
 
     try:
         ldap.update('cn=%s,ou=permission' % permission,


### PR DESCRIPTION
## The problem

I'm not sure how / why we didn't catch this earlier, but attempting to add a permission that's already existing leads to catastrophic failure : 

```
 $ yunohost user permission update nextcloud.main --add visitors
Attention : Le groupe 'visitors' a déjà l'autorisation 'nextcloud.main' activée
Attention : The permission was also implicitly granted to 'all_users' because it is required to allow the special group 'visitors'
Info : L’opération 'Mise à jour des accès pour la permission 'nextcloud'' a échouée ! Pour obtenir de l’aide, merci de partager le journal de l'opération en utilisant la commande 'yunohost log display 20200315-211915-user_permission_update-nextcloud --share'
Erreur : Impossible de mettre à jour la permission 'nextcloud.main': Une erreur est survenue lors de l’opération LDAP
```

(in my case, this happened during a nextcloud upgrade, making the whole upgrade procedure explode, though that was at the end so probably not that bad)

## Solution

Enforce unique elements inside `_update_ldap_group_permission`

## PR Status

Kind of tested on my machine

## How to test

Try to run `yunohost user permission update foo.main --add visitors` at least two times

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
