### PR TITLE
fix default arg parse for password

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2423,6 +2423,10 @@ class YunoHostArgumentFormatParser(object):
 
         if parsed_question.ask is None:
             parsed_question.ask = "Enter value for '%s':" % parsed_question.name
+        
+        # Empty value is parsed as empty string
+        if parsed_question.default == "":
+            parsed_question.default = None
 
         return parsed_question
 

--- a/src/yunohost/tests/test_apps_arguments_parsing.py
+++ b/src/yunohost/tests/test_apps_arguments_parsing.py
@@ -260,6 +260,10 @@ def test_parse_args_in_yunohost_format_password_no_input_optional():
 
     assert _parse_args_in_yunohost_format(answers, questions) == expected_result
 
+    questions = [{"name": "some_password", "type": "password", "optional": True, "default": ""}]
+
+    assert _parse_args_in_yunohost_format(answers, questions) == expected_result
+
 
 def test_parse_args_in_yunohost_format_password_optional_with_input():
     questions = [


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1709

> "Error while parsing password argument 'YNH_CONFIG_MAIN_ENCRYPTION_ENCRYPTION_PWD': password argument can't have a default value for security reason" while main.encryption.encryption_pwd has optional = true

## Solution

If the default value is an empty string, set it to `None`. ¯\\\_(ツ)\_/¯

## PR Status

...

## How to test

...
