### PR TITLE
[fix] intermediate_certificate is now included in signed certificate

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -539,12 +539,6 @@ def _fetch_and_enable_new_certificate(domain, staging=False, no_checks=False):
 
         raise YunohostError('certmanager_cert_signing_failed')
 
-    import requests  # lazy loading this module for performance reasons
-    try:
-        intermediate_certificate = requests.get(INTERMEDIATE_CERTIFICATE_URL, timeout=30).text
-    except requests.exceptions.Timeout as e:
-        raise YunohostError('certmanager_couldnt_fetch_intermediate_cert')
-
     # Now save the key and signed certificate
     logger.debug("Saving the key and signed certificate...")
 
@@ -573,7 +567,6 @@ def _fetch_and_enable_new_certificate(domain, staging=False, no_checks=False):
 
     with open(domain_cert_file, "w") as f:
         f.write(signed_certificate)
-        f.write(intermediate_certificate)
 
     _set_permissions(domain_cert_file, "root", "ssl-cert", 0o640)
 


### PR DESCRIPTION
Fix https://github.com/YunoHost/issues/issues/1644

## The problem

Describe in issue.

## Solution

Don't add the intermediate certificate, it's now included in the signed certificate.

## PR Status

Work on prod for me ™

## How to test

- choose a signed domain
- look in /etc/yunohost/certs/domain.tld/crt.pem
- observe that the 2 last entries are duplicated
- apply the patch
- yunohost domain cert-renew domain.tld --force
- look at the file again (**USING ABSOLUTE PATH**, the symlink to the folder is **changed** so if you have cd in the folder you'll be looking at the old file), last 2 entries are not duplicated anymore