### PR TITLE
[wip] YunoHost "as a python lib" ? Move moulinette initialization and other stuff to src/yunohost/__init__.py

### DIFF
--- a/bin/yunohost
+++ b/bin/yunohost
@@ -4,34 +4,29 @@
 import os
 import sys
 import argparse
-import glob
 
-import moulinette
+sys.path.insert(0, "/usr/lib/moulinette/")
+import yunohost
 
-# Directory and file to be used by logging
-LOG_DIR = '/var/log/yunohost'
-LOG_FILE = 'yunohost-cli.log'
-
-# Initialization & helpers functions -----------------------------------
 
 def _parse_cli_args():
     """Parse additional arguments for the cli"""
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--output-as',
         choices=['json', 'plain', 'none'], default=None,
-        help="Output result in another format",
+        help="Output result in another format"
     )
     parser.add_argument('--debug',
         action='store_true', default=False,
-        help="Log and print debug messages",
+        help="Log and print debug messages"
     )
     parser.add_argument('--quiet',
         action='store_true', default=False,
-        help="Don't produce any output",
+        help="Don't produce any output"
     )
     parser.add_argument('--timeout',
         type=int, default=None,
-        help="Number of seconds before this command will timeout because it can't acquire the lock (meaning that another command is currently running), by default there is no timeout and the command will wait until it can get the lock",
+        help="Number of seconds before this command will timeout because it can't acquire the lock (meaning that another command is currently running), by default there is no timeout and the command will wait until it can get the lock"
     )
     # deprecated arguments
     parser.add_argument('--plain',
@@ -52,101 +47,20 @@ def _parse_cli_args():
     return (parser, opts, args)
 
 
-def init(debug=False, quiet=False, logfile='%s/%s' % (LOG_DIR, LOG_FILE)):
-
-    logdir = os.path.dirname(logfile)
-    if not os.path.isdir(logdir):
-        os.makedirs(logdir, 0750)
-
-    moulinette.init(logging_config={
-        'version': 1,
-        'disable_existing_loggers': True,
-        'formatters': {
-            'tty-debug': {
-                'format': '%(relativeCreated)-4d %(fmessage)s'
-            },
-            'precise': {
-                'format': '%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
-            },
-        },
-        'filters': {
-            'action': {
-                '()': 'moulinette.utils.log.ActionFilter',
-            },
-        },
-        'handlers': {
-            'tty': {
-                'level': 'DEBUG' if debug else 'INFO',
-                'class': 'moulinette.interfaces.cli.TTYHandler',
-                'formatter': 'tty-debug' if debug else '',
-            },
-            'file': {
-                'class': 'logging.FileHandler',
-                'formatter': 'precise',
-                'filename': logfile,
-                'filters': ['action'],
-            },
-        },
-        'loggers': {
-            'yunohost': {
-                'level': 'DEBUG',
-                'handlers': ['file', 'tty'] if not quiet else ['file'],
-                'propagate': False,
-            },
-            'moulinette': {
-                'level': 'DEBUG',
-                'handlers': [],
-                'propagate': True,
-            },
-            'moulinette.interface': {
-                'level': 'DEBUG',
-                'handlers': ['file', 'tty'] if not quiet else ['file'],
-                'propagate': False,
-            },
-        },
-        'root': {
-            'level': 'DEBUG',
-            'handlers': ['file', 'tty'] if debug else ['file'],
-        },
-    })
-
-
-# Main action ----------------------------------------------------------
-
 if __name__ == '__main__':
     if os.geteuid() != 0:
-        # since moulinette isn't initialized, we can't use m18n here
         sys.stderr.write("\033[1;31mError:\033[0m yunohost command must be "
                          "run as root or with sudo.\n")
         sys.exit(1)
 
     parser, opts, args = _parse_cli_args()
-    init(debug=opts.debug, quiet=opts.quiet)
-
-    # Check that YunoHost is installed
-    allowed_if_not_installed = ['tools postinstall', 'backup restore', 'log display']
-    if not os.path.isfile('/etc/yunohost/installed') and \
-       (len(args) < 2 or (args[0] + ' ' + args[1] not in allowed_if_not_installed)):
-
-        from moulinette import m18n
-        from moulinette.interfaces.cli import colorize, get_locale
-
-        # Init i18n
-        m18n.load_namespace('yunohost')
-        m18n.set_locale(get_locale())
-
-        # Print error and exit
-        print(colorize(m18n.g('error'), 'red') + " " + m18n.n('yunohost_not_installed'))
-        sys.exit(1)
-
-    extensions = [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
 
     # Execute the action
-    ret = moulinette.cli(
-        ['yunohost'] + extensions,
-        args,
+    yunohost.cli(
+        debug=opts.debug,
+        quiet=opts.quiet,
         output_as=opts.output_as,
         timeout=opts.timeout,
-        parser_kwargs={'top_parser': parser},
+        args=args,
+        parser=parser
     )
-    sys.exit(ret)

--- a/bin/yunohost
+++ b/bin/yunohost
@@ -4,9 +4,9 @@
 import os
 import sys
 import argparse
+import glob
 
 import moulinette
-from moulinette.actionsmap import ActionsMap
 from moulinette.interfaces.cli import colorize, get_locale
 
 # Directory and file to be used by logging
@@ -117,13 +117,6 @@ def _init_moulinette(debug=False, quiet=False):
     # Initialize moulinette
     moulinette.init(logging_config=logging)
 
-
-def _retrieve_namespaces():
-    """Return the list of namespaces to load"""
-    extensions = [n for n in ActionsMap.get_namespaces() if n.startswith('ynh_')]
-    return ['yunohost'] + extensions
-
-
 # Main action ----------------------------------------------------------
 
 if __name__ == '__main__':
@@ -150,9 +143,11 @@ if __name__ == '__main__':
         print(colorize(m18n.g('error'), 'red') + " " + m18n.n('yunohost_not_installed'))
         sys.exit(1)
 
+    extensions = [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
+
     # Execute the action
     ret = moulinette.cli(
-        _retrieve_namespaces(),
+        ['yunohost'] + extensions,
         args,
         output_as=opts.output_as,
         timeout=opts.timeout,

--- a/bin/yunohost
+++ b/bin/yunohost
@@ -7,18 +7,12 @@ import argparse
 import glob
 
 import moulinette
-from moulinette.interfaces.cli import colorize, get_locale
 
 # Directory and file to be used by logging
 LOG_DIR = '/var/log/yunohost'
 LOG_FILE = 'yunohost-cli.log'
 
-# Create log directory
-if not os.path.isdir(LOG_DIR):
-    os.makedirs(LOG_DIR, 0750)
-
 # Initialization & helpers functions -----------------------------------
-
 
 def _parse_cli_args():
     """Parse additional arguments for the cli"""
@@ -58,11 +52,13 @@ def _parse_cli_args():
     return (parser, opts, args)
 
 
-def _init_moulinette(debug=False, quiet=False):
-    """Configure logging and initialize the moulinette"""
+def init(debug=False, quiet=False, logfile='%s/%s' % (LOG_DIR, LOG_FILE)):
 
-    # Custom logging configuration
-    logging = {
+    logdir = os.path.dirname(logfile)
+    if not os.path.isdir(logdir):
+        os.makedirs(logdir, 0750)
+
+    moulinette.init(logging_config={
         'version': 1,
         'disable_existing_loggers': True,
         'formatters': {
@@ -87,7 +83,7 @@ def _init_moulinette(debug=False, quiet=False):
             'file': {
                 'class': 'logging.FileHandler',
                 'formatter': 'precise',
-                'filename': '%s/%s' % (LOG_DIR, LOG_FILE),
+                'filename': logfile,
                 'filters': ['action'],
             },
         },
@@ -112,10 +108,8 @@ def _init_moulinette(debug=False, quiet=False):
             'level': 'DEBUG',
             'handlers': ['file', 'tty'] if debug else ['file'],
         },
-    }
+    })
 
-    # Initialize moulinette
-    moulinette.init(logging_config=logging)
 
 # Main action ----------------------------------------------------------
 
@@ -127,7 +121,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     parser, opts, args = _parse_cli_args()
-    _init_moulinette(opts.debug, opts.quiet)
+    init(debug=opts.debug, quiet=opts.quiet)
 
     # Check that YunoHost is installed
     allowed_if_not_installed = ['tools postinstall', 'backup restore', 'log display']
@@ -135,6 +129,8 @@ if __name__ == '__main__':
        (len(args) < 2 or (args[0] + ' ' + args[1] not in allowed_if_not_installed)):
 
         from moulinette import m18n
+        from moulinette.interfaces.cli import colorize, get_locale
+
         # Init i18n
         m18n.load_namespace('yunohost')
         m18n.set_locale(get_locale())

--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -16,10 +16,6 @@ DEFAULT_PORT = 6787
 LOG_DIR = '/var/log/yunohost'
 LOG_FILE = 'yunohost-api.log'
 
-# Create log directory
-if not os.path.isdir(LOG_DIR):
-    os.makedirs(LOG_DIR, 0750)
-
 # Initialization & helpers functions -----------------------------------
 
 
@@ -49,11 +45,13 @@ def _parse_api_args():
     return parser.parse_args()
 
 
-def _init_moulinette(debug=False):
-    """Configure logging and initialize the moulinette"""
+def init_api(debug=False, logfile='%s/%s' % (LOG_DIR, LOG_FILE)):
 
-    # Custom logging configuration
-    logging = {
+    logdir = os.path.dirname(logfile)
+    if not os.path.isdir(logdir):
+        os.makedirs(logdir, 0750)
+
+    moulinette.init(logging_config={
         'version': 1,
         'disable_existing_loggers': True,
         'formatters': {
@@ -77,7 +75,7 @@ def _init_moulinette(debug=False):
             'file': {
                 'class': 'logging.handlers.WatchedFileHandler',
                 'formatter': 'precise',
-                'filename': '%s/%s' % (LOG_DIR, LOG_FILE),
+                'filename': logfile,
                 'filters': ['action'],
             },
             'console': {
@@ -103,10 +101,7 @@ def _init_moulinette(debug=False):
             'level': 'DEBUG',
             'handlers': ['file'] + ['console'] if debug else [],
         },
-    }
-
-    # Initialize moulinette
-    moulinette.init(logging_config=logging)
+    })
 
 # Callbacks for additional routes --------------------------------------
 
@@ -120,7 +115,7 @@ def is_installed():
 
 if __name__ == '__main__':
     opts = _parse_api_args()
-    _init_moulinette(opts.debug)
+    init_api(opts.debug)
 
     extensions = [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
 

--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -1,22 +1,15 @@
 #! /usr/bin/python
 # -*- coding: utf-8 -*-
 
-import os
 import sys
 import argparse
-import glob
 
-import moulinette
+sys.path.insert(0, "/usr/lib/moulinette/")
+import yunohost
 
 # Default server configuration
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 6787
-
-# Directory and file to be used by logging
-LOG_DIR = '/var/log/yunohost'
-LOG_FILE = 'yunohost-api.log'
-
-# Initialization & helpers functions -----------------------------------
 
 
 def _parse_api_args():
@@ -45,86 +38,7 @@ def _parse_api_args():
     return parser.parse_args()
 
 
-def init_api(debug=False, logfile='%s/%s' % (LOG_DIR, LOG_FILE)):
-
-    logdir = os.path.dirname(logfile)
-    if not os.path.isdir(logdir):
-        os.makedirs(logdir, 0750)
-
-    moulinette.init(logging_config={
-        'version': 1,
-        'disable_existing_loggers': True,
-        'formatters': {
-            'console': {
-                'format': '%(relativeCreated)-5d %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
-            },
-            'precise': {
-                'format': '%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
-            },
-        },
-        'filters': {
-            'action': {
-                '()': 'moulinette.utils.log.ActionFilter',
-            },
-        },
-        'handlers': {
-            'api': {
-                'level': 'DEBUG' if debug else 'INFO',
-                'class': 'moulinette.interfaces.api.APIQueueHandler',
-            },
-            'file': {
-                'class': 'logging.handlers.WatchedFileHandler',
-                'formatter': 'precise',
-                'filename': logfile,
-                'filters': ['action'],
-            },
-            'console': {
-                'class': 'logging.StreamHandler',
-                'formatter': 'console',
-                'stream': 'ext://sys.stdout',
-                'filters': ['action'],
-            },
-        },
-        'loggers': {
-            'yunohost': {
-                'level': 'DEBUG',
-                'handlers': ['file', 'api'] + ['console'] if debug else [],
-                'propagate': False,
-            },
-            'moulinette': {
-                'level': 'DEBUG',
-                'handlers': [],
-                'propagate': True,
-            },
-        },
-        'root': {
-            'level': 'DEBUG',
-            'handlers': ['file'] + ['console'] if debug else [],
-        },
-    })
-
-# Callbacks for additional routes --------------------------------------
-
-
-def is_installed():
-    """ Check whether YunoHost is installed or not """
-    return {'installed': os.path.isfile('/etc/yunohost/installed')}
-
-
-# Main action ----------------------------------------------------------
-
 if __name__ == '__main__':
     opts = _parse_api_args()
-    init_api(opts.debug)
-
-    extensions = [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
-
     # Run the server
-    ret = moulinette.api(
-        ['yunohost'] + extensions,
-        host=opts.host,
-        port=opts.port,
-        routes={('GET', '/installed'): is_installed},
-        use_websocket=True
-    )
-    sys.exit(ret)
+    yunohost.api(debug=opts.debug, host=opts.host, port=opts.port)

--- a/bin/yunohost-api
+++ b/bin/yunohost-api
@@ -4,10 +4,9 @@
 import os
 import sys
 import argparse
+import glob
 
 import moulinette
-from moulinette.actionsmap import ActionsMap
-from moulinette.interfaces.cli import colorize
 
 # Default server configuration
 DEFAULT_HOST = 'localhost'
@@ -22,6 +21,7 @@ if not os.path.isdir(LOG_DIR):
     os.makedirs(LOG_DIR, 0750)
 
 # Initialization & helpers functions -----------------------------------
+
 
 def _parse_api_args():
     """Parse main arguments for the api"""
@@ -47,6 +47,7 @@ def _parse_api_args():
     )
 
     return parser.parse_args()
+
 
 def _init_moulinette(debug=False):
     """Configure logging and initialize the moulinette"""
@@ -107,31 +108,28 @@ def _init_moulinette(debug=False):
     # Initialize moulinette
     moulinette.init(logging_config=logging)
 
-def _retrieve_namespaces():
-    """Return the list of namespaces to load"""
-    extensions = [n for n in ActionsMap.get_namespaces() if n.startswith('ynh_')]
-    return ['yunohost'] + extensions
-
-
 # Callbacks for additional routes --------------------------------------
+
 
 def is_installed():
     """ Check whether YunoHost is installed or not """
-    return { 'installed': os.path.isfile('/etc/yunohost/installed') }
+    return {'installed': os.path.isfile('/etc/yunohost/installed')}
 
 
 # Main action ----------------------------------------------------------
 
 if __name__ == '__main__':
     opts = _parse_api_args()
-    _init_moulinette(opts.use_websocket, opts.debug, opts.verbose)
+    _init_moulinette(opts.debug)
+
+    extensions = [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
 
     # Run the server
     ret = moulinette.api(
-        _retrieve_namespaces(),
+        ['yunohost'] + extensions,
         host=opts.host,
         port=opts.port,
-        routes={ ('GET', '/installed'): is_installed, },
+        routes={('GET', '/installed'): is_installed},
         use_websocket=True
     )
     sys.exit(ret)

--- a/src/yunohost/__init__.py
+++ b/src/yunohost/__init__.py
@@ -6,8 +6,9 @@ import sys
 import glob
 
 import moulinette
+from moulinette import m18n
 from moulinette.utils.log import configure_logging
-
+from moulinette.interfaces.cli import colorize, get_locale
 
 def is_installed():
     return os.path.isfile('/etc/yunohost/installed')
@@ -66,18 +67,16 @@ def check_command_is_valid_before_postinstall(args):
                                     'log display']
 
     if (len(args) < 2 or (args[0] + ' ' + args[1] not in allowed_if_not_postinstalled)):
-
-        # This function is called before m18n is initialized, so we only initialized
-        # the specific bit to be able to call m18n.n/g()...
-        from moulinette import m18n
-        from moulinette.interfaces.cli import colorize, get_locale
-
-        # Init i18n
-        m18n.load_namespace('yunohost')
-        m18n.set_locale(get_locale())
-
+        init_i18n()
         print(colorize(m18n.g('error'), 'red') + " " + m18n.n('yunohost_not_installed'))
         sys.exit(1)
+
+
+def init_i18n():
+    # This should only be called when not willing to go through moulinette.cli
+    # or moulinette.api but still willing to call m18n.n/g...
+    m18n.load_namespace('yunohost')
+    m18n.set_locale(get_locale())
 
 
 def init_logging(interface="cli",

--- a/src/yunohost/__init__.py
+++ b/src/yunohost/__init__.py
@@ -1,0 +1,202 @@
+#! /usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import glob
+
+import moulinette
+from moulinette.utils.log import configure_logging
+
+
+def is_installed():
+    return os.path.isfile('/etc/yunohost/installed')
+
+
+def cli(debug, quiet, output_as, timeout, args, parser):
+
+    init_logging(interface="cli", debug=debug, quiet=quiet)
+
+    # Check that YunoHost is installed
+    if not is_installed():
+        check_command_is_valid_before_postinstall(args)
+
+    ret = moulinette.cli(
+        ['yunohost'] + extensions(),
+        args,
+        output_as=output_as,
+        timeout=timeout,
+        parser_kwargs={'top_parser': parser},
+    )
+    sys.exit(ret)
+
+
+def api(debug, host, port):
+
+    init_logging(debug=debug)
+
+    def is_installed_api():
+        return {'installed': is_installed()}
+
+    # FIXME : someday, maybe find a way to disable route /postinstall if
+    # postinstall already done ...
+
+    ret = moulinette.api(
+        ['yunohost'] + extensions(),
+        host=host,
+        port=port,
+        routes={('GET', '/installed'): is_installed_api},
+        use_websocket=True
+    )
+    sys.exit(ret)
+
+
+def extensions():
+    # This is probably not used anywhere, but the actionsmap and code can be
+    # extended by creating such files that contain bits of actionmap...
+    return [f.split('/')[-1][:-4] for f in glob.glob("/usr/share/moulinette/actionsmap/ynh_*.yml")]
+
+
+def check_command_is_valid_before_postinstall(args):
+
+    allowed_if_not_postinstalled = ['tools postinstall',
+                                    'tools versions',
+                                    'backup list',
+                                    'backup restore',
+                                    'log display']
+
+    if (len(args) < 2 or (args[0] + ' ' + args[1] not in allowed_if_not_postinstalled)):
+
+        # This function is called before m18n is initialized, so we only initialized
+        # the specific bit to be able to call m18n.n/g()...
+        from moulinette import m18n
+        from moulinette.interfaces.cli import colorize, get_locale
+
+        # Init i18n
+        m18n.load_namespace('yunohost')
+        m18n.set_locale(get_locale())
+
+        print(colorize(m18n.g('error'), 'red') + " " + m18n.n('yunohost_not_installed'))
+        sys.exit(1)
+
+
+def init_logging(interface="cli",
+                 debug=False,
+                 quiet=False,
+                 logdir="/var/log/yunohost"):
+
+    logfile = os.path.join(logdir, "yunohost-%s.log" % interface)
+
+    if not os.path.isdir(logdir):
+        os.makedirs(logdir, 0750)
+
+    # ####################################################################### #
+    #  Logging configuration for CLI (or any other interface than api...)     #
+    # ####################################################################### #
+    if interface != "api":
+        configure_logging({
+            'version': 1,
+            'disable_existing_loggers': True,
+            'formatters': {
+                'tty-debug': {
+                    'format': '%(relativeCreated)-4d %(fmessage)s'
+                },
+                'precise': {
+                    'format': '%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
+                },
+            },
+            'filters': {
+                'action': {
+                    '()': 'moulinette.utils.log.ActionFilter',
+                },
+            },
+            'handlers': {
+                'tty': {
+                    'level': 'DEBUG' if debug else 'INFO',
+                    'class': 'moulinette.interfaces.cli.TTYHandler',
+                    'formatter': 'tty-debug' if debug else '',
+                },
+                'file': {
+                    'class': 'logging.FileHandler',
+                    'formatter': 'precise',
+                    'filename': logfile,
+                    'filters': ['action'],
+                },
+            },
+            'loggers': {
+                'yunohost': {
+                    'level': 'DEBUG',
+                    'handlers': ['file', 'tty'] if not quiet else ['file'],
+                    'propagate': False,
+                },
+                'moulinette': {
+                    'level': 'DEBUG',
+                    'handlers': [],
+                    'propagate': True,
+                },
+                'moulinette.interface': {
+                    'level': 'DEBUG',
+                    'handlers': ['file', 'tty'] if not quiet else ['file'],
+                    'propagate': False,
+                },
+            },
+            'root': {
+                'level': 'DEBUG',
+                'handlers': ['file', 'tty'] if debug else ['file'],
+            },
+        })
+    # ####################################################################### #
+    #  Logging configuration for API                                          #
+    # ####################################################################### #
+    else:
+        configure_logging({
+            'version': 1,
+            'disable_existing_loggers': True,
+            'formatters': {
+                'console': {
+                    'format': '%(relativeCreated)-5d %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
+                },
+                'precise': {
+                    'format': '%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(fmessage)s'
+                },
+            },
+            'filters': {
+                'action': {
+                    '()': 'moulinette.utils.log.ActionFilter',
+                },
+            },
+            'handlers': {
+                'api': {
+                    'level': 'DEBUG' if debug else 'INFO',
+                    'class': 'moulinette.interfaces.api.APIQueueHandler',
+                },
+                'file': {
+                    'class': 'logging.handlers.WatchedFileHandler',
+                    'formatter': 'precise',
+                    'filename': logfile,
+                    'filters': ['action'],
+                },
+                'console': {
+                    'class': 'logging.StreamHandler',
+                    'formatter': 'console',
+                    'stream': 'ext://sys.stdout',
+                    'filters': ['action'],
+                },
+            },
+            'loggers': {
+                'yunohost': {
+                    'level': 'DEBUG',
+                    'handlers': ['file', 'api'] + ['console'] if debug else [],
+                    'propagate': False,
+                },
+                'moulinette': {
+                    'level': 'DEBUG',
+                    'handlers': [],
+                    'propagate': True,
+                },
+            },
+            'root': {
+                'level': 'DEBUG',
+                'handlers': ['file'] + ['console'] if debug else [],
+            },
+        })


### PR DESCRIPTION
## The problem

Continuation of https://github.com/YunoHost/yunohost/pull/922 to : 
- try to clean the mess happening in bin/yunohost and bin/yunohost-api
- have a way for people to easily write scripts that call yunohost functions (well i don't even know if that's a good idea in terms of avoiding people to break their own server...)

## Solution

Factorize some stuff into src/yunohost/__init__.py ...hopefully improving the readability of bin/yunohost and bin/yunohost-api ... (well that huge wall of json to configure logging is still a pain but can't easily be simplified...)

Regarding the possibility to write scripts, for now it looks something like : 

```python
import sys
sys.path.insert(0, "/usr/lib/moulinette/")
import yunohost
yunohost.init_logging() # possibly set debug=True if needed, but when writing script supposedly you ain't debugging yunohost itself, and full log is still available in yunohost-cli.log and yunohost log list...
yunohost.init_i18n()

from yunohost.user import user_create

user_create(username="foo", ...)

```

## PR Status

WIP but sortof working

## How to test

Run the yunohost command with various options, same for yunohost-api ... Also test the case where /etc/yunohost/installed doesnt exist yet...

And test to manually import and run yunohost functions...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
