### PR TITLE
[FIX] New CN for LE.

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -651,6 +651,12 @@ def _get_status(domain):
             "code": "lets-encrypt",
             "verbose": "Let's Encrypt",
         }
+    
+    elif cert_issuer == "R3":
+        CA_type = {
+            "code": "lets-encrypt",
+            "verbose": "Let's Encrypt",
+        }
 
     elif cert_issuer.startswith("Fake LE"):
         CA_type = {

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -646,13 +646,7 @@ def _get_status(domain):
             "verbose": "Self-signed",
         }
 
-    elif cert_issuer.startswith("Let's Encrypt"):
-        CA_type = {
-            "code": "lets-encrypt",
-            "verbose": "Let's Encrypt",
-        }
-    
-    elif cert_issuer == "R3":
+    elif cert_issuer.startswith("Let's Encrypt") or cert_issuer == "R3":
         CA_type = {
             "code": "lets-encrypt",
             "verbose": "Let's Encrypt",


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/probleme-lors-renouvellement-certificat-lets-encrypt-issue-during-lets-encrypt-renewal/13478/5

## Solution

Change name of certificate.
Example of a new certificate : 
```
>>> print(issuer)
{'countryName': 'US', 'organizationName': "Let's Encrypt", 'commonName': 'R3'}

```

## PR Status

...

## How to test

...
