### PR TITLE
Add logging and persistent as default config for new muc room

### DIFF
--- a/data/templates/metronome/domain.tpl.cfg.lua
+++ b/data/templates/metronome/domain.tpl.cfg.lua
@@ -47,6 +47,10 @@ Component "muc.{{ domain }}" "muc"
 
   muc_event_rate = 0.5
   muc_burst_factor = 10
+  room_default_config = {
+    logging = true,
+    persistent = true
+  };
 
 ---Set up a PubSub server
 Component "pubsub.{{ domain }}" "pubsub"


### PR DESCRIPTION
https://github.com/YunoHost/issues/issues/1609

## The problem

To sum up, with the XMPP android client conversations, some message can be lost in some circumstances, because conversations does not set "logging" and "persistent" options which are waited by metronome
...

## Solution
The solution is to set room_default_config in the MUC component configuration
(This is all thanks to the latest ommit of maranda https://github.com/maranda/metronome/commit/3bd36d3b88bf9508ba7cf71cbd4fff65c3497bdd which is in the metronome version 3.14.1)
...

## PR Status
The change in the commit should work
...

## How to test
  - Create a new private group in conversations
  - invite several users. Let's say Tarzan, Jane and Mannie
  - discuss and then disconnect Tarzan
  - Jane keep talking
  - Tarzan connect again

With the modification all three people should have the same content, without the change Tarzan will miss jane's messages and that's another story.
...

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
