### PR TITLE
Don't add unprotected_urls if it's already in skipped_urls

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1338,7 +1338,7 @@ def app_ssowatconf():
             url = _sanitized_absolute_url(perm_info["url"])
             perm_info["url"] = url
             if "visitors" in perm_info["allowed"]:
-                if url not in unprotected_urls:
+                if url not in unprotected_urls and url not in skipped_urls:
                     unprotected_urls.append(url)
 
                 # Legacy stuff : we remove now protected-urls that might have been declared as unprotected earlier...


### PR DESCRIPTION
## The problem

In case of app with skipped_urls, the conf ssowat contains app url in skipped and also in unprotected. This break completely the target of the skipped_urls

## Solution

Just add in unprotected if it's already in skipped.

## PR Status

Tested on my side with bitwarden

## How to test

Just install an app with skipped_urls and run ssowatconf

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
