### PR TITLE
Keep track of 'parent' operation in operation loggers

### DIFF
--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -28,6 +28,7 @@ import os
 import re
 import yaml
 import collections
+import glob
 
 from datetime import datetime
 from logging import FileHandler, getLogger, Formatter
@@ -334,6 +335,8 @@ class OperationLogger(object):
     This class record logs and metadata like context or start time/end time.
     """
 
+    _instances = []
+
     def __init__(self, operation, related_to=None, **kwargs):
         # TODO add a way to not save password on app installation
         self.operation = operation
@@ -344,6 +347,8 @@ class OperationLogger(object):
         self.logger = None
         self._name = None
         self.data_to_redact = []
+        self.parent = self.parent_logger()
+        self._instances.append(self)
 
         for filename in ["/etc/yunohost/mysql", "/etc/yunohost/psql"]:
             if os.path.exists(filename):
@@ -353,6 +358,50 @@ class OperationLogger(object):
 
         if not os.path.exists(self.path):
             os.makedirs(self.path)
+
+    def parent_logger(self):
+
+        # If there are other operation logger instances
+        for instance in reversed(self._instances):
+            # Is one of these operation logger started but not yet done ?
+            if instance.started_at is not None and instance.ended_at is None:
+                # We are a child of the first one we found
+                return instance.name
+
+        locks = read_file("/var/run/moulinette_yunohost.lock").strip().split("\n")
+        # If we're the process with the lock, we're the root logger
+        if locks == [] or str(os.getpid()) in locks:
+            return None
+
+        # If we get here, we are in a yunohost command called by a yunohost
+        # (maybe indirectly from an app script for example...)
+        #
+        # The strategy is :
+        # 1. list 20 most recent log files
+        # 2. iterate over the PID of parent processes
+        # 3. see if parent process has some log file open (being actively
+        # written in)
+        # 4. if among those file, there's an operation log file, we use the id
+        # of the most recent file
+
+        recent_operation_logs = sorted(glob.iglob("/var/log/yunohost/categories/operation/*.log"), key=os.path.getctime, reverse=True)[:20]
+
+        import psutil
+        proc = psutil.Process().parent()
+        while proc is not None:
+            # We use proc.open_files() to list files opened / actively used by this proc
+            # We only keep files matching a recent yunohost operation log
+            active_logs = sorted([f.path for f in proc.open_files() if f.path in recent_operation_logs], key=os.path.getctime, reverse=True)
+            if active_logs != []:
+                # extra the log if from the full path
+                return os.path.basename(active_logs[0])[:-4]
+            else:
+                proc = proc.parent()
+                continue
+
+        # If nothing found, assume we're the root operation logger
+        return None
+
 
     def start(self):
         """
@@ -440,6 +489,7 @@ class OperationLogger(object):
         data = {
             'started_at': self.started_at,
             'operation': self.operation,
+            'parent': self.parent,
         }
         if self.related_to is not None:
             data['related_to'] = self.related_to
@@ -475,8 +525,10 @@ class OperationLogger(object):
         self.ended_at = datetime.utcnow()
         self._error = error
         self._success = error is None
+
         if self.logger is not None:
             self.logger.removeHandler(self.file_handler)
+            self.file_handler.close()
 
         is_api = msettings.get('interface') == 'api'
         desc = _get_description_from_name(self.name)


### PR DESCRIPTION
## The problem

So hmyeah clearly not the priority but I got tired of seeing so many different operations when running `yunohost log list` ... Following the integration of group/permissions we now have many operations which contains "sub" operations.

For example : adding a user will create an operation logger, but it will also create a "child" operation to create a group and update group all_users.
Similarly, "app_install" will create permissions and update it. (not even mentionning if the install fails and app is autoremoved, which also delete permissions etc..)

With this, we quickly end up with so many operations that it's less straightforward to find the log of the original "parent" operation you are interested in ...

Would be nice to be able to improve the CLI .. not sure how, maybe only list "root" operations by default in "yunohost log list" (i don't really know yet what to aim for exactly...) but at least be able to tweak the log list view in the webadmin to highlight "root" operations ... or display "child" operations differently ...

## Solution

Add a notion of "parent" for operations. Not really used for anything yet.

In the most simple case : 
- Operation A is started. There's no other active operation logger, so it's the root.
- Operation B is started. It finds that instance A is still active and therefore defines its parent as being A.
- Operation B is closed
- Operation A is closed
- Operation C is started. There's no other active operation logger, so it's the root.
- Operation C is closed

However there are more complex cases where we need black magic:
- Operation A is started
- A script or hook is ran (typically an app script)
- The script or hook contains `yunohost foo bar` (for example, a domain creation, or a regenconf)
- Operation B is started (so in a different process than A)
- Operation B identifies that it's not in the "root" process. It looks at which .log files are being used by parent processes until it fines the log of operation A being actively written by some parent process. Therefore it defines its parent as being A.
- Operation B is closed
- Operation A is closed

Writing this, I realize that it doesn't cover the self-upgrade system that completely operates in an unrelated process child and this won't work, but I guess we can live with it.

## PR Status

Tested and working on my side

## How to test

For example, create a user. Use "yunohost log list" to list recent operations. Look into the yaml file and you should see that stuff related to permission/group have a "parent" key set.

For the more advanced case, I used a dummy app containing a "yunohost domain add foo.com". Checked that log for the domain creation indeed gets related to the app install operation even though they run in different processes.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
