### PR TITLE
[fix] show config panel

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1573,7 +1573,7 @@ def app_config_show_panel(operation_logger, app):
                         option["default"] = parsed_values[generated_name]
 
                     args_dict = _parse_args_in_yunohost_format(
-                        [{option["name"]: parsed_values[generated_name]}],
+                        {option["name"]: parsed_values[generated_name]},
                         [option]
                     )
                     option["default"] = args_dict[option["name"]][0]


### PR DESCRIPTION
## The problem

https://ci-apps-unstable.yunohost.org/ci/job/769
> yunohost app config show-panel wordpress
Warning: Warning: This feature is experimental and not considered stable, you should not use it unless you know what you are doing.
Info: The operation 'Show the config panel of the 'wordpress' app' could not be completed. Please share the full log of this operation using the command 'yunohost log display 20201125-164852-app_config_show_panel-wordpress --share' to get help
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 72, in <module>
    parser=parser
  File "/usr/lib/moulinette/yunohost/__init__.py", line 29, in cli
    top_parser=parser
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 120, in cli
    args, output_as=output_as, timeout=timeout
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 469, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 587, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/log.py", line 358, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/app.py", line 1580, in app_config_show_panel
    [option]
  File "/usr/lib/moulinette/yunohost/app.py", line 2630, in _parse_args_in_yunohost_format
    answer = parser.parse(question=question, user_answers=user_answers)
  File "/usr/lib/moulinette/yunohost/app.py", line 2434, in parse
    question = self.parse_question(question, user_answers)
  File "/usr/lib/moulinette/yunohost/app.py", line 2521, in parse_question
    question = super(BooleanArgumentParser, self).parse_question(question, user_answers)
  File "/usr/lib/moulinette/yunohost/app.py", line 2426, in parse_question
    parsed_question.value = user_answers.get(parsed_question.name)
AttributeError: 'list' object has no attribute 'get'

## Solution

...

## PR Status

...

## How to test

...
