### PR TITLE
[enh] if app has a DESCRIPTION.md, display it before starting the installation

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -739,6 +739,9 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
     else:
         app_instance_name = app_id
 
+    if 'DESCRIPTION.md' in os.listdir(extracted_app_folder):
+        msignals.file_display(os.path.join(extracted_app_folder, "DESCRIPTION.md"))
+
     # Retrieve arguments list for install script
     args_dict = {} if not args else \
         dict(urlparse.parse_qsl(args, keep_blank_values=True))

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -623,7 +623,7 @@ def app_upgrade(app=[], url=None, file=None, force=False):
             if os.path.exists(os.path.join(extracted_app_folder, "manifest.toml")):
                 os.system('mv "%s/manifest.toml" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
-            for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf"]:
+            for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf", "DESCRIPTION.md"]:
                 if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
                     os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 
@@ -801,7 +801,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
         os.system('cp %s/manifest.toml %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
 
-    for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf"]:
+    for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf", "DESCRIPTION.md"]:
         if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
             os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 


### PR DESCRIPTION
## The problem

For quite some time it has been requested for application to be able to display more content than just the short line of description.

## Solution

Linked to https://github.com/YunoHost/moulinette/pull/265

I don't remember all the discussion on how we could do that etc ... but I do remember the one that asked to display the README.md of the application to the user before the installation.

I don't think that README.md is appropriate because it is meant for github users and contributors but displaying the content of a file is really a minimalist and very flexible modification. Therefor displaying the content of `DESCRIPTION.md` (or another name if someone finds something better) seems like a good way forward.

Obligatory screeshots (don't mind the content, it's just garbage to test it):

![image](https://user-images.githubusercontent.com/41827/103448770-79fb7b00-4c9e-11eb-8344-5cf55d704829.png)

![image](https://user-images.githubusercontent.com/41827/103448775-88499700-4c9e-11eb-86dd-96da6e9a7314.png)

## PR Status

Working for me, but only in CLI, I'm not sure on how to do that correctly with web and the admin is being totally rewritten :<  

## How to test

This PR is needed https://github.com/YunoHost/moulinette/pull/265

Add a `DESCRIPTION.md` file to an application then try to install it.

Play with the length of the content of the file to spawn or not the paging.