### PR TITLE
[enh] Force HTTPOnly and Secure for all cookies

### DIFF
--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -30,6 +30,9 @@ more_set_headers "X-Download-Options : noopen";
 more_set_headers "X-Permitted-Cross-Domain-Policies : none";
 more_set_headers "X-Frame-Options : SAMEORIGIN";
 
+# Force HTTPOnly and Secure for all cookies
+proxy_cookie_path ~$ "; HTTPOnly; Secure;";
+
 # Disable gzip to protect against BREACH
 # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
 gzip off;


### PR DESCRIPTION
## The problem

HTTP allow to specify some secure options about cookies to avoid some attacks.

## Solution

Here i suggest to add HTTPOnly and secure for each cookies of all apps.

I am not sure of this approach, we need to think it with several examples of apps

## PR Status

To discuss

## How to test

...
