### PR TITLE
Fix optional args

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2498,8 +2498,9 @@ class PasswordArgumentParser(YunoHostArgumentFormatParser):
         if any(char in question.value for char in self.forbidden_chars):
             raise YunohostError('pattern_password_app', forbidden_chars=self.forbidden_chars)
 
-        from yunohost.utils.password import assert_password_is_strong_enough
-        assert_password_is_strong_enough('user', question.value)
+        if not question.optional:
+            from yunohost.utils.password import assert_password_is_strong_enough
+            assert_password_is_strong_enough('user', question.value)
 
         return super(PasswordArgumentParser, self)._post_parse_value(question)
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2498,7 +2498,8 @@ class PasswordArgumentParser(YunoHostArgumentFormatParser):
         if any(char in question.value for char in self.forbidden_chars):
             raise YunohostError('pattern_password_app', forbidden_chars=self.forbidden_chars)
 
-        if not question.optional:
+        # If it's an optional argument the value should be empty or strong enough
+        if not question.optional or question.value:
             from yunohost.utils.password import assert_password_is_strong_enough
             assert_password_is_strong_enough('user', question.value)
 

--- a/src/yunohost/tests/test_apps_arguments_parsing.py
+++ b/src/yunohost/tests/test_apps_arguments_parsing.py
@@ -95,6 +95,15 @@ def test_parse_args_in_yunohost_format_string_optional_with_input():
         assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
 
+def test_parse_args_in_yunohost_format_string_optional_with_empty_input():
+    questions = [{"name": "some_string", "ask": "some question", "optional": True, }]
+    answers = {}
+    expected_result = OrderedDict({"some_string": ("", "string")})
+
+    with patch.object(msignals, "prompt", return_value=""):
+        assert _parse_args_in_yunohost_format(answers, questions) == expected_result
+
+
 def test_parse_args_in_yunohost_format_string_optional_with_input_without_ask():
     questions = [{"name": "some_string", "optional": True, }]
     answers = {}
@@ -265,6 +274,22 @@ def test_parse_args_in_yunohost_format_password_optional_with_input():
     expected_result = OrderedDict({"some_password": ("some_value", "password")})
 
     with patch.object(msignals, "prompt", return_value="some_value"):
+        assert _parse_args_in_yunohost_format(answers, questions) == expected_result
+
+
+def test_parse_args_in_yunohost_format_password_optional_with_empty_input():
+    questions = [
+        {
+            "name": "some_password",
+            "ask": "some question",
+            "type": "password",
+            "optional": True,
+        }
+    ]
+    answers = {}
+    expected_result = OrderedDict({"some_password": ("", "password")})
+
+    with patch.object(msignals, "prompt", return_value=""):
         assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
 
@@ -441,6 +466,17 @@ def test_parse_args_in_yunohost_format_path_optional_with_input():
     expected_result = OrderedDict({"some_path": ("some_value", "path")})
 
     with patch.object(msignals, "prompt", return_value="some_value"):
+        assert _parse_args_in_yunohost_format(answers, questions) == expected_result
+
+
+def test_parse_args_in_yunohost_format_path_optional_with_empty_input():
+    questions = [
+        {"name": "some_path", "ask": "some question", "type": "path", "optional": True, }
+    ]
+    answers = {}
+    expected_result = OrderedDict({"some_path": ("", "path")})
+
+    with patch.object(msignals, "prompt", return_value=""):
         assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
 
@@ -660,6 +696,22 @@ def test_parse_args_in_yunohost_format_boolean_optional_with_input():
     expected_result = OrderedDict({"some_boolean": (1, "boolean")})
 
     with patch.object(msignals, "prompt", return_value="y"):
+        assert _parse_args_in_yunohost_format(answers, questions) == expected_result
+
+
+def test_parse_args_in_yunohost_format_boolean_optional_with_empty_input():
+    questions = [
+        {
+            "name": "some_boolean",
+            "ask": "some question",
+            "type": "boolean",
+            "optional": True,
+        }
+    ]
+    answers = {}
+    expected_result = OrderedDict({"some_boolean": (0, "boolean")})
+
+    with patch.object(msignals, "prompt", return_value=""):
         assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
 

--- a/src/yunohost/tests/test_apps_arguments_parsing.py
+++ b/src/yunohost/tests/test_apps_arguments_parsing.py
@@ -256,9 +256,9 @@ def test_parse_args_in_yunohost_format_password_input_no_ask():
 def test_parse_args_in_yunohost_format_password_no_input_optional():
     questions = [{"name": "some_password", "type": "password", "optional": True, }]
     answers = {}
+    expected_result = OrderedDict({"some_password": ("", "password")})
 
-    with pytest.raises(YunohostError):
-        _parse_args_in_yunohost_format(answers, questions)
+    assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
 
 def test_parse_args_in_yunohost_format_password_optional_with_input():
@@ -727,7 +727,7 @@ def test_parse_args_in_yunohost_format_boolean_optional_with_empty_input():
         }
     ]
     answers = {}
-    expected_result = OrderedDict({"some_boolean": (0, "boolean")})
+    expected_result = OrderedDict({"some_boolean": (0, "boolean")})  # default to false
 
     with patch.object(msignals, "prompt", return_value=""):
         assert _parse_args_in_yunohost_format(answers, questions) == expected_result

--- a/src/yunohost/tests/test_apps_arguments_parsing.py
+++ b/src/yunohost/tests/test_apps_arguments_parsing.py
@@ -418,6 +418,24 @@ def test_parse_args_in_yunohost_format_password_strong_enough():
         _parse_args_in_yunohost_format({"some_password": "password"}, questions)
 
 
+def test_parse_args_in_yunohost_format_password_optional_strong_enough():
+    questions = [
+        {
+            "name": "some_password",
+            "ask": "some question",
+            "type": "password",
+            "optional": True,
+        }
+    ]
+
+    with pytest.raises(YunohostError):
+        # too short
+        _parse_args_in_yunohost_format({"some_password": "a"}, questions)
+
+    with pytest.raises(YunohostError):
+        _parse_args_in_yunohost_format({"some_password": "password"}, questions)
+
+
 def test_parse_args_in_yunohost_format_path():
     questions = [{"name": "some_path", "type": "path", }]
     answers = {"some_path": "some_value"}


### PR DESCRIPTION
## The problem

For an optional password:

> Error: The password needs to be at least 8 characters long

## Solution

Do not check if the password is strong enough if it's an optional parameter.

## PR Status

...

## How to test

Install [jirafeau_ynh](https://github.com/YunoHost-Apps/jirafeau_ynh) and play with value of the optional password
