### PR TITLE
Update nginx SSL conf with new Mozilla recommendation

### DIFF
--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -1,24 +1,22 @@
-{% if compatibility == "modern" %}
-# Ciphers with modern compatibility
-# https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=modern
-# The following configuration use modern ciphers, but remove compatibility with some old clients (android < 5.0, Internet Explorer < 10, ...)
-ssl_protocols TLSv1.2;
-ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-ssl_prefer_server_ciphers on;
-{% else %}
-# As suggested by Mozilla : https://wiki.mozilla.org/Security/Server_Side_TLS and https://en.wikipedia.org/wiki/Curve25519
-ssl_ecdh_curve secp521r1:secp384r1:prime256v1;
-ssl_prefer_server_ciphers on;
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;  # about 40000 sessions
+ssl_session_tickets off;
+
+# nginx 1.10 in stretch doesn't support TLS1.3 and Mozilla doesn't have any
+# "modern" config recommendation with it.
+# So until buster the modern conf is same as intermediate
+{% if compatibility == "modern" %} {% else %} {% endif %}
 
 # Ciphers with intermediate compatibility
-# https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.6.2&openssl=1.0.1t&hsts=yes&profile=intermediate
-ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+# generated 2020-04-03, Mozilla Guideline v5.4, nginx 1.10.3, OpenSSL 1.1.1l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=nginx&version=1.10.3&config=intermediate&openssl=1.1.1l&guideline=5.4
+ssl_protocols TLSv1.2;
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_prefer_server_ciphers off;
 
 # Uncomment the following directive after DH generation
 # > openssl dhparam -out /etc/ssl/private/dh2048.pem -outform PEM -2 2048
 #ssl_dhparam /etc/ssl/private/dh2048.pem;
-{% endif %}
 
 # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security

--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -8,8 +8,8 @@ ssl_session_tickets off;
 {% if compatibility == "modern" %} {% else %} {% endif %}
 
 # Ciphers with intermediate compatibility
-# generated 2020-04-03, Mozilla Guideline v5.4, nginx 1.10.3, OpenSSL 1.1.1l, intermediate configuration
-# https://ssl-config.mozilla.org/#server=nginx&version=1.10.3&config=intermediate&openssl=1.1.1l&guideline=5.4
+# generated 2020-04-03, Mozilla Guideline v5.4, nginx 1.10.3, OpenSSL 1.1.0l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=nginx&version=1.10.3&config=intermediate&openssl=1.1.0l&guideline=5.4
 ssl_protocols TLSv1.2;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 ssl_prefer_server_ciphers off;

--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -1,5 +1,5 @@
 ssl_session_timeout 1d;
-ssl_session_cache shared:SSL:10m;  # about 40000 sessions
+ssl_session_cache shared:SSL:50m;  # about 200000 sessions
 ssl_session_tickets off;
 
 # nginx 1.10 in stretch doesn't support TLS1.3 and Mozilla doesn't have any

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -33,12 +33,10 @@ server {
     listen [::]:443 ssl http2;
     server_name {{ domain }};
 
+    include /etc/nginx/conf.d/security.conf.inc;
+
     ssl_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
     ssl_certificate_key /etc/yunohost/certs/{{ domain }}/key.pem;
-    ssl_session_timeout 5m;
-    ssl_session_cache shared:SSL:50m;
-
-    include /etc/nginx/conf.d/security.conf.inc;
 
     {% if domain_cert_ca != "Self-signed" %}
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
@@ -85,12 +83,10 @@ server {
         client_max_body_size 105M; # Choose a value a bit higher than the max upload configured in XMPP server
     }
 
+    include /etc/nginx/conf.d/security.conf.inc;
+
     ssl_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
     ssl_certificate_key /etc/yunohost/certs/{{ domain }}/key.pem;
-    ssl_session_timeout 5m;
-    ssl_session_cache shared:SSL:50m;
-
-    include /etc/nginx/conf.d/security.conf.inc;
 
     {% if domain_cert_ca != "Self-signed" %}
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";


### PR DESCRIPTION
## The problem

Nginx ciphers and other security settings not up to date with Mozilla's recommendation (in particular w.r.t. using TLSv1 and 1.1)

## Solution

c.f. https://ssl-config.mozilla.org/#server=nginx&version=1.10.3&config=intermediate&openssl=1.1.1l&ocsp=false&guideline=5.4

Though we can't have any "modern" configuration with 1.10.3... (lack supports for TLS1.3 I believe) Need buster to have nginx 1.14...

## PR Status

Yolocommited, hopefully not breaking everything

## How to test

Regen nginx conf, clear browser cache and test that it works.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
