### PR TITLE
Fix service add log type default value

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -996,7 +996,6 @@ service:
                     choices:
                         - file
                         - systemd
-                    default: file
                 --test_status:
                     help: Specify a custom bash command to check the status of the service. Note that it only makes sense to specify this if the corresponding systemd service does not return the proper information already.
                 --test_conf:

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -70,7 +70,8 @@ def service_add(name, description=None, log=None, log_type=None, test_status=Non
         if log_type is not None:
             logger.warning("/!\\ Packagers! --log_type is deprecated. You do not need to specify --log_type systemd anymore ... Yunohost now automatically fetch the journalctl of the systemd service by default.")
             # Usually when adding such a service, the service name will be provided so we remove it as it's not a log file path
-            log.remove(name)
+            if name in log:
+                log.remove(name)
 
         service['log'] = log
 


### PR DESCRIPTION
## The problem

When invoking:

```
yunohost service add postgresql --log /var/log/postgresql/postgresql-9.6-main.log --description "PostgreSQL RDBMS"
```
(I'm not sure I'm supposed to do that in app script, but that's another story), it fails with:

```
Warning: /!\ Packagers! --log_type is deprecated. You do not need to specify --log_type systemd anymore ... Yunohost now automatically fetch the journalctl of the systemd service by default.
Warning: Traceback (most recent call last):
Warning:   File "/usr/bin/yunohost", line 218, in <module>
Warning:     timeout=opts.timeout,
Warning:   File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 150, in cli
Warning:     moulinette.run(args, output_as=output_as, password=password, timeout=timeout)
Warning:   File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 464, in run
Warning:     ret = self.actionsmap.process(args, timeout=timeout)
Warning:   File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 587, in process
Warning:     return func(**arguments)
Warning:   File "/usr/lib/moulinette/yunohost/service.py", line 73, in service_add
Warning:     log.remove(name)
Warning: ValueError: list.remove(x): x not in list
```

## Solution

Guard the list.remove behing a `if x in list`, and while I'm at it, remove the default value of log_type, as we are checking if log_type is None.

## PR Status

Tested on lxc container

## How to test

Use the command above.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
