### PR TITLE
Fix possible security issue with these cookie files

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -237,9 +237,14 @@ ynh_local_curl () {
 
     # Wait untils nginx has fully reloaded (avoid curl fail with http2)
     sleep 2
+    
+    local cookiefile=/tmp/ynh-$app-cookie.txt
+    touch $cookiefile
+    chown root $cookiefile
+    chmod 700 $cookiefile
 
     # Curl the URL
-    curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar /tmp/ynh-$app-cookie.txt --cookie /tmp/ynh-$app-cookie.txt
+    curl --silent --show-error -kL -H "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar $cookiefile --cookie $cookiefile
 }
 
 # Render templates with Jinja2


### PR DESCRIPTION
## The problem

In this new change to persist cookie between curl calls, I believe we're opening a possible security issue : the cookie file is written in tmp and ends up being readable by every other on the system, which could possibly be used to steal credentials.

## Solution

Enforce file permissions

## PR Status

Yolocommited

## How to test

Try to use the helper, check if it's readable by a non-root user

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
