### PR TITLE
[enh] in order to be able to change user password in CLI without writing it in clear (issue #714)

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -165,8 +165,11 @@ user:
                     full: --change-password
                     help: New password to set
                     metavar: PASSWORD
+                    nargs: "?"
+                    const: 0
                     extra:
                         pattern: *pattern_password
+                        comment: good_practices_about_user_password
                 --add-mailforward:
                     help: Mailforward addresses to add
                     nargs: "*"

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -169,7 +169,6 @@ user:
                     const: 0
                     extra:
                         pattern: *pattern_password
-                        comment: good_practices_about_user_password
                 --add-mailforward:
                     help: Mailforward addresses to add
                     nargs: "*"

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -324,7 +324,9 @@ def user_update(operation_logger, username, firstname=None, lastname=None, mail=
     if lastname and firstname:
         new_attr_dict['cn'] = new_attr_dict['displayName'] = [firstname + ' ' + lastname]
 
-    if change_password:
+    if change_password is not None:
+        if not change_password:
+            change_password = msignals.prompt(m18n.n("ask_password"), True, True)
         # Ensure sufficiently complex password
         assert_password_is_strong_enough("user", change_password)
 

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -324,8 +324,12 @@ def user_update(operation_logger, username, firstname=None, lastname=None, mail=
     if lastname and firstname:
         new_attr_dict['cn'] = new_attr_dict['displayName'] = [firstname + ' ' + lastname]
 
+    # change_password is None if user_update is not called to change the password
     if change_password is not None:
-        if not change_password:
+        # when in the cli interface if the option to change the password is called
+        # without a specified value, change_password will be set to the const 0.
+        # In this case we prompt for the new password.
+        if msettings.get('interface') == 'cli' and not change_password:
             change_password = msignals.prompt(m18n.n("ask_password"), True, True)
         # Ensure sufficiently complex password
         assert_password_is_strong_enough("user", change_password)


### PR DESCRIPTION
## The problem

To update a user password in CLI, the only way is to write the new password in clear using "yunohost user update username -p new_password". This puts the new password in clear in some logs. This is issue https://github.com/YunoHost/issues/issues/714.

## Solution

This PR allows to call the "yunohost user update" command with option -p but without an argument, in which case the admin is prompted for the new password.

## PR Status

Ready for tests.

## How to test

...
