### PR TITLE
Diagnose ssl libs installed from sury

### DIFF
--- a/data/hooks/conf_regen/10-apt
+++ b/data/hooks/conf_regen/10-apt
@@ -7,12 +7,13 @@ do_pre_regen() {
 
     mkdir --parents "${pending_dir}/etc/apt/preferences.d"
 
-    for package in "php" "php-fpm" "php-mysql" "php-xml" "php-zip" "php-mbstring" "php-ldap" "php-gd" "php-curl" "php-bz2" "php-json" "php-sqlite3" "php-intl" "openssl" "libssl1.1" "libssl-dev"
+    packages_to_refuse_from_sury="php php-fpm php-mysql php-xml php-zip php-mbstring php-ldap php-gd php-curl php-bz2 php-json php-sqlite3 php-intl openssl libssl1.1 libssl-dev"
+    for package in $packages_to_refuse_from_sury
     do
         echo "
 Package: $package
 Pin: origin \"packages.sury.org\" 
-Pin-Priority: -1" >> "/etc/apt/preferences.d/extra_php_version"
+Pin-Priority: -1" >> "${pending_dir}/etc/apt/preferences.d/extra_php_version"
     done
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -146,6 +146,8 @@
     "diagnosis_basesystem_ynh_single_version": "{package} version: {version} ({repo})",
     "diagnosis_basesystem_ynh_main_version": "Server is running YunoHost {main_version} ({repo})",
     "diagnosis_basesystem_ynh_inconsistent_versions": "You are running inconsistent versions of the YunoHost packages... most probably because of a failed or partial upgrade.",
+    "diagnosis_package_installed_from_sury": "Some system packages should be downgraded",
+    "diagnosis_package_installed_from_sury_details": "Some packages were inadvertendly installed from a third-party repository called Sury. The Yunohost team improved the strategy that handle these packages, but it's expected that some setups that installed PHP7.3 apps while still on Stretch have some remaining inconsistencies. To fix this situation, you should try running the following command: <cmd>{cmd_to_fix}</cmd>",
     "diagnosis_display_tip": "To see the issues found, you can go to the Diagnosis section of the webadmin, or run 'yunohost diagnosis show --issues' from the command-line.",
     "diagnosis_failed_for_category": "Diagnosis failed for category '{category}': {error}",
     "diagnosis_cache_still_valid": "(Cache still valid for {category} diagnosis. Won't re-diagnose it yet!)",


### PR DESCRIPTION
## The problem

We regularly see people with failed app installs or other things, related to the fact that libssl1.1 is installed from sury, but not libssl-dev (or viceversa).

## Solution

It's difficult to automatically downgrade the packages, but at least we can diagnose and recommend to people the right command to fix their setup

## PR Status

Tested on my side

## How to test

Create a situation where libssl-dev and/or libssl1.1 is installed from sury, then run the diagnosis for "basesystem"
