### PR TITLE
Better error message when psql is not there for database_exists

### DIFF
--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -187,7 +187,13 @@ ynh_psql_database_exists() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"
+    # if psql is not there, we cannot check the db
+    # though it could exists.
+    if ! command -v psql
+    then
+      ynh_print_err -m "PostgreSQL is not installed, impossible to check for db existence."
+      return 1
+    elif ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"
     then
         return 1
     else


### PR DESCRIPTION
## The problem

If app packager checks too soon for db existence (before postgres is installed) the error message is not very clear.

## Solution

Just add a litte error message if psql cannot be found. The install crashes the same, but the packager now knows why, hopefully.

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
