### PR TITLE
[fix] config_appy return link

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1574,6 +1574,7 @@ def app_config_apply(operation_logger, app, args):
 
     logger.success("Config updated as expected")
     return {
+        "app": app,
         "logs": operation_logger.success(),
     }
 


### PR DESCRIPTION
## The problem

Error after apply config because [webadmin needs](https://github.com/YunoHost/yunohost-admin/blob/79301a80836d92d30a96eb62938fc8f3d341b77d/src/js/yunohost/controllers/apps.js#L366) `app`

## Solution

Add `app` as return value

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
