### PR TITLE
[FIX] patch sources list for armbian

### DIFF
--- a/src/yunohost/data_migrations/0015_migrate_to_buster.py
+++ b/src/yunohost/data_migrations/0015_migrate_to_buster.py
@@ -173,9 +173,7 @@ class MyMigration(Migration):
             command = "sed -i -e 's@ stretch @ buster @g' " \
                       "-e '/backports/ s@^#*@#@' " \
                       "-e 's@ stretch/updates @ buster/updates @g' " \
-                      "-e 's@ stretch-updates @ buster-updates @g' " \
-                      "-e 's@ stretch-utils @ buster-utils @g' " \
-                      "-e 's@ stretch-desktop @ buster-desktop @g' " \
+                      "-e 's@ stretch-@ buster-@g' " \
                       "{}".format(f)
             os.system(command)
 

--- a/src/yunohost/data_migrations/0015_migrate_to_buster.py
+++ b/src/yunohost/data_migrations/0015_migrate_to_buster.py
@@ -174,6 +174,8 @@ class MyMigration(Migration):
                       "-e '/backports/ s@^#*@#@' " \
                       "-e 's@ stretch/updates @ buster/updates @g' " \
                       "-e 's@ stretch-updates @ buster-updates @g' " \
+                      "-e 's@ stretch-utils @ buster-utils @g' " \
+                      "-e 's@ stretch-desktop @ buster-desktop @g' " \
                       "{}".format(f)
             os.system(command)
 


### PR DESCRIPTION
## The problem

After the migration I got this message during `apt update`
> Hit:7 https://apt.armbian.com buster InRelease
Reading package lists... Done
Building dependency tree       
Reading state information... Done
All packages are up to date.
W: Skipping acquire of configured file 'stretch-utils/binary-armhf/Packages' as repository 'http://apt.armbian.com buster InRelease' doesn't have the component 'stretch-utils' (component misspelt in sources.list?)
W: Skipping acquire of configured file 'stretch-utils/Contents-armhf' as repository 'http://apt.armbian.com buster InRelease' doesn't have the component 'stretch-utils' (component misspelt in sources.list?)
W: Skipping acquire of configured file 'stretch-desktop/binary-armhf/Packages' as repository 'http://apt.armbian.com buster InRelease' doesn't have the component 'stretch-desktop' (component misspelt in sources.list?)
W: Skipping acquire of configured file 'stretch-desktop/Contents-armhf' as repository 'http://apt.armbian.com buster InRelease' doesn't have the component 'stretch-desktop' (component misspelt in sources.list?)


## Solution

Replace `stretch` to `buster` in the file `/etc/apt/sources.list.d/armbian.list`, which contains without this patch:
> deb http://apt.armbian.com buster main stretch-utils stretch-desktop


## PR Status

...

## How to test

...
