### PR TITLE
Keep helpers consistent

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -576,9 +576,10 @@ ynh_app_upstream_version () {
     # Declare an array to define the options of this helper.
     local legacy_args=m
     local -A args_array=( [m]=manifest= )
-    local manifest=""
+    local manifest
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
+    manifest="${manifest:-}"
 
     if [[ "$manifest" != "" ]] && [[ -e "$manifest" ]];
     then


### PR DESCRIPTION
## Solution

In other places, we define the local variable, call `ynh_handle_getopts_args` then we assign a default value if needed

## PR Status

...

## How to test

...
