### PR TITLE
Fix acme snippet detection

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -110,7 +110,7 @@
     "backup_unable_to_organize_files": "Could not use the quick method to organize files in the archive",
     "backup_with_no_backup_script_for_app": "The app '{app:s}' has no backup script. Ignoring.",
     "backup_with_no_restore_script_for_app": "The '{app:s}' has no restoration script, you will not be able to automatically restore the backup of this app.",
-    "certmanager_acme_not_configured_for_domain": "Certificate for the domain '{domain:s}' does not appear to be correctly installed. Please run 'cert-install' for this domain first.",
+    "certmanager_acme_not_configured_for_domain": "The ACME challenge cannot be ran for this domain right now because you are missing a code snippet in nginx conf... Please make sure that your nginx configuration is up to date using `yunohost tools regen-conf nginx --dry-run --with-diff`.",
     "certmanager_attempt_to_renew_nonLE_cert": "The certificate for the domain '{domain:s}' is not issued by Let's Encrypt. Cannot renew it automatically!",
     "certmanager_attempt_to_renew_valid_cert": "The certificate for the domain '{domain:s}' is not about to expire! (You may use --force if you know what you're doing)",
     "certmanager_attempt_to_replace_valid_cert": "You are attempting to overwrite a good and valid certificate for domain {domain:s}! (Use --force to bypass)",

--- a/locales/en.json
+++ b/locales/en.json
@@ -110,7 +110,7 @@
     "backup_unable_to_organize_files": "Could not use the quick method to organize files in the archive",
     "backup_with_no_backup_script_for_app": "The app '{app:s}' has no backup script. Ignoring.",
     "backup_with_no_restore_script_for_app": "The '{app:s}' has no restoration script, you will not be able to automatically restore the backup of this app.",
-    "certmanager_acme_not_configured_for_domain": "The ACME challenge cannot be ran for this domain right now because you are missing a code snippet in nginx conf... Please make sure that your nginx configuration is up to date using `yunohost tools regen-conf nginx --dry-run --with-diff`.",
+    "certmanager_acme_not_configured_for_domain": "The ACME challenge cannot be ran for {domain} right now because its nginx conf lacks the corresponding code snippet... Please make sure that your nginx configuration is up to date using `yunohost tools regen-conf nginx --dry-run --with-diff`.",
     "certmanager_attempt_to_renew_nonLE_cert": "The certificate for the domain '{domain:s}' is not issued by Let's Encrypt. Cannot renew it automatically!",
     "certmanager_attempt_to_renew_valid_cert": "The certificate for the domain '{domain:s}' is not about to expire! (You may use --force if you know what you're doing)",
     "certmanager_attempt_to_replace_valid_cert": "You are attempting to overwrite a good and valid certificate for domain {domain:s}! (Use --force to bypass)",

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -34,16 +34,14 @@ import glob
 
 from datetime import datetime
 
-from yunohost.vendor.acme_tiny.acme_tiny import get_crt as sign_certificate
-
-from yunohost.utils.error import YunohostError
+from moulinette import m18n
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import read_file
 
+from yunohost.vendor.acme_tiny.acme_tiny import get_crt as sign_certificate
+from yunohost.utils.error import YunohostError
 from yunohost.utils.network import get_public_ip
 
-from moulinette import m18n
-from yunohost.app import app_ssowatconf
 from yunohost.service import _run_service_command
 from yunohost.regenconf import regen_conf
 from yunohost.log import OperationLogger
@@ -597,7 +595,7 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     from yunohost.domain import _get_maindomain
     if domain == _get_maindomain():
         # Include xmpp-upload subdomain in subject alternate names
-        subdomain="xmpp-upload." + domain
+        subdomain = "xmpp-upload." + domain
         try:
             _dns_ip_match_public_ip(get_public_ip(), subdomain)
             csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])


### PR DESCRIPTION
## The problem

Follow up of https://github.com/YunoHost/yunohost/pull/917 ... Did not realize we had this check that explicitly depends on the name of the old legacy file ... But now that it changed, renew is gonna be broken and we gotta fix it.

## Solution

Fix the code to detect the new code snippet is there... + update error message accordingly

## PR Status

Tested and working on my side

## How to test

```
$ yunohost tools shell
> from yunohost.certificate import _check_acme_challenge_configuration
> _check_acme_challenge_configuration("your.test.domain.tld")

-> without the fix, probably False
-> with the fix : True (if your nginx conf is up to date)
```
## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
