### PR TITLE
fix v6 detection when using wg-quick

### DIFF
--- a/data/hooks/diagnosis/10-ip.py
+++ b/data/hooks/diagnosis/10-ip.py
@@ -108,7 +108,7 @@ class IPDiagnoser(Diagnoser):
             return False
 
         # If we are indeed connected in ipv4 or ipv6, we should find a default route
-        routes = check_output("ip -%s route" % protocol).split("\n")
+        routes = check_output("ip -%s route show table all" % protocol).split("\n")
 
         def is_default_route(r):
             # Typically the default route starts with "default"

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -57,7 +57,7 @@ def get_public_ip_from_remote_server(protocol=4):
         return None
 
     # If we are indeed connected in ipv4 or ipv6, we should find a default route
-    routes = check_output("ip -%s route" % protocol).split("\n")
+    routes = check_output("ip -%s route show table all" % protocol).split("\n")
     def is_default_route(r):
         # Typically the default route starts with "default"
         # But of course IPv6 is more complex ... e.g. on internet cube there's


### PR DESCRIPTION
## The problem

When using wg-quick to setup a wireguard remote endpoint as a default gateway, the default route doesn't appear in the output of `ip -6 route`.

## Solution

Display all routes, from all routing tables.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
