### PR TITLE
[fix] Reverse DNS check

### DIFF
--- a/data/hooks/diagnosis/24-mail.py
+++ b/data/hooks/diagnosis/24-mail.py
@@ -2,7 +2,6 @@
 
 import os
 import dns.resolver
-import socket
 import re
 
 from subprocess import CalledProcessError
@@ -118,15 +117,25 @@ class MailDiagnoser(Diagnoser):
                 details = ["diagnosis_mail_fcrdns_nok_details",
                            "diagnosis_mail_fcrdns_nok_alternatives_4"]
 
-            try:
-                rdns_domain, _, _ = socket.gethostbyaddr(ip)
-            except socket.herror:
+            rev = dns.reversename.from_address(ip)
+            subdomain = str(rev.split(3)[0])
+            query = subdomain
+            if ipversion == 4:
+                query += '.in-addr.arpa'
+            else:
+                query += '.ip6.arpa'
+
+            # Do the DNS Query
+            status, value = dig(query, 'PTR')
+            if status == "nok":
                 yield dict(meta={"test": "mail_fcrdns", "ipversion": ipversion},
                            data={"ip": ip, "ehlo_domain": self.ehlo_domain},
                            status="ERROR",
                            summary="diagnosis_mail_fcrdns_dns_missing",
                            details=details)
                 continue
+
+            rdns_domain = value[0] if len(value) > 0 else ''
             if rdns_domain != self.ehlo_domain:
                 details = ["diagnosis_mail_fcrdns_different_from_ehlo_domain_details"] + details
                 yield dict(meta={"test": "mail_fcrdns", "ipversion": ipversion},


### PR DESCRIPTION
## The problem

If there is the domain configure in /etc/host the method with socket does not work.

## Solution

Replace the socket request with a dig PTR request on reverse IP

## PR Status

Ready (tested with an ip with a bad PTR.

## How to test

Run diagnosis and see reverse dns

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
