### PR TITLE
Get rid of domain-specific acme-challenge snippet, use a single snippet included in every conf

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -110,6 +110,21 @@ do_post_regen() {
     mkdir -p "/etc/nginx/conf.d/${domain}.d"
   done
 
+  # Get rid of legacy lets encrypt snippets
+  for domain in $domain_list; do
+      # If the legacy letsencrypt / acme-challenge domain-specific snippet is still there
+      if [ -e /etc/nginx/conf.d/${domain}.d/000-acmechallenge.conf ]
+      then
+          # And if we're effectively including the new domain-independant snippet now
+          if grep -q "include /etc/nginx/conf.d/acme-challenge.conf.inc;" /etc/nginx/conf.d/${domain}.conf
+          then
+              # Delete the old domain-specific snippet
+              rm /etc/nginx/conf.d/${domain}.d/000-acmechallenge.conf
+          fi
+      fi
+  done
+
+
   # Reload nginx configuration
   pgrep nginx && service nginx reload
 }

--- a/data/templates/nginx/plain/acme-challenge.conf.inc
+++ b/data/templates/nginx/plain/acme-challenge.conf.inc
@@ -1,0 +1,5 @@
+location ^~ '/.well-known/acme-challenge/'
+{
+        default_type "text/plain";
+        alias /tmp/acme-challenge-public/;
+}

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -10,6 +10,8 @@ server {
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 
+    include /etc/nginx/conf.d/acme-challenge.conf.inc;
+
     include /etc/nginx/conf.d/{{ domain }}.d/*.conf;
 
     location /yunohost/admin {

--- a/locales/en.json
+++ b/locales/en.json
@@ -120,7 +120,6 @@
     "certmanager_cert_renew_success": "Let's Encrypt certificate renewed for the domain '{domain:s}'",
     "certmanager_cert_signing_failed": "Could not sign the new certificate",
     "certmanager_certificate_fetching_or_enabling_failed": "Trying to use the new certificate for {domain:s} did not work…",
-    "certmanager_conflicting_nginx_file": "Could not prepare domain for ACME challenge: the NGINX configuration file {filepath:s} is conflicting and should be removed first",
     "certmanager_couldnt_fetch_intermediate_cert": "Timed out when trying to fetch intermediate certificate from Let's Encrypt. Certificate installation/renewal aborted—please try again later.",
     "certmanager_domain_cert_not_selfsigned": "The certificate for domain {domain:s} is not self-signed. Are you sure you want to replace it? (Use '--force' to do so.)",
     "certmanager_domain_dns_ip_differs_from_public_ip": "The DNS 'A' record for the domain '{domain:s}' is different from this server's IP. If you recently modified your A record, please wait for it to propagate (some DNS propagation checkers are available online). (If you know what you are doing, use '--no-checks' to turn off those checks.)",


### PR DESCRIPTION
## The problem

c.f. https://forum.yunohost.org/t/audit-nginx-avec-gixy/10797

The current acme-challenge location should in fact end with `/` according to the current code ... but it wasn't the case in the past. And for some reason the code didn't overwrite the file if it was already there (and it's not called during renew either)... Anyway 

## Solution

The code dates back from my very early days in Yunohost where I wasn't aware of the regenconf system. Instead, we should just include a common snippet and include it in all nginx confs.

Though when doing so, we have to take care of legacy (sigh) and make sure the nginx conf is indeed really updated before getting rid of the old file.

## PR Status

Yolocommited, not tested

## How to test

Setup a domain with letsencrypt (or maybe just manually add the old 000-acmechallenge.conf, no need to actually fetch the cert) and run the new regen-conf, check that the old 000-acmechallenge.conf does get removed only if the domain conf is correctly updated.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
