### PR TITLE
Add multimedia helpers and hooks

### DIFF
--- a/data/helpers.d/multimedia
+++ b/data/helpers.d/multimedia
@@ -1,0 +1,87 @@
+readonly MEDIA_GROUP=multimedia
+readonly MEDIA_DIRECTORY=/home/yunohost.multimedia
+
+# Initialize the multimedia directory system
+#
+# usage: ynh_multimedia_build_main_dir
+ynh_multimedia_build_main_dir() {
+
+    ## Création du groupe multimedia
+    groupadd -f $MEDIA_GROUP
+
+    ## Création des dossiers génériques
+    mkdir -p "$MEDIA_DIRECTORY"
+    mkdir -p "$MEDIA_DIRECTORY/share"
+    mkdir -p "$MEDIA_DIRECTORY/share/Music"
+    mkdir -p "$MEDIA_DIRECTORY/share/Picture"
+    mkdir -p "$MEDIA_DIRECTORY/share/Video"
+    mkdir -p "$MEDIA_DIRECTORY/share/eBook"
+
+    ## Création des dossiers utilisateurs
+    for user in $(yunohost user list --output-as json | jq -r '.users | keys[]')
+    do
+        mkdir -p "$MEDIA_DIRECTORY/$user"
+        mkdir -p "$MEDIA_DIRECTORY/$user/Music"
+        mkdir -p "$MEDIA_DIRECTORY/$user/Picture"
+        mkdir -p "$MEDIA_DIRECTORY/$user/Video"
+        mkdir -p "$MEDIA_DIRECTORY/$user/eBook"
+        ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
+        # Création du lien symbolique dans le home de l'utilisateur.
+        ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+        # Propriétaires des dossiers utilisateurs.
+        chown -R $user "$MEDIA_DIRECTORY/$user"
+    done
+    # Default yunohost hooks for post_user_create,delete will take care
+    # of creating/deleting corresponding multimedia folders when users
+    # are created/deleted in the future...
+
+    ## Application des droits étendus sur le dossier multimedia.
+    # Droit d'écriture pour le groupe et le groupe multimedia en acl et droit de lecture pour other:
+    setfacl -RnL -m g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$MEDIA_DIRECTORY"
+    # Application de la même règle que précédemment, mais par défaut pour les nouveaux fichiers.
+    setfacl -RnL -m d:g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$MEDIA_DIRECTORY"
+    # Réglage du masque par défaut. Qui garantie (en principe...) un droit maximal à rwx. Donc pas de restriction de droits par l'acl.
+    setfacl -RL -m m::rwx "$MEDIA_DIRECTORY"
+}
+
+# Add a directory in yunohost.multimedia
+# This "directory" will be a symbolic link to a existing directory.
+#
+# usage: ynh_multimedia_addfolder "Source directory" "Destination directory"
+#
+# | arg: -s, --source_dir= - Source directory - The real directory which contains your medias.
+# | arg: -d, --dest_dir= - Destination directory - The name and the place of the symbolic link, relative to "/home/yunohost.multimedia"
+ynh_multimedia_addfolder() {
+
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=source_dir= [d]=dest_dir= )
+	local source_dir
+	local dest_dir
+
+    # Ajout d'un lien symbolique vers le dossier à partager
+	ln -sfn "$source_dir" "$MEDIA_DIRECTORY/$dest_dir"
+
+	## Application des droits étendus sur le dossier ajouté
+	# Droit d'écriture pour le groupe et le groupe multimedia en acl et droit de lecture pour other:
+	setfacl -RnL -m g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$source_dir"
+	# Application de la même règle que précédemment, mais par défaut pour les nouveaux fichiers.
+	setfacl -RnL -m d:g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$source_dir"
+	# Réglage du masque par défaut. Qui garantie (en principe...) un droit maximal à rwx. Donc pas de restriction de droits par l'acl.
+	setfacl -RL -m m::rwx "$source_dir"
+}
+
+# Allow an user to have an write authorisation in multimedia directories
+#
+# usage: ynh_multimedia_addaccess user_name
+#
+# | arg: -u, --user_name= - The name of the user which gain this access.
+ynh_multimedia_addaccess () {
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [u]=user_name=)
+	local user_name
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	groupadd -f multimedia
+	usermod -a -G multimedia $user_name
+}

--- a/data/hooks/post_user_create/ynh_multimedia
+++ b/data/hooks/post_user_create/ynh_multimedia
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+user=$1
+ 
+readonly MEDIA_GROUP=multimedia
+readonly MEDIA_DIRECTORY=/home/yunohost.multimedia
+
+# We only do this if multimedia directory is enabled (= the folder exists)
+[ -e "$MEDIA_DIRECTORY" ] || exit
+
+mkdir -p "$MEDIA_DIRECTORY/$user"
+mkdir -p "$MEDIA_DIRECTORY/$user/Music"
+mkdir -p "$MEDIA_DIRECTORY/$user/Picture"
+mkdir -p "$MEDIA_DIRECTORY/$user/Video"
+mkdir -p "$MEDIA_DIRECTORY/$user/eBook"
+ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
+# Création du lien symbolique dans le home de l'utilisateur.
+ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+# Propriétaires des dossiers utilisateurs.
+chown -R $user "$MEDIA_DIRECTORY/$user"
+
+## Application des droits étendus sur le dossier multimedia.
+# Droit d'écriture pour le groupe et le groupe multimedia en acl et droit de lecture pour other:
+setfacl -RnL -m g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$MEDIA_DIRECTORY/$user"
+# Application de la même règle que précédemment, mais par défaut pour les nouveaux fichiers.
+setfacl -RnL -m d:g:$MEDIA_GROUP:rwX,g::rwX,o:r-X "$MEDIA_DIRECTORY/$user"
+# Réglage du masque par défaut. Qui garantie (en principe...) un droit maximal à rwx. Donc pas de restriction de droits par l'acl.
+setfacl -RL -m m::rwx "$MEDIA_DIRECTORY/$user"

--- a/data/hooks/post_user_create/ynh_multimedia
+++ b/data/hooks/post_user_create/ynh_multimedia
@@ -6,7 +6,7 @@ readonly MEDIA_GROUP=multimedia
 readonly MEDIA_DIRECTORY=/home/yunohost.multimedia
 
 # We only do this if multimedia directory is enabled (= the folder exists)
-[ -e "$MEDIA_DIRECTORY" ] || exit
+[ -e "$MEDIA_DIRECTORY" ] || exit 0
 
 mkdir -p "$MEDIA_DIRECTORY/$user"
 mkdir -p "$MEDIA_DIRECTORY/$user/Music"

--- a/data/hooks/post_user_delete/ynh_multimedia
+++ b/data/hooks/post_user_delete/ynh_multimedia
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+user=$1
+MEDIA_DIRECTORY=/home/yunohost.multimedia
+
+if [ -n "$user" ] && [ -e "$MEDIA_DIRECTORY/$user" ]; then
+    sudo rm -r "$MEDIA_DIRECTORY/$user"
+fi

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: ${python3:Depends}, ${misc:Depends}
  , rspamd, opendkim-tools, postsrsd, procmail, mailutils
  , redis-server
  , metronome (>=3.14.0)
+ , acl
  , git, curl, wget, cron, unzip, jq, bc
  , lsb-release, haveged, fake-hwclock, equivs, lsof, whois
 Recommends: yunohost-admin


### PR DESCRIPTION
## The problem

Multimedia helpers are overly complex, downloading stuff from an external repo (why?) just to have a bunch of helper/hooks ...

Also today an user reported this https://forum.yunohost.org/t/cant-install-app-transmission-nextcloud/13826 where everything exploded because of unecessary sudos all over the place ...

## Solution

Add the multimedia helpers and hooks in the core ...

This supersedes https://github.com/YunoHost/yunohost/pull/525

Note that I did not port `ynh_multimedia_movefolder` because it doesn't seem to be used in any app

## PR Status

Yolo commited, not tested

## How to test

Try to install an app that rely on the multimedia helpers. In fact not so many of them do : airsonic, (ampache), calibreweb, couchpotato, minidlna, navidrome, nextcloud, transmission