### PR TITLE
Fix postfix ciphers

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -33,14 +33,20 @@ smtpd_tls_cert_file = /etc/yunohost/certs/{{ main_domain }}/crt.pem
 smtpd_tls_key_file = /etc/yunohost/certs/{{ main_domain }}/key.pem
 smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
 smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
-smtpd_tls_mandatory_ciphers = medium
+# smtpd_tls_mandatory_ciphers = medium # (c.f. below)
 
 # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam.pem
 # not actually 1024 bits, this applies to all DHE >= 1024 bits
 # smtpd_tls_dh1024_param_file = /path/to/dhparam.pem
 
-tls_medium_cipherlist = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
+# This custom medium cipherlist recommendation only works if we have a DH ... which we don't, c.f. https://github.com/YunoHost/issues/issues/93
+# On the other hand, the postfix doc strongly discourage tweaking this list ... So whatever, let's keep the mandatory_ciphers to high like we did before applying the Mozilla recommendation ...
+#tls_medium_cipherlist = ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
 tls_preempt_cipherlist = no
+
+# Custom Yunohost stuff ... because we can't use the recommendation about medium cipher list ...
+smtpd_tls_mandatory_ciphers=high
+smtpd_tls_eecdh_grade = ultra
 ###############################################################################
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
 smtpd_tls_loglevel=1


### PR DESCRIPTION
## The problem

Previous change in postfix ciphers actually broke the entire TLS stuff ... 

```
$ grep "TLS library problem" mail.warn
 warning: TLS library problem: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:../ssl/record/rec_layer_s3.c:1407:SSL alert number 40:
```

(you gotta send emails to other servers to reproduce this)

which results in TLS handshake failing, and servers falling back to plaintext as far as I understand. 

I was able to pinpoint the issue to the custom cipher list ... I believe they assume that a DH parameter is available, which isn't the case until we fix https://github.com/YunoHost/issues/issues/93 ... (which could in fact being solved by running a 1-minute cronjob once but anyway...)

Digging [postfix's doc](http://www.postfix.org/postconf.5.html#tls_medium_cipherlist), in fact : 

>You are strongly encouraged to not change this setting. 

## Solution

Let's fall back to the previous setting which was 

```
smtpd_tls_mandatory_ciphers=high
smtpd_tls_eecdh_grade = ultra
```

and does work ... It looks legit to me, but I'm no security expert...

## PR Status

Tested and works for me 

## How to test

Send email to other servers with/without the fix, and observe warnings about TLS handshake in mail.warn

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
