### PR TITLE
Fix getopts with empty parameters

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -147,26 +147,30 @@ ynh_handle_getopts_args () {
 									break
 								fi
 							else
-								# Else, add this value to this option
-								# Each value will be separated by ';'
-								if [ -n "${!option_var}" ]
-								then
-									# If there's already another value for this option, add a ; before adding the new value
-									eval ${option_var}+="\;"
-								fi
+                                # Ignore empty parameters
+                                if [ -n "${all_args[$i]}" ]
+                                then
+                                    # Else, add this value to this option
+                                    # Each value will be separated by ';'
+                                    if [ -n "${!option_var}" ]
+                                    then
+                                        # If there's already another value for this option, add a ; before adding the new value
+                                        eval ${option_var}+="\;"
+                                    fi
 
-								# Remove the \ that escape - at beginning of values.
-								all_args[i]="${all_args[i]//\\TOBEREMOVED\\/}"
+                                    # Remove the \ that escape - at beginning of values.
+                                    all_args[i]="${all_args[i]//\\TOBEREMOVED\\/}"
 
-								# For the record.
-								# We're using eval here to get the content of the variable stored itself as simple text in $option_var...
-								# Other ways to get that content would be to use either ${!option_var} or declare -g ${option_var}
-								# But... ${!option_var} can't be used as left part of an assignation.
-								# declare -g ${option_var} will create a local variable (despite -g !) and will not be available for the helper itself.
-								# So... Stop fucking arguing each time that eval is evil... Go find an other working solution if you can find one!
+                                    # For the record.
+                                    # We're using eval here to get the content of the variable stored itself as simple text in $option_var...
+                                    # Other ways to get that content would be to use either ${!option_var} or declare -g ${option_var}
+                                    # But... ${!option_var} can't be used as left part of an assignation.
+                                    # declare -g ${option_var} will create a local variable (despite -g !) and will not be available for the helper itself.
+                                    # So... Stop fucking arguing each time that eval is evil... Go find an other working solution if you can find one!
 
-								eval ${option_var}+='"${all_args[$i]}"'
-								shift_value=$(( shift_value + 1 ))
+                                    eval ${option_var}+='"${all_args[$i]}"'
+                                fi
+                                shift_value=$(( shift_value + 1 ))
 							fi
 						done
 					fi


### PR DESCRIPTION
## The problem

Getopts "bugs" if you do something like `my_helper --param1="value1" `
Notice the trailing space at the end.
This will be interpreted as a another value for the first parameter. So you will have `param1="value1;"`
Not a big problem, but it can be, and actually it may fail apt with a "php7.0;-fpm"

## Solution

To not add a trailing space is an obvious solution, but not enough in case of optional parameter added by a script.
So, ignore empty parameters.

## PR Status

Tested and working as expected.
Should be merge as soon as possible as it breaks the current php helpers with nextcloud.

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 

@YunoHost/apps 