### PR TITLE
[fix] ynh_add_fpm_config: Do not reload php-fpm if conf breaks it

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -256,7 +256,13 @@ WantedBy=multi-user.target
         # Restart the service, as this service is either stopped or only for this app
         ynh_systemd_action --service_name=$fpm_service --action=restart
     else
-        # Reload PHP, to not impact other parts of the system using PHP
+        # Validate that the new php conf doesn't break php-fpm entirely
+        php-fpm${phpversion} --test 2>/dev/null \
+        && ynh_systemd_action --service_name=$fpm_service --action=reload \
+        || { php-fpm${phpversion} --test || true;
+             ynh_secure_remove --file="$finalphpconf";
+             ynh_die --message="The new configuration broke php-fpm?"
+        }
         ynh_systemd_action --service_name=$fpm_service --action=reload
     fi
 }


### PR DESCRIPTION
## The problem

When an app installs a bad php conf file, php-fpm gets reloaded and suddenly all php apps are down.

## Solution

We can be a bit smarter than this and validate with `php-fpm7.3 --test` that the conf is alright before reloading the service

## PR Status

Tested and working on my side

## How to test

Well I ended up doing this because I broke hotspot with some related issue. You can reproduce it by installing hotspot_ynh from the commit dc7139bed4ada8bf4bc90cf163767d8cf2a63675 ... Or any other php app with a broken php config.

Without this patch, the install fails and php7.3-fpm is down after the operation finishes. With this patch, the php7.3-fpm service doesn't get reloaded and is still up (and the bad config file gets removed even if the packager forgot to remove it in the 'remove ' script)
