### PR TITLE
Normalize conf template handling for nginx, php-fpm, systemd and fail2ban using ynh_add_config

### DIFF
--- a/data/helpers.d/fail2ban
+++ b/data/helpers.d/fail2ban
@@ -16,11 +16,8 @@
 # |                           for example : 'var_1 var_2 ...'
 #
 # This will use a template in ../conf/f2b_jail.conf and ../conf/f2b_filter.conf
-#   __APP__      by  $app
-#
-#  You can dynamically replace others variables by example :
-#   __VAR_1__    by $var_1
-#   __VAR_2__    by $var_2
+# See the documentation of ynh_add_config for a description of the template
+# format and how placeholders are replaced with actual variables.
 #
 # Generally your template will look like that by example (for synapse):
 #
@@ -64,73 +61,45 @@
 # Requires YunoHost version 3.5.0 or higher.
 ynh_add_fail2ban_config () {
     # Declare an array to define the options of this helper.
-    local legacy_args=lrmptv
-    local -A args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= [t]=use_template [v]=others_var=)
+    local legacy_args=lrmpt
+    local -A args_array=( [l]=logpath= [r]=failregex= [m]=max_retry= [p]=ports= [t]=use_template)
     local logpath
     local failregex
     local max_retry
     local ports
-    local others_var
     local use_template
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     max_retry=${max_retry:-3}
     ports=${ports:-http,https}
-    others_var=${others_var:-}
     use_template="${use_template:-0}"
 
-    finalfail2banjailconf="/etc/fail2ban/jail.d/$app.conf"
-    finalfail2banfilterconf="/etc/fail2ban/filter.d/$app.conf"
-    ynh_backup_if_checksum_is_different "$finalfail2banjailconf"
-    ynh_backup_if_checksum_is_different "$finalfail2banfilterconf"
-
-    if [ $use_template -eq 1 ]
+    if [ $use_template -ne 1 ]
     then
-        # Usage 2, templates
-        cp ../conf/f2b_jail.conf $finalfail2banjailconf
-        cp ../conf/f2b_filter.conf $finalfail2banfilterconf
-
-        if [ -n "${app:-}" ]
-        then
-            ynh_replace_string "__APP__" "$app" "$finalfail2banjailconf"
-            ynh_replace_string "__APP__" "$app" "$finalfail2banfilterconf"
-        fi
-
-        # Replace all other variable given as arguments
-        for var_to_replace in $others_var
-        do
-            # ${var_to_replace^^} make the content of the variable on upper-cases
-            # ${!var_to_replace} get the content of the variable named $var_to_replace
-            ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banjailconf"
-            ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalfail2banfilterconf"
-        done
-
-    else
         # Usage 1, no template. Build a config file from scratch.
         test -n "$logpath" || ynh_die "ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
         test -n "$failregex" || ynh_die "ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
 
-        tee $finalfail2banjailconf <<EOF
-[$app]
+        echo "
+[__APP__]
 enabled = true
-port = $ports
-filter = $app
-logpath = $logpath
-maxretry = $max_retry
-EOF
+port = __PORTS__
+filter = __APP__
+logpath = __LOGPATH__
+maxretry = __MAX_RETRY__
+" > ../conf/f2b_jail.conf
 
-    tee $finalfail2banfilterconf <<EOF
+       echo "
 [INCLUDES]
 before = common.conf
 [Definition]
-failregex = $failregex
+failregex = __FAILREGEX__
 ignoreregex =
-EOF
+" > ../conf/f2b_filter.conf
     fi
 
-    # Common to usage 1 and 2.
-    ynh_store_file_checksum "$finalfail2banjailconf"
-    ynh_store_file_checksum "$finalfail2banfilterconf"
+    ynh_add_config --template="../conf/f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
+    ynh_add_config --template="../conf/f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 

--- a/data/helpers.d/nginx
+++ b/data/helpers.d/nginx
@@ -2,60 +2,25 @@
 
 # Create a dedicated nginx config
 #
-# usage: ynh_add_nginx_config "list of others variables to replace"
-#
-# | arg: list - (Optional) list of others variables to replace separated by spaces. For example : 'path_2 port_2 ...'
+# usage: ynh_add_nginx_config
 #
 # This will use a template in ../conf/nginx.conf
-#   __PATH__      by  $path_url
-#   __DOMAIN__    by  $domain
-#   __PORT__      by  $port
-#   __NAME__      by  $app
-#   __FINALPATH__ by  $final_path
-#   __PHPVERSION__ by  $YNH_PHP_VERSION ($YNH_PHP_VERSION is either the default php version or the version defined for the app)
+# See the documentation of ynh_add_config for a description of the template
+# format and how placeholders are replaced with actual variables.
 #
-#  And dynamic variables (from the last example) :
-#   __PATH_2__    by $path_2
-#   __PORT_2__    by $port_2
+# Additionally, ynh_add_nginx_config will replace:
+# - #sub_path_only      by empty string if path_url is not '/'
+# - #root_path_only     by empty string if path_url  *is*  '/'
+#
+# This allows to enable/disable specific behaviors dependenging on the install
+# location
 #
 # Requires YunoHost version 2.7.2 or higher.
-# Requires YunoHost version 2.7.13 or higher for dynamic variables
 ynh_add_nginx_config () {
-    finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
-    local others_var=${1:-}
-    ynh_backup_if_checksum_is_different --file="$finalnginxconf"
-    cp ../conf/nginx.conf "$finalnginxconf"
 
-    # To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
-    # Substitute in a nginx config file only if the variable is not empty
-    if test -n "${path_url:-}"
-    then
-        # path_url_slash_less is path_url, or a blank value if path_url is only '/'
-        local path_url_slash_less=${path_url%/}
-        ynh_replace_string --match_string="__PATH__/" --replace_string="$path_url_slash_less/" --target_file="$finalnginxconf"
-        ynh_replace_string --match_string="__PATH__" --replace_string="$path_url" --target_file="$finalnginxconf"
-    fi
-    if test -n "${domain:-}"; then
-        ynh_replace_string --match_string="__DOMAIN__" --replace_string="$domain" --target_file="$finalnginxconf"
-    fi
-    if test -n "${port:-}"; then
-        ynh_replace_string --match_string="__PORT__" --replace_string="$port" --target_file="$finalnginxconf"
-    fi
-    if test -n "${app:-}"; then
-        ynh_replace_string --match_string="__NAME__" --replace_string="$app" --target_file="$finalnginxconf"
-    fi
-    if test -n "${final_path:-}"; then
-        ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalnginxconf"
-    fi
-    ynh_replace_string --match_string="__PHPVERSION__" --replace_string="$YNH_PHP_VERSION" --target_file="$finalnginxconf"
+    local finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 
-    # Replace all other variable given as arguments
-    for var_to_replace in $others_var
-    do
-        # ${var_to_replace^^} make the content of the variable on upper-cases
-        # ${!var_to_replace} get the content of the variable named $var_to_replace 
-        ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalnginxconf"
-    done
+    ynh_add_config --template="../conf/nginx.conf" --destination="$finalnginxconf"
 
     if [ "${path_url:-}" != "/" ]
     then
@@ -63,8 +28,6 @@ ynh_add_nginx_config () {
     else
         ynh_replace_string --match_string="^#root_path_only" --replace_string="" --target_file="$finalnginxconf"
     fi
-
-    ynh_store_file_checksum --file="$finalnginxconf"
 
     ynh_systemd_action --service_name=nginx --action=reload
 }

--- a/data/helpers.d/nginx
+++ b/data/helpers.d/nginx
@@ -20,14 +20,15 @@ ynh_add_nginx_config () {
 
     local finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 
-    ynh_add_config --template="../conf/nginx.conf" --destination="$finalnginxconf"
-
     if [ "${path_url:-}" != "/" ]
     then
-        ynh_replace_string --match_string="^#sub_path_only" --replace_string="" --target_file="$finalnginxconf"
+        ynh_replace_string --match_string="^#sub_path_only" --replace_string="" --target_file="../conf/nginx.conf"
     else
-        ynh_replace_string --match_string="^#root_path_only" --replace_string="" --target_file="$finalnginxconf"
+        ynh_replace_string --match_string="^#root_path_only" --replace_string="" --target_file="../conf/nginx.conf"
     fi
+
+    ynh_add_config --template="../conf/nginx.conf" --destination="$finalnginxconf"
+
 
     ynh_systemd_action --service_name=nginx --action=reload
 }

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -132,7 +132,6 @@ ynh_add_fpm_config () {
     ynh_app_setting_set --app=$app --key=fpm_service --value="$fpm_service"
     ynh_app_setting_set --app=$app --key=fpm_dedicated_service --value="$dedicated_service"
     ynh_app_setting_set --app=$app --key=phpversion --value=$phpversion
-    finalphpconf="$fpm_config_dir/pool.d/$app.conf"
 
     # Migrate from mutual PHP service to dedicated one.
     if [ $dedicated_service -eq 1 ]
@@ -151,8 +150,6 @@ ynh_add_fpm_config () {
         fi
     fi
 
-    ynh_backup_if_checksum_is_different --file="$finalphpconf"
-
     if [ $use_template -eq 1 ]
     then
         # Usage 1, use the template in conf/php-fpm.conf
@@ -162,12 +159,6 @@ ynh_add_fpm_config () {
         fi
         # Make sure now that the template indeed exists
         [ -e "$phpfpm_path" ] || ynh_die --message="Unable to find template to configure PHP-FPM."
-        cp "$phpfpm_path" "$finalphpconf"
-        ynh_replace_string --match_string="__NAMETOCHANGE__" --replace_string="$app" --target_file="$finalphpconf"
-        ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalphpconf"
-        ynh_replace_string --match_string="__USER__" --replace_string="$app" --target_file="$finalphpconf"
-        ynh_replace_string --match_string="__PHPVERSION__" --replace_string="$phpversion" --target_file="$finalphpconf"
-
     else
         # Usage 2, generate a PHP-FPM config file with ynh_get_scalable_phpfpm
 
@@ -178,82 +169,78 @@ ynh_add_fpm_config () {
         # Define the values to use for the configuration of PHP.
         ynh_get_scalable_phpfpm --usage=$usage --footprint=$footprint
 
-        # Copy the default file
-        cp "/etc/php/$phpversion/fpm/pool.d/www.conf" "$finalphpconf"
+        local phpfpm_path="../conf/php-fpm.conf"
+        echo "
+[__APP__]
 
-        # Replace standard variables into the default file
-        ynh_replace_string --match_string="^\[www\]" --replace_string="[$app]" --target_file="$finalphpconf"
-        ynh_replace_string --match_string=".*listen = .*" --replace_string="listen = /var/run/php/php$phpversion-fpm-$app.sock" --target_file="$finalphpconf"
-        ynh_replace_string --match_string="^user = .*" --replace_string="user = $app" --target_file="$finalphpconf"
-        ynh_replace_string --match_string="^group = .*" --replace_string="group = $app" --target_file="$finalphpconf"
-        ynh_replace_string --match_string=".*chdir = .*" --replace_string="chdir = $final_path" --target_file="$finalphpconf"
+user = __APP__
+group = __APP__
 
-        # Configure FPM children
-        ynh_replace_string --match_string=".*pm = .*" --replace_string="pm = $php_pm" --target_file="$finalphpconf"
-        ynh_replace_string --match_string=".*pm.max_children = .*" --replace_string="pm.max_children = $php_max_children" --target_file="$finalphpconf"
-        ynh_replace_string --match_string=".*pm.max_requests = .*" --replace_string="pm.max_requests = 500" --target_file="$finalphpconf"
-        ynh_replace_string --match_string=".*request_terminate_timeout = .*" --replace_string="request_terminate_timeout = 1d" --target_file="$finalphpconf"
+chdir = __FINALPATH__
+
+listen = /var/run/php/php__PHPVERSION__-fpm-__APP__.sock
+listen.owner = www-data
+listen.group = www-data
+
+pm = __PHP_PM__
+pm.max_children = __PHP_MAX_CHILDREN__
+pm.max_requests = 500
+request_terminate_timeout = 1d
+" > $phpfpm_path
+
         if [ "$php_pm" = "dynamic" ]
         then
-            ynh_replace_string --match_string=".*pm.start_servers = .*" --replace_string="pm.start_servers = $php_start_servers" --target_file="$finalphpconf"
-            ynh_replace_string --match_string=".*pm.min_spare_servers = .*" --replace_string="pm.min_spare_servers = $php_min_spare_servers" --target_file="$finalphpconf"
-            ynh_replace_string --match_string=".*pm.max_spare_servers = .*" --replace_string="pm.max_spare_servers = $php_max_spare_servers" --target_file="$finalphpconf"
+            echo "
+pm.start_servers = __PHP_START_SERVERS__
+pm.min_spare_servers = __PHP_MIN_SPARE_SERVERS__
+pm.max_spare_servers = __PHP_MAX_SPARE_SERVERS__
+" >> $phpfpm_path
+
         elif [ "$php_pm" = "ondemand" ]
         then
-            ynh_replace_string --match_string=".*pm.process_idle_timeout = .*" --replace_string="pm.process_idle_timeout = 10s" --target_file="$finalphpconf"
-        fi
-
-        # Comment unused parameters
-        if [ "$php_pm" != "dynamic" ]
-        then
-            ynh_replace_string --match_string=".*\(pm.start_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
-            ynh_replace_string --match_string=".*\(pm.min_spare_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
-            ynh_replace_string --match_string=".*\(pm.max_spare_servers = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
-        fi
-        if [ "$php_pm" != "ondemand" ]
-        then
-            ynh_replace_string --match_string=".*\(pm.process_idle_timeout = .*\)" --replace_string=";\1" --target_file="$finalphpconf"
+            echo "
+pm.process_idle_timeout = 10s
+" >> $phpfpm_path
         fi
 
         # Concatene the extra config.
         if [ -e ../conf/extra_php-fpm.conf ]; then
-            cat ../conf/extra_php-fpm.conf >> "$finalphpconf"
+            cat ../conf/extra_php-fpm.conf >> "$phpfpm_path"
         fi
     fi
 
-    chown root: "$finalphpconf"
-    ynh_store_file_checksum --file="$finalphpconf"
+    local finalphpconf="$fpm_config_dir/pool.d/$app.conf"
+    ynh_add_config --template="$phpfpm_path" --destination="$finalphpconf"
 
     if [ -e "../conf/php-fpm.ini" ]
     then
         ynh_print_warn --message="Packagers ! Please do not use a separate php ini file, merge your directives in the pool file instead."
-        finalphpini="$fpm_config_dir/conf.d/20-$app.ini"
-        ynh_backup_if_checksum_is_different "$finalphpini"
-        cp ../conf/php-fpm.ini "$finalphpini"
-        chown root: "$finalphpini"
-        ynh_store_file_checksum "$finalphpini"
+        ynh_add_config --template="../conf/php-fpm.ini" --destination="$fpm_config_dir/conf.d/20-$app.ini"
     fi
 
     if [ $dedicated_service -eq 1 ]
     then
         # Create a dedicated php-fpm.conf for the service
         local globalphpconf=$fpm_config_dir/php-fpm-$app.conf
-        cp /etc/php/${phpversion}/fpm/php-fpm.conf $globalphpconf
 
-        ynh_replace_string --match_string="^[; ]*pid *=.*" --replace_string="pid = /run/php/php${phpversion}-fpm-$app.pid" --target_file="$globalphpconf"
-        ynh_replace_string --match_string="^[; ]*error_log *=.*" --replace_string="error_log = /var/log/php/fpm-php.$app.log" --target_file="$globalphpconf"
-        ynh_replace_string --match_string="^[; ]*syslog.ident *=.*" --replace_string="syslog.ident = php-fpm-$app" --target_file="$globalphpconf"
-        ynh_replace_string --match_string="^[; ]*include *=.*" --replace_string="include = $finalphpconf" --target_file="$globalphpconf"
+echo "[global]
+pid = /run/php/php__PHPVERSION__-fpm-__APP__.pid
+error_log = /var/log/php/fpm-php.__APP__.log
+syslog.ident = php-fpm-__APP__
+include = __FINALPHPCONF__
+" > ../conf/php-fpm-$app.conf
+
+        ynh_add_config --template="../config/php-fpm-$app.conf" --destination="$globalphpconf"
 
         # Create a config for a dedicated PHP-FPM service for the app
         echo "[Unit]
-Description=PHP $phpversion FastCGI Process Manager for $app
+Description=PHP __PHPVERSION__ FastCGI Process Manager for __APP__
 After=network.target
 
-[Service] 
+[Service]
 Type=notify
-PIDFile=/run/php/php${phpversion}-fpm-$app.pid
-ExecStart=/usr/sbin/php-fpm$phpversion --nodaemonize --fpm-config $globalphpconf
+PIDFile=/run/php/php__PHPVERSION__-fpm-__APP__.pid
+ExecStart=/usr/sbin/php-fpm__PHPVERSION__ --nodaemonize --fpm-config __GLOBALPHPCONF__
 ExecReload=/bin/kill -USR2 \$MAINPID
 
 [Install]

--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -3,61 +3,27 @@
 # Create a dedicated systemd config
 #
 # usage: ynh_add_systemd_config [--service=service] [--template=template]
-# usage: ynh_add_systemd_config [--service=service] [--template=template]  [--others_var="list of others variables to replace"]
 # | arg: -s, --service=     - Service name (optionnal, $app by default)
 # | arg: -t, --template=    - Name of template file (optionnal, this is 'systemd' by default, meaning ./conf/systemd.service will be used as template)
-# | arg: -v, --others_var=  - List of others variables to replace separated by a space. For example: 'var_1 var_2 ...'
 #
 # This will use the template ../conf/<templatename>.service
-# to generate a systemd config, by replacing the following keywords
-# with global variables that should be defined before calling
-# this helper :
-#
-#   __APP__       by  $app
-#   __FINALPATH__ by  $final_path
-#
-# And dynamic variables (from the last example) :
-#   __VAR_1__    by $var_1
-#   __VAR_2__    by $var_2
+# See the documentation of ynh_add_config for a description of the template
+# format and how placeholders are replaced with actual variables.
 #
 # Requires YunoHost version 2.7.11 or higher.
 ynh_add_systemd_config () {
     # Declare an array to define the options of this helper.
-    local legacy_args=stv
-    local -A args_array=( [s]=service= [t]=template= [v]=others_var= )
+    local legacy_args=st
+    local -A args_array=( [s]=service= [t]=template=)
     local service
     local template
-    local others_var
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     local service="${service:-$app}"
     local template="${template:-systemd.service}"
-    others_var="${others_var:-}"
 
-    finalsystemdconf="/etc/systemd/system/$service.service"
-    ynh_backup_if_checksum_is_different --file="$finalsystemdconf"
-    cp ../conf/$template "$finalsystemdconf"
+    ynh_add_config --template="../conf/$template" --destination="/etc/systemd/system/$service.service"
 
-    # To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
-    # Substitute in a nginx config file only if the variable is not empty
-    if [ -n "${final_path:-}" ]; then
-        ynh_replace_string --match_string="__FINALPATH__" --replace_string="$final_path" --target_file="$finalsystemdconf"
-    fi
-    if [ -n "${app:-}" ]; then
-        ynh_replace_string --match_string="__APP__" --replace_string="$app" --target_file="$finalsystemdconf"
-    fi
-
-    # Replace all other variables given as arguments
-    for var_to_replace in $others_var
-    do
-        # ${var_to_replace^^} make the content of the variable on upper-cases
-        # ${!var_to_replace} get the content of the variable named $var_to_replace 
-        ynh_replace_string --match_string="__${var_to_replace^^}__" --replace_string="${!var_to_replace}" --target_file="$finalsystemdconf"
-    done
-
-    ynh_store_file_checksum --file="$finalsystemdconf"
-
-    chown root: "$finalsystemdconf"
     systemctl enable $service --quiet
     systemctl daemon-reload
 }

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -322,6 +322,7 @@ ynh_add_config () {
     ynh_backup_if_checksum_is_different --file="$destination"
 
     cp "$template_path" "$destination"
+    chown root: "$destination"
 
     ynh_replace_vars --file="$destination"
 


### PR DESCRIPTION
## The problem

Conf handling is a mess, we have tons of ynh_replace_string all over the place, and some ugly --othervar options to replace "other vars", lack of consistency, etc

## Solution

Use the new `ynh_add_config` helper to consistently handle template hydration (and backup/save of the checksum ugh)

## PR Status

Yolocommited

## How to test

Gotta install some apps idk
