### PR TITLE
[enh] display domain_path of app on app list

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -163,6 +163,9 @@ def app_info(app, full=False):
         'version': local_manifest.get('version', '-'),
     }
 
+    if "domain" in settings and "path" in settings:
+        ret["domain_path"] = settings["domain"] + settings["path"]
+
     if not full:
         return ret
 


### PR DESCRIPTION
## The problem

When listing the applications with `yunohost app list` we don't show by default were the application is installed. People end up having to learn about the existence of `yunohost app map` just for that and it's a bit stupid (and it doesn't display the same information).

![image](https://user-images.githubusercontent.com/41827/103440897-daac9880-4c49-11eb-811f-206618e991cb.png)

## Solution

Add, when domain and path is available for an app, the `domain_path` key like this:

![image](https://user-images.githubusercontent.com/41827/103440904-e4360080-4c49-11eb-98a6-16e2b8abaec4.png)

## PR Status

Tested and working.

## How to test

Just do a `yunohost app list`
