### PR TITLE
[fix] postfix per-domain destination concurrency

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -170,7 +170,7 @@ smtpd_milters = inet:localhost:11332
 milter_default_action = accept
 
 # Avoid to send simultaneously too many emails
-smtp_destination_concurrency_limit = 1
+smtp_destination_concurrency_limit = 2
 default_destination_rate_delay = 5s
 
 # Avoid email adress scanning


### PR DESCRIPTION

## The problem

Postfix has this very peculiar behavior where the behavior of some config items changes depending on the value. 
Here, if `smtp_destination_concurrency_limit` is set to 1, then according to http://www.postfix.org/postconf.5.html#default_destination_concurrency_limit it doesn't mean "1 concurrent mail per domain, but per recipient address".

## Solution

So, if set to 1, it means we can send any volume of e-mails concurrently (with a 5s delay) if all recipient addresses are different.
In order to avoid this, we should increase the value to restore the expected behavior (concurrency per domain, not per recipient).

## PR Status

...

## How to test

Send datalove <3

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
