### PR TITLE
App changelog.md

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -60,7 +60,7 @@ APPS_CATALOG_CRON_PATH = "/etc/cron.daily/yunohost-fetch-apps-catalog"
 APPS_CATALOG_API_VERSION = 2
 APPS_CATALOG_DEFAULT_URL = "https://app.yunohost.org/default"
 APPS_FILES_TO_SAVE = ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml",
-                      "conf", "DESCRIPTION.md"]
+                      "conf", "DESCRIPTION.md", "CHANGELOG.md"]
 re_app_instance_name = re.compile(
     r'^(?P<appid>[\w-]+?)(__(?P<appinstancenb>[1-9][0-9]*))?$'
 )
@@ -520,6 +520,9 @@ def app_upgrade(app=[], url=None, file=None, force=False):
         _assert_system_is_sane_for_app(manifest, "pre")
 
         app_setting_path = APPS_SETTING_PATH + '/' + app_instance_name
+
+        if 'CHANGELOG.md' in os.listdir(extracted_app_folder):
+            msignals.file_display(os.path.join(extracted_app_folder, "CHANGELOG.md"))
 
         # Retrieve arguments list for upgrade script
         # TODO: Allow to specify arguments

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -59,7 +59,8 @@ APPS_CATALOG_CONF = '/etc/yunohost/apps_catalog.yml'
 APPS_CATALOG_CRON_PATH = "/etc/cron.daily/yunohost-fetch-apps-catalog"
 APPS_CATALOG_API_VERSION = 2
 APPS_CATALOG_DEFAULT_URL = "https://app.yunohost.org/default"
-
+APPS_FILES_TO_SAVE = ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml",
+                      "conf", "DESCRIPTION.md"]
 re_app_instance_name = re.compile(
     r'^(?P<appid>[\w-]+?)(__(?P<appinstancenb>[1-9][0-9]*))?$'
 )
@@ -623,7 +624,7 @@ def app_upgrade(app=[], url=None, file=None, force=False):
             if os.path.exists(os.path.join(extracted_app_folder, "manifest.toml")):
                 os.system('mv "%s/manifest.toml" "%s/scripts" %s' % (extracted_app_folder, extracted_app_folder, app_setting_path))
 
-            for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf", "DESCRIPTION.md"]:
+            for file_to_copy in APPS_FILES_TO_SAVE:
                 if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
                     os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 
@@ -801,7 +802,7 @@ def app_install(operation_logger, app, label=None, args=None, no_remove_on_failu
         os.system('cp %s/manifest.toml %s' % (extracted_app_folder, app_setting_path))
     os.system('cp -R %s/scripts %s' % (extracted_app_folder, app_setting_path))
 
-    for file_to_copy in ["actions.json", "actions.toml", "config_panel.json", "config_panel.toml", "conf", "DESCRIPTION.md"]:
+    for file_to_copy in APPS_FILES_TO_SAVE:
         if os.path.exists(os.path.join(extracted_app_folder, file_to_copy)):
             os.system('cp -R %s/%s %s' % (extracted_app_folder, file_to_copy, app_setting_path))
 


### PR DESCRIPTION
## The problem

Like https://github.com/YunoHost/yunohost/pull/1126 but for CHANGELOG.md during app upgrade.

The advance: some apps seems to already have a CHANGELOG.md

On the downside this will probably force app developers to write their CHANGELOG.md in an intelligible manner for users.

## Solution

Display it during app upgrade.

![image](https://user-images.githubusercontent.com/41827/103456905-dd1afb00-4cfa-11eb-989d-030f5f8717fe.png)

## PR Status

Tested and working for me.

## How to test

Try to upgrade an app that has a CHANGELOG.md file using also this PR https://github.com/YunoHost/moulinette/pull/265