### PR TITLE
Check for fatal code errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,6 +117,11 @@ lint:
   script:
     - tox -e lint
 
+invalidcode:
+  extends: .lint-stage
+  script:
+    - tox -e invalidcode
+
 # Disabled, waiting for buster
 #format-check:
 #  extends: .lint-stage

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2331,6 +2331,7 @@ def _check_manifest_requirements(manifest, app_instance_name):
     # Iterate over requirements
     for pkgname, spec in requirements.items():
         if not packages.meets_version_specifier(pkgname, spec):
+            version = packages.ynh_packages_version()[pkgname]["version"]
             raise YunohostError('app_requirements_unmeet',
                                 pkgname=pkgname, version=version,
                                 spec=spec, app=app_instance_name)

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -926,12 +926,12 @@ def dump_app_log_extract_for_debugging(operation_logger):
         r"ynh_script_progression"
     ]
 
-    filters = [re.compile(f) for f in filters]
+    filters = [re.compile(f_) for f_ in filters]
 
     lines_to_display = []
     for line in lines:
 
-        if not ": " in line.strip():
+        if ": " not in line.strip():
             continue
 
         # A line typically looks like

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -528,10 +528,10 @@ def _build_dns_conf(domain, ttl=3600, include_empty_AAAA_if_no_ipv6=False):
     ####################
 
     records = {
-        "basic": [{"name": name, "ttl": ttl, "type": type_, "value": value} for name, ttl, type_, value in basic],
-        "xmpp": [{"name": name, "ttl": ttl, "type": type_, "value": value} for name, ttl, type_, value in xmpp],
-        "mail": [{"name": name, "ttl": ttl, "type": type_, "value": value} for name, ttl, type_, value in mail],
-        "extra": [{"name": name, "ttl": ttl, "type": type_, "value": value} for name, ttl, type_, value in extra],
+        "basic": [{"name": name, "ttl": ttl_, "type": type_, "value": value} for name, ttl_, type_, value in basic],
+        "xmpp": [{"name": name, "ttl": ttl_, "type": type_, "value": value} for name, ttl_, type_, value in xmpp],
+        "mail": [{"name": name, "ttl": ttl_, "type": type_, "value": value} for name, ttl_, type_, value in mail],
+        "extra": [{"name": name, "ttl": ttl_, "type": type_, "value": value} for name, ttl_, type_, value in extra],
     }
 
     ##################

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -26,7 +26,6 @@
 
 import re
 import os
-import re
 import time
 import yaml
 import subprocess

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,16 @@ skip_install=True
 deps =
   pytest >= 4.6.3, < 5.0
   pyyaml >= 5.1.2, < 6.0
+  flake8 >= 3.7.9, < 3.8
 commands =
     pytest {posargs}
 
 [testenv:lint]
 skip_install=True
 commands = flake8 src doc data tests
+deps = flake8
+
+[testenv:invalidcode]
+skip_install=True
+commands = flake8 src data --exclude src/yunohost/tests --select F --ignore F401,F841
 deps = flake8


### PR DESCRIPTION
## The problem

Realized we had again code with undefined var...

## Solution

Add a check with tox that shall fail, but only catches really fatal stuff like undefined vars / redefining vars etc ... Ignore stuff like "import not at the top" or "unused var" ... should make wider tests in the future, but c.f. previous work from Kayou, we need a lot of cleaning to make tox/flake8 really happy.

## PR Status

Tested on my side

## How to test

Run the test o/

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
