### PR TITLE
Add possibility to download backups

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -913,6 +913,14 @@ backup:
                     help: Print sizes in human readable format
                     action: store_true
 
+        ### backup_download()
+        download:
+            action_help: (API only) Request to download the file
+            api: GET /backup/download/<name>
+            arguments:
+                name:
+                    help: Name of the local backup archive
+
         ### backup_delete()
         delete:
             action_help: Delete a backup archive


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/838

Currently backup can't be downloaded from the webadmin which is kind of "not cool" and not practical

## Solution

Implement that possibility ... the tricky part is that moulinette is built such that it calls the python functions and expect to get serializable data like lists, dict ... so how exactly are you supposed to return a file ?

Solved this by adding the possibility in the moulinette to return a raw HTTP reponse, and using `bottle.static_file` to return the requested archive file.

(Initially I was investigating the use of X-Accel-Redirect but so far doesn't seem to be needed ? I wouldn't be able to tell what's better from a technical point of view though)

## PR Status

Done

## How to test

Fetch the relevant PRs (c.f. [moulinette](https://github.com/YunoHost/moulinette/pull/255)  + [yunohost-admin](https://github.com/YunoHost/yunohost-admin/pull/312) PR) and try to download a backup ... I tested it with a 3GB backup and seems to work