### PR TITLE
Use organization name for le cert

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -637,6 +637,7 @@ def _get_status(domain):
 
     cert_subject = cert.get_subject().CN
     cert_issuer = cert.get_issuer().CN
+    organization_name = cert.get_issuer().O
     valid_up_to = datetime.strptime(cert.get_notAfter(), "%Y%m%d%H%M%SZ")
     days_remaining = (valid_up_to - datetime.utcnow()).days
 
@@ -646,7 +647,7 @@ def _get_status(domain):
             "verbose": "Self-signed",
         }
 
-    elif cert_issuer.startswith("Let's Encrypt") or cert_issuer == "R3":
+    elif organization_name == "Let's Encrypt":
         CA_type = {
             "code": "lets-encrypt",
             "verbose": "Let's Encrypt",

--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -61,7 +61,7 @@ KEY_SIZE = 3072
 VALIDITY_LIMIT = 15  # days
 
 # For tests
-STAGING_CERTIFICATION_AUTHORITY = "https://acme-staging.api.letsencrypt.org"
+STAGING_CERTIFICATION_AUTHORITY = "https://acme-staging-v02.api.letsencrypt.org"
 # For prod
 PRODUCTION_CERTIFICATION_AUTHORITY = "https://acme-v02.api.letsencrypt.org"
 


### PR DESCRIPTION
## The problem

- LE changed the CN: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
- Staging fails

## Solution

- Use the organization name instead of the commonName: https://www.pyopenssl.org/en/stable/api/crypto.html?highlight=get_issuer#OpenSSL.crypto.X509Name
- Update the stating url

## PR Status

...

## How to test

...
