### PR TITLE
Refuse the installation of an app with a point in its name

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -33,6 +33,7 @@
     "app_manifest_install_ask_password": "Choose an administration password for this app",
     "app_manifest_install_ask_admin": "Choose an administrator user for this app",
     "app_manifest_install_ask_is_public": "Should this app be exposed to anonymous visitors?",
+    "app_name_invalid": "Invalid app name",
     "app_not_upgraded": "The app '{failed_app}' failed to upgrade, and as a consequence the following apps' upgrades have been cancelled: {apps}",
     "app_not_correctly_installed": "{app:s} seems to be incorrectly installed",
     "app_not_installed": "Could not find {app:s} in the list of installed apps: {all_apps}",

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -705,7 +705,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
 
     raw_app_list = _load_apps_catalog()["apps"]
 
-    if app in raw_app_list or ('@' in app) or ('http://' in app) or ('https://' in app):
+    if app in raw_app_list or ('@' in app) or ('http://' in app) or ('https://' in app) or ('.' in app):
 
         # If we got an app name directly (e.g. just "wordpress"), we gonna test this name
         if app in raw_app_list:
@@ -714,11 +714,15 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
         # extract "bar" and test if we know this app
         elif ('http://' in app) or ('https://' in app):
             app_name_to_test = app.strip("/").split("/")[-1].replace("_ynh", "")
+        elif '.' in app:
+            app_name_to_test = app
         else:
             # FIXME : watdo if '@' in app ?
             app_name_to_test = None
 
-        if app_name_to_test in raw_app_list:
+        if '.' in app_name_to_test:
+            raise YunohostError('app_name_invalid')
+        elif app_name_to_test in raw_app_list:
 
             state = raw_app_list[app_name_to_test].get("state", "notworking")
             level = raw_app_list[app_name_to_test].get("level", None)


### PR DESCRIPTION
## The problem

As described in https://github.com/YunoHost/issues/issues/1525

## Solution

Refuse app names with point in app_install

## PR Status

To be tested

## How to test

Run yunohost app install [app name with a point]
For example run yunohost app install foo.bar
And it should refuse the installation