### PR TITLE
[fix] Make sure to return '/' and not empty string for stuff on domain root

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -239,7 +239,7 @@ def app_map(app=None, raw=False, user=None):
                 perm_domain, perm_path = perm_url.split("/", 1)
                 perm_path = "/" + perm_path.rstrip("/")
 
-            perm_path = perm_path if perm_path != "" else "/"
+            perm_path = perm_path if perm_path.strip() != "" else "/"
 
             return perm_domain, perm_path
 
@@ -1269,7 +1269,7 @@ def app_ssowatconf():
                 perm_domain, perm_path = perm_url.split("/", 1)
                 perm_path = "/" + perm_path.rstrip("/")
 
-            perm_path = perm_path if perm_path != "" else "/"
+            perm_path = perm_path if perm_path.strip() != "" else "/"
 
             return perm_domain + perm_path
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -239,6 +239,8 @@ def app_map(app=None, raw=False, user=None):
                 perm_domain, perm_path = perm_url.split("/", 1)
                 perm_path = "/" + perm_path.rstrip("/")
 
+            perm_path = perm_path if perm_path != "" else "/"
+
             return perm_domain, perm_path
 
         this_app_perms = {p: i for p, i in permissions.items() if p.startswith(app_id + ".") and i["url"]}
@@ -274,7 +276,6 @@ def app_map(app=None, raw=False, user=None):
                 continue
 
             perm_domain, perm_path = _sanitized_absolute_url(perm_info["url"])
-
             if perm_name.endswith(".main"):
                 perm_label = label
             else:
@@ -1105,10 +1106,11 @@ def app_makedefault(operation_logger, app, domain=None):
     elif domain not in domain_list()['domains']:
         raise YunohostError('domain_unknown')
 
-    operation_logger.start()
     if '/' in app_map(raw=True)[domain]:
         raise YunohostError('app_make_default_location_already_used', app=app, domain=app_domain,
                             other_app=app_map(raw=True)[domain]["/"]["id"])
+
+    operation_logger.start()
 
     # TODO / FIXME : current trick is to add this to conf.json.persisten
     # This is really not robust and should be improved
@@ -1266,6 +1268,8 @@ def app_ssowatconf():
             else:
                 perm_domain, perm_path = perm_url.split("/", 1)
                 perm_path = "/" + perm_path.rstrip("/")
+
+            perm_path = perm_path if perm_path != "" else "/"
 
             return perm_domain + perm_path
 

--- a/src/yunohost/tests/test_apps.py
+++ b/src/yunohost/tests/test_apps.py
@@ -9,7 +9,7 @@ from conftest import message, raiseYunohostError
 from moulinette import m18n
 from moulinette.utils.filesystem import mkdir
 
-from yunohost.app import app_install, app_remove, app_ssowatconf, _is_installed, app_upgrade
+from yunohost.app import app_install, app_remove, app_ssowatconf, _is_installed, app_upgrade, app_map
 from yunohost.domain import _get_maindomain, domain_add, domain_remove, domain_list
 from yunohost.utils.error import YunohostError
 from yunohost.tests.test_permission import check_LDAP_db_integrity, check_permission_for_apps
@@ -142,6 +142,12 @@ def test_legacy_app_install_main_domain():
 
     install_legacy_app(main_domain, "/legacy")
 
+    app_map_ = app_map(raw=True)
+    assert main_domain in app_map_
+    assert '/legacy' in app_map_[main_domain]
+    assert 'id' in app_map_[main_domain]['/legacy']
+    assert app_map_[main_domain]['/legacy']['id'] == 'legacy_app'
+
     assert app_is_installed(main_domain, "legacy_app")
     assert app_is_exposed_on_http(main_domain, "/legacy", "This is a dummy app")
 
@@ -165,6 +171,12 @@ def test_legacy_app_install_secondary_domain(secondary_domain):
 def test_legacy_app_install_secondary_domain_on_root(secondary_domain):
 
     install_legacy_app(secondary_domain, "/")
+
+    app_map_ = app_map(raw=True)
+    assert secondary_domain in app_map_
+    assert '/' in app_map_[secondary_domain]
+    assert 'id' in app_map_[secondary_domain]['/']
+    assert app_map_[secondary_domain]['/']['id'] == 'legacy_app'
 
     assert app_is_installed(secondary_domain, "legacy_app")
     assert app_is_exposed_on_http(secondary_domain, "/", "This is a dummy app")


### PR DESCRIPTION
## The problem

This is a small regression introduced in 3.7 when refactoring app_ssowatconf and app_map : when an app is installed on the root of a domain, `app_map` should return something like 

`domain.tld/: foo`

and not : 

`domain.tld: foo`

(notice the trailing /)

The lack of `/` break some checks like here https://github.com/YunoHost/yunohost/blob/stretch-unstable/src/yunohost/app.py#L1109 which in turns trigger https://github.com/YunoHost/issues/issues/1572 (it should not be possible to make default app an app that's already on the root ...)

(Note that the makedefault system is still heavily buggy but can't be fixed until we properly implement domain settings, which is also needed to enable/disable mail/xmpp per-domain, and we also have to think about how to handle nasty backup/restore or change-url cases...)

## Solution

Force the path var to be at least `/` if it's empty

## PR Status

Tested `app_map` but not sure about all the implications this change can have .. Let's see what the tests say.

## How to test

Install an app on root, check what `app_map` returns with/without this fix

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
