### PR TITLE
[fix] custom_portal and custom_overlay redirect

### DIFF
--- a/data/templates/nginx/plain/yunohost_panel.conf.inc
+++ b/data/templates/nginx/plain/yunohost_panel.conf.inc
@@ -4,5 +4,5 @@ sub_filter_once on;
 # Apply to other mime types than text/html
 sub_filter_types application/xhtml+xml;
 # Prevent YunoHost panel files from being blocked by specific app rules
-location ~ (ynh_portal.js|ynh_overlay.css|ynh_userinfo.json) {
+location ~ (ynh_portal.js|ynh_overlay.css|ynh_userinfo.json|ynhtheme/custom_portal.js|ynhtheme/custom_overlay.css) {
 }


### PR DESCRIPTION
## The problem

https://github.com/YunoHost-Apps/gitlab_ynh/issues/105

After login, we are redirected on https://domain.tld/ynhtheme/custom_portal.js instead of https://domain.tld/

## Solution

Add `ynhtheme/custom_portal.js|ynhtheme/custom_overlay.css` inside the yunohost_panel.conf.inc file

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
