### PR TITLE
Update mailstack ciphers

### DIFF
--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -12,10 +12,25 @@ protocols = imap sieve {% if pop3_enabled == "True" %}pop3{% endif %}
 
 mail_plugins = $mail_plugins quota
 
-ssl = yes
+###############################################################################
+
+# generated 2020-04-03, Mozilla Guideline v5.4, Dovecot 2.2.27, OpenSSL 1.1.1l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=dovecot&version=2.2.27&config=intermediate&openssl=1.1.1l&guideline=5.4
+
+ssl = required
+
 ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem
 ssl_key = </etc/yunohost/certs/{{ main_domain }}/key.pem
-ssl_protocols = !SSLv3
+
+ssl_dh_parameters_length = 2048
+
+# intermediate configuration
+ssl_protocols = TLSv1.2 TLSv1.3
+ssl_cipher_list = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+ssl_prefer_server_ciphers = no
+
+###############################################################################
+
 
 passdb {
   args = /etc/dovecot/dovecot-ldap.conf

--- a/data/templates/dovecot/dovecot.conf
+++ b/data/templates/dovecot/dovecot.conf
@@ -14,8 +14,8 @@ mail_plugins = $mail_plugins quota
 
 ###############################################################################
 
-# generated 2020-04-03, Mozilla Guideline v5.4, Dovecot 2.2.27, OpenSSL 1.1.1l, intermediate configuration
-# https://ssl-config.mozilla.org/#server=dovecot&version=2.2.27&config=intermediate&openssl=1.1.1l&guideline=5.4
+# generated 2020-04-03, Mozilla Guideline v5.4, Dovecot 2.2.27, OpenSSL 1.1.0l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=dovecot&version=2.2.27&config=intermediate&openssl=1.1.0l&guideline=5.4
 
 ssl = required
 
@@ -25,7 +25,7 @@ ssl_key = </etc/yunohost/certs/{{ main_domain }}/key.pem
 ssl_dh_parameters_length = 2048
 
 # intermediate configuration
-ssl_protocols = TLSv1.2 TLSv1.3
+ssl_protocols = TLSv1.2
 ssl_cipher_list = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
 ssl_prefer_server_ciphers = no
 

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -18,35 +18,39 @@ append_dot_mydomain = no
 readme_directory = no
 
 # -- TLS for incoming connections
-# By default, TLS is disabled in the Postfix SMTP server, so no difference to
-# plain Postfix is visible. Explicitly switch it on with "smtpd_tls_security_level = may".
-smtpd_tls_security_level=may
+###############################################################################
+# generated 2020-04-03, Mozilla Guideline v5.4, Postfix 3.1.14, OpenSSL 1.1.1l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=postfix&version=3.1.14&config=intermediate&openssl=1.1.1l&guideline=5.4
 
-# Sending AUTH data over an unencrypted channel poses a security risk.
-# When TLS layer encryption is optional ("smtpd_tls_security_level = may"), it
-# may however still be useful to only offer AUTH when TLS is active. To maintain
-# compatibility with non-TLS clients, the default is to accept AUTH without
-# encryption. In order to change this behavior, we set "smtpd_tls_auth_only = yes".
-smtpd_tls_auth_only=yes
+# (No modern conf support until we're on buster...)
+# {% if compatibility == "intermediate" %} {% else %} {% endif %}
+
+smtpd_use_tls = yes
+
+smtpd_tls_security_level = may
+smtpd_tls_auth_only = yes
 smtpd_tls_cert_file = /etc/yunohost/certs/{{ main_domain }}/crt.pem
 smtpd_tls_key_file = /etc/yunohost/certs/{{ main_domain }}/key.pem
-smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH, RC4, 3DES
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
+smtpd_tls_mandatory_ciphers = medium
+
+# curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam.pem
+# not actually 1024 bits, this applies to all DHE >= 1024 bits
+# smtpd_tls_dh1024_param_file = /path/to/dhparam.pem
+
+tls_medium_cipherlist = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+tls_preempt_cipherlist = no
+###############################################################################
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_loglevel=1
-{% if compatibility == "intermediate" %}
-smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
-{% else %}
-smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3,!TLSv1,!TLSv1.1
-{% endif %}
-smtpd_tls_mandatory_ciphers=high
-smtpd_tls_eecdh_grade = ultra
 
 # -- TLS for outgoing connections
 # Use TLS if this is supported by the remote SMTP server, otherwise use plaintext.
 smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
-smtp_tls_exclude_ciphers = $smtpd_tls_exclude_ciphers
-smtp_tls_mandatory_ciphers= $smtpd_tls_mandatory_ciphers
+smtp_tls_exclude_ciphers = aNULL, MD5, DES, ADH, RC4, 3DES
+smtp_tls_mandatory_ciphers= high
 smtp_tls_loglevel=1
 
 # Configure Root CA certificates

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -19,8 +19,8 @@ readme_directory = no
 
 # -- TLS for incoming connections
 ###############################################################################
-# generated 2020-04-03, Mozilla Guideline v5.4, Postfix 3.1.14, OpenSSL 1.1.1l, intermediate configuration
-# https://ssl-config.mozilla.org/#server=postfix&version=3.1.14&config=intermediate&openssl=1.1.1l&guideline=5.4
+# generated 2020-04-03, Mozilla Guideline v5.4, Postfix 3.1.14, OpenSSL 1.1.0l, intermediate configuration
+# https://ssl-config.mozilla.org/#server=postfix&version=3.1.14&config=intermediate&openssl=1.1.0l&guideline=5.4
 
 # (No modern conf support until we're on buster...)
 # {% if compatibility == "intermediate" %} {% else %} {% endif %}


### PR DESCRIPTION
## The problem

Configurations are not up to date with Mozilla's recommendation ...

## Solution

Apply recommendation

For dovecot that sounds pretty legit and okay ... For postfix, I'm less confident about what I'm doing ... in particular because there's no recommendation for the `smtp_` settings, which I believe define what happens for the interaction with other servers

## PR Status

Yolocommited :s 

## How to test

Uh try to configure an email client and submit some mails to deliver to external servers

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
