### PR TITLE
Stupid yolopatch for not-normalized app path settings >_>

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1892,6 +1892,18 @@ def _get_app_settings(app_id):
         # If label contains unicode char, this may later trigger issues when building strings...
         # FIXME: this should be propagated to read_yaml so that this fix applies everywhere I think...
         settings = {k: _encode_string(v) for k, v in settings.items()}
+
+        # Stupid fix for legacy bullshit
+        # In the past, some setups did not have proper normalization for app domain/path
+        # Meaning some setups (as of January 2021) still have path=/foobar/ (with a trailing slash)
+        # resulting in stupid issue unless apps using ynh_app_normalize_path_stuff
+        # So we yolofix the settings if such an issue is found >_>
+        # A simple call  to `yunohost app list` (which happens quite often) should be enough
+        # to migrate all app settings ... so this can probably be removed once we're past Bullseye...
+        if settings.get("path", "").endswith("/"):
+            settings["path"] = settings["path"].rstrip("/")
+            _set_app_settings(app_id, settings)
+
         if app_id == settings['id']:
             return settings
     except (IOError, TypeError, KeyError):
@@ -2423,7 +2435,7 @@ class YunoHostArgumentFormatParser(object):
 
         if parsed_question.ask is None:
             parsed_question.ask = "Enter value for '%s':" % parsed_question.name
-        
+
         # Empty value is parsed as empty string
         if parsed_question.default == "":
             parsed_question.default = None

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1900,8 +1900,8 @@ def _get_app_settings(app_id):
         # So we yolofix the settings if such an issue is found >_>
         # A simple call  to `yunohost app list` (which happens quite often) should be enough
         # to migrate all app settings ... so this can probably be removed once we're past Bullseye...
-        if settings.get("path", "").endswith("/"):
-            settings["path"] = settings["path"].rstrip("/")
+        if settings.get("path", "").endswith("/") or not settings.get("path", "/").startswith("/"):
+            settings["path"] = "/" + settings["path"].strip("/")
             _set_app_settings(app_id, settings)
 
         if app_id == settings['id']:

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1900,7 +1900,7 @@ def _get_app_settings(app_id):
         # So we yolofix the settings if such an issue is found >_>
         # A simple call  to `yunohost app list` (which happens quite often) should be enough
         # to migrate all app settings ... so this can probably be removed once we're past Bullseye...
-        if settings.get("path", "").endswith("/") or not settings.get("path", "/").startswith("/"):
+        if settings.get("path") != "/" and (settings.get("path", "").endswith("/") or not settings.get("path", "/").startswith("/")):
             settings["path"] = "/" + settings["path"].strip("/")
             _set_app_settings(app_id, settings)
 


### PR DESCRIPTION
## The problem

Hmpf c.f. https://github.com/YunoHost-Apps/nextcloud_ynh/issues/362

Old setups before we properly normalized domain/path may still have some `path` settings ending with a trailing `/` resulting in stupid issue unless the app uses `ynh_normalize_path` (which they did, but i recently advised they don't because i though this issue was longtime gone but it's not >_>)

## Solution

Yolofix the damn setting on each _get_app_setting so that we can later remove this bullshit ...

To be backported and released as hotfix on 4.1.x...

## PR Status

Yolocommited

## How to test

Zblerg
