### PR TITLE
[fix] DNS conf

### DIFF
--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -258,7 +258,6 @@ def domain_dns_conf(domain, ttl=None):
 
     """
 
-    domains = domain_list()
     if domain not in domain_list()['domains']:
         raise YunohostError('domain_name_unknown', domain=domain)
 

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -258,6 +258,10 @@ def domain_dns_conf(domain, ttl=None):
 
     """
 
+    domains = domain_list()
+    if domain not in domain_list()['domains']:
+        raise YunohostError('domain_name_unknown', domain=domain)
+
     ttl = 3600 if ttl is None else ttl
 
     dns_conf = _build_dns_conf(domain, ttl)


### PR DESCRIPTION
## The problem

From cli, it's possible to get a DNS conf for a domain not added. In this case, the dkim dns rules are not added. A simple typo in cli and the user configure the DNS badly.

## Solution
Check the domain is in the listed of domain added

## PR Status
Tested and ready

## How to test
```
yunohost domain dns-conf unknowndomain.local
```
