### PR TITLE
Allow to overwrite pm.max_children

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -402,7 +402,7 @@ ynh_get_scalable_phpfpm () {
         php_max_children=$max_proc
     fi
 
-    # Get an potential forced value for php_max_children
+    # Get a potential forced value for php_max_children
     local php_forced_max_children=$(ynh_app_setting_get --app=$app --key=php_forced_max_children)
     if [ -n "$php_forced_max_children" ]; then
         php_max_children=$php_forced_max_children

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -402,6 +402,12 @@ ynh_get_scalable_phpfpm () {
         php_max_children=$max_proc
     fi
 
+    # Get an potential forced value for php_max_children
+    local php_forced_max_children=$(ynh_app_setting_get --app=$app --key=php_forced_max_children)
+    if [ -n "$php_forced_max_children" ]; then
+        php_max_children=$php_forced_max_children
+    fi
+
     if [ "$php_pm" = "dynamic" ]
     then
         # Define pm.start_servers, pm.min_spare_servers and pm.max_spare_servers for a dynamic process manager


### PR DESCRIPTION
## The problem

For some use case, an admin may want to force the limit for the number of max_children for php.
For example, an instance of nextcloud alone on a server with a big load.
The only way for now to do that is to overwrite the config file manually.

## Solution

Allow a config key `php_forced_max_children` into the settings.yml to overcome the limit.
This settings has as purpose to be included into a config_panel, along with other php paramaters.
I'll do it later, probably with nextcloud first.

## PR Status

Ready to be reviewed

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 