### PR TITLE
[fix] MySQL server has gone away in nextcloud

### DIFF
--- a/data/templates/mysql/my.cnf
+++ b/data/templates/mysql/my.cnf
@@ -28,7 +28,7 @@ port            = 3306
 socket          = /var/run/mysqld/mysqld.sock
 skip-external-locking
 key_buffer_size = 16K
-max_allowed_packet = 1M
+max_allowed_packet = 16M
 table_open_cache = 4
 sort_buffer_size = 64K
 read_buffer_size = 256K


### PR DESCRIPTION


## The problem
Nextcloud fail due to mysql queries refused with those message in log:
```
[Warning] Aborted connection 110060 to db: 'nextcloud' user: 'nextcloud' host: 'localhost' (Got a packet bigger than 'max_allowed_packet' bytes)
```


## Solution

Update `max_allowed_packet` to the default value inside maraidb 10.3 (16M)
See https://mariadb.com/kb/en/server-system-variables/#max_allowed_packet

## PR Status

Ready

## How to test

I don't know how to reproduce exactly the bug with nextcloud, i think it could be reproduced with image bigger than 1M inside user profil, but it's hypothetical.
Change max_allowed_packet has fixed the issue in my impacted ynh setup.