### PR TITLE
Try to show smarter / more useful logs by filtering irrelevant lines like set +x etc

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1659,7 +1659,7 @@ log:
                 --share:
                     help: Share the full log using yunopaste
                     action: store_true
-                -f:
+                -i:
                     full: --filter-irrelevant
                     help: Do not show some lines deemed not relevant (like set +x or helper argument parsing)
                     action: store_true

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1659,6 +1659,10 @@ log:
                 --share:
                     help: Share the full log using yunopaste
                     action: store_true
+                -f:
+                    full: --filter-irrelevant
+                    help: Do not show some lines deemed not relevant (like set +x or helper argument parsing)
+                    action: store_true
 
 
 #############################

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -35,7 +35,7 @@ ynh_exit_properly () {
         ynh_clean_setup	# Call the function to do specific cleaning for the app.
     fi
 
-    ynh_die	# Exit with error status
+    exit 1  # Exit with error status
 }
 
 # Exits if an error occurs during the execution of the script.

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -35,7 +35,10 @@ ynh_exit_properly () {
         ynh_clean_setup	# Call the function to do specific cleaning for the app.
     fi
 
-    exit 1  # Exit with error status
+    # Exit with error status
+    # We don't call ynh_die basically to avoid unecessary 10-ish
+    # debug lines about parsing args and stuff just to exit 1..
+    exit 1
 }
 
 # Exits if an error occurs during the execution of the script.

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -916,6 +916,7 @@ def dump_app_log_extract_for_debugging(operation_logger):
 
     filters = [
         r"set [+-]x$",
+        r"set [+-]o xtrace$",
         r"local \w+$",
         r"local legacy_args=.*$",
         r".*Helper used in legacy mode.*",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -920,7 +920,7 @@ def dump_app_log_extract_for_debugging(operation_logger):
         r"local legacy_args=.*$",
         r".*Helper used in legacy mode.*",
         r"args_array=.*$",
-        r"declare -Ar args_array$",
+        r"local -A args_array$",
         r"ynh_handle_getopts_args",
         r"ynh_script_progression"
     ]

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -914,6 +914,19 @@ def dump_app_log_extract_for_debugging(operation_logger):
     with open(operation_logger.log_path, "r") as f:
         lines = f.readlines()
 
+    filters = [
+        r"set [+-]x$",
+        r"local \w+$",
+        r"local legacy_args=.*$",
+        r".*Helper used in legacy mode.*",
+        r"args_array=.*$",
+        r"declare -Ar args_array$",
+        r"ynh_handle_getopts_args",
+        r"ynh_script_progression"
+    ]
+
+    filters = [re.compile(f) for f in filters]
+
     lines_to_display = []
     for line in lines:
 
@@ -924,6 +937,10 @@ def dump_app_log_extract_for_debugging(operation_logger):
         # 2019-10-19 16:10:27,611: DEBUG - + mysql -u piwigo --password=********** -B piwigo
         # And we just want the part starting by "DEBUG - "
         line = line.strip().split(": ", 1)[1]
+
+        if any(filter_.search(line) for filter_ in filters):
+            continue
+
         lines_to_display.append(line)
 
         if line.endswith("+ ynh_exit_properly") or " + ynh_die " in line:

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -122,7 +122,7 @@ def log_list(category=[], limit=None, with_details=False):
     return result
 
 
-def log_display(path, number=None, share=False):
+def log_display(path, number=None, share=False, filter_irrelevant=False):
     """
     Display a log file enriched with metadata if any.
 
@@ -202,9 +202,24 @@ def log_display(path, number=None, share=False):
 
     # Display logs if exist
     if os.path.exists(log_path):
+
+        if filter_irrelevant:
+            filters = [
+                r"set [+-]x$",
+                r"local \w+$",
+                r"local legacy_args=.*$",
+                r".*Helper used in legacy mode.*",
+                r"args_array=.*$",
+                r"declare -Ar args_array$",
+                r"ynh_handle_getopts_args",
+                r"ynh_script_progression"
+            ]
+        else:
+            filters = []
+
         from yunohost.service import _tail
         if number:
-            logs = _tail(log_path, int(number))
+            logs = _tail(log_path, int(number), filters=filters)
         else:
             logs = read_file(log_path)
         infos['log_path'] = log_path

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -206,6 +206,7 @@ def log_display(path, number=None, share=False, filter_irrelevant=False):
         if filter_irrelevant:
             filters = [
                 r"set [+-]x$",
+                r"set [+-]o xtrace$",
                 r"local \w+$",
                 r"local legacy_args=.*$",
                 r".*Helper used in legacy mode.*",

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -210,7 +210,7 @@ def log_display(path, number=None, share=False, filter_irrelevant=False):
                 r"local legacy_args=.*$",
                 r".*Helper used in legacy mode.*",
                 r"args_array=.*$",
-                r"declare -Ar args_array$",
+                r"local -A args_array$",
                 r"ynh_handle_getopts_args",
                 r"ynh_script_progression"
             ]

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -23,6 +23,8 @@
 
     Manage services
 """
+
+import re
 import os
 import re
 import time
@@ -616,7 +618,7 @@ def _save_services(services):
         raise
 
 
-def _tail(file, n):
+def _tail(file, n, filters=[]):
     """
     Reads a n lines from f with an offset of offset lines.  The return
     value is a tuple in the form ``(lines, has_more)`` where `has_more` is
@@ -626,6 +628,9 @@ def _tail(file, n):
     """
     avg_line_length = 74
     to_read = n
+
+    if filters:
+        filters = [re.compile(f) for f in filters]
 
     try:
         if file.endswith(".gz"):
@@ -646,6 +651,9 @@ def _tail(file, n):
 
                 pos = f.tell()
                 lines = f.read().splitlines()
+
+                for filter_ in filters:
+                    lines = [l for l in lines if not filter_.search(l)]
 
                 if len(lines) >= to_read:
                     return lines[-to_read:]


### PR DESCRIPTION
## The problem

This is again me procrastinating instead of fixing bugs for 3.8 lol

Anyway, just stumbled on some debug logs that was showing a lot of "set +x" or "Helper used in legacy mode" or "local foo" which ain't so helpful (c.f. also the screenshot in https://github.com/YunoHost/yunohost-admin/pull/294 ) . It's not unusual to see half the lines of the 20ish last lines of some debug log filled with these

## Solution

 So in the same vein as [this PR](https://github.com/YunoHost/yunohost-admin/pull/294), this is an attempt to increase the likelyhood that users would be able to identify the issue themselves by removing some lines which we know aren't gonna be relevant. This is also meant to help more advanced users / app packagers because this hack is also applied to debug info show during app script failures.

The goal would be to apply this filter when viewing a log in the webadmin. Though it would *not* be applied if the user clicks "show more lines" of share the logs on yunopaste. (Though depending on how 100% confident that these lines ain't useful we could also enable it all the time but idk ...)


## PR Status

Tested and working on my side

## How to test

Install an app that you know will fail, check `yunohost log display` with/without -f

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
