### PR TITLE
Clean stale file/hashes in regen-conf

### DIFF
--- a/src/yunohost/regenconf.py
+++ b/src/yunohost/regenconf.py
@@ -485,6 +485,12 @@ def _update_conf_hashes(category, hashes):
     if category_conf is None:
         category_conf = {}
 
+    # If a file shall be removed and is indeed removed, forget entirely about
+    # that path.
+    # It avoid keeping weird old entries like
+    # /etc/nginx/conf.d/some.domain.that.got.removed.conf
+    hashes = {path: hash_ for path, hash_ in hashes.items() if hash_ is not None or os.path.exists(path)}
+
     category_conf['conffiles'] = hashes
     categories[category] = category_conf
     _save_regenconf_infos(categories)

--- a/src/yunohost/tests/test_regenconf.py
+++ b/src/yunohost/tests/test_regenconf.py
@@ -118,3 +118,48 @@ def test_stale_hashes_if_file_manually_deleted():
 
     assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
     assert TEST_DOMAIN_DNSMASQ_CONFIG not in _get_conf_hashes("dnsmasq")
+
+# This test only works if you comment the part at the end of the regen-conf in
+# dnsmasq that auto-flag /etc/dnsmasq.d/foo.bar as "to be removed" (using touch)
+# ... But we want to keep it because they also possibly flag files that were
+# never known by the regen-conf (e.g. if somebody adds a
+# /etc/dnsmasq.d/my.custom.extension)
+# Ideally we could use a system that's able to properly state 'no file in this
+# folder should exist except the ones excplicitly defined by regen-conf' but
+# that's too much work for the scope of this commit.
+#
+# ... Anyway, the proper way to write these tests would be to use a dummy
+# regen-conf hook just for tests but meh I'm lazy
+#
+#def test_stale_hashes_if_file_manually_modified():
+#    """
+#    Same as other test, but manually delete the file in between and check
+#    behavior
+#    """
+#
+#    domain_add(TEST_DOMAIN)
+#
+#    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+#    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+#
+#    os.system("echo '#pwet' > %s" % TEST_DOMAIN_DNSMASQ_CONFIG)
+#
+#    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+#    assert open(TEST_DOMAIN_DNSMASQ_CONFIG).read().strip() == "#pwet"
+#
+#    regen_conf(names=["dnsmasq"])
+#
+#    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+#    assert open(TEST_DOMAIN_DNSMASQ_CONFIG).read().strip() == "#pwet"
+#    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+#
+#    domain_remove(TEST_DOMAIN)
+#
+#    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+#    assert open(TEST_DOMAIN_DNSMASQ_CONFIG).read().strip() == "#pwet"
+#    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+#
+#    regen_conf(names=["dnsmasq"], force=True)
+#
+#    assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+#    assert TEST_DOMAIN_DNSMASQ_CONFIG not in _get_conf_hashes("dnsmasq")

--- a/src/yunohost/tests/test_regenconf.py
+++ b/src/yunohost/tests/test_regenconf.py
@@ -1,30 +1,24 @@
-import glob
 import os
-import pytest
-import shutil
-import requests
 
-from conftest import message, raiseYunohostError
-
-from moulinette import m18n
-from moulinette.utils.filesystem import mkdir
-
-from yunohost.domain import _get_maindomain, domain_add, domain_remove, domain_list
-from yunohost.utils.error import YunohostError
-from yunohost.regenconf import manually_modified_files, _get_conf_hashes, _force_clear_hashes
+from yunohost.domain import domain_add, domain_remove, domain_list
+from yunohost.regenconf import regen_conf, manually_modified_files, _get_conf_hashes, _force_clear_hashes
 
 TEST_DOMAIN = "secondarydomain.test"
-TEST_DOMAIN_NGINX_CONFIG = "/etc/nginx/conf.d/secondarydomain.test.conf"
+TEST_DOMAIN_NGINX_CONFIG = "/etc/nginx/conf.d/%s.conf" % TEST_DOMAIN
+TEST_DOMAIN_DNSMASQ_CONFIG = "/etc/dnsmasq.d/%s" % TEST_DOMAIN
+
 
 def setup_function(function):
 
     _force_clear_hashes([TEST_DOMAIN_NGINX_CONFIG])
     clean()
 
+
 def teardown_function(function):
 
     clean()
     _force_clear_hashes([TEST_DOMAIN_NGINX_CONFIG])
+
 
 def clean():
 
@@ -78,3 +72,49 @@ def test_add_domain_conf_already_exists():
     assert os.path.exists(TEST_DOMAIN_NGINX_CONFIG)
     assert TEST_DOMAIN_NGINX_CONFIG in _get_conf_hashes("nginx")
     assert TEST_DOMAIN_NGINX_CONFIG not in manually_modified_files()
+
+
+def test_stale_hashes_get_removed_if_empty():
+    """
+    This is intended to test that if a file gets removed and is indeed removed,
+    we don't keep a useless empty hash corresponding to an old file.
+    In this case, we test this using the dnsmasq conf file (we don't do this
+    using the nginx conf file because it's already force-removed during
+    domain_remove())
+    """
+
+    domain_add(TEST_DOMAIN)
+
+    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+
+    domain_remove(TEST_DOMAIN)
+
+    assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+    assert TEST_DOMAIN_DNSMASQ_CONFIG not in _get_conf_hashes("dnsmasq")
+
+
+def test_stale_hashes_if_file_manually_deleted():
+    """
+    Same as other test, but manually delete the file in between and check
+    behavior
+    """
+
+    domain_add(TEST_DOMAIN)
+
+    assert os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+
+    os.remove(TEST_DOMAIN_DNSMASQ_CONFIG)
+
+    assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+
+    regen_conf(names=["dnsmasq"])
+
+    assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+    assert TEST_DOMAIN_DNSMASQ_CONFIG in _get_conf_hashes("dnsmasq")
+
+    domain_remove(TEST_DOMAIN)
+
+    assert not os.path.exists(TEST_DOMAIN_DNSMASQ_CONFIG)
+    assert TEST_DOMAIN_DNSMASQ_CONFIG not in _get_conf_hashes("dnsmasq")


### PR DESCRIPTION
## The problem

So ugh this only took me like 4 hours to implement ... 

#### Problem 1

When you add then remove a domain, regenconf.yml will still contain dummy empty hash entries about the fact that "the file should be removed" - even if the file already got removed.

This is not a huge problem per se, but still weird that yunohost has some entries about stuff that happened years ago. (On a prod server I have a few entries about a few stupid domain names I added just for tests)

#### Problem 2

This one is a bit trickier.

The scenario is the following: 
- the admin adds a domain foo.bar
- therefore: the regen-conf creates file /etc/dnsmasq.d/foo.bar
- the admin manually *deletes* /etc/dnsmasq.d/foo.bar
- therefore: the file is now understood as manually deleted because there's the old file hash in regenconf.yml

 ... so far so good, that's the expected behavior. But then: 

- the admin remove domain foo.bar entirely
- ... but now the hash for /etc/dnsmasq.d/foo.bar is *still* in
regenconf.yml and and the file is still flagged as manually
modified/deleted... And the user cannot even do anything about it
except removing the hash in regenconf.yml...

Expected behavior: it should forget about that hash because dnsmasq's regen-conf doesn't say anything about what's the state of that file so it should assume that it should be deleted.

Note that the scenario get even worse if : 
- the admin tries to *re-add* foo.bar !
-  ... but because the file is still flagged as manually modified the regen-conf refuses to re-create the file.


## Solution

1. Forget about stale "empty" hashes. If file `/x/y/z` is flagged as "should be deleted" and is already deleted, no need to remember anything about it.
2. Handle stale "non-empty" hashes. If the a regen-conf hook generates file `a`, `b`, `c`, then later you re-run the same hook, and it only generates files `a` and `c`, it should assume that `b` is not relevant anymore and should be deleted.

Sorry about the tests which are a bit messy.... Thing is, it's not really a good practice to rely on domain_add/remove to make this test. Instead we should have a custom regen conf hook designed for testing but ugh I'm too lazy to implement all the testing properly...

Also note that in the ideal world, we should have a mechanism where hook could state that "every file in folder `/x/y/` should be deleted except for `z` and `k`" (which would also avoid our weird hacks about `touch`ing files to remove old stuff)

## PR Status

Tested on my side.

## How to test

Eh run the test / play with regen-conf and weird scenarios of manually-modified stuff etc.

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
