### PR TITLE
Attempt to simplify permission migration

### DIFF
--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -197,7 +197,7 @@ EOF
         if [[ "$1" == "set" ]] && [[ "${4:-}" == "/" ]]
         then
             ynh_permission_update --permission "main" --add "visitors"
-        elif [[ "$1" == "delete" ]] && [[ "${current_value:-}" == "/" ]]
+        elif [[ "$1" == "delete" ]] && [[ "${current_value:-}" == "/" ]] && [[ -n "$(ynh_app_setting_get --app=$2 --key='is_public' )" ]]
         then
             ynh_permission_update --permission "main" --remove "visitors"
         fi


### PR DESCRIPTION
## The problem

c.f. the discussion [here](https://github.com/YunoHost-Apps/hextris_ynh/pull/13#discussion_r400277294)

The migration procedure is complex because of the fact that removing skipped/unprotected uri will also affect the permission (because of another hack, c.f. the diff)

## Solution

Only apply the hack during unprotected/skipped deletion if is_public is not empty. This way this should not affect what we do in other contexts, and we can simplify the migration procedure to something like : 

```bash
if [ -n "$is_public" ]; then
       # Gotta make sure to delete is_public first 
       ynh_app_setting_delete --app=$app --key=is_public
       ynh_app_setting_delete --app=$app --key=skipped_uris
fi
```



## PR Status

Yolocommited, not tested...

## How to test

c.f. what's done in hextris...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
