### PR TITLE
Simplify apt/php dependencies helpers

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -360,7 +360,6 @@ ynh_add_sury() {
 #
 # usage: ynh_add_app_dependencies --package=phpversion [--replace]
 # | arg: -p, --package=     - Packages to add as dependencies for the app.
-# | arg: -r, --replace      - Replace dependencies instead of adding to existing ones.
 #
 # Requires YunoHost version 3.8.1 or higher.
 ynh_add_app_dependencies () {
@@ -368,24 +367,10 @@ ynh_add_app_dependencies () {
     local legacy_args=pr
     local -A args_array=( [p]=package= [r]=replace)
     local package
-    local replace
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
-    replace=${replace:-0}
 
-    local current_dependencies=""
-    if [ $replace -eq 0 ]
-    then
-        local dep_app=${app//_/-}	# Replace all '_' by '-'
-        if ynh_package_is_installed --package="${dep_app}-ynh-deps"
-        then
-            current_dependencies="$(dpkg-query --show --showformat='${Depends}' ${dep_app}-ynh-deps) "
-        fi
-
-        current_dependencies=${current_dependencies// | /|}
-    fi
-
-    ynh_install_app_dependencies "${current_dependencies}${package}"
+    ynh_install_app_dependencies "${package}"
 }
 
 # Remove fake package and its dependencies
@@ -450,7 +435,7 @@ ynh_install_extra_app_dependencies () {
     ynh_install_extra_repo --repo="$repo" $key --priority=995 --name=$name
 
     # Install requested dependencies from this extra repository.
-    ynh_add_app_dependencies --package="$package"
+    ynh_install_app_dependencies --package="$package"
 
     # Remove this extra repository after packages are installed
     ynh_remove_extra_repo --name=$app

--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -209,6 +209,8 @@ ynh_package_install_from_equivs () {
     ynh_package_is_installed "$pkgname"
 }
 
+YNH_INSTALL_APP_DEPENDENCIES_REPLACE="true"
+
 # Define and install dependencies with a equivs control file
 #
 # This helper can/should only be called once per app
@@ -247,6 +249,24 @@ ynh_install_app_dependencies () {
         # [^,]\+ matches all characters except ','
         # Ex: 'package>=1.0' will be replaced by 'package (>= 1.0)'
         dependencies="$(echo "$dependencies" | sed 's/\([^(\<=\>]\)\([\<=\>]\+\)\([^,]\+\)/\1 (\2 \3)/g')"
+    fi
+
+    # The first time we run ynh_install_app_dependencies, we will replace the
+    # entire control file (This is in particular meant to cover the case of
+    # upgrade script where ynh_install_app_dependencies is called with this
+    # expected effect) Otherwise, any subsequent call will add dependencies
+    # to those already present in the equivs control file.
+    if [[ $YNH_INSTALL_APP_DEPENDENCIES_REPLACE == "true" ]]
+    then
+        YNH_INSTALL_APP_DEPENDENCIES_REPLACE="false"
+    else
+        local current_dependencies=""
+        if ynh_package_is_installed --package="${dep_app}-ynh-deps"
+        then
+            current_dependencies="$(dpkg-query --show --showformat='${Depends}' ${dep_app}-ynh-deps) "
+        fi
+        current_dependencies=${current_dependencies// | /|}
+        dependencies="$current_dependencies $dependencies"
     fi
 
     #
@@ -290,6 +310,9 @@ EOF
     rm /tmp/${dep_app}-ynh-deps.control
     ynh_app_setting_set --app=$app --key=apt_dependencies --value="$dependencies"
 }
+
+
+
 
 # Add dependencies to install with ynh_install_app_dependencies
 #

--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -283,14 +283,7 @@ ynh_install_app_dependencies () {
             # And sury ain't already in sources.lists
             if ! grep --recursive --quiet "^ *deb.*sury" /etc/apt/sources.list*
             then
-                # Re-add sury
-                ynh_install_extra_repo --repo="https://packages.sury.org/php/ $(ynh_get_debian_release) main" --key="https://packages.sury.org/php/apt.gpg" --name=extra_php_version --priority=600
-
-                # Pin this sury repository to prevent sury of doing shit
-                for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
-                do
-                    ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
-                done
+                ynh_add_sury
             fi
         fi
     fi
@@ -311,7 +304,24 @@ EOF
     ynh_app_setting_set --app=$app --key=apt_dependencies --value="$dependencies"
 }
 
+# Add sury repository with adequate pin strategy
+#
+# [internal]
+#
+# usage: ynh_add_sury
+#
+ynh_add_sury() {
 
+    # Add an extra repository for those packages
+    ynh_install_extra_repo --repo="https://packages.sury.org/php/ $(ynh_get_debian_release) main" --key="https://packages.sury.org/php/apt.gpg" --name=extra_php_version --priority=600
+
+    # Pin this extra repository after packages are installed to prevent sury of doing shit
+    for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
+    do
+        ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
+    done
+
+}
 
 
 # Add dependencies to install with ynh_install_app_dependencies

--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -251,6 +251,25 @@ ynh_install_app_dependencies () {
         dependencies="$(echo "$dependencies" | sed 's/\([^(\<=\>]\)\([\<=\>]\+\)\([^,]\+\)/\1 (\2 \3)/g')"
     fi
 
+    # Check for specific php dependencies which requires sury
+    # This grep will for example return "7.4" if dependencies is "foo bar php7.4-pwet php-gni"
+    local specific_php_version=$(echo $dependencies | tr '-' ' ' | grep -o -E "\<php[0-9.]+\>" | sed 's/php//g' | sort | uniq)
+
+    # Ignore case where the php version found is the one available in debian vanilla
+    [[ "$specific_php_version" != "$YNH_DEFAULT_PHP_VERSION" ]] || specific_php_version=""
+
+    if [[ -n "$specific_php_version" ]]
+    then
+        # Cover a small edge case where a packager could have specified "php7.4-pwet php5-gni" which is confusing
+        [[ $(echo $specific_php_version | wc -l) -eq 1 ]] \
+            || ynh_die --message="Inconsistent php versions in dependencies ... found : $specific_php_version"
+
+        dependencies+=", php${specific_php_version}, php${specific_php_version}-fpm, php${specific_php_version}-common"
+
+        ynh_add_sury
+    fi
+
+
     # The first time we run ynh_install_app_dependencies, we will replace the
     # entire control file (This is in particular meant to cover the case of
     # upgrade script where ynh_install_app_dependencies is called with this
@@ -264,16 +283,16 @@ ynh_install_app_dependencies () {
         if ynh_package_is_installed --package="${dep_app}-ynh-deps"
         then
             current_dependencies="$(dpkg-query --show --showformat='${Depends}' ${dep_app}-ynh-deps) "
+            current_dependencies=${current_dependencies// | /|}
         fi
-        current_dependencies=${current_dependencies// | /|}
-        dependencies="$current_dependencies $dependencies"
+        dependencies="$current_dependencies, $dependencies"
     fi
 
     #
     # Epic ugly hack to fix the goddamn dependency nightmare of sury
     # Sponsored by the "Djeezusse Fokin Kraiste Why Do Adminsys Has To Be So Fucking Complicated I Should Go Grow Potatoes Instead Of This Shit" collective
     # https://github.com/YunoHost/issues/issues/1407
-    # 
+    #
     # If we require to install php dependency
     if echo $dependencies | grep --quiet 'php'
     then
@@ -301,7 +320,20 @@ EOF
     ynh_package_install_from_equivs /tmp/${dep_app}-ynh-deps.control \
         || ynh_die --message="Unable to install dependencies"	# Install the fake package and its dependencies
     rm /tmp/${dep_app}-ynh-deps.control
+
     ynh_app_setting_set --app=$app --key=apt_dependencies --value="$dependencies"
+
+    if [[ -n "$specific_php_version" ]]
+    then
+        # Set the default php version back as the default version for php-cli.
+        update-alternatives --set php /usr/bin/php$YNH_DEFAULT_PHP_VERSION
+
+        # Store phpversion into the config of this app
+        ynh_app_setting_set $app phpversion $specific_php_version
+
+        # Integrate new php-fpm service in yunohost
+        yunohost service add php${specific_php_version}-fpm --log "/var/log/php${phpversion}-fpm.log"
+    fi
 }
 
 # Add sury repository with adequate pin strategy
@@ -315,7 +347,7 @@ ynh_add_sury() {
     # Add an extra repository for those packages
     ynh_install_extra_repo --repo="https://packages.sury.org/php/ $(ynh_get_debian_release) main" --key="https://packages.sury.org/php/apt.gpg" --name=extra_php_version --priority=600
 
-    # Pin this extra repository after packages are installed to prevent sury of doing shit
+    # Pin this extra repository after packages are installed to prevent sury from doing shit
     for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
     do
         ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
@@ -365,7 +397,26 @@ ynh_add_app_dependencies () {
 # Requires YunoHost version 2.6.4 or higher.
 ynh_remove_app_dependencies () {
     local dep_app=${app//_/-}	# Replace all '_' by '-'
+
+    local current_dependencies=""
+    if ynh_package_is_installed --package="${dep_app}-ynh-deps"
+    then
+        current_dependencies="$(dpkg-query --show --showformat='${Depends}' ${dep_app}-ynh-deps) "
+        current_dependencies=${current_dependencies// | /|}
+    fi
+
     ynh_package_autopurge ${dep_app}-ynh-deps	# Remove the fake package and its dependencies if they not still used.
+
+    # Check if this app used a specific php version ... in which case we check
+    # if the corresponding php-fpm is still there. Otherwise, we remove the
+    # service from yunohost as well
+
+    local specific_php_version=$(echo $dependencies | tr '-' ' ' | grep -o -E "\<php[0-9.]+\>" | sed 's/php//g' | sort | uniq)
+    [[ "$specific_php_version" != "$YNH_DEFAULT_PHP_VERSION" ]] || specific_php_version=""
+    if [[ -n "$specific_php_version" ]] && ! ynh_package_is_installed --package="php${specific_php_version}-fpm";
+    then
+        yunohost service remove php${specific_php_version}-fpm
+    fi
 }
 
 # Install packages from an extra repository properly.

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -353,8 +353,7 @@ ynh_install_php () {
         echo "$YNH_APP_INSTANCE_NAME:$phpversion" | tee --append "/etc/php/ynh_app_version"
     fi
 
-    # Add an extra repository for those packages
-    ynh_install_extra_repo --repo="https://packages.sury.org/php/ $(ynh_get_debian_release) main" --key="https://packages.sury.org/php/apt.gpg" --priority=995 --name=extra_php_version --priority=600
+    ynh_add_sury
 
     # Install requested dependencies from this extra repository.
     # Install php-fpm first, otherwise php will install apache as a dependency.
@@ -363,12 +362,6 @@ ynh_install_php () {
 
     # Set the default php version back as the default version for php-cli.
     update-alternatives --set php /usr/bin/php$YNH_DEFAULT_PHP_VERSION
-
-    # Pin this extra repository after packages are installed to prevent sury of doing shit
-    for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
-    do
-        ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
-    done
 
     # Advertise service in admin panel
     yunohost service add php${phpversion}-fpm --log "/var/log/php${phpversion}-fpm.log"

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -100,7 +100,7 @@ ynh_add_fpm_config () {
     elif [ -n "$package" ]
     then
         # Install the additionnal packages from the default repository
-        ynh_add_app_dependencies --package="$package"
+        ynh_install_app_dependencies "$package"
     fi
 
     if [ $dedicated_service -eq 1 ]
@@ -335,36 +335,13 @@ ynh_install_php () {
     ynh_handle_getopts_args "$@"
     package=${package:-}
 
-    # Store phpversion into the config of this app
-    ynh_app_setting_set $app phpversion $phpversion
-
     if [ "$phpversion" == "$YNH_DEFAULT_PHP_VERSION" ]
     then
         ynh_die "Do not use ynh_install_php to install php$YNH_DEFAULT_PHP_VERSION"
     fi
 
-    # Create the file if doesn't exist already
-    touch /etc/php/ynh_app_version
-
-    # Do not add twice the same line
-    if ! grep --quiet "$YNH_APP_INSTANCE_NAME:" "/etc/php/ynh_app_version"
-    then
-        # Store the ID of this app and the version of php requested for it
-        echo "$YNH_APP_INSTANCE_NAME:$phpversion" | tee --append "/etc/php/ynh_app_version"
-    fi
-
-    ynh_add_sury
-
-    # Install requested dependencies from this extra repository.
-    # Install php-fpm first, otherwise php will install apache as a dependency.
-    ynh_add_app_dependencies --package="php${phpversion}-fpm"
-    ynh_add_app_dependencies --package="php$phpversion php${phpversion}-common $package"
-
-    # Set the default php version back as the default version for php-cli.
-    update-alternatives --set php /usr/bin/php$YNH_DEFAULT_PHP_VERSION
-
-    # Advertise service in admin panel
-    yunohost service add php${phpversion}-fpm --log "/var/log/php${phpversion}-fpm.log"
+    ynh_install_app_dependencies "$package"
+    ynh_app_setting_set $app phpversion $phpversion
 }
 
 # Remove the specific version of php used by the app.
@@ -375,35 +352,7 @@ ynh_install_php () {
 #
 # Requires YunoHost version 3.8.1 or higher.
 ynh_remove_php () {
-    # Get the version of php used by this app
-    local phpversion=$(ynh_app_setting_get $app phpversion)
-
-    if [ "$phpversion" == "$YNH_DEFAULT_PHP_VERSION" ] || [ -z "$phpversion" ]
-    then
-        if [ "$phpversion" == "$YNH_DEFAULT_PHP_VERSION" ]
-        then
-            ynh_print_err "Do not use ynh_remove_php to remove php$YNH_DEFAULT_PHP_VERSION !"
-        fi
-        return 0
-    fi
-
-    # Create the file if doesn't exist already
-    touch /etc/php/ynh_app_version
-
-    # Remove the line for this app
-    sed --in-place "/$YNH_APP_INSTANCE_NAME:$phpversion/d" "/etc/php/ynh_app_version"
-
-    # If no other app uses this version of php, remove it.
-    if ! grep --quiet "$phpversion" "/etc/php/ynh_app_version"
-    then
-        # Remove the service from the admin panel
-        if ynh_package_is_installed --package="php${phpversion}-fpm"; then
-            yunohost service remove php${phpversion}-fpm
-        fi
-
-        # Purge php dependencies for this version.
-        ynh_package_autopurge "php$phpversion php${phpversion}-fpm php${phpversion}-common"
-    fi
+    ynh_remove_app_dependencies
 }
 
 # Define the values to configure php-fpm


### PR DESCRIPTION
## The problem

Following https://forum.yunohost.org/t/pdoexception-queryexception-could-not-find-driver/11848/18 I went berserk about the apt/php dependency helpers that are overcomplicated and error prone.

The explanation behind the story is that the app was using : 
```
ynh_install_php  # + some options to install some packages
[...]
ynh_install_app_dependencies "some other packages"
```

But `ynh_install_app_dependencies` behavior is such that it forgets about any dependency previously installed, which later led to the removal of the php dependency of the app (in this case, php-pgsql)

Apparently the "right" way is to use the `--package` option in `ynh_add_fpm_config` to install specific php dependency but imho that's neither obvious, semantic nor good sense to install some apt dependency at the beginning of the install, and some other at some other time - but only if they are not about the default php version ...

More generally, the current way to install apt dependency is hella confusing... There's 
- `ynh_install_app_dependency`
- `ynh_add_app_dependency`
- `ynh_install_extra_app_dependency`
- `ynh_install_php`
- `ynh_add_fpm_config --package`

(not to mention the associated removal helpers and add_repo and pin etc...)

This is creating overly complex stuff and bugs, both in apps (c.f. previous example + all the apps that need to split "regular" dependency and php dependency) and in the helpers themselves (spotted during this refactoring), and is hell to debug because there are dozens of call to apt and other things. 

While it's understandable because of the history of the whole thing and the lack clear strategy for sury, now that we have a better understanding and clarified what to do with php, we should simplify all of this before creating additional technical debt...

## Solution

If you need to install apt dependencies, you should call `ynh_install_app_dependencies`. Period. And you should be able to call it multiple time without it forgetting about previously installed deps. If sury needs to be installed, then it can be automatically determined because of the presence of a php7.X-foo in the list that does not corresponds to the vanilla php version.

This PR is therefore aiming to get rid of `ynh_add_app_dependency`, `ynh_install_php`, and the `--package` option of `ynh_add_fpm_config`. Since we can't do this in one go because some app depends on it, for now they are kept while app's code should be adapted ... then we can remove them in a follow-up PR.



## PR Status

Only partially tested on pixelfed for now but should be more tested to validate that there's no regression on other apps ...

## How to test

Zblerg try to install apps that depends on previously mentionned helpers

## Validation

- [ ] Principle agreement 0/2 : 
- [ ] Quick review 0/1 : 
- [ ] Simple test 0/1 : 
- [ ] Deep review 0/1 : 
