### PR TITLE
Improve systemd settings for slapd

### DIFF
--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -63,6 +63,9 @@ do_pre_regen() {
   cp -a ldap.conf slapd.conf "$ldap_dir"
   cp -a sudo.schema mailserver.schema yunohost.schema "$schema_dir"
 
+  mkdir -p ${pending_dir}/etc/systemd/system/slapd.service.d/
+  cp systemd-override.conf ${pending_dir}/etc/systemd/system/slapd.service.d/ynh-override.conf
+
   install -D -m 644 slapd.default "${pending_dir}/etc/default/slapd"
 }
 
@@ -82,6 +85,13 @@ do_post_regen() {
   chown -R root:ssl-cert /etc/yunohost/certs/yunohost.org/
   chmod o-rwx /etc/yunohost/certs/yunohost.org/
   chmod -R g+rx /etc/yunohost/certs/yunohost.org/
+
+  # If we changed the systemd ynh-override conf
+  if echo "$regen_conf_files" | sed 's/,/\n/g' | grep -q "^/etc/systemd/system/slapd.service.d/ynh-override.conf$"
+  then
+      systemctl daemon-reload
+      systemctl restart slapd
+  fi
 
   [ -z "$regen_conf_files" ] && exit 0
 

--- a/data/templates/slapd/systemd-override.conf
+++ b/data/templates/slapd/systemd-override.conf
@@ -1,0 +1,9 @@
+[Service]
+# Prevent slapd from getting killed by oom reaper as much as possible
+OOMScoreAdjust=-1000
+# If slapd exited (for instance if got killed) the service should not be
+# considered as active anymore...
+RemainAfterExit=no
+# Automatically restart the service if the service gets down
+Restart=always
+RestartSec=3


### PR DESCRIPTION
## The problem

As experience several times on our infra, slapd is likely to get killed by OOM reaper when system runs out of memory, which is catastrophic as it handles all auth requests except for root. So slapd killed = admin locked out (apart from ssh root@ on local network or direct access)

## Solution

- Add some overrides to the systemd configuration such that : 
- We adjust the OOM score to decrease the likelihood of slapd getting killed (this is in fact the case for other critical services like sshd, but for some reason not for slapd...)
- Even if slapd gets killed, it should automatically restart instead of being reported as "active (exited)" by systemd as if everything was fine. This is done with `RemainAfterExit=no` and `Restart=always`

## PR Status

Tested on my side and working

## How to test

- Pull the branch
- `cat /proc/$(pgrep slapd)/oom_score_adj` should show something like 0
- Run `yunohost tools regen-conf slapd`
- `cat /proc/$(pgrep slapd)/oom_score_adj` should show -1000
- Run `pkill slapd` then `systemctl status slapd` and you should see the service restarting in the next 3 secs

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
