### PR TITLE
[fix] Reduce right given to ynh users with ssh

### DIFF
--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -70,20 +70,11 @@ Subsystem sftp internal-sftp
 # Disallow unallowed users to use SSH as a VPN-like or a X11 server
 AllowTcpForwarding no
 AllowStreamLocalForwarding no
-GatewayPorts no
-X11Forwarding no
-PermitTTY no
 PermitUserRC no
 
-# Chroot standard users
-ChrootDirectory /home/%u
-
 Match User admin,root
-    ChrootDirectory none
     AllowTcpForwarding yes
-    GatewayPorts no
-    X11Forwarding yes
-    PermitTTY yes
+    AllowStreamLocalForwarding yes
     PermitUserRC yes
 
 

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -66,12 +66,26 @@ AcceptEnv LANG LC_*
 
 # SFTP stuff
 Subsystem sftp internal-sftp
-Match User sftpusers
-        ForceCommand internal-sftp
-        ChrootDirectory /home/%u
-        AllowTcpForwarding no
-        GatewayPorts no
-        X11Forwarding no
+
+# Disallow unallowed users to use SSH as a VPN-like or a X11 server
+AllowTcpForwarding no
+AllowStreamLocalForwarding no
+GatewayPorts no
+X11Forwarding no
+PermitTTY no
+PermitUserRC no
+
+# Chroot standard users
+ChrootDirectory /home/%u
+
+Match User admin,root
+    ChrootDirectory none
+    AllowTcpForwarding yes
+    GatewayPorts no
+    X11Forwarding yes
+    PermitTTY yes
+    PermitUserRC yes
+
 
 # root login is allowed on local networks
 # It's meant to be a backup solution in case LDAP is down and

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -67,9 +67,11 @@ AcceptEnv LANG LC_*
 # SFTP stuff
 Subsystem sftp internal-sftp
 
-# Disallow unallowed users to use SSH as a VPN-like or a X11 server
+# Forbid users from using their account SSH as a VPN (even if SSH login is disabled)
 AllowTcpForwarding no
 AllowStreamLocalForwarding no
+
+# Disable .ssh/rc, which could be edited (e.g. from Nextcloud or whatever) by users to execute arbitrary commands even if SSH login is disabled
 PermitUserRC no
 
 Match User admin,root


### PR DESCRIPTION
## The problem

...

## Solution

Forbid standard user to use several ssh feature. Only admin and root are allowed to do that.
Remove 'sftpusers' unknown user

## PR Status

Ready

## How to test

...
