### PR TITLE
[fix] Rework ynh_psql_test_if_first_run

### DIFF
--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PSQL_ROOT_PWD_FILE=/etc/yunohost/psql
+PSQL_VERSION=9.6
 
 # Open a connection as a user
 #
@@ -273,6 +274,7 @@ ynh_psql_remove_db() {
 }
 
 # Create a master password and set up global settings
+# It also make sure that postgresql is installed and running
 # Please always call this script in install and restore scripts
 #
 # usage: ynh_psql_test_if_first_run
@@ -280,45 +282,38 @@ ynh_psql_remove_db() {
 # Requires YunoHost version 2.7.13 or higher.
 ynh_psql_test_if_first_run() {
 
-    if [ -f "$PSQL_ROOT_PWD_FILE" ]
+    # Make sure postgresql is indeed installed
+    dpkg --list | grep -q "ii  postgresql-$PSQL_VERSION" || ynh_die "postgresql-$PSQL_VERSION is not installed !?"
+
+    # Check for some weird issue where postgresql could be installed but etc folder would not exist ...
+    [ -e "/etc/postgresql/$PSQL_VERSION" ] || ynh_die "It looks like postgresql was not properly configured ? /etc/postgresql/$PSQL_VERSION is missing ... Could be due to a locale issue, c.f.https://serverfault.com/questions/426989/postgresql-etc-postgresql-doesnt-exist"
+
+    # Make sure postgresql is started and enabled
+    # (N.B. : to check the active state, we check the cluster state because
+    # postgresql could be flagged as active even though the cluster is in
+    # failed state because of how the service is configured..)
+    systemctl is-active postgresql@$PSQL_VERSION-main -q || ynh_systemd_action --service_name=postgresql --action=restart
+    systemctl is-enabled postgresql -q || systemctl enable postgresql
+
+    # If this is the very first time, we define the root password
+    # and configure a few things
+    if [ ! -f "$PSQL_ROOT_PWD_FILE" ]
     then
-        ynh_print_info --message="PostgreSQL is already installed, no need to create master password"
-        return
+        local pg_hba=/etc/postgresql/$PSQL_VERSION/main/pg_hba.conf
+
+        local psql_root_password="$(ynh_string_random)"
+        echo "$psql_root_password" >$PSQL_ROOT_PWD_FILE
+        sudo --login --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$psql_root_password'" postgres
+
+        # force all user to connect to local databases using hashed passwords
+        # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html#EXAMPLE-PG-HBA.CONF
+        # Note: we can't use peer since YunoHost create users with nologin
+        #  See: https://github.com/YunoHost/yunohost/blob/unstable/data/helpers.d/user
+        ynh_replace_string --match_string="local\(\s*\)all\(\s*\)all\(\s*\)peer" --replace_string="local\1all\2all\3md5" --target_file="$pg_hba"
+
+        # Integrate postgresql service in yunohost
+        yunohost service add postgresql --log "/var/log/postgresql/"
+
+        ynh_systemd_action --service_name=postgresql --action=reload
     fi
-
-    local psql_root_password="$(ynh_string_random)"
-    echo "$psql_root_password" >$PSQL_ROOT_PWD_FILE
-
-    if [ -e /etc/postgresql/9.4/ ]
-    then
-        local pg_hba=/etc/postgresql/9.4/main/pg_hba.conf
-        local logfile=/var/log/postgresql/postgresql-9.4-main.log
-    elif [ -e /etc/postgresql/9.6/ ]
-    then
-        local pg_hba=/etc/postgresql/9.6/main/pg_hba.conf
-        local logfile=/var/log/postgresql/postgresql-9.6-main.log
-    else
-        if dpkg --list | grep -q "ii  postgresql-9."
-        then
-            ynh_die "It looks like postgresql was not properly configured ? /etc/postgresql/9.* is missing ... Could be due to a locale issue, c.f.https://serverfault.com/questions/426989/postgresql-etc-postgresql-doesnt-exist"
-        else
-            ynh_die "postgresql shoud be 9.4 or 9.6"
-        fi
-    fi
-
-    ynh_systemd_action --service_name=postgresql --action=start
-
-    sudo --login --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$psql_root_password'" postgres
-
-    # force all user to connect to local databases using hashed passwords
-    # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html#EXAMPLE-PG-HBA.CONF
-    # Note: we can't use peer since YunoHost create users with nologin
-    #  See: https://github.com/YunoHost/yunohost/blob/unstable/data/helpers.d/user
-    ynh_replace_string --match_string="local\(\s*\)all\(\s*\)all\(\s*\)peer" --replace_string="local\1all\2all\3md5" --target_file="$pg_hba"
-
-    # Advertise service in admin panel
-    yunohost service add postgresql --log "$logfile"
-
-    systemctl enable postgresql
-    ynh_systemd_action --service_name=postgresql --action=reload
 }


### PR DESCRIPTION
## The problem

Had a story today about a user that for some reason had postgresql already installed but cluster service was down ...

## Solution

psql first time helper should make sure the service is started ... In fact the current code of the helper is pretty weird and can be simplified and made more explicit

## PR Status

Done

## How to test

Install an app that uses postgresql

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
