### PR TITLE
[fix] Enforce permissions for stuff in /etc/yunohost/

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -65,6 +65,30 @@ EOF
 
 }
 
+do_post_regen() {
+  regen_conf_files=$1
+
+  ######################
+  # Enfore permissions #
+  ######################
+
+  # Certs
+  # We do this with find because there could be a lot of them...
+  chown -R root:ssl-cert /etc/yunohost/certs
+  chmod 750 /etc/yunohost/certs
+  find /etc/yunohost/certs/ -type f -exec chmod 640 {} \;
+  find /etc/yunohost/certs/ -type d -exec chmod 750 {} \;
+
+  # Misc configuration / state files
+  chown root:root $(ls /etc/yunohost/{*.yml,*.yaml,*.json,mysql,psql} 2>/dev/null)
+  chmod 600 $(ls /etc/yunohost/{*.yml,*.yaml,*.json,mysql,psql} 2>/dev/null)
+
+  # Apps folder, custom hooks folder
+  [[ ! -e /etc/yunohost/hooks.d ]] || (chown root /etc/yunohost/hooks.d && chmod 700 /etc/yunohost/hooks.d)
+  [[ ! -e /etc/yunohost/apps ]] || (chown root /etc/yunohost/apps && chmod 700 /etc/yunohost/apps)
+
+}
+
 _update_services() {
   python2 - << EOF
 import yaml
@@ -132,6 +156,7 @@ case "$1" in
     do_pre_regen $4
     ;;
   post)
+    do_post_regen $4
     ;;
   init)
     do_init_regen

--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -82,9 +82,6 @@ do_post_regen() {
   chown root:openldap /etc/ldap/slapd.conf
   chown -R openldap:openldap /etc/ldap/schema/
   chown -R openldap:openldap /etc/ldap/slapd.d/
-  chown -R root:ssl-cert /etc/yunohost/certs/yunohost.org/
-  chmod o-rwx /etc/yunohost/certs/yunohost.org/
-  chmod -R g+rx /etc/yunohost/certs/yunohost.org/
 
   # If we changed the systemd ynh-override conf
   if echo "$regen_conf_files" | sed 's/,/\n/g' | grep -q "^/etc/systemd/system/slapd.service.d/ynh-override.conf$"

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -55,6 +55,9 @@ do_post_regen() {
   done
 
   # fix some permissions
+
+  # metronome should be in ssl-cert group to let it access SSL certificates
+  usermod -aG ssl-cert metronome
   chown -R metronome: /var/lib/metronome/
   chown -R metronome: /etc/metronome/conf.d/
 


### PR DESCRIPTION
## The problem

We realized there are some permission issues in /etc/yunohost ... Some happens in some edgy cases (like some /etc/yunohost/apps/$appname folder with permission for others enabled...)

## Solution

Enforce permissions for stuff in /etc/yunohost/ through the regenconf ... Also that covers the case where a user might have tweaked permissions manually (or system is from an old era) ...

One could wonder "why not just chmod o-rwx /etc/yunohost" ? And the reason is that i'm not 100% sure that there aren't edge cases where a non-root user needs some access ... Though in the end that'd be pretty equivalent to what I did so I don't know ... But should at least check with for example vpnclient_ynh ...

## PR Status

Kindof tested on my side but kind of touchy...

## How to test

Run the regenconf, check permissions in /etc/yunohost

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
