### PR TITLE
Add the -F flag to prevent grep from using the user password as a regex pattern

### DIFF
--- a/src/yunohost/utils/password.py
+++ b/src/yunohost/utils/password.py
@@ -171,7 +171,7 @@ class PasswordValidator(object):
         # Grep the password in the file
         # We use '-f -' to feed the pattern (= the password) through
         # stdin to avoid it being shown in ps -ef --forest...
-        command = "grep -q -f - %s" % MOST_USED_PASSWORDS
+        command = "grep -q -F -f - %s" % MOST_USED_PASSWORDS
         p = subprocess.Popen(command.split(), stdin=subprocess.PIPE)
         p.communicate(input=password)
         return not bool(p.returncode)


### PR DESCRIPTION
## The problem
Issue #[1534](https://github.com/YunoHost/issues/issues/1435)
## Solution
Add the -F flag to the grep command.

## PR Status

...

## How to test

...
