### PR TITLE
[enh] Real CSP headers for the webadmin

### DIFF
--- a/data/templates/nginx/plain/yunohost_admin.conf.inc
+++ b/data/templates/nginx/plain/yunohost_admin.conf.inc
@@ -6,6 +6,9 @@ location /yunohost/admin/ {
     default_type text/html;
     index index.html;
 
+    more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; connect-src 'self' https://raw.githubusercontent.com https://paste.yunohost.org wss://$host; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; object-src 'none';";
+    more_set_headers "Content-Security-Policy-Report-Only:";
+
     # Short cache on handlebars templates
     location ~* \.(?:ms)$ {
       expires 5m;

--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -22,7 +22,7 @@ ssl_prefer_server_ciphers off;
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security
 # https://observatory.mozilla.org/
 more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'";
+more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: wss: 'unsafe-inline' 'unsafe-eval'  ";
 more_set_headers "X-Content-Type-Options : nosniff";
 more_set_headers "X-XSS-Protection : 1; mode=block";
 more_set_headers "X-Download-Options : noopen";

--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -22,7 +22,7 @@ ssl_prefer_server_ciphers off;
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security
 # https://observatory.mozilla.org/
 more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: wss: 'unsafe-inline' 'unsafe-eval'  ";
+more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: 'unsafe-inline' 'unsafe-eval'  ";
 more_set_headers "X-Content-Type-Options : nosniff";
 more_set_headers "X-XSS-Protection : 1; mode=block";
 more_set_headers "X-Download-Options : noopen";

--- a/data/templates/nginx/yunohost_admin.conf
+++ b/data/templates/nginx/yunohost_admin.conf
@@ -22,7 +22,6 @@ server {
 
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
     more_set_headers "Referrer-Policy : 'same-origin'";
-    more_set_headers "Content-Security-Policy : upgrade-insecure-requests; object-src 'none'; script-src https: 'unsafe-eval'";
 
     location / {
         return 302 https://$http_host/yunohost/admin;


### PR DESCRIPTION
## The problem

Angry red CSP errors in JS console on the webadmin (when accessed via a domain) because of websocket

## Solution

~~Add websocket to default-src~~

~~Dunno the implication but considering we're in Report-Only anyway, that just removes the error ...~~

Well, I ended up digging into implementing an actual CSP ... Though I might have forgotten something ... c.f. https://github.com/YunoHost/yunohost/pull/961#issuecomment-620903303

## PR Status

Tested and working on my side

## How to test

Go to the webadmin and open JS console

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
