### PR TITLE
Define a new "yunohost app search" command

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -569,6 +569,13 @@ app:
                     full: --with-categories
                     help: Also return a list of app categories
                     action: store_true
+                    
+        ### app_search()
+        search:
+            action_help: Search installable apps
+            arguments:
+                string:
+                    help: Return matching app name or description with "string"
 
         fetchlist:
             deprecated: true

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -104,6 +104,23 @@ def app_catalog(full=False, with_categories=False):
         return {"apps": catalog["apps"]}
     else:
         return {"apps": catalog["apps"], "categories": catalog["categories"]}
+    
+
+def app_search(string):
+    """
+    Return a dict of apps whose description or name match the search string
+    """
+    
+    # Retrieve a simple dict listing all apps
+    catalog_of_apps = app_catalog()
+    
+    # Selecting apps according to a match in app name or description
+    for app in catalog_of_apps["apps"].items():
+        if not (re.search(string, app[0], flags=re.IGNORECASE) or
+                re.search(string, app[1]['description'], flags=re.IGNORECASE)):
+            del catalog_of_apps["apps"][app[0]]
+
+    return catalog_of_apps
 
 
 # Old legacy function...


### PR DESCRIPTION
## The problem

According to the issue https://github.com/YunoHost/issues/issues/1360 there is no such search function as one would expect before installing anything

## Solution

Create a simple function to search in the YunoHost app catalog, in the app name or description

## PR Status

Ready to test

## How to test

It defines a new command which you can use as :
yunohost app search [string]
for example :
yunohost app search caldav
yunohost app search agendav

