### PR TITLE
Semantic improvements for PHP helpers PR (in particular RAM helper)

### DIFF
--- a/data/helpers.d/hardware
+++ b/data/helpers.d/hardware
@@ -10,16 +10,16 @@
 ynh_get_ram () {
 	# Declare an array to define the options of this helper.
 	declare -Ar args_array=( [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
-    local free
-    local total
+	local free
+	local total
 	local ignore_swap
 	local only_swap
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 	ignore_swap=${ignore_swap:-0}
 	only_swap=${only_swap:-0}
-    free=${free:-0}
-    total=${total:-0}
+	free=${free:-0}
+	total=${total:-0}
 
 	local total_ram=$(vmstat --stats --unit M | grep "total memory" | awk '{print $1}')
 	local total_swap=$(vmstat --stats --unit M | grep "total swap" | awk '{print $1}')
@@ -43,9 +43,9 @@ ynh_get_ram () {
 			# Use only the amount of free swap
 			ram=$free_swap
 		fi
-    elif [ $total -eq 1 ]
-    then
-	    local ram=$total_ram_swap
+	elif [ $total -eq 1 ]
+	then
+		local ram=$total_ram_swap
 		if [ $ignore_swap -eq 1 ]
 		then
 			# Use only the amount of free ram
@@ -55,9 +55,9 @@ ynh_get_ram () {
 			# Use only the amount of free swap
 			ram=$total_swap
 		fi
-    else
-        echo "Uhoh, you should choose --free or --total when using ynh_get_ram" >&2
-        ram=0
+	else
+		ynh_print_warn --message="You have to choose --free or --total when using ynh_get_ram"
+		ram=0
 	fi
 
     echo $ram
@@ -65,25 +65,25 @@ ynh_get_ram () {
 
 # Return 0 or 1 depending if the system has a given amount of RAM+swap free or total
 #
-# usage: ynh_require_ram [--amount=RAM required in Mb] [--free|--total] [--ignore_swap|--only_swap]
-# | arg: -a, --amount - The amount to require, in Mb
+# usage: ynh_require_ram --required=RAM required in Mb [--free|--total] [--ignore_swap|--only_swap]
+# | arg: -r, --required - The amount to require, in Mb
 # | arg: -f, --free  - Count free RAM+swap
 # | arg: -t, --total - Count total RAM+swap
 # | arg: -s, --ignore_swap - Ignore swap, consider only real RAM
 # | arg: -o, --only_swap - Ignore real RAM, consider only swap
 ynh_require_ram () {
     # Declare an array to define the options of this helper.
-	declare -Ar args_array=( [a]=amount= [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
-    local amount
+    declare -Ar args_array=( [r]=required= [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
+    local required
     local free
     local total
-	local ignore_swap
-	local only_swap
-	# Manage arguments with getopts
-	ynh_handle_getopts_args "$@"
-	amount=${amount:-0}
+    local ignore_swap
+    local only_swap
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
     # Dunno if that's the right way to do, but that's some black magic to be able to
     # forward the bool args to ynh_get_ram easily?
+    # If the variable $free is not empty, set it to '--free'
     free=${free:+--free}
     total=${total:+--total}
     ignore_swap=${ignore_swap:+--ignore_swap}
@@ -91,7 +91,7 @@ ynh_require_ram () {
 
     local ram=$(ynh_get_ram $free $total $ignore_swap $only_swap)
 
-    if [ $ram -lt $amount ]
+    if [ $ram -lt $required ]
     then
         return 1
     else

--- a/data/helpers.d/hardware
+++ b/data/helpers.d/hardware
@@ -1,24 +1,25 @@
 #!/bin/bash
 
-# Check the amount of available RAM
+# Get the total or free amount of RAM+swap on the system
 #
-# usage: ynh_check_ram [--required=RAM required in Mb] [--ignore_swap|--only_swap] [--free_ram]
-# | arg: -r, --required= - Amount of RAM required in Mb. The helper will return 0 is there's enough RAM, or 1 otherwise.
-# If --required isn't set, the helper will print the amount of RAM, in Mb.
-# | arg: -s, --ignore_swap - Ignore swap
-# | arg: -o, --only_swap - Ignore real RAM, consider only swap.
-# | arg: -f, --free_ram  - Count only free RAM, not the total amount of RAM available.
-ynh_available_ram () {
+# usage: ynh_get_ram [--free|--total] [--ignore_swap|--only_swap]
+# | arg: -f, --free  - Count free RAM+swap
+# | arg: -t, --total - Count total RAM+swap
+# | arg: -s, --ignore_swap - Ignore swap, consider only real RAM
+# | arg: -o, --only_swap - Ignore real RAM, consider only swap
+ynh_get_ram () {
 	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [r]=required= [s]=ignore_swap [o]=only_swap [f]=free_ram )
-	local required
+	declare -Ar args_array=( [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
+    local free
+    local total
 	local ignore_swap
 	local only_swap
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
-	required=${required:-}
 	ignore_swap=${ignore_swap:-0}
 	only_swap=${only_swap:-0}
+    free=${free:-0}
+    total=${total:-0}
 
 	local total_ram=$(vmstat --stats --unit M | grep "total memory" | awk '{print $1}')
 	local total_swap=$(vmstat --stats --unit M | grep "total swap" | awk '{print $1}')
@@ -29,11 +30,10 @@ ynh_available_ram () {
 	local free_ram_swap=$(( free_ram + free_swap ))
 
 	# Use the total amount of ram
-	local ram=$total_ram_swap
-	if [ $free_ram -eq 1 ]
+	if [ $free -eq 1 ]
 	then
 		# Use the total amount of free ram
-		ram=$free_ram_swap
+		local ram=$free_ram_swap
 		if [ $ignore_swap -eq 1 ]
 		then
 			# Use only the amount of free ram
@@ -43,7 +43,9 @@ ynh_available_ram () {
 			# Use only the amount of free swap
 			ram=$free_swap
 		fi
-	else
+    elif [ $total -eq 1 ]
+    then
+	    local ram=$total_ram_swap
 		if [ $ignore_swap -eq 1 ]
 		then
 			# Use only the amount of free ram
@@ -53,20 +55,46 @@ ynh_available_ram () {
 			# Use only the amount of free swap
 			ram=$total_swap
 		fi
+    else
+        echo "Uhoh, you should choose --free or --total when using ynh_get_ram" >&2
+        ram=0
 	fi
 
-	if [ -n "$required" ]
-	then
-		# Return 1 if the amount of ram isn't enough.
-		if [ $ram -lt $required ]
-		then
-			return 1
-		else
-			return 0
-		fi
+    echo $ram
+}
 
-	# If no RAM is required, return the amount of available ram.
-	else
-		echo $ram
-	fi
+# Return 0 or 1 depending if the system has a given amount of RAM+swap free or total
+#
+# usage: ynh_require_ram [--amount=RAM required in Mb] [--free|--total] [--ignore_swap|--only_swap]
+# | arg: -a, --amount - The amount to require, in Mb
+# | arg: -f, --free  - Count free RAM+swap
+# | arg: -t, --total - Count total RAM+swap
+# | arg: -s, --ignore_swap - Ignore swap, consider only real RAM
+# | arg: -o, --only_swap - Ignore real RAM, consider only swap
+ynh_require_ram () {
+    # Declare an array to define the options of this helper.
+	declare -Ar args_array=( [a]=amount= [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
+    local amount
+    local free
+    local total
+	local ignore_swap
+	local only_swap
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+	amount=${amount:-0}
+    # Dunno if that's the right way to do, but that's some black magic to be able to
+    # forward the bool args to ynh_get_ram easily?
+    free=${free:+--free}
+    total=${total:+--total}
+    ignore_swap=${ignore_swap:+--ignore_swap}
+    only_swap=${only_swap:+--only_swap}
+
+    local ram=$(ynh_get_ram $free $total $ignore_swap $only_swap)
+
+    if [ $ram -lt $amount ]
+    then
+        return 1
+    else
+        return 0
+    fi
 }

--- a/data/helpers.d/hardware
+++ b/data/helpers.d/hardware
@@ -2,22 +2,22 @@
 
 # Check the amount of available RAM
 #
-# usage: ynh_check_ram [--required=RAM required in Mb] [--no_swap|--only_swap] [--free_ram]
+# usage: ynh_check_ram [--required=RAM required in Mb] [--ignore_swap|--only_swap] [--free_ram]
 # | arg: -r, --required= - Amount of RAM required in Mb. The helper will return 0 is there's enough RAM, or 1 otherwise.
 # If --required isn't set, the helper will print the amount of RAM, in Mb.
-# | arg: -s, --no_swap   - Ignore swap
+# | arg: -s, --ignore_swap - Ignore swap
 # | arg: -o, --only_swap - Ignore real RAM, consider only swap.
 # | arg: -f, --free_ram  - Count only free RAM, not the total amount of RAM available.
-ynh_check_ram () {
+ynh_available_ram () {
 	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [r]=required= [s]=no_swap [o]=only_swap [f]=free_ram )
+	declare -Ar args_array=( [r]=required= [s]=ignore_swap [o]=only_swap [f]=free_ram )
 	local required
-	local no_swap
+	local ignore_swap
 	local only_swap
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
 	required=${required:-}
-	no_swap=${no_swap:-0}
+	ignore_swap=${ignore_swap:-0}
 	only_swap=${only_swap:-0}
 
 	local total_ram=$(vmstat --stats --unit M | grep "total memory" | awk '{print $1}')
@@ -34,7 +34,7 @@ ynh_check_ram () {
 	then
 		# Use the total amount of free ram
 		ram=$free_ram_swap
-		if [ $no_swap -eq 1 ]
+		if [ $ignore_swap -eq 1 ]
 		then
 			# Use only the amount of free ram
 			ram=$free_ram
@@ -44,7 +44,7 @@ ynh_check_ram () {
 			ram=$free_swap
 		fi
 	else
-		if [ $no_swap -eq 1 ]
+		if [ $ignore_swap -eq 1 ]
 		then
 			# Use only the amount of free ram
 			ram=$total_ram

--- a/data/helpers.d/hardware
+++ b/data/helpers.d/hardware
@@ -9,6 +9,7 @@
 # | arg: -o, --only_swap - Ignore real RAM, consider only swap
 ynh_get_ram () {
 	# Declare an array to define the options of this helper.
+	local legacy_args=ftso
 	declare -Ar args_array=( [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
 	local free
 	local total
@@ -73,6 +74,7 @@ ynh_get_ram () {
 # | arg: -o, --only_swap - Ignore real RAM, consider only swap
 ynh_require_ram () {
     # Declare an array to define the options of this helper.
+    local legacy_args=rftso
     declare -Ar args_array=( [r]=required= [f]=free [t]=total [s]=ignore_swap [o]=only_swap )
     local required
     local free

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -309,7 +309,7 @@ ynh_get_scalable_phpfpm () {
     fi
 
     # Get the total of RAM available, except swap.
-    local max_ram=$(ynh_check_ram --no_swap)
+    local max_ram=$(ynh_get_ram --total --ignore_swap)
 
     at_least_one() {
         # Do not allow value below 1

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -311,7 +311,7 @@ ynh_get_scalable_phpfpm () {
     # Get the total of RAM available, except swap.
     local max_ram=$(ynh_check_ram --no_swap)
 
-    less0() {
+    at_least_one() {
         # Do not allow value below 1
         if [ $1 -le 0 ]
         then
@@ -331,7 +331,7 @@ ynh_get_scalable_phpfpm () {
     then
         php_max_children=$(( $php_max_children / 2 ))
     fi
-    php_max_children=$(less0 $php_max_children)
+    php_max_children=$(at_least_one $php_max_children)
 
     # To not overload the proc, limit the number of children to 4 times the number of cores.
     local core_number=$(nproc)
@@ -345,13 +345,13 @@ ynh_get_scalable_phpfpm () {
     then
         # Define pm.start_servers, pm.min_spare_servers and pm.max_spare_servers for a dynamic process manager
         php_min_spare_servers=$(( $php_max_children / 8 ))
-        php_min_spare_servers=$(less0 $php_min_spare_servers)
+        php_min_spare_servers=$(at_least_one $php_min_spare_servers)
 
         php_max_spare_servers=$(( $php_max_children / 2 ))
-        php_max_spare_servers=$(less0 $php_max_spare_servers)
+        php_max_spare_servers=$(at_least_one $php_max_spare_servers)
 
         php_start_servers=$(( $php_min_spare_servers + ( $php_max_spare_servers - $php_min_spare_servers ) /2 ))
-        php_start_servers=$(less0 $php_start_servers)
+        php_start_servers=$(at_least_one $php_start_servers)
     else
         php_min_spare_servers=0
         php_max_spare_servers=0


### PR DESCRIPTION
Here's me being again obsessed with semantics ¯\\\_\(ツ)\_/¯

In particular proposing to:
- split `ynh_check_ram` into `ynh_get_ram` (to get RAM infos) and `ynh_require_ram` (which uses `ynh_get_ram` to check that a specific RAM info is larger than a requirement)
- make it explicit wether we're interested in the total amount of RAM, or the free amount of RAM ... both not to be mistaken with the "available" amount of RAM which to me is a third different info (c.f. `free -h`)
