### PR TITLE
[fix] uid will be tested as a string

### DIFF
--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -165,8 +165,8 @@ def user_create(operation_logger, username, firstname, lastname, mail, password,
     operation_logger.start()
 
     # Get random UID/GID
-    all_uid = {x.pw_uid for x in pwd.getpwall()}
-    all_gid = {x.gr_gid for x in grp.getgrall()}
+    all_uid = {str(x.pw_uid) for x in pwd.getpwall()}
+    all_gid = {str(x.gr_gid) for x in grp.getgrall()}
 
     uid_guid_found = False
     while not uid_guid_found:


### PR DESCRIPTION
## The problem

We randomly pick a uid for the new user and we test it this UID exist.

The problem is that the uid is a string and the list already existing uid and guid in which we test if it exists are stored in it thus the comparison will always fail.

## Solution

Transform everything into strings.

## PR Status

...

## How to test

Randomly create users to see that it won't be a problem if you really wants to.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
