### PR TITLE
Fix ynh_find_port

### DIFF
--- a/data/helpers.d/network
+++ b/data/helpers.d/network
@@ -17,7 +17,7 @@ ynh_find_port () {
 	ynh_handle_getopts_args "$@"
 
 	test -n "$port" || ynh_die --message="The argument of ynh_find_port must be a valid port."
-	while ss -nltu | grep -q -w "*:$port"       # Check if the port is free
+	while ss -nltu | awk '{print$5}' | grep -q -E ":$port$"       # Check if the port is free
 	do
 		port=$((port+1))	# Else, pass to next port
 	done

--- a/data/helpers.d/network
+++ b/data/helpers.d/network
@@ -17,7 +17,7 @@ ynh_find_port () {
 	ynh_handle_getopts_args "$@"
 
 	test -n "$port" || ynh_die --message="The argument of ynh_find_port must be a valid port."
-	while ss -nltu | grep -q -w :$port       # Check if the port is free
+	while ss -nltu | grep -q -w "*:$port"       # Check if the port is free
 	do
 		port=$((port+1))	# Else, pass to next port
 	done


### PR DESCRIPTION
## The problem

ynh_find_port returns false positive for port already used since we changed it to use `ss`.

This is the reason why so many apps are in regression on Buster (and in fact, Stretch Unstable too) and stuck on level 6 : https://dash.yunohost.org/appci/compare/stable...buster (well, "only" seven apps in fact)

## Solution

The reason is that `grep -w` wants an exact match, but there's actually a star `*` in front of the string ...

Maybe we also want to make sure the line contains LISTEN and tcp, but I don't really know much. Anyway it's better to have false-negatives than false-positives.

## PR Status

Should be working ... tested the `ss | grep`, but not the helper itself...

## How to test

Use `ynh_find_port` on an already used port, like for example the xmpp port 5222

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
