### PR TITLE
fix legacy permission migration

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1344,7 +1344,7 @@ class RestoreManager():
                                       auth_header=permission_infos.get("auth_header"),
                                       label=permission_infos.get('label') if perm_name == "main" else permission_infos.get("sublabel"),
                                       show_tile=permission_infos.get("show_tile", True),
-                                      protected=permission_infos.get("protected", True),
+                                      protected=permission_infos.get("protected", False),
                                       sync_perm=False)
 
                 permission_sync_to_user()

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -1343,7 +1343,7 @@ class RestoreManager():
                                       additional_urls=permission_infos.get("additional_urls"),
                                       auth_header=permission_infos.get("auth_header"),
                                       label=permission_infos.get('label') if perm_name == "main" else permission_infos.get("sublabel"),
-                                      show_tile=permission_infos.get("show_tile", None),
+                                      show_tile=permission_infos.get("show_tile", True),
                                       protected=permission_infos.get("protected", True),
                                       sync_perm=False)
 

--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -104,7 +104,7 @@ class SetupGroupPermissions():
                 allowed = [user for user in permission.split(',') if user in known_users]
             else:
                 allowed = ["all_users"]
-            permission_create(app + ".main", url=url, allowed=allowed, protected=False, sync_perm=False)
+            permission_create(app + ".main", url=url, allowed=allowed, show_tile=True, protected=False, sync_perm=False)
 
             app_setting(app, 'allowed_users', delete=True)
 
@@ -185,12 +185,12 @@ def migrate_legacy_permission_settings(app=None):
         if unprotected_urls != []:
             permission_create(app + ".legacy_unprotected_uris", additional_urls=unprotected_urls,
                               auth_header=True, label=legacy_permission_label(app, "unprotected"),
-                              show_tile=False, allowed='visitors', protected=True, sync_perm=False)
+                              show_tile=True, allowed='visitors', protected=False, sync_perm=False)
         if protected_urls != []:
             permission_create(app + ".legacy_protected_uris", additional_urls=protected_urls,
                               auth_header=True, label=legacy_permission_label(app, "protected"),
-                              show_tile=False, allowed=user_permission_list()['permissions'][app + ".main"]['allowed'],
-                              protected=True, sync_perm=False)
+                              show_tile=True, allowed=user_permission_list()['permissions'][app + ".main"]['allowed'],
+                              protected=False, sync_perm=False)
 
         legacy_permission_settings = [
             "skipped_uris",

--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -185,12 +185,12 @@ def migrate_legacy_permission_settings(app=None):
         if unprotected_urls != []:
             permission_create(app + ".legacy_unprotected_uris", additional_urls=unprotected_urls,
                               auth_header=True, label=legacy_permission_label(app, "unprotected"),
-                              show_tile=True, allowed='visitors', protected=False, sync_perm=False)
+                              show_tile=False, allowed='visitors', protected=True, sync_perm=False)
         if protected_urls != []:
             permission_create(app + ".legacy_protected_uris", additional_urls=protected_urls,
                               auth_header=True, label=legacy_permission_label(app, "protected"),
-                              show_tile=True, allowed=user_permission_list()['permissions'][app + ".main"]['allowed'],
-                              protected=False, sync_perm=False)
+                              show_tile=False, allowed=user_permission_list()['permissions'][app + ".main"]['allowed'],
+                              protected=True, sync_perm=False)
 
         legacy_permission_settings = [
             "skipped_uris",


### PR DESCRIPTION
## The problem

https://github.com/YunoHost-Apps/nextcloud_ynh/pull/346#issuecomment-751996938

> YunoHost tile is still absent


## Solution

Set `show_tile` to `True` 

## PR Status

...

## How to test

...
