### PR TITLE
fix boolean arg parse

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2537,10 +2537,10 @@ class BooleanArgumentParser(YunoHostArgumentFormatParser):
         if isinstance(question.value, bool):
             return 1 if question.value else 0
 
-        if str(question.value).lower() in ["1", "yes", "y"]:
+        if str(question.value).lower() in ["1", "yes", "y", "true"]:
             return 1
 
-        if str(question.value).lower() in ["0", "no", "n"]:
+        if str(question.value).lower() in ["0", "no", "n", "false"]:
             return 0
 
         raise YunohostError('app_argument_choice_invalid', name=question.name,

--- a/src/yunohost/tests/test_apps_arguments_parsing.py
+++ b/src/yunohost/tests/test_apps_arguments_parsing.py
@@ -616,6 +616,18 @@ def test_parse_args_in_yunohost_format_boolean_all_yes():
         _parse_args_in_yunohost_format({"some_boolean": True}, questions) ==
         expected_result
     )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "True"}, questions) ==
+        expected_result
+    )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "TRUE"}, questions) ==
+        expected_result
+    )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "true"}, questions) ==
+        expected_result
+    )
 
 
 def test_parse_args_in_yunohost_format_boolean_all_no():
@@ -651,6 +663,18 @@ def test_parse_args_in_yunohost_format_boolean_all_no():
     )
     assert (
         _parse_args_in_yunohost_format({"some_boolean": False}, questions) ==
+        expected_result
+    )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "False"}, questions) ==
+        expected_result
+    )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "FALSE"}, questions) ==
+        expected_result
+    )
+    assert (
+        _parse_args_in_yunohost_format({"some_boolean": "false"}, questions) ==
         expected_result
     )
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1709
> We used to set values to true or false but it doesn't accept it anymore, returning "Use one of these choices 'yes, no, y, n, 1, 0' 

## Solution

Add `true` and `false` string as possible answer

## PR Status

...

## How to test

...
