### PR TITLE
[enh] Better problematic apt dependencies auto-investigation mechanism

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -191,17 +191,17 @@ ynh_package_install_from_equivs () {
     cp "$controlfile" "${TMPDIR}/control"
     (cd "$TMPDIR"
     LC_ALL=C equivs-build ./control 1> /dev/null
-    dpkg --force-depends --install "./${pkgname}_${pkgversion}_all.deb" 2>&1)
+    LC_ALL=C dpkg --force-depends --install "./${pkgname}_${pkgversion}_all.deb" 2>&1 | tee ./dpkg_log)
 
     ynh_package_install --fix-broken || \
         { # If the installation failed 
         # (the following is ran inside { } to not start a subshell otherwise ynh_die wouldnt exit the original process)
-        # Get the list of dependencies from the deb
-        local dependencies="$(dpkg --info "$TMPDIR/${pkgname}_${pkgversion}_all.deb" | grep Depends | \
-            sed 's/^ Depends: //' | sed 's/,//g' | tr -d '|')"
+        # Parse the list of problematic dependencies from dpkg's log ...
+        # (relevant lines look like: "foo-ynh-deps depends on bar; however:")
+        local problematic_dependencies="$(cat dpkg_log | grep -oP '(?<=-ynh-deps depends on ).*(?=; however)')"
         # Fake an install of those dependencies to see the errors
         # The sed command here is, Print only from '--fix-broken' to the end.
-        ynh_package_install $dependencies --dry-run | sed --quiet '/--fix-broken/,$p' >&2
+        ynh_package_install $problematic_dependencies --dry-run | sed --quiet '/--fix-broken/,$p' >&2
         ynh_die --message="Unable to install dependencies"; }
     [[ -n "$TMPDIR" ]] && rm --recursive --force $TMPDIR	# Remove the temp dir.
 

--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -198,10 +198,10 @@ ynh_package_install_from_equivs () {
         # (the following is ran inside { } to not start a subshell otherwise ynh_die wouldnt exit the original process)
         # Parse the list of problematic dependencies from dpkg's log ...
         # (relevant lines look like: "foo-ynh-deps depends on bar; however:")
-        local problematic_dependencies="$(cat dpkg_log | grep -oP '(?<=-ynh-deps depends on ).*(?=; however)')"
+        local problematic_dependencies="$(cat $TMPDIR/dpkg_log | grep -oP '(?<=-ynh-deps depends on ).*(?=; however)' | tr '\n' ' ')"
         # Fake an install of those dependencies to see the errors
-        # The sed command here is, Print only from '--fix-broken' to the end.
-        ynh_package_install $problematic_dependencies --dry-run | sed --quiet '/--fix-broken/,$p' >&2
+        # The sed command here is, Print only from 'Reading state info' to the end.
+        [[ -n "$problematic_dependencies" ]] && ynh_package_install $problematic_dependencies --dry-run 2>&1 | sed --quiet '/Reading state info/,$p' | grep -v "fix-broken\|Reading state info" >&2
         ynh_die --message="Unable to install dependencies"; }
     [[ -n "$TMPDIR" ]] && rm --recursive --force $TMPDIR	# Remove the temp dir.
 


### PR DESCRIPTION
## The problem

We regularly have dependency issues with apt and apt is absolutely fucking stupid and lazy about explaining what the hell actually is going on... There's currently a mechanism that tries to explicitly `apt install --dry-run` all the dependencies of the app such that apt spits out some relevant info... However it fails in multiple case because : 
- it tries to install all dependencies and not just the problematic ones, which dilute the relevant info
- it doesnt properly handle cases where `bar1 | bar2` is requested ... which may generated red-herrings if bar2 is, like, a dependency only available on stretch but you're on buster, or vice-versa

## Solution

Grep what are the problematic packages from dpkg's log (lines like `foo-ynh-deps depends on bar ; however:`) and try to `apt install --dry-run` these only.

## PR Status

Not tested

## How to test

Try to trigger a situation where an app wants to install dependencies but it cant ...
