### PR TITLE
Revoke before drop

### DIFF
--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -107,9 +107,9 @@ ynh_psql_create_db() {
 ynh_psql_drop_db() {
 	local db=$1
 	# First, force disconnection of all clients connected to the database
-	# https://stackoverflow.com/questions/5408156/how-to-drop-a-postgresql-database-if-there-are-active-connections-to-it
-	# https://dba.stackexchange.com/questions/16426/how-to-drop-all-connections-to-a-specific-database-without-stopping-the-server
-	ynh_psql_execute_as_root --sql="SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db';" --database="$db"
+	# https://stackoverflow.com/questions/17449420/postgresql-unable-to-drop-database-because-of-some-auto-connections-to-db
+	ynh_psql_execute_as_root --sql="REVOKE CONNECT ON DATABASE $db FROM public;" --database="$db"
+	ynh_psql_execute_as_root --sql="SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db' AND pid <> pg_backend_pid();" --database="$db"
 	sudo --login --user=postgres dropdb $db
 }
 


### PR DESCRIPTION
## The problem

Sometime postgresql can't be removed with this message:
> dropdb: database removal failed: ERROR:  database "thedb" is being accessed by other usersWarning: 
DETAIL:  There is 1 other session using the database.

## Solution

https://stackoverflow.com/questions/5408156/how-to-drop-a-postgresql-database-if-there-are-active-connections-to-it
Revoke before dumb the db.
 
## PR Status

Done

## How to test

You can install an app which use a psql db, install pgadmin, look the db with pgadmin and remove the app which use psql at the same time.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
