### PR TITLE
[Epic Fix] ynh_install_app_dependencies

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -264,7 +264,7 @@ ynh_install_app_dependencies () {
 
                 # Pin this sury repository to prevent sury of doing shit
                 ynh_pin_repo --package="*" --pin="origin \"packages.sury.org\"" --priority=200 --name=extra_php_version
-                ynh_pin_repo --package="php${$YNH_DEFAULT_PHP_VERSION}*" --pin="origin \"packages.sury.org\"" --priority=600 --name=extra_php_version --append
+                ynh_pin_repo --package="php${YNH_DEFAULT_PHP_VERSION}*" --pin="origin \"packages.sury.org\"" --priority=600 --name=extra_php_version --append
             fi
         fi
     fi


### PR DESCRIPTION
## The problem

> Warning: /usr/share/yunohost/helpers.d/apt: line 267: php${$YNH_DEFAULT_PHP_VERSION}*: bad substitution

## Solution

...

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
