### PR TITLE
Ugly hack to workaround sury pinning issues when installing dependencies

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -193,17 +193,37 @@ ynh_package_install_from_equivs () {
     LC_ALL=C equivs-build ./control 1> /dev/null
     dpkg --force-depends --install "./${pkgname}_${pkgversion}_all.deb" 2>&1)
 
-    ynh_package_install --fix-broken || \
+    # Let's try to see if install will work using dry-run. It it fails,
+    # it could be because the pinning of sury is blocking some package install
+    # c.f. for example: https://github.com/YunoHost/issues/issues/1563#issuecomment-623406509
+    # ... In that case, we use an ugly hack were we'll use a tweaked
+    # preferences.d directory with looser contrains for sury...
+    if ! ynh_package_install --fix-broken --dry-run >/dev/null 2>&1 && [ -e /etc/apt/preferences.d/extra_php_version ]
+    then
+        cp -r /etc/apt/preferences.d/ /etc/apt/preferences.d.tmp/
+        sed 's/^Pin-Priority: .*/Pin-Priority: 600/g' -i /etc/apt/preferences.d.tmp/extra_php_version
+        local apt_tweaks='--option Dir::Etc::preferencesparts=preferences.d.tmp'
+        # Try a dry-run again to see if that fixes the issue ...
+        # If it did not, then that's probably not related to sury.
+        ynh_package_install $apt_tweaks --fix-broken --dry-run >/dev/null 2>&1 || apt_tweaks=""
+    else
+        local apt_tweaks=""
+    fi
+
+    # Try to install for real
+    ynh_package_install $apt_tweaks --fix-broken || \
         { # If the installation failed 
         # (the following is ran inside { } to not start a subshell otherwise ynh_die wouldnt exit the original process)
+        rm --recursive --force /etc/apt/preferences.d.tmp/
         # Get the list of dependencies from the deb
         local dependencies="$(dpkg --info "$TMPDIR/${pkgname}_${pkgversion}_all.deb" | grep Depends | \
             sed 's/^ Depends: //' | sed 's/,//g')"
         # Fake an install of those dependencies to see the errors
         # The sed command here is, Print only from '--fix-broken' to the end.
-        ynh_package_install $dependencies --dry-run | sed --quiet '/--fix-broken/,$p' >&2
+        ynh_package_install $apt_tweaks $dependencies --dry-run | sed --quiet '/--fix-broken/,$p' >&2
         ynh_die --message="Unable to install dependencies"; }
     [[ -n "$TMPDIR" ]] && rm --recursive --force $TMPDIR	# Remove the temp dir.
+    rm --recursive --force /etc/apt/preferences.d.tmp/
 
     # check if the package is actually installed
     ynh_package_is_installed "$pkgname"


### PR DESCRIPTION
## The problem

As discussed [here](https://github.com/YunoHost/issues/issues/1563#issuecomment-623406509) or [here](https://github.com/YunoHost/issues/issues/1563#issuecomment-623406509) or [here](https://paste.yunohost.org/raw/logudeyuji) ... : we currently have some stupid issues because of sury that leads to situation where "Application Foo cannot be installed after application Bar is installed".

The explanation is : 
- One application (for example: nextcloud) will install php7.3-zip (or other sury deps combination will trigger similar issues)
- php7.3-zip depends on libzip4
- Both php7.3-zip and libzip4 are installed from sury and live happily. In particular, libzip4 is now version 1.5-whatever
- Then you try to install another app. For example: framaforms
- Framaforms depends on libzip-dev
- libzip-dev depends on libzip4 with a very strict dependency on the version number. Both must have the same version number
- But now sury is pinned with priority 200 (which I believe is a feature, meant to avoid upgrading all system packages to sury)
- So apt won't take libzip-dev from sury but from the regular Debian repo. So it wants to install libzip-dev version 1.1-whatever.
- But then it realizes that doesn't match libzip4 version which is 1.5
- Install fails

## Solution

*(Well, the real solution here would be some sort of real dependency containerization system but that's a whole different story)*

The source of the issue here seems to be the (low) pinning priority of Sury ... But we don't want to touch it because that's by design (though we could debate to use Sury 100% ... but we've seen that it can trigger other issues with openssl vs. python-pip and other things we may not know about)

*But* when we install app dependencies, it sounds legit to relax the priority of Sury if it's an issue to install the dependency...

So the strategy is : 
- simulate the install using --dry-run
- if we see there's an issue, try to relax the pinning priority of sury
- this is done in a separate preferences.d folder such that if whatever crash happens, running "apt dist-upgrade" will still use the regular pinning priority
- go on with the install

## PR Status

Tested by installing Nextcloud then Framaforms

## How to test

Install Nextcloud then Framaforms (though that's not the only possible scenario where this happens)

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
