### PR TITLE
Increase ldap size limit?

### DIFF
--- a/data/templates/slapd/ldap.conf
+++ b/data/templates/slapd/ldap.conf
@@ -8,7 +8,7 @@
 BASE   dc=yunohost,dc=org
 URI    ldap://localhost:389
 
-#SIZELIMIT	12
+SIZELIMIT	10000
 #TIMELIMIT	15
 #DEREF		never
 


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/error-ldap-size-limit-exceeded/13332

Default size limit is ~500

## Solution

Increase the (client?) size limit to 10000

## PR Status

Not sure what i'm doing :s 

## How to test

Uuuuugh gotta test adding 500 users I suppose @_@
