### PR TITLE
Typo fix for error or diagnostics messages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -171,7 +171,7 @@
     "diagnosis_dns_good_conf": "DNS records are correctly configured for domain {domain} (category {category})",
     "diagnosis_dns_bad_conf": "Some DNS records are missing or incorrect for domain {domain} (category {category})",
     "diagnosis_dns_missing_record": "According to the recommended DNS configuration, you should add a DNS record with the following info.<br>Type: <code>{type}</code><br>Name: <code>{name}</code><br>Value: <code>{value}</code>",
-    "diagnosis_dns_discrepancy": "The following DNS record does not seem to follow the recommended configuration:<br>Type: <code>{type}</code><br>Name: <code>{name}</code><br>Current value: <code>{current}</code><br>Excepted value: <code>{value}</code>",
+    "diagnosis_dns_discrepancy": "The following DNS record does not seem to follow the recommended configuration:<br>Type: <code>{type}</code><br>Name: <code>{name}</code><br>Current value: <code>{current}</code><br>Expected value: <code>{value}</code>",
     "diagnosis_dns_point_to_doc": "Please check the documentation at <a href='https://yunohost.org/dns_config'>https://yunohost.org/dns_config</a> if you need help about configuring DNS records.",
     "diagnosis_domain_expiration_not_found": "Unable to check the expiration date for some domains",
     "diagnosis_domain_not_found_details": "The domain {domain} doesn't exist in WHOIS database or is expired!",

--- a/src/yunohost/hook.py
+++ b/src/yunohost/hook.py
@@ -432,7 +432,7 @@ def _hook_exec_bash(path, args, no_trace, chdir, env, user, return_format, logge
                     returncontent[key] = value
 
         else:
-            raise YunohostError("Excepted value for return_format is either 'json' or 'plain_dict', got '%s'" % return_format)
+            raise YunohostError("Expected value for return_format is either 'json' or 'plain_dict', got '%s'" % return_format)
     finally:
         stdreturndir = os.path.split(stdreturn)[0]
         os.remove(stdreturn)


### PR DESCRIPTION
## The problem

There are typos in error messages when a wrong value has been detected. The string talks about 'excepted' whereas this should be 'expected' (as this is about expectations, not exceptions we are talking about).

## Solution

Use 'Expected'

## PR Status

None

## How to test

Look at the new diagnosis/diagnostics feature when there is an error. Mine was about the DNS values which reported:
```
Name: @
Current value: [u'50 one_server.', u'10 another_server.']
Excepted value: 10 my_own_domain.
```

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
