### PR TITLE
Wait for fail2ban to reload

### DIFF
--- a/data/helpers.d/fail2ban
+++ b/data/helpers.d/fail2ban
@@ -130,7 +130,7 @@ EOF
   ynh_store_file_checksum "$finalfail2banjailconf"
   ynh_store_file_checksum "$finalfail2banfilterconf"
 
-  ynh_systemd_action --service_name=fail2ban --action=reload
+  ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 
   local fail2ban_error="$(journalctl -u fail2ban | tail -n50 | grep "WARNING.*$app.*")"
   if [[ -n "$fail2ban_error" ]]; then

--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -133,7 +133,7 @@ ynh_systemd_action() {
         for i in $(seq 1 $timeout)
         do
             # Read the log until the sentence is found, that means the app finished to start. Or run until the timeout
-            if grep --quiet "$line_match" "$templog"
+            if grep --extended-regexp --quiet "$line_match" "$templog"
             then
                 ynh_print_info --message="The service $service_name has correctly executed the action ${action}."
                 break


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/echec-installation-wordpress-yunohost-sur-raspberry-pi-3/10987/19
We often see fail2ban failing to reload or to restart.
That is because, if fail2ban have too many IP banned, it will need a long time to reload. So if we ask fail2ban to reload to many times, it may not have fully reload yet when we ask it to reload again. And so the service appears as inactive, because not fully started nor stopped.

## Solution

As for many other services, wait for the service to be ready.

## PR Status

Tested.
Can be reviewed.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 