### PR TITLE
Do not advertise upgrades for bad-quality apps

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -182,19 +182,29 @@ def _app_upgradable(app_infos):
     from packaging import version
 
     # Determine upgradability
-    # In case there is neither update_time nor install_time, we assume the app can/has to be upgraded
 
-    # Firstly use the version to know if an upgrade is available
-    app_is_in_catalog = bool(app_infos.get("from_catalog"))
+    app_in_catalog = app_infos.get("from_catalog")
     installed_version = version.parse(app_infos.get("version", "0~ynh0"))
     version_in_catalog = version.parse(app_infos.get("from_catalog", {}).get("manifest", {}).get("version", "0~ynh0"))
 
-    if app_is_in_catalog and '~ynh' in str(installed_version) and '~ynh' in str(version_in_catalog):
+    if not app_in_catalog:
+        return "url_required"
+
+    # Do not advertise upgrades for bad-quality apps
+    if not app_in_catalog.get("level", -1) >= 5 or app_in_catalog.get("state") != "working":
+        return "bad_quality"
+
+    # If the app uses the standard version scheme, use it to determine
+    # upgradability
+    if '~ynh' in str(installed_version) and '~ynh' in str(version_in_catalog):
         if installed_version < version_in_catalog:
             return "yes"
+        else:
+            return "no"
 
-    if not app_is_in_catalog:
-        return "url_required"
+    # Legacy stuff for app with old / non-standard version numbers...
+
+    # In case there is neither update_time nor install_time, we assume the app can/has to be upgraded
     if not app_infos["from_catalog"].get("lastUpdate") or not app_infos["from_catalog"].get("git"):
         return "url_required"
 


### PR DESCRIPTION
## The problem

In some cases, Yunohost may tell the user that some upgrade is available, which in fact introduces regressions to the app. For example libreto was level 7 but recently dropped to level 2, then breaking backup etc...

## Solution

Only advertise upgrades for good-quality apps

## PR Status

Yolocommited but should be working

## How to test

Eeeh idk try to install some bad quality apps and check if the "upgradable" key in "yunohost app info <theapp>" is "bad_quality"
