### PR TITLE
[enh] service.py cleanup  + add tests for services

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,6 +92,12 @@ test-regenconf:
     - cd src/yunohost
     - py.test tests/test_regenconf.py
 
+test-service:
+  extends: .test-stage
+  script:
+    - cd src/yunohost
+    - py.test tests/test_service.py
+
 ########################################
 # LINTER
 ########################################

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -426,6 +426,13 @@ def service_log(name, number=50):
     result["journalctl"] = _get_journalctl_logs(name, number).splitlines()
 
     for log_path in log_list:
+
+        if not os.path.exists(log_path):
+            continue
+
+        # Make sure to resolve symlinks
+        log_path = os.path.realpath(log_path)
+
         # log is a file, read it
         if os.path.isfile(log_path):
             result[log_path] = _tail(log_path, number)

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -427,8 +427,11 @@ def service_log(name, number=50):
 
     for log_path in log_list:
         # log is a file, read it
-        if not os.path.isdir(log_path):
-            result[log_path] = _tail(log_path, number) if os.path.exists(log_path) else []
+        if os.path.isfile(log_path):
+            result[log_path] = _tail(log_path, number)
+            continue
+        elif not os.path.isdir(log_path):
+            result[log_path] = []
             continue
 
         for log_file in os.listdir(log_path):

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -314,9 +314,8 @@ def service_status(names=[]):
 
         else:
             translation_key = "service_description_%s" % name
-            if "description" in infos is not None:
-                description = infos.get("description")
-            else:
+            description = infos.get("description")
+            if not description:
                 description = m18n.n(translation_key)
 
             # that mean that we don't have a translation for this string

--- a/src/yunohost/tests/test_service.py
+++ b/src/yunohost/tests/test_service.py
@@ -1,0 +1,97 @@
+import os
+
+from conftest import message, raiseYunohostError
+
+from yunohost.service import _get_services, _save_services, service_status, service_add, service_remove
+
+
+def setup_function(function):
+
+    clean()
+
+
+def teardown_function(function):
+
+    clean()
+
+
+def clean():
+
+    # To run these tests, we assume ssh(d) service exists and is running
+    assert os.system("pgrep sshd >/dev/null") == 0
+
+    services = _get_services()
+    assert "ssh" in services
+
+    if "dummyservice" in services:
+        del services["dummyservice"]
+        _save_services(services)
+
+
+def test_service_status_all():
+
+    status = service_status()
+    assert "ssh" in status.keys()
+    assert status["ssh"]["status"] == "running"
+
+
+def test_service_status_single():
+
+    status = service_status("ssh")
+    assert "status" in status.keys()
+    assert status["status"] == "running"
+
+
+def test_service_status_unknown_service(mocker):
+
+    with raiseYunohostError(mocker, 'service_unknown'):
+        service_status(["ssh", "doesnotexists"])
+
+
+def test_service_add():
+
+    service_add("dummyservice", description="A dummy service to run tests")
+    assert "dummyservice" in service_status().keys()
+
+
+def test_service_remove():
+
+    service_add("dummyservice", description="A dummy service to run tests")
+    assert "dummyservice" in service_status().keys()
+    service_remove("dummyservice")
+    assert "dummyservice" not in service_status().keys()
+
+
+def test_service_remove_service_that_doesnt_exists(mocker):
+
+    assert "dummyservice" not in service_status().keys()
+
+    with raiseYunohostError(mocker, 'service_unknown'):
+        service_remove("dummyservice")
+
+    assert "dummyservice" not in service_status().keys()
+
+
+def test_service_update_to_add_properties():
+
+    service_add("dummyservice", description="")
+    assert not _get_services()["dummyservice"].get("test_status")
+    service_add("dummyservice", description="", test_status="true")
+    assert _get_services()["dummyservice"].get("test_status") == "true"
+
+
+def test_service_update_to_change_properties():
+
+    service_add("dummyservice", description="", test_status="false")
+    assert _get_services()["dummyservice"].get("test_status") == "false"
+    service_add("dummyservice", description="", test_status="true")
+    assert _get_services()["dummyservice"].get("test_status") == "true"
+
+
+def test_service_update_to_remove_properties():
+
+    service_add("dummyservice", description="", test_status="false")
+    assert _get_services()["dummyservice"].get("test_status") == "false"
+    service_add("dummyservice", description="", test_status="")
+    assert not _get_services()["dummyservice"].get("test_status")
+


### PR DESCRIPTION
## The problem

I was about to implement `service_update` without realizing that apps already updated service by just calling `service_add` again which just overwrite currently existing services and that's fine

Nevertheless found a few things to clean

## Solution

Clean stuff, depecate log_type, and ended up writing a few tests :| 

## PR Status

Tested and working on my side

## How to test

Run the tests and zblerg

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
