### PR TITLE
[fix] Make sure app nginx confs do not prevent the loading of /yunohost/sso

### DIFF
--- a/data/templates/nginx/plain/yunohost_sso.conf.inc
+++ b/data/templates/nginx/plain/yunohost_sso.conf.inc
@@ -2,4 +2,6 @@
 rewrite ^/yunohost/sso$ /yunohost/sso/ permanent;
 
 location /yunohost/sso/ {
+   # This is an empty location, only meant to avoid other locations
+   # from matching /yunohost/sso, such that it's correctly handled by ssowat
 }

--- a/data/templates/nginx/plain/yunohost_sso.conf.inc
+++ b/data/templates/nginx/plain/yunohost_sso.conf.inc
@@ -1,0 +1,5 @@
+# Avoid the nginx path/alias traversal weakness ( #1037 )
+rewrite ^/yunohost/sso$ /yunohost/sso/ permanent;
+
+location /yunohost/sso/ {
+}

--- a/data/templates/nginx/server.tpl.conf
+++ b/data/templates/nginx/server.tpl.conf
@@ -14,7 +14,7 @@ server {
 
     include /etc/nginx/conf.d/{{ domain }}.d/*.conf;
 
-    location /yunohost/admin {
+    location /yunohost {
         return 301 https://$http_host$request_uri;
     }
 
@@ -60,6 +60,7 @@ server {
 
     include /etc/nginx/conf.d/{{ domain }}.d/*.conf;
 
+    include /etc/nginx/conf.d/yunohost_sso.conf.inc;
     include /etc/nginx/conf.d/yunohost_admin.conf.inc;
     include /etc/nginx/conf.d/yunohost_api.conf.inc;
 


### PR DESCRIPTION
## The problem

It seems rewrite rules are interpreted before access_by_lua_file script, this create some problem to access SSO with app installed on root domain...

https://forum.yunohost.org/t/acces-interface-utilisateur-cms/12553

## Solution

Create a location nginx to isolate /yunohost/sso from this kind of rules defined by apps.
Another solution as been explored in ssowat by replacing uri by request-uri, but some other issues come, so this method fix quickly this issue.

## PR Status

Ready

## How to test

Regen con and install grav on root domain adn try to access SSO
