### PR TITLE
Make dyndns update more resilient to ns0.yunohost.org being down

### DIFF
--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -218,7 +218,13 @@ def dyndns_update(operation_logger, dyn_host="dyndns.yunohost.org", domain=None,
 
     def resolve_domain(domain, rdtype):
 
-        ok, result = dig(domain, rdtype, resolvers=[dyn_host])
+        # FIXME make this work for IPv6-only hosts too..
+        ok, result = dig(dyn_host, "A")
+        dyn_host_ip = result[0] if ok == "ok" and len(result) else None
+        if not dyn_host_ip:
+            raise YunohostError("Failed to resolve %s" % dyn_host)
+     
+        ok, result = dig(domain, rdtype, resolvers=[dyn_host_ip])
         if ok == "ok":
             return result[0] if len(result) else None
         elif result[0] == "Timeout":

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -35,7 +35,6 @@ from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import write_to_file, read_file
 from moulinette.utils.network import download_json
-from moulinette.utils.process import check_output
 
 from yunohost.utils.error import YunohostError
 from yunohost.domain import _get_maindomain, _build_dns_conf

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -34,12 +34,12 @@ from moulinette import m18n
 from moulinette.core import MoulinetteError
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import write_to_file, read_file
-from moulinette.utils.network import download_json, dig
+from moulinette.utils.network import download_json
 from moulinette.utils.process import check_output
 
 from yunohost.utils.error import YunohostError
 from yunohost.domain import _get_maindomain, _build_dns_conf
-from yunohost.utils.network import get_public_ip
+from yunohost.utils.network import get_public_ip, dig
 from yunohost.log import is_unit_operation
 
 logger = getActionLogger('yunohost.dyndns')


### PR DESCRIPTION
## The problem

So i finally got fed up with yunohost's dyndns cron job flooding mails when ns0.yunohost.org (our bind9) is down (or just because considering the cron job runs every 2 minutes, at some point a dig command will fail for whatever reason and will result in an email being sent)

The email content is not pretty:

```
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 72, in <module>
    parser=parser
  File "/usr/lib/moulinette/yunohost/__init__.py", line 29, in cli
    top_parser=parser
  File "/usr/lib/python2.7/dist-packages/moulinette/__init__.py", line 120, in cli
    args, output_as=output_as, timeout=timeout
  File "/usr/lib/python2.7/dist-packages/moulinette/interfaces/cli.py", line 477, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/moulinette/actionsmap.py", line 592, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/log.py", line 358, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/dyndns.py", line 219, in dyndns_update
    old_ipv4 = check_output("dig @%s +short %s" % (dyn_host, domain)) or None
  File "/usr/lib/python2.7/dist-packages/moulinette/utils/process.py", line 31, in check_output
    return subprocess.check_output(args, stderr=stderr, shell=shell, **kwargs).strip()
  File "/usr/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'dig @dyndns.yunohost.org +short yoloswag.ynh.fr' returned non-zero exit status 9
```

## Solution

The current code tries to perform a dig request on `ns0.yunohost.org` (= same IP than `dyndns.yunohost.org`) and miserably fail if it's down ... Too bad because we actually have a `ns1.yunohost.org` which is supposed to be the fallback server ...

In fact, if ns0.yunohost.org is down we can just fallback to a regular "use external resolvers". The current design was doing the request on ns0.yunohost.org because that's the best way to make sure the right IP is on the authoritative server (otherwise we run into TTL/propagation/cache considerations) but falling back to default resolvers is "good enough" in a context where our bind9 is temporarily down I suppose ... Though it will take ~1 min (30s + 30s) for the command to complete because it's waiting for a timeout ... but still less worse than sending an email with an ugly python stacktrace every 2 minutes ...

## PR Status

Tested and working on my side

## How to test

Uuuuh break our bind9 and try to `yunohost dyndns update`
