### PR TITLE
Fix ynh_add_fpm_config with template in restore

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -148,8 +148,12 @@ ynh_add_fpm_config () {
 
     if [ $use_template -eq 1 ]
     then
-        # Usage 1, use the template in ../conf/php-fpm.conf
-        cp ../conf/php-fpm.conf "$finalphpconf"
+        # Usage 1, use the template in conf/php-fpm.conf
+        local phpfpm_path="../conf/php-fpm.conf"
+        if [ ! -e "$phpfpm_path" ]; then
+            phpfpm_path="../settings/conf/php-fpm.conf"	# Into the restore script, the php-fpm template is not at the same place
+        fi
+        cp "$phpfpm_path" "$finalphpconf"
         ynh_replace_string --match_string="__NAMETOCHANGE__" --replace_string="$app" --target_file="$finalphpconf"
         ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalphpconf"
         ynh_replace_string --match_string="__USER__" --replace_string="$app" --target_file="$finalphpconf"

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -153,6 +153,8 @@ ynh_add_fpm_config () {
         if [ ! -e "$phpfpm_path" ]; then
             phpfpm_path="../settings/conf/php-fpm.conf"	# Into the restore script, the php-fpm template is not at the same place
         fi
+        # Make sure now that the template indeed exists
+        [ -e "$phpfpm_path" ] || ynh_die --message="Unable to find template to configure php-fpm."
         cp "$phpfpm_path" "$finalphpconf"
         ynh_replace_string --match_string="__NAMETOCHANGE__" --replace_string="$app" --target_file="$finalphpconf"
         ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalphpconf"


### PR DESCRIPTION
## The problem
`ynh_add_fpm_config` doesn't work with a template in restoration context due to different path to `php-fpm.conf` file (as raised here: 
https://github.com/YunoHost/yunohost/pull/881/files#r429565721)

## Solution

Test the 2 possibles paths (as already done here https://github.com/YunoHost/yunohost/blob/stretch-unstable/data/helpers.d/apt#L247-L250)

## PR Status

Tested in the frame of cachet package here: https://github.com/YunoHost-Apps/cachet_ynh/pull/13/commits/12680d1be3ec21c3cca975ab850841738d768b15

## How to test

Test the cachet package, or use the helper with a template in restoration context.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
