### PR TITLE
Add apt conf regen hook

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -265,12 +265,6 @@ ynh_install_app_dependencies () {
             then
                 # Re-add sury
                 ynh_install_extra_repo --repo="https://packages.sury.org/php/ $(ynh_get_debian_release) main" --key="https://packages.sury.org/php/apt.gpg" --name=extra_php_version --priority=600
-
-                # Pin this sury repository to prevent sury of doing shit
-                for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
-                do
-                    ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
-                done
             fi
         fi
     fi

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -364,12 +364,6 @@ ynh_install_php () {
     # Set the default PHP version back as the default version for php-cli.
     update-alternatives --set php /usr/bin/php$YNH_DEFAULT_PHP_VERSION
 
-    # Pin this extra repository after packages are installed to prevent sury of doing shit
-    for package_to_not_upgrade in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
-    do
-        ynh_pin_repo --package="$package_to_not_upgrade" --pin="origin \"packages.sury.org\"" --priority="-1" --name=extra_php_version --append
-    done
-
     # Advertise service in admin panel
     yunohost service add php${phpversion}-fpm --log "/var/log/php${phpversion}-fpm.log"
 }

--- a/data/hooks/conf_regen/10-apt
+++ b/data/hooks/conf_regen/10-apt
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+do_pre_regen() {
+    pending_dir=$1
+
+    mkdir --parents "${pending_dir}/etc/apt/preferences.d"
+
+    for package in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
+    do
+        echo "
+Package: $package
+Pin: origin \"packages.sury.org\" 
+Pin-Priority: -1" >> "/etc/apt/preferences.d/extra_php_version"
+    done
+}
+
+do_post_regen() {
+  regen_conf_files=$1
+}
+
+FORCE=${2:-0}
+DRY_RUN=${3:-0}
+
+case "$1" in
+  pre)
+    do_pre_regen $4
+    ;;
+  post)
+    do_post_regen $4
+    ;;
+  *)
+    echo "hook called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
## The problem

There are some weird inconsistencies related to the sury pinning policy and php package installs ... that's complicated to explain and i'm half drunk but basically it makes everything simpler and consistent to just manage the sury pinning policy from a regen-conf hook (even if sury isn't enabled ... it doesn't hurt to set the pinning policy anyway)

That way we can make sure that in the future, if we have to update the pinning policy, there's no weird stuff required about "having to re-run an install or upgrade of an app that uses sury for the pinning policy to get upgraded". It just gets upgraded because it's handled by the regenconf hook no matter what.

## Solution

Implement a regenconf hook for apt, more specifically to handle the apt pinning policy

## PR Status

Done, tested and working on my side

## How to test

Run the regen-conf, check the content of /etc/apt/preferences.d/extra_php_version
