### PR TITLE
mod_storage_ldap: change :users() to :nodes().

### DIFF
--- a/lib/metronome/modules/mod_storage_ldap.lua
+++ b/lib/metronome/modules/mod_storage_ldap.lua
@@ -228,7 +228,7 @@ function driver:stores(username, type, pattern)
     return nil, "not implemented";
 end
 
-function driver:store_exists(username, datastore, type)
+function driver:store_exists(username, type)
     return nil, "not implemented";
 end
 
@@ -236,7 +236,7 @@ function driver:purge(username)
     return nil, "not implemented";
 end
 
-function driver:users()
+function driver:nodes(type)
     return nil, "not implemented";
 end
 


### PR DESCRIPTION
That reflects changes to storagemanager API in 3.14.0.

## The problem

users() method has been replaced with nodes()

## PR Status

Final.

## How to test

Wait for 3.14.0, although there's no code in Metronome which currently makes use of the users storagemanager method so it could be safely used until releases. That would just avoid an eventual traceback on future releases.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
