### PR TITLE
use ynh_port_available in ynh_find_port

### DIFF
--- a/data/helpers.d/network
+++ b/data/helpers.d/network
@@ -18,7 +18,7 @@ ynh_find_port () {
     ynh_handle_getopts_args "$@"
 
     test -n "$port" || ynh_die --message="The argument of ynh_find_port must be a valid port."
-    while ss --numeric --listening --tcp --udp | awk '{print$5}' | grep --quiet --extended-regexp ":$port$"       # Check if the port is free
+    while ! ynh_port_available --port=$port
     do
         port=$((port+1))	# Else, pass to next port
     done
@@ -42,7 +42,7 @@ ynh_port_available () {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    if ss --numeric --listening --tcp --udp | grep --quiet --word-regexp :$port
+    if ss --numeric --listening --tcp --udp | awk '{print$5}' | grep --quiet --extended-regexp ":$port$"       # Check if the port is free
     then
         return 1
     else


### PR DESCRIPTION
## The problem

Duplicate the code. `ynh_port_available` may not work on ipv6

## Solution

Apply the patch to `ynh_port_available` and use it in `ynh_find_port`

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
