### PR TITLE
[fix] Unix permission on dkim

### DIFF
--- a/data/hooks/backup/22-conf_mail
+++ b/data/hooks/backup/22-conf_mail
@@ -3,6 +3,7 @@
 source /usr/share/yunohost/helpers
 ynh_abort_if_errors
 YNH_CWD="${YNH_BACKUP_DIR%/}/conf/dkim"
+mkdir -p "$YNH_CWD"
 cd "$YNH_CWD"
 
 ynh_backup --src_path="/etc/dkim"

--- a/data/hooks/backup/22-conf_mail
+++ b/data/hooks/backup/22-conf_mail
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-# Exit hook on subcommand error or unset variable
-set -eu
-
-# Source YNH helpers
 source /usr/share/yunohost/helpers
+ynh_abort_if_errors
+YNH_CWD="${YNH_BACKUP_DIR%/}/conf/dkim"
+cd "$YNH_CWD"
 
-# Backup destination
-backup_dir="${1}/etc/dkim"
-
-# Backup the configuration
-ynh_backup "/etc/dkim" "$backup_dir"
+ynh_backup --src_path="/etc/dkim"

--- a/data/hooks/restore/22-conf_mail
+++ b/data/hooks/restore/22-conf_mail
@@ -3,3 +3,9 @@
 backup_dir="$1/etc/dkim"
 
 cp -a $backup_dir/. /etc/dkim
+
+chown -R root:root /etc/dkim
+chown _rspamd:root /etc/dkim
+chown _rspamd:root /etc/dkim/*.mail.key
+chmod 600 /etc/dkim/*.mail.txt
+chmod 400 /etc/dkim/*.mail.key

--- a/data/hooks/restore/22-conf_mail
+++ b/data/hooks/restore/22-conf_mail
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-backup_dir="$1/etc/dkim"
+backup_dir="$1/conf/dkim"
 
-cp -a $backup_dir/. /etc/dkim
+cp -a $backup_dir/etc/dkim/. /etc/dkim
 
 chown -R root:root /etc/dkim
 chown _rspamd:root /etc/dkim
 chown _rspamd:root /etc/dkim/*.mail.key
-chmod 600 /etc/dkim/*.mail.txt
-chmod 400 /etc/dkim/*.mail.key


### PR DESCRIPTION
## The problem

In some case, during a restore operation, it could be possible _rspamd user have not the same id on a a new server. So we are not sure permission are ok

## Solution

Redefine permission on each dkim file during restore operation

## PR Status

Ready

## How to test

...
