### PR TITLE
Misc command rename and alias

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1519,9 +1519,11 @@ tools:
                         action: store_true
 
               ### tools_migrations_migrate()
-              migrate:
+              run:
                   action_help: Run migrations
-                  api: POST /migrations/migrate
+                  api: POST /migrations/run
+                  deprecated_alias:
+                     - migrate
                   arguments:
                     targets:
                         help: Migrations to run (all pendings by default)

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1681,7 +1681,7 @@ log:
                     default: 50
                     type: int
                 --share:
-                    help: Share the full log using yunopaste
+                    help: (Deprecated, see yunohost log share) Share the full log using yunopaste
                     action: store_true
                 -i:
                     full: --filter-irrelevant
@@ -1691,6 +1691,14 @@ log:
                     full: --with-suboperations
                     help: Include metadata about sub-operations of this operation... (e.g. initializing groups/permissions when installing an app)
                     action: store_true
+
+        ### log_share()
+        share:
+            action_help: Share the full log on yunopaste (alias to display --share)
+            api: GET /logs/share
+            arguments:
+                path:
+                    help: Log file to share
 
 
 #############################

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1518,7 +1518,7 @@ tools:
                         help: list only migrations already performed
                         action: store_true
 
-              ### tools_migrations_migrate()
+              ### tools_migrations_run()
               run:
                   action_help: Run migrations
                   api: POST /migrations/run

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1668,10 +1668,12 @@ log:
                     help: Include metadata about operations that are not the main operation but are sub-operations triggered by another ongoing operation... (e.g. initializing groups/permissions when installing an app)
                     action: store_true
 
-        ### log_display()
-        display:
+        ### log_show()
+        show:
             action_help: Display a log content
-            api: GET /logs/display
+            api: GET /logs/<path>
+            deprecated_alias:
+                - display
             arguments:
                 path:
                     help: Log file which to display the content
@@ -1694,7 +1696,7 @@ log:
 
         ### log_share()
         share:
-            action_help: Share the full log on yunopaste (alias to display --share)
+            action_help: Share the full log on yunopaste (alias to show --share)
             api: GET /logs/share
             arguments:
                 path:

--- a/debian/postinst
+++ b/debian/postinst
@@ -15,7 +15,7 @@ do_configure() {
       yunohost tools regen-conf --output-as none
 
       echo "Launching migrations..."
-      yunohost tools migrations migrate --auto
+      yunohost tools migrations run --auto
 
       echo "Re-diagnosing server health..."
       yunohost diagnosis run --force

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -199,7 +199,7 @@
     "log_corrupted_md_file": "El fitxer de metadades YAML associat amb els registres està malmès: « {md_file} »\nError: {error}",
     "log_category_404": "La categoria de registres « {category} » no existeix",
     "log_link_to_log": "El registre complet d'aquesta operació: «<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>»",
-    "log_help_to_get_log": "Per veure el registre de l'operació « {desc} », utilitzeu l'ordre « yunohost log display {name} »",
+    "log_help_to_get_log": "Per veure el registre de l'operació « {desc} », utilitzeu l'ordre « yunohost log show {name}{name} »",
     "log_link_to_failed_log": "No s'ha pogut completar l'operació « {desc} ». Per obtenir ajuda, <a href=\"#/tools/logs/{name}\">proveïu el registre complete de l'operació clicant aquí</a>",
     "log_help_to_get_failed_log": "No s'ha pogut completar l'operació « {desc} ». Per obtenir ajuda, compartiu el registre complete de l'operació utilitzant l'ordre « yunohost log share {name} »",
     "log_does_exists": "No hi ha cap registre per l'operació amb el nom« {log} », utilitzeu « yunohost log list » per veure tots els registre d'operació disponibles",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -201,7 +201,7 @@
     "log_link_to_log": "El registre complet d'aquesta operació: «<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>»",
     "log_help_to_get_log": "Per veure el registre de l'operació « {desc} », utilitzeu l'ordre « yunohost log display {name} »",
     "log_link_to_failed_log": "No s'ha pogut completar l'operació « {desc} ». Per obtenir ajuda, <a href=\"#/tools/logs/{name}\">proveïu el registre complete de l'operació clicant aquí</a>",
-    "log_help_to_get_failed_log": "No s'ha pogut completar l'operació « {desc} ». Per obtenir ajuda, compartiu el registre complete de l'operació utilitzant l'ordre « yunohost log display {name} --share »",
+    "log_help_to_get_failed_log": "No s'ha pogut completar l'operació « {desc} ». Per obtenir ajuda, compartiu el registre complete de l'operació utilitzant l'ordre « yunohost log share {name} »",
     "log_does_exists": "No hi ha cap registre per l'operació amb el nom« {log} », utilitzeu « yunohost log list » per veure tots els registre d'operació disponibles",
     "log_operation_unit_unclosed_properly": "L'operació no s'ha tancat de forma correcta",
     "log_app_change_url": "Canvia l'URL de l'aplicació « {} »",

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -292,7 +292,7 @@
     "migrations_migration_has_failed": "La migració {id} ha fallat, cancel·lant. Error: {exception}",
     "migrations_no_migrations_to_run": "No hi ha cap migració a fer",
     "migrations_skip_migration": "Saltant migració {id}...",
-    "migrations_to_be_ran_manually": "La migració {id} s'ha de fer manualment. Aneu a Eines → Migracions a la interfície admin, o executeu «yunohost tools migrations migrate».",
+    "migrations_to_be_ran_manually": "La migració {id} s'ha de fer manualment. Aneu a Eines → Migracions a la interfície admin, o executeu «yunohost tools migrations run».",
     "migrations_need_to_accept_disclaimer": "Per fer la migració {id}, heu d'acceptar aquesta clàusula de no responsabilitat:\n---\n{disclaimer}\n---\nSi accepteu fer la migració, torneu a executar l'ordre amb l'opció «--accept-disclaimer».",
     "no_internet_connection": "El servidor no està connectat a Internet",
     "not_enough_disk_space": "No hi ha prou espai en «{path:s}»",

--- a/locales/de.json
+++ b/locales/de.json
@@ -269,7 +269,7 @@
     "global_settings_unknown_setting_from_settings_file": "Unbekannter Schlüssel in den Einstellungen: '{setting_key:s}', verwerfen und speichern in /etc/yunohost/settings-unknown.json",
     "log_link_to_log": "Vollständiges Log dieser Operation: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
     "global_settings_setting_example_bool": "Beispiel einer booleschen Option",
-    "log_help_to_get_log": "Um das Protokoll der Operation '{desc}' anzuzeigen, verwende  den Befehl 'yunohost log display {name}'",
+    "log_help_to_get_log": "Um das Protokoll der Operation '{desc}' anzuzeigen, verwende  den Befehl 'yunohost log show {name}{name}'",
     "global_settings_setting_security_nginx_compatibility": "Kompatibilität vs. Sicherheitskompromiss für den Webserver NGINX. Beeinflusst die Chiffren (und andere sicherheitsrelevante Aspekte)",
     "backup_php5_to_php7_migration_may_fail": "Dein Archiv konnte nicht für PHP 7 konvertiert werden, Du kannst deine PHP-Anwendungen möglicherweise nicht wiederherstellen (Grund: {error:s})",
     "global_settings_setting_service_ssh_allow_deprecated_dsa_hostkey": "Erlaubt die Verwendung eines (veralteten) DSA-Hostkeys für die SSH-Daemon-Konfiguration",

--- a/locales/de.json
+++ b/locales/de.json
@@ -284,7 +284,7 @@
     "good_practices_about_admin_password": "Sie sind nun dabei, ein neues Administrationspasswort zu definieren. Das Passwort sollte mindestens 8 Zeichen lang sein - obwohl es sinnvoll ist, ein längeres Passwort (z.B. eine Passphrase) und/oder eine Variation von Zeichen (Groß- und Kleinschreibung, Ziffern und Sonderzeichen) zu verwenden.",
     "log_corrupted_md_file": "Die mit Protokollen verknüpfte YAML-Metadatendatei ist beschädigt: '{md_file}\nFehler: {error}''",
     "global_settings_cant_serialize_settings": "Einstellungsdaten konnten nicht serialisiert werden, Grund: {reason:s}",
-    "log_help_to_get_failed_log": "Der Vorgang'{desc}' konnte nicht abgeschlossen werden. Bitte teile das vollständige Protokoll dieser Operation mit dem Befehl 'yunohost log display {name} --share', um Hilfe zu erhalten",
+    "log_help_to_get_failed_log": "Der Vorgang'{desc}' konnte nicht abgeschlossen werden. Bitte teile das vollständige Protokoll dieser Operation mit dem Befehl 'yunohost log share {name}', um Hilfe zu erhalten",
     "backup_no_uncompress_archive_dir": "Dieses unkomprimierte Archivverzeichnis gibt es nicht",
     "log_app_change_url": "Ändere die URL der Anwendung '{}'",
     "global_settings_setting_security_password_user_strength": "Stärke des Benutzerpassworts",

--- a/locales/en.json
+++ b/locales/en.json
@@ -362,7 +362,7 @@
     "log_link_to_log": "Full log of this operation: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
     "log_help_to_get_log": "To view the log of the operation '{desc}', use the command 'yunohost log display {name}'",
     "log_link_to_failed_log": "Could not complete the operation '{desc}'. Please provide the full log of this operation by <a href=\"#/tools/logs/{name}\">clicking here</a> to get help",
-    "log_help_to_get_failed_log": "The operation '{desc}' could not be completed. Please share the full log of this operation using the command 'yunohost log display {name} --share' to get help",
+    "log_help_to_get_failed_log": "The operation '{desc}' could not be completed. Please share the full log of this operation using the command 'yunohost log share {name}' to get help",
     "log_does_exists": "There is no operation log with the name '{log}', use 'yunohost log list' to see all available operation logs",
     "log_operation_unit_unclosed_properly": "Operation unit has not been closed properly",
     "log_app_change_url": "Change the URL of the '{}' app",

--- a/locales/en.json
+++ b/locales/en.json
@@ -467,7 +467,7 @@
     "migrations_running_forward": "Running migration {id}...",
     "migrations_skip_migration": "Skipping migration {id}...",
     "migrations_success_forward": "Migration {id} completed",
-    "migrations_to_be_ran_manually":  "Migration {id} has to be run manually. Please go to Tools → Migrations on the webadmin page, or run `yunohost tools migrations migrate`.",
+    "migrations_to_be_ran_manually":  "Migration {id} has to be run manually. Please go to Tools → Migrations on the webadmin page, or run `yunohost tools migrations run`.",
     "not_enough_disk_space": "Not enough free space on '{path:s}'",
     "invalid_number": "Must be a number",
     "operation_interrupted": "The operation was manually interrupted?",

--- a/locales/en.json
+++ b/locales/en.json
@@ -360,7 +360,7 @@
     "iptables_unavailable": "You cannot play with iptables here. You are either in a container or your kernel does not support it",
     "log_corrupted_md_file": "The YAML metadata file associated with logs is damaged: '{md_file}\nError: {error}'",
     "log_link_to_log": "Full log of this operation: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
-    "log_help_to_get_log": "To view the log of the operation '{desc}', use the command 'yunohost log display {name}'",
+    "log_help_to_get_log": "To view the log of the operation '{desc}', use the command 'yunohost log show {name}{name}'",
     "log_link_to_failed_log": "Could not complete the operation '{desc}'. Please provide the full log of this operation by <a href=\"#/tools/logs/{name}\">clicking here</a> to get help",
     "log_help_to_get_failed_log": "The operation '{desc}' could not be completed. Please share the full log of this operation using the command 'yunohost log share {name}' to get help",
     "log_does_exists": "There is no operation log with the name '{log}', use 'yunohost log list' to see all available operation logs",

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -358,7 +358,7 @@
     "dyndns_registration_failed": "Ne povis registri DynDNS-domajnon: {error:s}",
     "migration_0003_not_jessie": "La nuna Debian-distribuo ne estas Jessie!",
     "user_unknown": "Nekonata uzanto: {user:s}",
-    "migrations_to_be_ran_manually": "Migrado {id} devas funkcii permane. Bonvolu iri al Iloj → Migradoj en la retpaĝa paĝo, aŭ kuri `yunohost tools migrations migrate`.",
+    "migrations_to_be_ran_manually": "Migrado {id} devas funkcii permane. Bonvolu iri al Iloj → Migradoj en la retpaĝa paĝo, aŭ kuri `yunohost tools migrations run`.",
     "migration_0008_warning": "Se vi komprenas tiujn avertojn kaj volas ke YunoHost preterlasu vian nunan agordon, faru la migradon. Alie, vi ankaŭ povas salti la migradon, kvankam ĝi ne rekomendas.",
     "certmanager_cert_renew_success": "Ni Ĉifru atestilon renovigitan por la domajno '{domain:s}'",
     "global_settings_reset_success": "Antaŭaj agordoj nun estas rezervitaj al {path:s}",

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -295,7 +295,7 @@
     "restore_extracting": "Eltirante bezonatajn dosierojn el la ar theivo…",
     "upnp_port_open_failed": "Ne povis malfermi havenon per UPnP",
     "log_app_upgrade": "Ĝisdatigu la aplikon '{}'",
-    "log_help_to_get_failed_log": "La operacio '{desc}' ne povis finiĝi. Bonvolu dividi la plenan ŝtipon de ĉi tiu operacio per la komando 'yunohost log display {name} --share' por akiri helpon",
+    "log_help_to_get_failed_log": "La operacio '{desc}' ne povis finiĝi. Bonvolu dividi la plenan ŝtipon de ĉi tiu operacio per la komando 'yunohost log share {name}' por akiri helpon",
     "migration_description_0002_migrate_to_tsig_sha256": "Plibonigu sekurecon de DynDNS TSIG-ĝisdatigoj per SHA-512 anstataŭ MD5",
     "port_already_closed": "Haveno {port:d} estas jam fermita por {ip_version:s} rilatoj",
     "hook_name_unknown": "Nekonata hoko-nomo '{name:s}'",

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -397,7 +397,7 @@
     "password_too_simple_4": "La pasvorto bezonas almenaŭ 12 signojn kaj enhavas ciferon, majuskle, pli malaltan kaj specialajn signojn",
     "migration_0003_main_upgrade": "Komencanta ĉefa ĝisdatigo …",
     "regenconf_file_updated": "Agordodosiero '{conf}' ĝisdatigita",
-    "log_help_to_get_log": "Por vidi la protokolon de la operacio '{desc}', uzu la komandon 'yunohost log display {name}'",
+    "log_help_to_get_log": "Por vidi la protokolon de la operacio '{desc}', uzu la komandon 'yunohost log show {name}{name}'",
     "global_settings_setting_security_nginx_compatibility": "Kongruo vs sekureca kompromiso por la TTT-servilo NGINX. Afektas la ĉifradojn (kaj aliajn aspektojn pri sekureco)",
     "no_internet_connection": "La servilo ne estas konektita al la interreto",
     "migration_0008_dsa": "• La DSA-ŝlosilo estos malŝaltita. Tial vi eble bezonos nuligi spuran averton de via SSH-kliento kaj revizii la fingrospuron de via servilo;",

--- a/locales/es.json
+++ b/locales/es.json
@@ -408,7 +408,7 @@
     "log_app_change_url": "Cambiar el URL de la aplicación «{}»",
     "log_operation_unit_unclosed_properly": "La unidad de operación no se ha cerrado correctamente",
     "log_does_exists": "No existe ningún registro de actividades con el nombre '{log}', ejecute 'yunohost log list' para ver todos los registros de actividades disponibles",
-    "log_help_to_get_failed_log": "No se pudo completar la operación «{desc}». Para obtener ayuda, comparta el registro completo de esta operación ejecutando la orden «yunohost log display {name} --share»",
+    "log_help_to_get_failed_log": "No se pudo completar la operación «{desc}». Para obtener ayuda, comparta el registro completo de esta operación ejecutando la orden «yunohost log share {name}»",
     "log_link_to_failed_log": "No se pudo completar la operación «{desc}». Para obtener ayuda, proporcione el registro completo de esta operación <a href=\"#/tools/logs/{name}\">pulsando aquí</a>",
     "log_help_to_get_log": "Para ver el registro de la operación «{desc}», ejecute la orden «yunohost log display {name}»",
     "log_link_to_log": "Registro completo de esta operación: «<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>»",

--- a/locales/es.json
+++ b/locales/es.json
@@ -410,7 +410,7 @@
     "log_does_exists": "No existe ningún registro de actividades con el nombre '{log}', ejecute 'yunohost log list' para ver todos los registros de actividades disponibles",
     "log_help_to_get_failed_log": "No se pudo completar la operación «{desc}». Para obtener ayuda, comparta el registro completo de esta operación ejecutando la orden «yunohost log share {name}»",
     "log_link_to_failed_log": "No se pudo completar la operación «{desc}». Para obtener ayuda, proporcione el registro completo de esta operación <a href=\"#/tools/logs/{name}\">pulsando aquí</a>",
-    "log_help_to_get_log": "Para ver el registro de la operación «{desc}», ejecute la orden «yunohost log display {name}»",
+    "log_help_to_get_log": "Para ver el registro de la operación «{desc}», ejecute la orden «yunohost log show {name}{name}»",
     "log_link_to_log": "Registro completo de esta operación: «<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>»",
     "log_category_404": "La categoría de registro «{category}» no existe",
     "log_corrupted_md_file": "El archivo de metadatos YAML asociado con el registro está dañado: «{md_file}\nError: {error}»",

--- a/locales/es.json
+++ b/locales/es.json
@@ -303,7 +303,7 @@
     "permission_created": "Creado el permiso «{permission:s}»",
     "permission_already_exist": "El permiso «{permission}» ya existe",
     "pattern_password_app": "Las contraseñas no pueden incluir los siguientes caracteres: {forbidden_chars}",
-    "migrations_to_be_ran_manually": "La migración {id} hay que ejecutarla manualmente. Vaya a Herramientas → Migraciones en la página web de administración o ejecute `yunohost tools migrations migrate`.",
+    "migrations_to_be_ran_manually": "La migración {id} hay que ejecutarla manualmente. Vaya a Herramientas → Migraciones en la página web de administración o ejecute `yunohost tools migrations run`.",
     "migrations_success_forward": "Migración {id} completada",
     "migrations_skip_migration": "Omitiendo migración {id}…",
     "migrations_running_forward": "Ejecutando migración {id}…",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -280,7 +280,7 @@
     "log_help_to_get_log": "Pour voir le journal de cette opération '{desc}', utilisez la commande 'yunohost log display {name}'",
     "log_link_to_failed_log": "L’opération '{desc}' a échoué ! Pour obtenir de l’aide, merci de partager le journal de l’opération en <a href=\"#/tools/logs/{name}\">cliquant ici</a>",
     "backup_php5_to_php7_migration_may_fail": "Impossible de convertir votre archive pour prendre en charge PHP 7, vous pourriez ne plus pouvoir restaurer vos applications PHP (cause : {error:s})",
-    "log_help_to_get_failed_log": "L’opération '{desc}' a échoué ! Pour obtenir de l’aide, merci de partager le journal de l’opération en utilisant la commande 'yunohost log display {name} --share'",
+    "log_help_to_get_failed_log": "L’opération '{desc}' a échoué ! Pour obtenir de l’aide, merci de partager le journal de l’opération en utilisant la commande 'yunohost log share {name}'",
     "log_does_exists": "Il n’y a pas de journal des opérations avec le nom '{log}', utilisez 'yunohost log list' pour voir tous les journaux d’opérations disponibles",
     "log_operation_unit_unclosed_properly": "L’opération ne s’est pas terminée correctement",
     "log_app_change_url": "Changer l’URL de l’application '{}'",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -277,7 +277,7 @@
     "log_corrupted_md_file": "Le fichier YAML de métadonnées associé aux logs est corrompu : '{md_file}'\nErreur : {error}",
     "log_category_404": "Le journal de la catégorie '{category}' n’existe pas",
     "log_link_to_log": "Journal complet de cette opération : '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\"> {desc} </a>'",
-    "log_help_to_get_log": "Pour voir le journal de cette opération '{desc}', utilisez la commande 'yunohost log display {name}'",
+    "log_help_to_get_log": "Pour voir le journal de cette opération '{desc}', utilisez la commande 'yunohost log show {name}{name}'",
     "log_link_to_failed_log": "L’opération '{desc}' a échoué ! Pour obtenir de l’aide, merci de partager le journal de l’opération en <a href=\"#/tools/logs/{name}\">cliquant ici</a>",
     "backup_php5_to_php7_migration_may_fail": "Impossible de convertir votre archive pour prendre en charge PHP 7, vous pourriez ne plus pouvoir restaurer vos applications PHP (cause : {error:s})",
     "log_help_to_get_failed_log": "L’opération '{desc}' a échoué ! Pour obtenir de l’aide, merci de partager le journal de l’opération en utilisant la commande 'yunohost log share {name}'",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -256,7 +256,7 @@
     "app_upgrade_app_name": "Mise à jour de {app}...",
     "backup_output_symlink_dir_broken": "Votre répertoire d’archivage '{path:s}' est un lien symbolique brisé. Peut-être avez-vous oublié de re/monter ou de brancher le support de stockage sur lequel il pointe.",
     "migrations_list_conflict_pending_done": "Vous ne pouvez pas utiliser --previous et --done simultanément.",
-    "migrations_to_be_ran_manually": "La migration {id} doit être lancée manuellement. Veuillez aller dans Outils > Migrations dans l’interface admin, ou lancer `yunohost tools migrations migrate`.",
+    "migrations_to_be_ran_manually": "La migration {id} doit être lancée manuellement. Veuillez aller dans Outils > Migrations dans l’interface admin, ou lancer `yunohost tools migrations run`.",
     "migrations_need_to_accept_disclaimer": "Pour lancer la migration {id}, vous devez accepter cet avertissement :\n---\n{disclaimer}\n---\nSi vous acceptez de lancer la migration, veuillez relancer la commande avec l’option --accept-disclaimer.",
     "service_description_avahi-daemon": "Vous permet d’atteindre votre serveur en utilisant « yunohost.local » sur votre réseau local",
     "service_description_dnsmasq": "Gère la résolution des noms de domaine (DNS)",

--- a/locales/it.json
+++ b/locales/it.json
@@ -531,7 +531,7 @@
     "pattern_email_forward": "Dev'essere un indirizzo mail valido, simbolo '+' accettato (es: tizio+tag@example.com)",
     "operation_interrupted": "L'operazione è stata interrotta manualmente?",
     "invalid_number": "Dev'essere un numero",
-    "migrations_to_be_ran_manually": "Migrazione {id} dev'essere eseguita manualmente. Vai in Strumenti → Migrazioni nella pagina webadmin, o esegui `yunohost tools migrations migrate`.",
+    "migrations_to_be_ran_manually": "Migrazione {id} dev'essere eseguita manualmente. Vai in Strumenti → Migrazioni nella pagina webadmin, o esegui `yunohost tools migrations run`.",
     "migrations_success_forward": "Migrazione {id} completata",
     "migrations_skip_migration": "Salto migrazione {id}...",
     "migrations_running_forward": "Eseguo migrazione {id}...",

--- a/locales/it.json
+++ b/locales/it.json
@@ -278,7 +278,7 @@
     "log_corrupted_md_file": "Il file dei metadati YAML associato con i registri è danneggiato: '{md_file}'\nErrore: {error}",
     "log_category_404": "La categoria di registrazione '{category}' non esiste",
     "log_link_to_log": "Registro completo di questa operazione: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
-    "log_help_to_get_log": "Per vedere il registro dell'operazione '{desc}', usa il comando 'yunohost log display {name}'",
+    "log_help_to_get_log": "Per vedere il registro dell'operazione '{desc}', usa il comando 'yunohost log show {name}{name}'",
     "global_settings_setting_security_postfix_compatibility": "Bilanciamento tra compatibilità e sicurezza per il server Postfix. Riguarda gli algoritmi di cifratura (e altri aspetti legati alla sicurezza)",
     "log_link_to_failed_log": "Impossibile completare l'operazione '{desc}'! Per ricevere aiuto, per favore fornisci il registro completo dell'operazione <a href=\"#/tools/logs/{name}\">cliccando qui</a>",
     "log_help_to_get_failed_log": "L'operazione '{desc}' non può essere completata. Per ottenere aiuto, per favore condividi il registro completo dell'operazione utilizzando il comando 'yunohost log share {name}'",

--- a/locales/it.json
+++ b/locales/it.json
@@ -281,7 +281,7 @@
     "log_help_to_get_log": "Per vedere il registro dell'operazione '{desc}', usa il comando 'yunohost log display {name}'",
     "global_settings_setting_security_postfix_compatibility": "Bilanciamento tra compatibilità e sicurezza per il server Postfix. Riguarda gli algoritmi di cifratura (e altri aspetti legati alla sicurezza)",
     "log_link_to_failed_log": "Impossibile completare l'operazione '{desc}'! Per ricevere aiuto, per favore fornisci il registro completo dell'operazione <a href=\"#/tools/logs/{name}\">cliccando qui</a>",
-    "log_help_to_get_failed_log": "L'operazione '{desc}' non può essere completata. Per ottenere aiuto, per favore condividi il registro completo dell'operazione utilizzando il comando 'yunohost log display {name} --share'",
+    "log_help_to_get_failed_log": "L'operazione '{desc}' non può essere completata. Per ottenere aiuto, per favore condividi il registro completo dell'operazione utilizzando il comando 'yunohost log share {name}'",
     "log_does_exists": "Non esiste nessun registro delle operazioni chiamato '{log}', usa 'yunohost log list' per vedere tutti i registri delle operazioni disponibili",
     "log_app_change_url": "Cambia l'URL dell'app '{}'",
     "log_app_install": "Installa l'app '{}'",

--- a/locales/nb_NO.json
+++ b/locales/nb_NO.json
@@ -132,7 +132,7 @@
     "domain_dyndns_already_subscribed": "Du har allerede abonnement på et DynDNS-domene",
     "log_category_404": "Loggkategorien '{category}' finnes ikke",
     "log_link_to_log": "Full logg for denne operasjonen: '<a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>'",
-    "log_help_to_get_log": "For å vise loggen for operasjonen '{desc}', bruk kommandoen 'yunohost log display {name}'",
+    "log_help_to_get_log": "For å vise loggen for operasjonen '{desc}', bruk kommandoen 'yunohost log show {name}{name}'",
     "log_user_create": "Legg til '{}' bruker",
     "app_change_url_success": "{app:s} nettadressen er nå {domain:s}{path:s}",
     "app_install_failed": "Kunne ikke installere {app}: {error}"

--- a/locales/oc.json
+++ b/locales/oc.json
@@ -303,7 +303,7 @@
     "log_help_to_get_log": "Per veire lo jornal d’aquesta operacion « {desc} », utilizatz la comanda « yunohost log display {name} »",
     "backup_php5_to_php7_migration_may_fail": "Impossible de convertir vòstre archiu per prendre en carga PHP 7, la restauracion de vòstras aplicacions PHP pòt reüssir pas a restaurar vòstras aplicacions PHP (rason : {error:s})",
     "log_link_to_failed_log": "L’operacion « {desc} » a pas capitat ! Per obténer d’ajuda, mercés <a href=\"#/tools/logs/{name}\"> de fornir lo jornal complèt de l’operacion</a>",
-    "log_help_to_get_failed_log": "L’operacion « {desc} » a pas reüssit ! Per obténer d’ajuda, mercés de partejar lo jornal d’audit complèt d’aquesta operacion en utilizant la comanda « yunohost log display {name} --share »",
+    "log_help_to_get_failed_log": "L’operacion « {desc} » a pas reüssit ! Per obténer d’ajuda, mercés de partejar lo jornal d’audit complèt d’aquesta operacion en utilizant la comanda « yunohost log share {name} »",
     "log_does_exists": "I a pas cap de jornal d’audit per l’operacion amb lo nom « {log} », utilizatz « yunohost log list » per veire totes los jornals d’operacion disponibles",
     "log_operation_unit_unclosed_properly": "L’operacion a pas acabat corrèctament",
     "log_app_change_url": "Cambiar l’URL de l’aplicacion « {} »",

--- a/locales/oc.json
+++ b/locales/oc.json
@@ -300,7 +300,7 @@
     "log_corrupted_md_file": "Lo fichièr YAML de metadonadas ligat als jornals d’audit es damatjat : « {md_file} »\nError : {error:s}",
     "log_category_404": "La categoria de jornals d’audit « {category} » existís pas",
     "log_link_to_log": "Jornal complèt d’aquesta operacion : <a href=\"#/tools/logs/{name}\" style=\"text-decoration:underline\">{desc}</a>",
-    "log_help_to_get_log": "Per veire lo jornal d’aquesta operacion « {desc} », utilizatz la comanda « yunohost log display {name} »",
+    "log_help_to_get_log": "Per veire lo jornal d’aquesta operacion « {desc} », utilizatz la comanda « yunohost log show {name}{name} »",
     "backup_php5_to_php7_migration_may_fail": "Impossible de convertir vòstre archiu per prendre en carga PHP 7, la restauracion de vòstras aplicacions PHP pòt reüssir pas a restaurar vòstras aplicacions PHP (rason : {error:s})",
     "log_link_to_failed_log": "L’operacion « {desc} » a pas capitat ! Per obténer d’ajuda, mercés <a href=\"#/tools/logs/{name}\"> de fornir lo jornal complèt de l’operacion</a>",
     "log_help_to_get_failed_log": "L’operacion « {desc} » a pas reüssit ! Per obténer d’ajuda, mercés de partejar lo jornal d’audit complèt d’aquesta operacion en utilizant la comanda « yunohost log share {name} »",

--- a/locales/oc.json
+++ b/locales/oc.json
@@ -281,7 +281,7 @@
     "migration_0003_problematic_apps_warning": "Notatz que las aplicacions seguentas, saique problematicas, son estadas desactivadas. Semblan d’aver estadas installadas d’una lista d’aplicacions o que son pas marcadas coma «working ».  En consequéncia, podèm pas assegurar que tendràn de foncionar aprèp la mesa a nivèl : {problematic_apps}",
     "migrations_migration_has_failed": "La migracion {id} a pas capitat, abandon. Error : {exception}",
     "migrations_skip_migration": "Passatge de la migracion {id}…",
-    "migrations_to_be_ran_manually": "La migracion {id} deu èsser lançada manualament. Mercés d’anar a Aisinas > Migracion dins l’interfàcia admin, o lançar « yunohost tools migrations migrate ».",
+    "migrations_to_be_ran_manually": "La migracion {id} deu èsser lançada manualament. Mercés d’anar a Aisinas > Migracion dins l’interfàcia admin, o lançar « yunohost tools migrations run ».",
     "migrations_need_to_accept_disclaimer": "Per lançar la migracion {id} , avètz d’acceptar aquesta clausa de non-responsabilitat :\n---\n{disclaimer}\n---\nS’acceptatz de lançar la migracion, mercés de tornar executar la comanda amb l’opcion accept-disclaimer.",
     "pattern_backup_archive_name": "Deu èsser un nom de fichièr valid compausat de 30 caractèrs alfanumerics al maximum e  « -_. »",
     "service_description_dovecot": "permet als clients de messatjariá d’accedir/recuperar los corrièls (via IMAP e POP3)",

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -130,7 +130,7 @@ def log_list(limit=None, with_details=False, with_suboperations=False):
     return {"operation": operations}
 
 
-def log_display(path, number=None, share=False, filter_irrelevant=False, with_suboperations=False):
+def log_show(path, number=None, share=False, filter_irrelevant=False, with_suboperations=False):
     """
     Display a log file enriched with metadata if any.
 
@@ -283,7 +283,7 @@ def log_display(path, number=None, share=False, filter_irrelevant=False, with_su
     return infos
 
 def log_share(path):
-    return log_display(path, share=True)
+    return log_show(path, share=True)
 
 
 def is_unit_operation(entities=['app', 'domain', 'group', 'service', 'user'],

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -282,6 +282,9 @@ def log_display(path, number=None, share=False, filter_irrelevant=False, with_su
 
     return infos
 
+def log_share(path):
+    return log_display(path, share=True)
+
 
 def is_unit_operation(entities=['app', 'domain', 'group', 'service', 'user'],
                       exclude=['password'], operation_key=None):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -641,7 +641,7 @@ def tools_upgrade(operation_logger, apps=None, system=False, allow_yunohost_upgr
             #
             # Here we use a dirty hack to run a command after the current
             # "yunohost tools upgrade", because the upgrade of yunohost
-            # will also trigger other yunohost commands (e.g. "yunohost tools migrations migrate")
+            # will also trigger other yunohost commands (e.g. "yunohost tools migrations run")
             # (also the upgrade of the package, if executed from the webadmin, is
             # likely to kill/restart the api which is in turn likely to kill this
             # command before it ends...)

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -792,7 +792,7 @@ def tools_migrations_list(pending=False, done=False):
     return {"migrations": migrations}
 
 
-def tools_migrations_migrate(targets=[], skip=False, auto=False, force_rerun=False, accept_disclaimer=False):
+def tools_migrations_run(targets=[], skip=False, auto=False, force_rerun=False, accept_disclaimer=False):
     """
     Perform migrations
 


### PR DESCRIPTION
## The problem

- [x] bored of having "diagnosis show" but "log display"
- [x] having "GET /log/display" is not restful, should be "GET /log/<logname>" 
- [x] bored of telling people to run "log display foobar --share" when we could have "log share foobar"
- [x] bore of running "diagnosis run" but "migrations migrate" (which calls method run)

## Solution

Rename, aliases etc

## PR Status

Tested and working on my side
Gotta adapt some stuff in webadmin too ...

## How to test

Run the commands idk
