### PR TITLE
do not reload php7.3 too fast

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -272,9 +272,9 @@ WantedBy=multi-user.target
         # Validate that the new php conf doesn't break php-fpm entirely
         if ! php-fpm${phpversion} --test 2>/dev/null
         then
-            php-fpm${phpversion} --test || true;
-            ynh_secure_remove --file="$finalphpconf";
-            ynh_die --message="The new configuration broke php-fpm?";
+            php-fpm${phpversion} --test || true
+            ynh_secure_remove --file="$finalphpconf"
+            ynh_die --message="The new configuration broke php-fpm?"
         fi
         ynh_systemd_action --service_name=$fpm_service --action=reload
     fi

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -270,12 +270,12 @@ WantedBy=multi-user.target
         ynh_systemd_action --service_name=$fpm_service --action=restart
     else
         # Validate that the new php conf doesn't break php-fpm entirely
-        php-fpm${phpversion} --test 2>/dev/null \
-        && ynh_systemd_action --service_name=$fpm_service --action=reload \
-        || { php-fpm${phpversion} --test || true;
-             ynh_secure_remove --file="$finalphpconf";
-             ynh_die --message="The new configuration broke php-fpm?";
-        }
+        if ! php-fpm${phpversion} --test 2>/dev/null
+        then
+            php-fpm${phpversion} --test || true;
+            ynh_secure_remove --file="$finalphpconf";
+            ynh_die --message="The new configuration broke php-fpm?";
+        fi
         ynh_systemd_action --service_name=$fpm_service --action=reload
     fi
 }


### PR DESCRIPTION
## The problem

When we run `systemctl reload-or-restart php7.3-fpm` too fast, the service may end up being stopped.

(Try: `systemctl reload-or-restart php7.3-fpm && systemctl reload-or-restart php7.3-fpm && systemctl reload-or-restart php7.3-fpm && systemctl reload-or-restart php7.3-fpm` then `systemctl status php7.3-fpm`)

## Solution

Avoid 2 reload for nothing (Should we reload right before the `ynh_die`?)

## PR Status

...

## How to test

...
