### PR TITLE
[mod] also display app label on remove_domain with apps

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -277,7 +277,7 @@
     "domain_dyndns_root_unknown": "Unknown DynDNS root domain",
     "domain_exists": "The domain already exists",
     "domain_hostname_failed": "Unable to set new hostname. This might cause an issue later (it might be fine).",
-    "domain_uninstall_app_first": "Those applications are still installed on your domain: {apps}. Please uninstall them before proceeding to domain removal",
+    "domain_uninstall_app_first": "Those applications are still installed on your domain:\n{apps}\n\nPlease uninstall them using 'yunohost app remove the_app_id' or move them to another domain using 'yunohost app change-url the_app_id' before proceeding to domain removal",
     "domain_name_unknown": "Domain '{domain}' unknown",
     "domain_unknown": "Unknown domain",
     "domains_available": "Available domains:",

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -206,10 +206,10 @@ def domain_remove(operation_logger, domain, force=False):
         settings = _get_app_settings(app)
         label = app_info(app)["name"]
         if settings.get("domain") == domain:
-            apps_on_that_domain.append("%s \"%s\" (on https://%s%s)" % (app, label, domain, settings["path"]) if "path" in settings else app)
+            apps_on_that_domain.append("    - %s \"%s\" on https://%s%s" % (app, label, domain, settings["path"]) if "path" in settings else app)
 
     if apps_on_that_domain:
-        raise YunohostError('domain_uninstall_app_first', apps=", ".join(apps_on_that_domain))
+        raise YunohostError('domain_uninstall_app_first', apps="\n".join(apps_on_that_domain))
 
     operation_logger.start()
     ldap = _get_ldap_interface()

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -182,7 +182,7 @@ def domain_remove(operation_logger, domain, force=False):
 
     """
     from yunohost.hook import hook_callback
-    from yunohost.app import app_ssowatconf
+    from yunohost.app import app_ssowatconf, app_info
     from yunohost.utils.ldap import _get_ldap_interface
 
     if not force and domain not in domain_list()['domains']:
@@ -204,8 +204,9 @@ def domain_remove(operation_logger, domain, force=False):
 
     for app in _installed_apps():
         settings = _get_app_settings(app)
+        label = app_info(app)["name"]
         if settings.get("domain") == domain:
-            apps_on_that_domain.append("%s (on https://%s%s)" % (app, domain, settings["path"]) if "path" in settings else app)
+            apps_on_that_domain.append("%s \"%s\" (on https://%s%s)" % (app, label, domain, settings["path"]) if "path" in settings else app)
 
     if apps_on_that_domain:
         raise YunohostError('domain_uninstall_app_first', apps=", ".join(apps_on_that_domain))


### PR DESCRIPTION
## The problem

Only app idea is shown on "yunohost domain remove" on an domain with apps installed on it.

This is problematic especially in the admin because the app id isn't show but the domain is.

![image](https://user-images.githubusercontent.com/41827/103444117-d68e7400-4c65-11eb-9183-5ea4ec510e24.png)

Before ^
## Solution

Display the app label.

Also suggest to change-url instead.

Also tells which command to uses.

![image](https://user-images.githubusercontent.com/41827/103444128-e1490900-4c65-11eb-932c-d1d5ea7a84f1.png)

After ^

## PR Status

Working

## How to test

`yunohost domain remove some_domain_with_apps.tld`
