### PR TITLE
Add conflicts with versions from backports for critical dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,13 @@ Suggests: htop, vim, rsync, acpi-support-base, udisks2
 Conflicts: iptables-persistent
  , apache2
  , bind9
+ , nginx-extras (>= 1.16)
+ , openssl (>= 1.1.1g)
+ , slapd (>= 2.4.49)
+ , dovecot-core (>= 2.3.7)
+ , redis-server (>= 5.0.7)
+ , fail2ban (>= 0.11)
+ , iptables (>= 1.8.3)
 Description: manageable and configured self-hosting server
  YunoHost aims to make self-hosting accessible to everyone. It configures
  an email, Web and IM server alongside a LDAP base. It also provides


### PR DESCRIPTION
## The problem

This is a follow-up of https://github.com/YunoHost/issues/issues/1563

We regularly see funky dependency issues because (not always) of backports or chain reactions because of extra apt remove ...

![](https://forum.yunohost.org/uploads/default/original/2X/0/04f27fd6dd1bca33c57d4c37a5d60f9c33555625.jpeg)

## Solution

One way to mitigate catastrophic consequences can be to add hard conflicts with backports versions for critical dependencies ... (For example we recently saw [multiples users having issues because slapd / dovecot / ... got upgraded to backport somehow](https://forum.yunohost.org/t/can-not-grab-the-user-info-and-login-to-the-mail-account-doveadm-returned-non-zero-exit-status/10684/6))

The versions number used in the diff are taken from example [from here](https://packages.debian.org/bullseye/nginx) each time comparing the buster-packport version (or when not available, the bullseye version) vs. the regular buster version.

Note that YunoHost is flagged as an Essential package (since something like 3.5 or .6) so in case of conflict, apt will complain: 

```
You are about to do something potentially harmful.
To continue type in the phrase 'Yes, do as I say!'
```

which should hopefully be enough to prevent stupid mistakes ...

Feel free to discuss alternative strategies if you know have some expertise about deb packages :/

## PR Status

This is absolutely not tested, I don't even know if the syntax is right lel

## How to test

Uh gotta build and try to install the package I suppose

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
