### PR TITLE
Refactor local CA management for more consistency and simpler postinstall

### DIFF
--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -3,71 +3,81 @@
 set -e
 
 ssl_dir="/usr/share/yunohost/yunohost-config/ssl/yunoCA"
+ynh_ca="/etc/yunohost/certs/yunohost.org/ca.pem"
+ynh_crt="/etc/yunohost/certs/yunohost.org/crt.pem"
+ynh_key="/etc/yunohost/certs/yunohost.org/key.pem"
+openssl_conf="/usr/share/yunohost/templates/ssl/openssl.cnf"
+
+regen_local_ca() {
+
+    domain="$1"
+
+    echo -e "\n# Creating local certification authority with domain=$domain\n"
+
+    # create certs and SSL directories
+    mkdir -p "/etc/yunohost/certs/yunohost.org"
+    mkdir -p "${ssl_dir}/"{ca,certs,crl,newcerts}
+
+    pushd ${ssl_dir}
+
+    # (Update the serial so that it's specific to this very instance)
+    # N.B. : the weird RANDFILE thing comes from:
+    # https://stackoverflow.com/questions/94445/using-openssl-what-does-unable-to-write-random-state-mean
+    RANDFILE=.rnd openssl rand -hex 19 > serial
+    rm -f index.txt
+    touch index.txt
+    cp /usr/share/yunohost/templates/ssl/openssl.cnf openssl.ca.cnf
+    sed -i s/yunohost.org/${domain}/g openssl.ca.cnf
+    openssl req -x509 \
+        -new \
+        -config openssl.ca.cnf \
+        -days 3650 \
+        -out ca/cacert.pem \
+        -keyout ca/cakey.pem \
+        -nodes \
+        -batch \
+        -subj /CN=${domain}/O=${domain%.*} 2>&1
+
+    chmod 640 ca/cacert.pem
+    chmod 640 ca/cakey.pem
+
+    cp ca/cacert.pem $ynh_ca
+    ln -sf "$ynh_ca" /etc/ssl/certs/ca-yunohost_crt.pem
+    update-ca-certificates
+
+    popd
+}
+
+
 
 do_init_regen() {
-  if [[ $EUID -ne 0 ]]; then
-    echo "You must be root to run this script" 1>&2
-    exit 1
-  fi
 
-  LOGFILE="/tmp/yunohost-ssl-init"
-
-  echo "Initializing a local SSL certification authority ..."
-  echo "(logs available in $LOGFILE)"
-
-  rm -f $LOGFILE
-  touch $LOGFILE
-
-  # create certs and SSL directories
-  mkdir -p "/etc/yunohost/certs/yunohost.org"
-  mkdir -p "${ssl_dir}/"{ca,certs,crl,newcerts}
-
-  # initialize some files
-  # N.B. : the weird RANDFILE thing comes from:
-  # https://stackoverflow.com/questions/94445/using-openssl-what-does-unable-to-write-random-state-mean
-  [[ -f "${ssl_dir}/serial" ]] \
-    || RANDFILE=.rnd openssl rand -hex 19 > "${ssl_dir}/serial"
-  [[ -f "${ssl_dir}/index.txt" ]] \
-    || touch "${ssl_dir}/index.txt"
-
-  openssl_conf="/usr/share/yunohost/templates/ssl/openssl.cnf"
-  ynh_ca="/etc/yunohost/certs/yunohost.org/ca.pem"
-  ynh_crt="/etc/yunohost/certs/yunohost.org/crt.pem"
-  ynh_key="/etc/yunohost/certs/yunohost.org/key.pem"
+  LOGFILE=/tmp/yunohost-ssl-init
+  echo "" > $LOGFILE
+  chown root:root $LOGFILE
+  chmod 640 $LOGFILE
 
   # create default certificates
   if [[ ! -f "$ynh_ca" ]]; then
-      echo -e "\n# Creating the CA key (?)\n" >>$LOGFILE
-
-      openssl req -x509 \
-        -new \
-        -config "$openssl_conf" \
-        -days 3650 \
-        -out "${ssl_dir}/ca/cacert.pem" \
-        -keyout "${ssl_dir}/ca/cakey.pem" \
-        -nodes -batch >>$LOGFILE 2>&1
-
-      cp "${ssl_dir}/ca/cacert.pem" "$ynh_ca"
-      ln -sf "$ynh_ca" /etc/ssl/certs/ca-yunohost_crt.pem
-      update-ca-certificates
+      regen_local_ca yunohost.org >>$LOGFILE
   fi
 
   if [[ ! -f "$ynh_crt" ]]; then
-      echo -e "\n# Creating initial key and certificate (?)\n" >>$LOGFILE
+      echo -e "\n# Creating initial key and certificate \n" >>$LOGFILE
 
       openssl req -new \
         -config "$openssl_conf" \
         -days 730 \
         -out "${ssl_dir}/certs/yunohost_csr.pem" \
         -keyout "${ssl_dir}/certs/yunohost_key.pem" \
-        -nodes -batch >>$LOGFILE 2>&1
+        -nodes -batch &>>$LOGFILE
 
       openssl ca \
         -config "$openssl_conf" \
         -days 730 \
         -in "${ssl_dir}/certs/yunohost_csr.pem" \
         -out "${ssl_dir}/certs/yunohost_crt.pem" \
-        -batch >>$LOGFILE 2>&1
+        -batch &>>$LOGFILE
 
       chmod 640 "${ssl_dir}/certs/yunohost_key.pem"
       chmod 640 "${ssl_dir}/certs/yunohost_crt.pem"
@@ -93,22 +103,16 @@ do_pre_regen() {
 do_post_regen() {
   regen_conf_files=$1
 
-  # Ensure that index.txt exists
-  index_txt=/usr/share/yunohost/yunohost-config/ssl/yunoCA/index.txt
-  [[ -f "${index_txt}" ]] || {
-    if [[ -f "${index_txt}.saved" ]]; then
-      # use saved database from 2.2
-      cp "${index_txt}.saved" "${index_txt}"
-    elif [[ -f "${index_txt}.old" ]]; then
-      # ... or use the state-1 database
-      cp "${index_txt}.old" "${index_txt}"
-    else
-      # ... or create an empty one
-      touch "${index_txt}"
-    fi
-  }
+  current_local_ca_domain=$(openssl x509 -in $ynh_ca -text | tr ',' '\n' | grep Issuer | awk '{print $4}')
+  main_domain=$(cat /etc/yunohost/current_host)
 
-  # TODO: regenerate certificates if conf changed?
+  if [[ "$current_local_ca_domain" != "$main_domain" ]]
+  then
+      regen_local_ca $main_domain
+      # Idk how useful this is, but this was in the previous python code (domain.main_domain())
+      ln -sf /etc/yunohost/certs/$domain/crt.pem /etc/ssl/certs/yunohost_crt.pem
+      ln -sf /etc/yunohost/certs/$domain/key.pem /etc/ssl/private/yunohost_key.pem
+  fi
 }
 
 FORCE=${2:-0}

--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -90,6 +90,8 @@ do_init_regen() {
 
   chown -R root:ssl-cert /etc/yunohost/certs/yunohost.org/
   chmod o-rwx /etc/yunohost/certs/yunohost.org/
+
+  install -D -m 644 $openssl_conf "${ssl_dir}/openssl.cnf"
 }
 
 do_pre_regen() {

--- a/locales/en.json
+++ b/locales/en.json
@@ -624,8 +624,6 @@
     "user_update_failed": "Could not update user {user}: {error}",
     "user_updated": "User info changed",
     "yunohost_already_installed": "YunoHost is already installed",
-    "yunohost_ca_creation_failed": "Could not create certificate authority",
-    "yunohost_ca_creation_success": "Local certification authority created.",
     "yunohost_configured": "YunoHost is now configured",
     "yunohost_installing": "Installing YunoHost...",
     "yunohost_not_installed": "YunoHost is not correctly installed. Please run 'yunohost tools postinstall'",

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -315,37 +315,7 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
 
     os.system('chmod 644 /etc/ssowat/conf.json.persistent')
 
-    # Create SSL CA
-    regen_conf(['ssl'], force=True)
-    ssl_dir = '/usr/share/yunohost/yunohost-config/ssl/yunoCA'
-    # (Update the serial so that it's specific to this very instance)
-    os.system("openssl rand -hex 19 > %s/serial" % ssl_dir)
-    commands = [
-        'rm %s/index.txt' % ssl_dir,
-        'touch %s/index.txt' % ssl_dir,
-        'cp %s/openssl.cnf %s/openssl.ca.cnf' % (ssl_dir, ssl_dir),
-        'sed -i s/yunohost.org/%s/g %s/openssl.ca.cnf ' % (domain, ssl_dir),
-        'openssl req -x509 -new -config %s/openssl.ca.cnf -days 3650 -out %s/ca/cacert.pem -keyout %s/ca/cakey.pem -nodes -batch -subj /CN=%s/O=%s' % (ssl_dir, ssl_dir, ssl_dir, domain, os.path.splitext(domain)[0]),
-        'cp %s/ca/cacert.pem /etc/ssl/certs/ca-yunohost_crt.pem' % ssl_dir,
-        'update-ca-certificates'
-    ]
-
-    for command in commands:
-        p = subprocess.Popen(
-            command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-        out, _ = p.communicate()
-
-        if p.returncode != 0:
-            logger.warning(out)
-            raise YunohostError('yunohost_ca_creation_failed')
-        else:
-            logger.debug(out)
-
-    logger.success(m18n.n('yunohost_ca_creation_success'))
-
     # New domain config
-    regen_conf(['nsswitch'], force=True)
     domain_add(domain, dyndns)
     domain_main_domain(domain)
 


### PR DESCRIPTION
# The problem

Postinstall is a bit lengthy and complex and the local CA management is a huge mess with bits everywhere. 

## Solution

This is an attempt to simplify / uniformize most aspects of the local CA management, and also one of the first pieces towargs heavy simplification of the postinstall process as a whole

## PR Status

Kind of tested but I'm battling with slapd which refuses to let me re-run the postinstall -_- ...

## How to test

Run the postinstall and also test changing the main domain, see if that's correctly propagated on the local CA
