### PR TITLE
[fix] detect misformated arguments in getopts

### DIFF
--- a/data/helpers.d/getopts
+++ b/data/helpers.d/getopts
@@ -130,6 +130,12 @@ ynh_handle_getopts_args () {
                         then
                             # Remove the option and the space, so keep only the value itself.
                             all_args[0]="${all_args[0]#-${parameter} }"
+
+                            # At this point, if all_args[0] start with "-", then the argument is not well formed
+                            if [ "${all_args[0]:0:1}" == "-" ]
+                            then
+                                ynh_die --message="Argument \"${all_args[0]}\" not valid! Did you use a single \"-\" instead of two?"
+                            fi
                             # Reduce the value of shift, because the option has been removed manually
                             shift_value=$(( shift_value - 1 ))
                         fi


### PR DESCRIPTION
## The problem

getops can enter in an infinite loop when using only one `-` when two are expected: https://github.com/YunoHost/yunohost/commit/15a7967f474be96d27381ecb739ac4ae09d243e9

## Solution

Detect this case, and die!

## PR Status

...

## How to test

...
