### PR TITLE
Do not create a new password if the user already exists

### DIFF
--- a/data/helpers.d/postgresql
+++ b/data/helpers.d/postgresql
@@ -229,12 +229,14 @@ ynh_psql_setup_db() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    local new_db_pwd=$(ynh_string_random) # Generate a random password
-    # If $db_pwd is not given, use new_db_pwd instead for db_pwd
-    db_pwd="${db_pwd:-$new_db_pwd}"
-
     if ! ynh_psql_user_exists --user=$db_user; then
+        local new_db_pwd=$(ynh_string_random) # Generate a random password
+        # If $db_pwd is not given, use new_db_pwd instead for db_pwd
+        db_pwd="${db_pwd:-$new_db_pwd}"
+        
         ynh_psql_create_user "$db_user" "$db_pwd"
+    elif [ -z $db_pwd ]; then
+        ynh_die --message="The user $db_user exists, please provide his password"
     fi
 
     ynh_psql_create_db "$db_name" "$db_user"                     # Create the database


### PR DESCRIPTION
## The problem

If the user exists, we don't need to create a new password, but use the current one.

## Solution

Create a new password only if the user doesn't exist, and force the usage of the option db_pwd if the user exists

## PR Status

...

## How to test

...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
