### PR TITLE
Silence info: wasn't deleted because it doesn't exist.

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -467,8 +467,8 @@ ynh_remove_extra_repo () {
 
     ynh_secure_remove "/etc/apt/sources.list.d/$name.list"
     ynh_secure_remove "/etc/apt/preferences.d/$name"
-    ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.gpg"
-    ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.asc"
+    ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.gpg" > /dev/null
+    ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.asc" > /dev/null
 
     # Update the list of package to exclude the old repo
     ynh_package_update


### PR DESCRIPTION
## The problem

When installing an application requiring an `ynh_install_extra_app_dependencies`, a `.gpg` or `.asc` key is installed. After the successful install of the dependency, the repository and the key are removed. We get then one of two info below:

- If a `.asc` key is remove we get this info:
`Info:  '/etc/apt/trusted.gpg.d/appName.gpg' wasn't deleted because it doesn't exist.`

- if a `.gpg` key is remove we get this info:
`Info:  '/etc/apt/trusted.gpg.d/appName.asc' wasn't deleted because it doesn't exist.`

## Solution

Silence output info for keys removal
