### PR TITLE
Support all kind of systemd units

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2790,7 +2790,7 @@ def _assert_system_is_sane_for_app(manifest, when):
         services.append("fail2ban")
 
     # List services currently down and raise an exception if any are found
-    faulty_services = [s for s in services if service_status(s)["status"] != "running"]
+    faulty_services = [s for s in services if service_status(s)["status"] not in ["running", "active"]]
     if faulty_services:
         if when == "pre":
             raise YunohostError('app_action_cannot_be_ran_because_required_services_down',

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -150,7 +150,7 @@ def service_start(names):
         if _run_service_command('start', name):
             logger.success(m18n.n('service_started', service=name))
         else:
-            if service_status(name)['status'] != 'running':
+            if service_status(name)['status'] not in ['running', 'active']:
                 raise YunohostError('service_start_failed', service=name, logs=_get_journalctl_logs(name))
             logger.debug(m18n.n('service_already_started', service=name))
 
@@ -385,7 +385,11 @@ def _get_service_information_from_systemd(service):
 
     # c.f. https://zignar.net/2014/09/08/getting-started-with-dbus-python-systemd/
     # Very interface, much intuitive, wow
-    service_unit = manager.LoadUnit(service + '.service')
+    service_name, service_extension = os.path.splitext(service)
+    service_extensions = ['.socket', '.device', '.mount', '.automount', '.swap', '.target', '.path', '.timer', '.slice', '.scope']
+    if service_extension not in service_extensions:
+        service = service + '.service'
+    service_unit = manager.LoadUnit(service)
     service_proxy = d.get_object('org.freedesktop.systemd1', str(service_unit))
     properties_interface = dbus.Interface(service_proxy, 'org.freedesktop.DBus.Properties')
 


### PR DESCRIPTION
## The problem

Impossible to add systemd units of other types than services in the installation of app.

This is due to the fact yunohost appends unit name with '.service' all the time.

I wanted this change because in [this pr for diaspora](https://github.com/YunoHost-Apps/diaspora_ynh/pull/2) I want to add only the `.target` unit file to yunohost services, and not the 2 or 3 systemd services for diaspora. And then I thought it'd be cool to be able to track all sort of units (mounts could be useful for instance).

Fixes https://github.com/YunoHost/issues/issues/1519

## Solution

Make yunohost behaves like systemd: only append .service if the unit name does not end with a possible unit suffix.

As only service units can be "running", we need to test for both "running" and "active" to consider a unit to be in the successful state. Therefore, some changes are needed in yunohost-admin too (I'm opening a PR soon). 

## PR Status

I tested on my instance, needs a PR in yunohost-admin too.

## How to test

use `sudo yunohost service add` on a socket or device unit for instance (find all the units with `systemctl list-units`)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
