### PR TITLE
Add a timeout to wget in helpers

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -436,7 +436,8 @@ ynh_install_extra_repo () {
     if [ -n "$key" ]
     then
         mkdir --parents "/etc/apt/trusted.gpg.d"
-        wget --quiet "$key" --output-document=- | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.gpg > /dev/null
+        # Timeout option is here to enforce the timeout on dns query and tcp connect (c.f. man wget)
+        wget --timeout 900 --quiet "$key" --output-document=- | gpg --dearmor | $wget_append /etc/apt/trusted.gpg.d/$name.gpg > /dev/null
     fi
 
     # Update the list of package with the new repo

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -144,7 +144,8 @@ ynh_setup_source () {
     then    # Use the local source file if it is present
         cp $local_src $src_filename
     else    # If not, download the source
-        local out=`wget --no-verbose --output-document=$src_filename $src_url 2>&1` || ynh_print_err --message="$out"
+        # Timeout option is here to enforce the timeout on dns query and tcp connect (c.f. man wget)
+        local out=`wget --timeout 900 --no-verbose --output-document=$src_filename $src_url 2>&1` || ynh_print_err --message="$out"
     fi
 
     # Check the control sum


### PR DESCRIPTION
## The problem

c.f. https://forum.yunohost.org/t/yunohost-command-not-ending/11177/7

Upgrading an app resulted in a never-ending command blocking all other yunohost commands

## Solution

`wget` was hanging indefinitely .. not sure exactly why but it's pretty clear that the issue is a lack of timeout. `wget` only has a read-timeout of 900 seconds enabled (meaning : if nothing received during 900 sec once downloaded started, command times out) but no timeout on dns queries and opening TCP connection except what system libs implement. (c.f. `man wget`)

We can add `--timeout 900` to set 900 sec timeout to all these operations.

N.B. : this doesn't mean that the overall operation can't take more than 900 secs, just that if absolutely nothing happens during 900 secs, the command exits.

## PR Status

Yolocommited, not tested ...

## How to test

Well I don't know how to mock a wget hanging forever ... But do we really need a test :s 

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
