### PR TITLE
[enh] Add x509 fingerprint in /etc/issue

### DIFF
--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fetch x509 fingerprint
+x509_fingerprint=$(openssl x509  -in /etc/yunohost/certs/yunohost.org/crt.pem -noout -fingerprint -sha256 | cut -d= -f2)
+
+
 # Fetch SSH fingerprints
 i=0
 for key in $(ls /etc/ssh/ssh_host_{ed25519,rsa,ecdsa}_key.pub 2> /dev/null) ; do 
@@ -40,6 +44,7 @@ LOGO_AND_FINGERPRINTS=$(cat << EOF
 $LOGO
 
  IP: ${local_ip}
+ X509 fingerprint: ${x509_fingerprint}
  SSH fingerprints:
  ${fingerprint[0]}
  ${fingerprint[1]}


### PR DESCRIPTION
## The problem

We display fingerprint for ssh, but not for https. Displaying sha256 for x509 allows user to check their webadmin https before to set password during postinstall or login.

## Solution

I choose to display only fingerprint for the default yunohost_admin panel (so the cert used by default in /etc/yunohost/certs/yunohost.org/crt.pem ).
User could check by doing: "display certificate" on firefox and check sha256 info.

```

  __   __  __   __  __    _  _______  __   __  _______  _______  _______
 |  | |  ||  | |  ||  |  | ||       ||  | |  ||       ||       ||       |
 |  |_|  ||  | |  ||   |_| ||   _   ||  |_|  ||   _   ||  _____||_     _|
 |       ||  |_|  ||       ||  | |  ||       ||  | |  || |_____   |   |
 |_     _||       ||  _    ||  |_|  ||   _   ||  |_|  ||_____  |  |   |
   |   |  |       || | |   ||       ||  | |  ||       | _____| |  |   |
   |___|  |_______||_|  |__||_______||__| |__||_______||_______|  |___|

 IP: 10.155.71.2
 X509 fingerprint: 82:24:71:73:5A:30:17:D6:14:18:94:D0:29:96:AB:19:9B:60:CA:ED:A5:C1:6A:5B:7D:05:51:6B:C6:41:6F:4E
 SSH fingerprints:
  - SHA256:nbVIxQc0yzVugsFmyO8r8zFgAFQYzzfnjgjbXm9iB6A (ECDSA)
  - SHA256:3n/wG4KpwgVVvC7qBdg9je0bE1OSTAtFQkev6746f7k (ED25519)
  - SHA256:pc46Sk7kCrgeaq/XbfTZFu/Q17OKDQv4ckbRiAlMZb4 (RSA)
 
 
```

## PR Status

Ready

## How to test

systemctl start yunoprompt
cat /etc/issue
