### PR TITLE
fix get_files_diff if {orig,new}_file is None

### DIFF
--- a/src/yunohost/regenconf.py
+++ b/src/yunohost/regenconf.py
@@ -440,13 +440,13 @@ def _get_files_diff(orig_file, new_file, as_string=False, skip_header=True):
 
     """
 
-    if os.path.exists(orig_file):
+    if orig_file and os.path.exists(orig_file):
         with open(orig_file, 'r') as orig_file:
             orig_file = orig_file.readlines()
     else:
         orig_file = []
 
-    if os.path.exists(new_file):
+    if new_file and os.path.exists(new_file):
         with open(new_file, 'r') as new_file:
             new_file = new_file.readlines()
     else:


### PR DESCRIPTION
## The problem

[Sometimes, new_file is set to `None`](https://github.com/YunoHost/yunohost/blob/7c2990ff9867fb027eb231baea590ee925eabc0d/src/yunohost/regenconf.py#L226-L239)

## Solution

...

## PR Status

...

## How to test

...
