### PR TITLE
[fix] key name of app label wasn't the real label

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -154,12 +154,13 @@ def app_info(app, full=False):
         raise YunohostError('app_not_installed', app=app, all_apps=_get_all_installed_apps_id())
 
     local_manifest = _get_manifest_of_app(os.path.join(APPS_SETTING_PATH, app))
+    permissions = user_permission_list(full=True, absolute_urls=True)["permissions"]
 
     settings = _get_app_settings(app)
 
     ret = {
         'description': _value_for_locale(local_manifest['description']),
-        'name': local_manifest['name'],
+        'name': permissions.get(app + ".main", {}).get("label", local_manifest['name']),
         'version': local_manifest.get('version', '-'),
     }
 
@@ -180,9 +181,10 @@ def app_info(app, full=False):
     ret['supports_backup_restore'] = (os.path.exists(os.path.join(APPS_SETTING_PATH, app, "scripts", "backup")) and
                                       os.path.exists(os.path.join(APPS_SETTING_PATH, app, "scripts", "restore")))
     ret['supports_multi_instance'] = is_true(local_manifest.get("multi_instance", False))
-    permissions = user_permission_list(full=True, absolute_urls=True)["permissions"]
+
     ret['permissions'] = {p: i for p, i in permissions.items() if p.startswith(app + ".")}
     ret['label'] = permissions.get(app + ".main", {}).get("label")
+
     if not ret['label']:
         logger.warning("Failed to get label for app %s ?" % app)
     return ret


### PR DESCRIPTION
## The problem

`app_info(app)["name"]` was returning the label of the app in the manifest which was the label from the app catalog, not the real label of the app that could have been changed.

![image](https://user-images.githubusercontent.com/41827/103443536-8365f280-4c60-11eb-837c-39ae21182e77.png)

Only generic labels ^

## Solution

Grab the real label, fall back on the manifest one if none is here.

![image](https://user-images.githubusercontent.com/41827/103443527-7812c700-4c60-11eb-8c57-1e577647b527.png)

New custom label for last app my_webapp__3 ^

## PR Status

Working, need previous branch avoid_calling_app_list_in_user_permission_list

## How to test

Have apps with custom labels, then "yunohost app list" or "yunohost app info the_app_id"