### PR TITLE
[fix] Avoid to define the ip on wildcard subdomains too

### DIFF
--- a/data/templates/dnsmasq/domain.tpl
+++ b/data/templates/dnsmasq/domain.tpl
@@ -1,8 +1,8 @@
-address=/{{ domain }}/{{ ipv4 }}
-address=/xmpp-upload.{{ domain }}/{{ ipv4 }}
+host-record={{ domain }},{{ ipv4 }}
+host-record=xmpp-upload.{{ domain }},{{ ipv4 }}
 {% if ipv6 %}
-address=/{{ domain }}/{{ ipv6 }}
-address=/xmpp-upload.{{ domain }}/{{ ipv6 }}
+host-record={{ domain }},{{ ipv6 }}
+host-record=xmpp-upload.{{ domain }},{{ ipv6 }}
 {% endif %}
 txt-record={{ domain }},"v=spf1 mx a -all"
 mx-host={{ domain }},{{ domain }},5


### PR DESCRIPTION
## The problem

Adding a domain avoid to be able to ping a subdomain on another machine

## Solution

Use host-record instead of address

## PR Status
Ready (tested just by changing the file in a server)

## How to test

```
yunohost domain add wikipedia.org
dig +short A wikipedia.org
dig +short A fr.wikipedia.org
```
