### PR TITLE
We need to have YNH_MANIFEST_VERSION also defined during backup/restore

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2771,7 +2771,7 @@ def _make_environment_for_app_script(app, args={}, args_prefix="APP_ARG_"):
         env_dict = {
             "YNH_APP_ID": app_id,
             "YNH_APP_INSTANCE_NAME": app,
-            "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb)
+            "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb),
             "YNH_APP_MANIFEST_VERSION": manifest.get("version", "?")
         }
 

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -359,7 +359,6 @@ def app_change_url(operation_logger, app, domain, path):
     args_list = [value[0] for value in args_odict.values()]
     args_list.append(app)
 
-
     # Prepare env. var. to pass to script
     env_dict = _make_environment_for_app_script(app, args=args_odict)
     env_dict["YNH_APP_OLD_DOMAIN"] = old_domain
@@ -813,7 +812,6 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
             del env_dict_for_logging["YNH_APP_ARG_%s" % arg_name.upper()]
 
     operation_logger.extra.update({'env': env_dict_for_logging})
-
 
     # Execute the app install script
     install_failed = True
@@ -2763,21 +2761,22 @@ def _assert_no_conflicting_apps(domain, path, ignore_app=None, full_domain=False
 
 def _make_environment_for_app_script(app, args={}, args_prefix="APP_ARG_"):
 
-        app_setting_path = os.path.join(APPS_SETTING_PATH, app)
+    app_setting_path = os.path.join(APPS_SETTING_PATH, app)
 
-        manifest = _get_manifest_of_app(app_setting_path)
-        app_id, app_instance_nb = _parse_app_instance_name(app)
+    manifest = _get_manifest_of_app(app_setting_path)
+    app_id, app_instance_nb = _parse_app_instance_name(app)
 
-        env_dict = {
-            "YNH_APP_ID": app_id,
-            "YNH_APP_INSTANCE_NAME": app,
-            "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb),
-            "YNH_APP_MANIFEST_VERSION": manifest.get("version", "?")
-        }
+    env_dict = {
+        "YNH_APP_ID": app_id,
+        "YNH_APP_INSTANCE_NAME": app,
+        "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb),
+        "YNH_APP_MANIFEST_VERSION": manifest.get("version", "?")
+    }
 
-        for arg_name, arg_value_and_type in args.items():
-            env_dict["YNH_%s%s" % (args_prefix, arg_name.upper())] = arg_value_and_type[0]
-        return env_dict
+    for arg_name, arg_value_and_type in args.items():
+        env_dict["YNH_%s%s" % (args_prefix, arg_name.upper())] = arg_value_and_type[0]
+
+    return env_dict
 
 
 def _parse_app_instance_name(app_instance_name):

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2777,7 +2777,7 @@ def _make_environment_for_app_script(app, args={}, args_prefix="APP_ARG_"):
 
         for arg_name, arg_value_and_type in args.items():
             env_dict["YNH_%s%s" % (args_prefix, arg_name.upper())] = arg_value_and_type[0]
-        return env_dic
+        return env_dict
 
 
 def _parse_app_instance_name(app_instance_name):

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -359,14 +359,9 @@ def app_change_url(operation_logger, app, domain, path):
     args_list = [value[0] for value in args_odict.values()]
     args_list.append(app)
 
-    # Prepare env. var. to pass to script
-    env_dict = _make_environment_dict(args_odict)
-    app_id, app_instance_nb = _parse_app_instance_name(app)
-    env_dict["YNH_APP_ID"] = app_id
-    env_dict["YNH_APP_INSTANCE_NAME"] = app
-    env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
-    env_dict["YNH_APP_MANIFEST_VERSION"] = manifest.get("version", "?")
 
+    # Prepare env. var. to pass to script
+    env_dict = _make_environment_for_app_script(app, args=args_odict)
     env_dict["YNH_APP_OLD_DOMAIN"] = old_domain
     env_dict["YNH_APP_OLD_PATH"] = old_path
     env_dict["YNH_APP_NEW_DOMAIN"] = domain
@@ -528,11 +523,7 @@ def app_upgrade(app=[], url=None, file=None, force=False):
         args_list.append(app_instance_name)
 
         # Prepare env. var. to pass to script
-        env_dict = _make_environment_dict(args_odict)
-        app_id, app_instance_nb = _parse_app_instance_name(app_instance_name)
-        env_dict["YNH_APP_ID"] = app_id
-        env_dict["YNH_APP_INSTANCE_NAME"] = app_instance_name
-        env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+        env_dict = _make_environment_for_app_script(app_instance_name, args=args_odict)
         env_dict["YNH_APP_UPGRADE_TYPE"] = upgrade_type
         env_dict["YNH_APP_MANIFEST_VERSION"] = str(app_new_version)
         env_dict["YNH_APP_CURRENT_VERSION"] = str(app_current_version)
@@ -762,20 +753,6 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     # Apply dirty patch to make php5 apps compatible with php7
     _patch_legacy_php_versions(extracted_app_folder)
 
-    # Prepare env. var. to pass to script
-    env_dict = _make_environment_dict(args_odict)
-    env_dict["YNH_APP_ID"] = app_id
-    env_dict["YNH_APP_INSTANCE_NAME"] = app_instance_name
-    env_dict["YNH_APP_INSTANCE_NUMBER"] = str(instance_number)
-    env_dict["YNH_APP_MANIFEST_VERSION"] = manifest.get("version", "?")
-
-    env_dict_for_logging = env_dict.copy()
-    for arg_name, arg_value_and_type in args_odict.items():
-        if arg_value_and_type[1] == "password":
-            del env_dict_for_logging["YNH_APP_ARG_%s" % arg_name.upper()]
-
-    operation_logger.extra.update({'env': env_dict_for_logging})
-
     # We'll check that the app didn't brutally edit some system configuration
     manually_modified_files_before_install = manually_modified_files()
 
@@ -826,6 +803,17 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     # For web app, the root path of the app will be added as url and the tile
     # will be enabled during the app install. C.f. 'app_register_url()' below.
     permission_create(app_instance_name + ".main", allowed=["all_users"], label=label, show_tile=False, protected=False)
+
+    # Prepare env. var. to pass to script
+    env_dict = _make_environment_for_app_script(app_instance_name, args=args_odict)
+
+    env_dict_for_logging = env_dict.copy()
+    for arg_name, arg_value_and_type in args_odict.items():
+        if arg_value_and_type[1] == "password":
+            del env_dict_for_logging["YNH_APP_ARG_%s" % arg_name.upper()]
+
+    operation_logger.extra.update({'env': env_dict_for_logging})
+
 
     # Execute the app install script
     install_failed = True
@@ -1476,12 +1464,7 @@ def app_action_run(operation_logger, app, action, args=None):
     args_odict = _parse_args_for_action(actions[action], args=args_dict)
     args_list = [value[0] for value in args_odict.values()]
 
-    app_id, app_instance_nb = _parse_app_instance_name(app)
-
-    env_dict = _make_environment_dict(args_odict, prefix="ACTION_")
-    env_dict["YNH_APP_ID"] = app_id
-    env_dict["YNH_APP_INSTANCE_NAME"] = app
-    env_dict["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+    env_dict = _make_environment_for_app_script(app, args=args_odict, args_prefix="ACTION_")
     env_dict["YNH_ACTION"] = action
 
     _, path = tempfile.mkstemp()
@@ -1492,7 +1475,7 @@ def app_action_run(operation_logger, app, action, args=None):
     os.chmod(path, 700)
 
     if action_declaration.get("cwd"):
-        cwd = action_declaration["cwd"].replace("$app", app_id)
+        cwd = action_declaration["cwd"].replace("$app", app)
     else:
         cwd = "/etc/yunohost/apps/" + app
 
@@ -2778,19 +2761,23 @@ def _assert_no_conflicting_apps(domain, path, ignore_app=None, full_domain=False
             raise YunohostError('app_location_unavailable', apps="\n".join(apps))
 
 
-def _make_environment_dict(args_dict, prefix="APP_ARG_"):
-    """
-    Convert a dictionnary containing manifest arguments
-    to a dictionnary of env. var. to be passed to scripts
+def _make_environment_for_app_script(app, args={}, args_prefix="APP_ARG_"):
 
-    Keyword arguments:
-        arg -- A key/value dictionnary of manifest arguments
+        app_setting_path = os.path.join(APPS_SETTING_PATH, app)
 
-    """
-    env_dict = {}
-    for arg_name, arg_value_and_type in args_dict.items():
-        env_dict["YNH_%s%s" % (prefix, arg_name.upper())] = arg_value_and_type[0]
-    return env_dict
+        manifest = _get_manifest_of_app(app_setting_path)
+        app_id, app_instance_nb = _parse_app_instance_name(app)
+
+        env_dict = {
+            "YNH_APP_ID": app_id,
+            "YNH_APP_INSTANCE_NAME": app,
+            "YNH_APP_INSTANCE_NUMBER": str(app_instance_nb)
+            "YNH_APP_MANIFEST_VERSION": manifest.get("version", "?")
+        }
+
+        for arg_name, arg_value_and_type in args.items():
+            env_dict["YNH_%s%s" % (args_prefix, arg_name.upper())] = arg_value_and_type[0]
+        return env_dic
 
 
 def _parse_app_instance_name(app_instance_name):

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -44,7 +44,7 @@ from moulinette.utils.filesystem import read_file, mkdir, write_to_yaml, read_ya
 
 from yunohost.app import (
     app_info, _is_installed,
-    _parse_app_instance_name,
+    _make_environment_for_app_script
     dump_app_log_extract_for_debugging,
     _patch_legacy_helpers,
     _patch_legacy_php_versions,
@@ -553,13 +553,8 @@ class BackupManager():
         env_var['YNH_BACKUP_CSV'] = tmp_csv
 
         if app is not None:
-            app_id, app_instance_nb = _parse_app_instance_name(app)
-            env_var["YNH_APP_ID"] = app_id
-            env_var["YNH_APP_INSTANCE_NAME"] = app
-            env_var["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
-            tmp_app_dir = os.path.join('apps/', app)
-            tmp_app_bkp_dir = os.path.join(self.work_dir, tmp_app_dir, 'backup')
-            env_var["YNH_APP_BACKUP_DIR"] = tmp_app_bkp_dir
+            env_var = _make_environment_for_app_script(app):
+            env_var["YNH_APP_BACKUP_DIR"] = os.path.join(self.work_dir, 'apps', app, 'backup')
 
         return env_var
 
@@ -1165,7 +1160,10 @@ class RestoreManager():
 
         logger.debug(m18n.n('restore_running_hooks'))
 
-        env_dict = self._get_env_var()
+        env_dict = {
+            'YNH_BACKUP_DIR' = self.work_dir
+            'YNH_BACKUP_CSV' = os.path.join(self.work_dir, "backup.csv")
+        }
         operation_logger.extra['env'] = env_dict
         operation_logger.flush()
         ret = hook_callback('restore',
@@ -1372,7 +1370,12 @@ class RestoreManager():
                 migrate_legacy_permission_settings(app=app_instance_name)
 
             # Prepare env. var. to pass to script
-            env_dict = self._get_env_var(app_instance_name)
+            env_dict = _make_environment_for_app_script(app_instance_name)
+            env_dict.update({
+                'YNH_BACKUP_DIR' = self.work_dir
+                'YNH_BACKUP_CSV' = os.path.join(self.work_dir, "backup.csv")
+                "YNH_APP_BACKUP_DIR" = os.path.join(self.work_dir, 'apps', app, 'backup')
+            })
 
             operation_logger.extra['env'] = env_dict
             operation_logger.flush()
@@ -1396,11 +1399,7 @@ class RestoreManager():
             remove_script = os.path.join(app_scripts_in_archive, 'remove')
 
             # Setup environment for remove script
-            app_id, app_instance_nb = _parse_app_instance_name(app_instance_name)
-            env_dict_remove = {}
-            env_dict_remove["YNH_APP_ID"] = app_id
-            env_dict_remove["YNH_APP_INSTANCE_NAME"] = app_instance_name
-            env_dict_remove["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
+            env_dict_remove = _make_environment_for_app_script(app)
 
             operation_logger = OperationLogger('remove_on_failed_restore',
                                                [('app', app_instance_name)],
@@ -1431,26 +1430,6 @@ class RestoreManager():
         finally:
             # Cleaning temporary scripts directory
             shutil.rmtree(tmp_folder_for_app_restore, ignore_errors=True)
-
-    def _get_env_var(self, app=None):
-        """ Define environment variable for hooks call """
-        env_var = {}
-        env_var['YNH_BACKUP_DIR'] = self.work_dir
-        env_var['YNH_BACKUP_CSV'] = os.path.join(self.work_dir, "backup.csv")
-
-        if app is not None:
-            app_dir_in_archive = os.path.join(self.work_dir, 'apps', app)
-            app_backup_in_archive = os.path.join(app_dir_in_archive, 'backup')
-
-            # Parse app instance name and id
-            app_id, app_instance_nb = _parse_app_instance_name(app)
-
-            env_var["YNH_APP_ID"] = app_id
-            env_var["YNH_APP_INSTANCE_NAME"] = app
-            env_var["YNH_APP_INSTANCE_NUMBER"] = str(app_instance_nb)
-            env_var["YNH_APP_BACKUP_DIR"] = app_backup_in_archive
-
-        return env_var
 
 #
 # Backup methods                                                            #

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1374,7 +1374,7 @@ class RestoreManager():
             env_dict.update({
                 'YNH_BACKUP_DIR': self.work_dir,
                 'YNH_BACKUP_CSV': os.path.join(self.work_dir, "backup.csv"),
-                'YNH_APP_BACKUP_DIR': os.path.join(self.work_dir, 'apps', app, 'backup')
+                'YNH_APP_BACKUP_DIR': os.path.join(self.work_dir, 'apps', app_instance_name, 'backup')
             })
 
             operation_logger.extra['env'] = env_dict
@@ -1399,7 +1399,7 @@ class RestoreManager():
             remove_script = os.path.join(app_scripts_in_archive, 'remove')
 
             # Setup environment for remove script
-            env_dict_remove = _make_environment_for_app_script(app)
+            env_dict_remove = _make_environment_for_app_script(app_instance_name)
 
             operation_logger = OperationLogger('remove_on_failed_restore',
                                                [('app', app_instance_name)],

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -553,7 +553,7 @@ class BackupManager():
         env_var['YNH_BACKUP_CSV'] = tmp_csv
 
         if app is not None:
-            env_var = _make_environment_for_app_script(app):
+            env_var = _make_environment_for_app_script(app)
             env_var["YNH_APP_BACKUP_DIR"] = os.path.join(self.work_dir, 'apps', app, 'backup')
 
         return env_var
@@ -1372,9 +1372,9 @@ class RestoreManager():
             # Prepare env. var. to pass to script
             env_dict = _make_environment_for_app_script(app_instance_name)
             env_dict.update({
-                'YNH_BACKUP_DIR' = self.work_dir
-                'YNH_BACKUP_CSV' = os.path.join(self.work_dir, "backup.csv")
-                "YNH_APP_BACKUP_DIR" = os.path.join(self.work_dir, 'apps', app, 'backup')
+                'YNH_BACKUP_DIR': self.work_dir
+                'YNH_BACKUP_CSV': os.path.join(self.work_dir, "backup.csv")
+                "YNH_APP_BACKUP_DIR": os.path.join(self.work_dir, 'apps', app, 'backup')
             })
 
             operation_logger.extra['env'] = env_dict

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1372,9 +1372,9 @@ class RestoreManager():
             # Prepare env. var. to pass to script
             env_dict = _make_environment_for_app_script(app_instance_name)
             env_dict.update({
-                'YNH_BACKUP_DIR': self.work_dir
-                'YNH_BACKUP_CSV': os.path.join(self.work_dir, "backup.csv")
-                "YNH_APP_BACKUP_DIR": os.path.join(self.work_dir, 'apps', app, 'backup')
+                'YNH_BACKUP_DIR': self.work_dir,
+                'YNH_BACKUP_CSV': os.path.join(self.work_dir, "backup.csv"),
+                'YNH_APP_BACKUP_DIR': os.path.join(self.work_dir, 'apps', app, 'backup')
             })
 
             operation_logger.extra['env'] = env_dict

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -553,7 +553,7 @@ class BackupManager():
         env_var['YNH_BACKUP_CSV'] = tmp_csv
 
         if app is not None:
-            env_var = _make_environment_for_app_script(app)
+            env_var.update(_make_environment_for_app_script(app))
             env_var["YNH_APP_BACKUP_DIR"] = os.path.join(self.work_dir, 'apps', app, 'backup')
 
         return env_var

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1161,8 +1161,8 @@ class RestoreManager():
         logger.debug(m18n.n('restore_running_hooks'))
 
         env_dict = {
-            'YNH_BACKUP_DIR' = self.work_dir
-            'YNH_BACKUP_CSV' = os.path.join(self.work_dir, "backup.csv")
+            'YNH_BACKUP_DIR': self.work_dir,
+            'YNH_BACKUP_CSV': os.path.join(self.work_dir, "backup.csv")
         }
         operation_logger.extra['env'] = env_dict
         operation_logger.flush()

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -44,7 +44,7 @@ from moulinette.utils.filesystem import read_file, mkdir, write_to_yaml, read_ya
 
 from yunohost.app import (
     app_info, _is_installed,
-    _make_environment_for_app_script
+    _make_environment_for_app_script,
     dump_app_log_extract_for_debugging,
     _patch_legacy_helpers,
     _patch_legacy_php_versions,


### PR DESCRIPTION
## The problem

c.f. for example : https://ci-apps-unstable.yunohost.org/ci/job/808

```
Backup of the application...
Start the LXC container.
Create witness files...
Working time: 6 seconds (08:08:01).
Working time: 6 seconds (08:08:07).
Backup successful. (0)
Info: yunohost.backup _collect_app_files - [918.1] Collecting files to be backed up for pgadmin...
Warning: yunohost.hook <lambda> - [918.1] /usr/share/yunohost/helpers.d/utils: line 587: YNH_APP_MANIFEST_VERSION: unbound variable
Error: yunohost.backup _collect_app_files - [918.1] Could not back up pgadmin
Info: yunohost.backup backup_create - [918.1] Creating a backup archive from the collected files...
```

## Solution

The way we handle the env dict for app is a mess and should be unified to be consistent across all app operations. Hence I introduce a proper `_make_environment_for_app_script that does this`, and in particular define `YNH_APP_MANIFEST_VERSION`

## PR Status

Yolocommited, testing using the CI ;P

## How to test

Try to backup/restore pgadmin I suppose
