### PR TITLE
Support more complex errors (be able to return additional data in a json structure)

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -930,7 +930,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
 
             permission_sync_to_user()
 
-            raise YunohostError(failure_message_with_debug_instructions, raw_msg=True)
+            raise YunohostError(failure_message_with_debug_instructions, raw_msg=True, log_ref=operation_logger.name)
 
     # Clean hooks and add new ones
     hook_remove(app_instance_name)

--- a/src/yunohost/utils/error.py
+++ b/src/yunohost/utils/error.py
@@ -32,11 +32,23 @@ class YunohostError(MoulinetteError):
     are translated via m18n.n (namespace) instead of m18n.g (global?)
     """
 
-    def __init__(self, key, raw_msg=False, *args, **kwargs):
+    def __init__(self, key, raw_msg=False, log_ref=None, *args, **kwargs):
         self.key = key  # Saving the key is useful for unit testing
         self.kwargs = kwargs  # Saving the key is useful for unit testing
+        self.log_ref = log_ref
         if raw_msg:
             msg = key
         else:
             msg = m18n.n(key, *args, **kwargs)
+
         super(YunohostError, self).__init__(msg, raw_msg=True)
+
+    def content(self):
+
+        if not self.log_ref:
+            return super(YunohostError, self).content()
+        else:
+            return {
+                "error": self.strerror,
+                "log_ref": self.log_ref
+            }


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1575

During failed app installs, we want to be able to return the log id to the API, such that it redirects the user to the relevant page instead of the current behavior where the user has to click a link ...

## Solution

[Tweak the moulinette](https://github.com/YunoHost/moulinette/pull/257) and YunohostError code such that we can return the log id to the API, which is then to be caught by the webadmin

## PR Status

Tested and working on my side (though not integrated in the webadmin so far)

## How to test

From the webadmin, trigger an app install error, and check in the network debug of the browser that the request answers contains a proper json with the log reference
