### PR TITLE
move BACKUP_CORE_ONLY message to standard output

### DIFF
--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -67,9 +67,9 @@ ynh_backup() {
     then
         if [ $BACKUP_CORE_ONLY -eq 1 ]
         then
-            ynh_print_warn --message="$src_path will not be saved, because 'BACKUP_CORE_ONLY' is set."
+            ynh_print_info --message="$src_path will not be saved, because 'BACKUP_CORE_ONLY' is set."
         else
-            ynh_print_warn --message="$src_path will not be saved, because 'do_not_backup_data' is set."
+            ynh_print_info --message="$src_path will not be saved, because 'do_not_backup_data' is set."
         fi
         return 0
     fi


### PR DESCRIPTION
## The problem
cf. https://github.com/YunoHost-Apps/nextcloud_ynh/issues/302

When backing up an app with `BACKUP_CORE_ONLY=1 yunohost backup create --apps APP`, the line stating that BACKUP_CORE_ONLY is set is sent to stderr.
It's very annoying when backups are made via the crontab and error output is sent by email... A lot of email containing only this line... which is not an error btw ;)
...

## Solution
Send this message to standard output

It seems that this was the cas before (https://github.com/YunoHost/yunohost/commit/68c30a943a9ef06c58553e3982226be19bef6c8d) but I haven't figure out why there has been this change (so maybe I'm missing something !)
...

## PR Status

...

## How to test
Backup an app with BACKUP_CORE_ONLY
e.g. `BACKUP_CORE_ONLY=1 yunohost backup create --apps nextcloud`
...
