### PR TITLE
More min_spare_servers for heavy apps

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -355,6 +355,18 @@ ynh_get_scalable_phpfpm () {
         footprint=50
     fi
 
+    # Define the factor to determine min_spare_servers
+    # To not have not enough children ready to start for heavy apps.
+    if [ $footprint -le 20 ]
+    then
+        min_spare_servers_factor=8
+    elif [ $footprint -le 35 ]
+    then
+        min_spare_servers_factor=5
+    else
+        min_spare_servers_factor=3
+    fi
+
     # Define the way the process manager handle child processes.
     if [ "$usage" = "low" ]
     then
@@ -405,7 +417,7 @@ ynh_get_scalable_phpfpm () {
     if [ "$php_pm" = "dynamic" ]
     then
         # Define pm.start_servers, pm.min_spare_servers and pm.max_spare_servers for a dynamic process manager
-        php_min_spare_servers=$(( $php_max_children / 8 ))
+        php_min_spare_servers=$(( $php_max_children / $min_spare_servers_factor ))
         php_min_spare_servers=$(at_least_one $php_min_spare_servers)
 
         php_max_spare_servers=$(( $php_max_children / 2 ))

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -356,7 +356,7 @@ ynh_get_scalable_phpfpm () {
     fi
 
     # Define the factor to determine min_spare_servers
-    # To not have not enough children ready to start for heavy apps.
+    # to avoid having too few children ready to start for heavy apps
     if [ $footprint -le 20 ]
     then
         min_spare_servers_factor=8


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/official-app-nextcloud/9223/113

It appears that `max_children / 8` create not enough `min_spare_servers` for an heavy app like nextcloud to be reactive if not currently used.
At the same time, for an app like leed, with no `min_spare_servers` when idle, it start without any trouble.

## Solution

Divide by 8 for a low footprint. By 5 for a medium and 3 for a high footprint app.
That way, for heavy app, we keep more children running at any time to not slow down too much the app when solicitated.

## PR Status

Not tested, but not sure we really need to.
Can be reviewed.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 