### PR TITLE
Remove useless robot protection code

### DIFF
--- a/data/templates/nginx/yunohost_admin.conf
+++ b/data/templates/nginx/yunohost_admin.conf
@@ -28,12 +28,6 @@ server {
     }
 
     location /yunohost {
-        # Block crawlers bot
-        if ($http_user_agent ~ (crawl|Googlebot|Slurp|spider|bingbot|tracker|click|parser|spider|facebookexternalhit) ) {
-            return 403;
-        }
-        # X-Robots-Tag to precise the rules applied.
-        add_header  X-Robots-Tag "nofollow, noindex, noarchive, nosnippet";
         # Redirect most of 404 to maindomain.tld/yunohost/sso
         access_by_lua_file /usr/share/ssowat/access.lua;
     }


### PR DESCRIPTION
## The problem

So I thought this piece of code was somewhat useful but never took the time to carefully think about it ... And for some reason I did and realized that it's pretty much useless, yet it gives a false sense of protection ...

Because of the way nginx handle request and because of other location block, this rules only apply to : 

- `httpS://1.2.3.4/yunohost`
- `httpS://1.2.3.4/yunohost/foobar` (with foobar != admin)

And in particular it doesn't apply to : 

- `http://1.2.3.4/*` (nor the https redirection because you get redirected to https://1.2.3.4/yunohost/admin
- `https://1.2.3.4/yunohost/admin`
- `http(s)://any.domain/*`

And I can't think why a robot would end up querying exactly `httpS://1.2.3.4/yunohost` rather than `https://1.2.3.4` or `https://domain.tld/`

## Solution

Remove the code snippet because it just gives a false sense of security when there's pretty much none.

Yes, there's probably something more clever to do about preventing robot indexation of yunohost/admin and/or yunohost/sso but this triggers many existential questions about where/when/how and I don't want to spend X hours on this topic. Feel free to iterate on the PR though...

## PR Status

Yolocomitted

## How to test

Look at HTTP response headers doing various requests
