### PR TITLE
[wip] Import users with a CSV

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -203,6 +203,23 @@ user:
             arguments:
                 username:
                     help: Username or email to get information
+        
+        ### user_import()
+        import:
+            action_help: Import several users from CSV
+            api: POST /users/import
+            arguments:
+                csv:
+                    help: "CSV file with columns username, email, quota, groups(separated by coma) and optionally password"
+                    type: open
+                -u:
+                    full: --update
+                    help: Update all existing users contained in the csv file (by default those users are ignored)
+                    action: store_true
+                -d:
+                    full: --delete
+                    help: Delete all existing users that are not contained in the csv file (by default those users are ignored)
+                    action: store_true
 
     subcategories:
         group:

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -496,6 +496,17 @@ def user_info(username):
     return result_dict
 
 
+def user_import(csv, update=False, delete=False):
+    """
+    Import users from CSV
+
+    Keyword argument:
+        csv -- CSV file with columns username, email, quota, groups and optionnally password
+
+    """
+    logger.warning(type(csv))
+    return {}
+
 #
 # Group subcategory
 #


### PR DESCRIPTION
## The problem

Several yunohost admins need a way to import several users. That's completely in the use case of small or medium communities servers (CHATONS & co).

## Solution
Create a cli command 
```
yunohost user import CSV_FILE [-u] [-d]
```

## PR Status



## How to test

You need https://github.com/YunoHost/moulinette/pull/258 and https://github.com/YunoHost/yunohost-admin/pull/322

## Other info

This PR was entirely financed by the new CNAM fablab. Thanks to them :) .