### PR TITLE
Automatically translate legacy rules in /etc/ssowat/conf.json.persistent

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1420,6 +1420,9 @@ def app_ssowatconf():
     with open('/etc/ssowat/conf.json', 'w+') as f:
         json.dump(conf_dict, f, sort_keys=True, indent=4)
 
+    from utils.legacy import translate_legacy_rules_in_ssowant_conf_json_persistent
+    translate_legacy_rules_in_ssowant_conf_json_persistent()
+
     logger.debug(m18n.n('ssowat_conf_generated'))
 
 

--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -1,7 +1,8 @@
+import os
 from moulinette import m18n
 from yunohost.utils.error import YunohostError
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_yaml
+from moulinette.utils.filesystem import read_json, write_to_json, read_yaml
 
 from yunohost.user import user_list, user_group_create, user_group_update
 from yunohost.app import app_setting, _installed_apps, _get_app_settings, _set_app_settings
@@ -206,3 +207,68 @@ def migrate_legacy_permission_settings(app=None):
         _set_app_settings(app, settings)
 
         permission_sync_to_user()
+
+
+def translate_legacy_rules_in_ssowant_conf_json_persistent():
+
+    if not os.path.exists("/etc/ssowat/conf.json.persistent"):
+        return
+
+    persistent = read_json("/etc/ssowat/conf.json.persistent")
+
+    legacy_rules = [
+        "skipped_urls",
+        "unprotected_urls",
+        "protected_urls",
+        "skipped_regex",
+        "unprotected_regex",
+        "protected_regex"
+    ]
+
+    if not any(legacy_rule in persistent for legacy_rule in legacy_rules):
+        return
+
+    if not isinstance(persistent.get("permissions"), dict):
+        persistent["permissions"] = {}
+
+    skipped_urls = persistent.get("skipped_urls", []) + ["re:" + r for r in persistent.get("skipped_regex", [])]
+    protected_urls = persistent.get("protected_urls", []) + ["re:" + r for r in persistent.get("protected_regex", [])]
+    unprotected_urls = persistent.get("unprotected_urls", []) + ["re:" + r for r in persistent.get("unprotected_regex", [])]
+
+    for legacy_rule in legacy_rules:
+        if legacy_rule in persistent:
+            del persistent[legacy_rule]
+
+    if skipped_urls:
+        persistent["permissions"]['custom_skipped'] = {
+            "users": [],
+            "label": "Custom permissions - skipped",
+            "show_tile": False,
+            "auth_header": False,
+            "public": True,
+            "uris": skipped_urls + persistent["permissions"].get("custom_skipped", {}).get("uris", []),
+        }
+
+    if unprotected_urls:
+        persistent["permissions"]['custom_unprotected'] = {
+            "users": [],
+            "label": "Custom permissions - unprotected",
+            "show_tile": False,
+            "auth_header": True,
+            "public": True,
+            "uris": unprotected_urls + persistent["permissions"].get("custom_unprotected", {}).get("uris", []),
+        }
+
+    if protected_urls:
+        persistent["permissions"]['custom_protected'] = {
+            "users": [],
+            "label": "Custom permissions - protected",
+            "show_tile": False,
+            "auth_header": True,
+            "public": False,
+            "uris": protected_urls + persistent["permissions"].get("custom_protected", {}).get("uris", []),
+        }
+
+    write_to_json("/etc/ssowat/conf.json.persistent", persistent)
+
+    logger.warning("Yunohost automatically translated some legacy rules in /etc/ssowat/conf.json.persistent to match the new permission system")


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1671

## Solution

Yunohost should translate legacy rules in /etc/ssowat/conf.json.persistent into the new format

While actually looking into implementing the initial idea from last meeting, though (which was about "loading only conf.json and not .persistent anymore", I was concerned with the following : 
- this requires changing the code of ssowat (which is doable but meh)
- if you want to just change the theme or logging level, it's annoying for the user to have to run "yunohost app ssowatconf" - many people will forget about this

So for now I decided to *only* translate the legacy rules (unprotected_urls, etc...) into the new permission structure *inside* /etc/ssowat/conf.json.persistent, and to keep everything else working the way it's working now. 

## PR Status

Tested and working on my side

## How to test

Add something like `"unprotected_uris": ["foo/bar"]` or `"unprotected_regex": ["foo/bar"]` to `/etc/ssowat/conf.json.persistent`. Run `yunohost app ssowatconf`, and the content of the json file should change
