### PR TITLE
Don't mess with Sury's pinning

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -460,7 +460,8 @@ ynh_remove_extra_repo () {
     name="${name:-$app}"
 
     ynh_secure_remove "/etc/apt/sources.list.d/$name.list"
-    ynh_secure_remove "/etc/apt/preferences.d/$name"
+    # Sury pinning is managed by the regenconf in the core...
+    [[ "$name" == "extra_php_version" ]] || ynh_secure_remove "/etc/apt/preferences.d/$name"
     ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.gpg" > /dev/null
     ynh_secure_remove "/etc/apt/trusted.gpg.d/$name.asc" > /dev/null
 
@@ -547,6 +548,9 @@ ynh_pin_repo () {
     else
         append="tee"
     fi
+
+    # Sury pinning is managed by the regenconf in the core...
+    [[ "$name" != "extra_php_version" ]] || return
 
     mkdir --parents "/etc/apt/preferences.d"
     echo "Package: $package


### PR DESCRIPTION
## The problem

c.f. https://forum.yunohost.org/t/impossible-de-mettre-a-jour-openssl/13717


## Solution

That was a while since we didn't hear of Sury issue ... This was due to installing Firefly : 

```
ERROR - Packagers /!\ This app manually modified some system configuration files! This should not happen! If you need to do so, you should implement a proper conf_regen hook. Those configuration were affected:
    - /etc/apt/preferences.d/extra_php_version
```

Though in fact my understanding is that it's because Firefly requires php 7.4 which therefore triggers the sury helpers, in turn messing with ` /etc/apt/preferences.d/extra_php_version` ... so adding an ugly if should do the trick

## PR Status

Yolocommited

## How to test

Installing Firefly I guess @_@
