### PR TITLE
Change url to the stable branch

### DIFF
--- a/doc/helper_doc_template.html
+++ b/doc/helper_doc_template.html
@@ -72,7 +72,7 @@
     </p>
     {% endif %}
     <p>
-        <a href="https://github.com/YunoHost/yunohost/blob/stretch-unstable/data/helpers.d/{{ category }}#L{{ h.line + 1 }}">Dude, show me the code !</a>
+        <a href="https://github.com/YunoHost/yunohost/blob/stretch-stable/data/helpers.d/{{ category }}#L{{ h.line + 1 }}">Dude, show me the code !</a>
     </p>
 
   </div>


### PR DESCRIPTION
## The problem

The helpers doc doesn't point to the stable branch, so links are broken as soon as we have an unstable version.

## Solution

Change this link \o/

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
