### PR TITLE
Add conflict rule against apache2 and bind9

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,6 +43,7 @@ Conflicts: iptables-persistent
  , yunohost-config-dovecot, yunohost-config-slapd
  , yunohost-config-nginx, yunohost-config-amavis
  , yunohost-config-mysql, yunohost-predepends
+ , apache2, bind9
 Replaces: moulinette-yunohost, yunohost-config
  , yunohost-config-others, yunohost-config-postfix
  , yunohost-config-dovecot, yunohost-config-slapd


### PR DESCRIPTION
## The problem

c.f. discussion on Yunohost apps, some app requires php-uploadprogress with has a "recommend libapache2-whatever which in turns install apache.

But we've seen many situations leading to apache or bind9 being installed which breaks critical services like nginx and dnsmasq...

## Solution

Bringing this once again because we really need to do something about it on the long term.

It's been discussed that some advanced user may want to install apache2 on the side, but fuck it, if they need it they can still force it using some `dpkg --force-conflicts` somehow.

## PR Status

Yolocommited

## How to test

Try to install apache or bind with this rule enabled..

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
