### PR TITLE
Dont diagnose all records for subdomains

### DIFF
--- a/data/hooks/diagnosis/12-dnsrecords.py
+++ b/data/hooks/diagnosis/12-dnsrecords.py
@@ -28,21 +28,24 @@ class DNSRecordsDiagnoser(Diagnoser):
         all_domains = domain_list()["domains"]
         for domain in all_domains:
             self.logger_debug("Diagnosing DNS conf for %s" % domain)
-            for report in self.check_domain(domain, domain == main_domain):
+            is_subdomain = domain.split(".",1)[1] in all_domains
+            for report in self.check_domain(domain, domain == main_domain, is_subdomain=is_subdomain):
                 yield report
 
         # FIXME : somewhere, should implement a check for reverse DNS ...
 
         # FIXME / TODO : somewhere, could also implement a check for domain expiring soon
 
-    def check_domain(self, domain, is_main_domain):
+    def check_domain(self, domain, is_main_domain, is_subdomain):
 
         expected_configuration = _build_dns_conf(domain)
 
-        # Here if there are no AAAA record, we should add something to expect "no" AAAA record
+        # FIXME: Here if there are no AAAA record, we should add something to expect "no" AAAA record
         # to properly diagnose situations where people have a AAAA record but no IPv6
-
         categories = ["basic", "mail", "xmpp", "extra"]
+        if is_subdomain:
+            categories = ["basic"]
+
         for category in categories:
 
             records = expected_configuration[category]

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -258,7 +258,17 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
         logger.info("Updated needed, going on...")
 
     dns_conf = _build_dns_conf(domain)
-    del dns_conf["extra"]  # Ignore records from the 'extra' category
+
+    for i, record in enumerate(dns_conf["extra"]):
+        # Ignore CAA record ... not sure why, we could probably enforce it...
+        if record[3] == "CAA":
+            del dns_conf["extra"][i]
+
+    # Delete custom DNS records, we don't support them (have to explicitly
+    # authorize them on dynette)
+    for category in dns_conf.keys():
+        if category not in ["basic", "mail", "xmpp", "extra"]:
+            del dns_conf[category]
 
     # Delete the old records for all domain/subdomains
 


### PR DESCRIPTION
## The problem

For each domain, currently, we generate a DNS record recommendation that include basic A/AAAA records + mail-related records + xmpp-related records. This makes a lot of sense for regular "root" domain like example.com or yolo.nohost.me. But if you add many app-dedicated domains like $app.example.com, you generally expect to only be relevant for web and not have a full mail stack + xmpp stack configured for each of those ... 

## Solution

The right answer to this imho is to allow admins to only enable specific features like web/mail/xmpp for each domain they add (and by default not recommending to add mail/xmpp for subdomains). But that require some work that'll only come after Buster

Currently though, the diagnosis diagnose every DNS records for every domain. A simple trick to reduce this madness is to assume that subdomains are only meant for web (probably not the case for 100% of use case, but still good enough) and therefore to check only A/AAAA records for those.

I also moved the wildcard recommendation to the "extra" category (such that it doesn't get  diagnosed for subdomains either).

## PR Status

Kind of tested, should be working

## How to test

Run a dnsrecords diagnosis on a "root" domain and subdomain

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
