### PR TITLE
firewall: force source port for UPnP.

### DIFF
--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -336,7 +336,7 @@ def firewall_upnp(action='status', no_refresh=False):
 
     # Refresh port mapping using UPnP
     if not no_refresh:
-        upnpc = miniupnpc.UPnP()
+        upnpc = miniupnpc.UPnP(localport=1)
         upnpc.discoverdelay = 3000
 
         # Discover UPnP device(s)


### PR DESCRIPTION
miniupnpc uses a random source port by default, the issue is that the
firewall rule to allow destination port 1900 incoming is unused because
the UPnP server will use the random source port as destination port in
the reply which iptables will block. Forcing the source port to be 1900
will ensure the UPnP server also uses that as destination port in the
reply and pass the firewall.

python-miniupnpc 2.0 or later is required for this change to have any
effect, it is otherwise silently ignored. A debian package upgrade is in
the works for official Yunohost repos.

Closes https://github.com/YunoHost/issues/issues/1463