### PR TITLE
Use system hostname by default for avahi

### DIFF
--- a/data/templates/avahi-daemon/avahi-daemon.conf
+++ b/data/templates/avahi-daemon/avahi-daemon.conf
@@ -19,7 +19,7 @@
 # file!
 
 [server]
-host-name=yunohost
+#host-name=yunohost
 domain-name=local
 #browse-domains=0pointer.de, zeroconf.org
 use-ipv4=yes


### PR DESCRIPTION
## The problem

The yunohost machine is registered as `yunohost.local` even when a different system hostname is set.
Running `avahi-resolve-address <yunohost machine IP>` always returns `yunohost.local`.

## Solution

Removing the `host-name` line in `/etc/avahi/avahi-daemon.conf` and restarting the `avahi-daemon` service solved the issue.
As described in the [avahi-demon manual](https://linux.die.net/man/5/avahi-daemon.conf):
> host-name= Set the host name avahi-daemon tries to register on the LAN. **If omited defaults to the system host name as set with the sethostname() system call**.
