### PR TITLE
YNH_DEFAULT_PHP_VERSION is now readonly

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-YNH_DEFAULT_PHP_VERSION=7.0
+readonly YNH_DEFAULT_PHP_VERSION=7.0
 # Declare the actual php version to use.
 # A packager willing to use another version of php can override the variable into its _common.sh.
 YNH_PHP_VERSION=${YNH_PHP_VERSION:-$YNH_DEFAULT_PHP_VERSION}


### PR DESCRIPTION
## The problem

An app could override this variable. 

## Solution

Set `YNH_DEFAULT_PHP_VERSION` to read-only. Not tested, however. Should I do it?

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
