### PR TITLE
Fix redis hook (bash does not allow empty function)

### DIFF
--- a/data/hooks/conf_regen/35-redis
+++ b/data/hooks/conf_regen/35-redis
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 do_pre_regen() {
+  :
 }
 
 do_post_regen() {


### PR DESCRIPTION
## The problem

The redis hook script contains an empty bash function. Bash does not support empty function.

## Solution

Add a dummy instruction inside the function (equivalent to true)

## PR Status

Done

## How to test

`yunohost tools regen-conf redis`
