### PR TITLE
No need for mysql root password

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -209,12 +209,13 @@ ynh_mysql_setup_db () {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    local new_db_pwd=$(ynh_string_random)	# Generate a random password
+    # Generate a random password
+    local new_db_pwd=$(ynh_string_random)
     # If $db_pwd is not provided, use new_db_pwd instead for db_pwd
     db_pwd="${db_pwd:-$new_db_pwd}"
 
-    ynh_mysql_create_db "$db_name" "$db_user" "$db_pwd"	# Create the database
-    ynh_app_setting_set --app=$app --key=mysqlpwd --value=$db_pwd	# Store the password in the app's config
+    ynh_mysql_create_db "$db_name" "$db_user" "$db_pwd"
+    ynh_app_setting_set --app=$app --key=mysqlpwd --value=$db_pwd
 }
 
 # Remove a database if it exists, and the associated user
@@ -225,22 +226,22 @@ ynh_mysql_setup_db () {
 #
 # Requires YunoHost version 2.6.4 or higher.
 ynh_mysql_remove_db () {
-	# Declare an array to define the options of this helper.
-	local legacy_args=un
-	declare -Ar args_array=( [u]=db_user= [n]=db_name= )
-	local db_user
-	local db_name
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
+    # Declare an array to define the options of this helper.
+    local legacy_args=un
+    declare -Ar args_array=( [u]=db_user= [n]=db_name= )
+    local db_user
+    local db_name
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
 
-	if mysqlshow | grep -q "^| $db_name "; then
-		ynh_mysql_drop_db $db_name
-	else
-		ynh_print_warn --message="Database $db_name not found"
-	fi
+    if mysqlshow | grep -q "^| $db_name "; then
+        ynh_mysql_drop_db $db_name
+    else
+        ynh_print_warn --message="Database $db_name not found"
+    fi
 
-	# Remove mysql user if it exists
-	if ynh_mysql_user_exists --user=$db_user; then
-		ynh_mysql_drop_user $db_user
-	fi
+    # Remove mysql user if it exists
+    if ynh_mysql_user_exists --user=$db_user; then
+        ynh_mysql_drop_user $db_user
+    fi
 }

--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -228,7 +228,7 @@ ynh_mysql_setup_db () {
 ynh_mysql_remove_db () {
     # Declare an array to define the options of this helper.
     local legacy_args=un
-    declare -Ar args_array=( [u]=db_user= [n]=db_name= )
+    local -Ar args_array=( [u]=db_user= [n]=db_name= )
     local db_user
     local db_name
     # Manage arguments with getopts

--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-MYSQL_ROOT_PWD_FILE=/etc/yunohost/mysql
-
 # Open a connection as a user
 #
 # example: ynh_mysql_connect_as --user="user" --password="pass" <<< "UPDATE ...;"
@@ -49,8 +47,7 @@ ynh_mysql_execute_as_root() {
         database="--database=$database"
     fi
 
-    ynh_mysql_connect_as --user="root" --password="$(cat $MYSQL_ROOT_PWD_FILE)" \
-        $database <<< "$sql"
+    mysql -B "$database" <<< "$sql"
 }
 
 # Execute a command from a file as root user
@@ -75,9 +72,7 @@ ynh_mysql_execute_file_as_root() {
         database="--database=$database"
     fi
 
-
-    ynh_mysql_connect_as --user="root" --password="$(cat $MYSQL_ROOT_PWD_FILE)" \
-        $database < "$file"
+    mysql -B "$database" < "$file"
 }
 
 # Create a database and grant optionnaly privilegies to a user
@@ -140,7 +135,7 @@ ynh_mysql_dump_db() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    mysqldump --user="root" --password="$(cat $MYSQL_ROOT_PWD_FILE)" --single-transaction --skip-dump-date "$database"
+    mysqldump --single-transaction --skip-dump-date "$database"
 }
 
 # Create a user
@@ -230,24 +225,22 @@ ynh_mysql_setup_db () {
 #
 # Requires YunoHost version 2.6.4 or higher.
 ynh_mysql_remove_db () {
-    # Declare an array to define the options of this helper.
-    local legacy_args=un
-    local -A args_array=( [u]=db_user= [n]=db_name= )
-    local db_user
-    local db_name
-    # Manage arguments with getopts
-    ynh_handle_getopts_args "$@"
+	# Declare an array to define the options of this helper.
+	local legacy_args=un
+	declare -Ar args_array=( [u]=db_user= [n]=db_name= )
+	local db_user
+	local db_name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
 
-    local mysql_root_password=$(cat $MYSQL_ROOT_PWD_FILE)
-    if mysqlshow --user=root --password=$mysql_root_password | grep --quiet "^| $db_name"
-    then	# Check if the database exists
-        ynh_mysql_drop_db $db_name	# Remove the database	
-    else
-        ynh_print_warn --message="Database $db_name not found"
-    fi
+	if mysqlshow | grep -q "^| $db_name "; then
+		ynh_mysql_drop_db $db_name
+	else
+		ynh_print_warn --message="Database $db_name not found"
+	fi
 
-    # Remove mysql user if it exists
-    if ynh_mysql_user_exists --user=$db_user; then
-        ynh_mysql_drop_user $db_user
-    fi
+	# Remove mysql user if it exists
+	if ynh_mysql_user_exists --user=$db_user; then
+		ynh_mysql_drop_user $db_user
+	fi
 }

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -19,6 +19,7 @@ do_post_regen() {
       # dpkg-reconfigure will initialize mysql (if it ain't already)
       # It enabled auth_socket for root, so no need to define any root password...
       # c.f. : cat /var/lib/dpkg/info/mariadb-server-10.3.postinst | grep install_db -C3
+      MYSQL_PKG="$(dpkg --list | sed -ne 's/^ii  \(mariadb-server-[[:digit:].]\+\) .*$/\1/p')"
       dpkg-reconfigure -freadline -u "$MYSQL_PKG" 2>&1
 
       systemctl -q is-active mariadb.service \

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-MYSQL_PKG="$(dpkg --list | sed -ne 's/^ii  \(mariadb-server-[[:digit:].]\+\) .*$/\1/p')"
 . /usr/share/yunohost/helpers
 
 do_pre_regen() {
@@ -27,17 +26,30 @@ do_post_regen() {
 
       sleep 5
 
-      echo "" | mysql && echo "Can't connect to mysql using unix_socket auth ... something went wrong during initial configuration of mysql !?"
+      echo "" | mysql && echo "Can't connect to mysql using unix_socket auth ... something went wrong during initial configuration of mysql !?" >&2
   fi
 
-  if [ ! -e /etc/yunohost/mysql ]
-  then
-      # Dummy password that's not actually used nor meaningful ...
-      # (because mysql is supposed to be configured to use unix_socket on new setups)
-      # but keeping it for legacy
-      # until we merge https://github.com/YunoHost/yunohost/pull/912 ...
-      ynh_string_random 10 > /etc/yunohost/mysql
-      chmod 400 /etc/yunohost/mysql
+  # Legacy code to get rid of /etc/yunohost/mysql ...
+  # Nowadays, we can simply run mysql while being run as root of unix_socket/auth_socket is enabled...
+  if [ -f /etc/yunohost/mysql ]; then
+
+      # This is a trick to check if we're able to use mysql without password
+      # Expect instances installed in stretch to already have unix_socket
+      #configured, but not old instances from the jessie/wheezy era
+      if ! echo "" | mysql
+      then
+          password="$(cat /etc/yunohost/mysql)"
+          # Enable plugin unix_socket for root on localhost
+          mysql -u root -p"$password" <<< "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED WITH unix_socket WITH GRANT OPTION;"
+      fi
+
+      # If now we're able to login without password, drop the mysql password
+      if echo "" | mysql
+      then
+          rm /etc/yunohost/mysql
+      else
+          echo "Can't connect to mysql using unix_socket auth ... something went wrong while trying to get rid of mysql password !?" >&2
+      fi
   fi
 
   # mysql is supposed to be an alias to mariadb... but in some weird case is not

--- a/data/hooks/restore/11-conf_ynh_mysql
+++ b/data/hooks/restore/11-conf_ynh_mysql
@@ -1,5 +1,0 @@
-# We don't backup/restore mysql password anymore
-# c.f. https://github.com/YunoHost/yunohost/pull/912
-
-# This is a dummy empty file as a workaround for
-# https://github.com/YunoHost/issues/issues/1553 until it is fixed

--- a/src/yunohost/tests/test_apps.py
+++ b/src/yunohost/tests/test_apps.py
@@ -55,18 +55,11 @@ def clean():
         for folderpath in glob.glob("/var/www/*%s*" % test_app):
             shutil.rmtree(folderpath, ignore_errors=True)
 
-        os.system(
-            "bash -c \"mysql -u root --password=$(cat /etc/yunohost/mysql) 2>/dev/null <<< 'DROP DATABASE %s' \""
-            % test_app
-        )
-        os.system(
-            "bash -c \"mysql -u root --password=$(cat /etc/yunohost/mysql) 2>/dev/null <<< 'DROP USER %s@localhost'\""
-            % test_app
-        )
+        os.system("bash -c \"mysql -B 2>/dev/null <<< 'DROP DATABASE %s' \"" % test_app)
+        os.system("bash -c \"mysql -B 2>/dev/null <<< 'DROP USER %s@localhost'\"" % test_app)
 
-    os.system(
-        "systemctl reset-failed nginx"
-    )  # Reset failed quota for service to avoid running into start-limit rate ?
+    # Reset failed quota for service to avoid running into start-limit rate ?
+    os.system("systemctl reset-failed nginx")
     os.system("systemctl start nginx")
 
     # Clean permissions


### PR DESCRIPTION
## The problem

Another change on top of the removal of the backup/restore of mysql password.

This one is a bit more touchy though ... so to be discussed.

The problem is that managing that mysql password in /etc/yunohost/mysql is a bit annoying (gotta call a damn dpkg-reconfigure to change or define it wtf) and it's actually a security risk to use it in command line as the password will show up to other unix users in `ps -ef` ... Same thing can be said for psql btw ...

As I realized today, we don't need to do this anymore. Mariadb ships a auth_socket/unix_socket plugin that allows to authenticate just from the fact that you're already root, which makes more sense than some funky password.

## Solution

Adapt helpers to call `mysql` without password, and auto-migrate to enable unix_socket as auth plugin for root in the regen-conf (it's in fact only needed for people that come from the wheezy/jessie era)

## PR Status

Tested the migration part but didn't carefully test the helpers...

## How to test

Zblerg :| 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
