### PR TITLE
Abort postinstall if /etc/yunohost/apps ain't empty

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -6,10 +6,18 @@ do_configure() {
   rm -rf /var/cache/moulinette/*
 
   if [ ! -f /etc/yunohost/installed ]; then
-      bash /usr/share/yunohost/hooks/conf_regen/01-yunohost init
-      bash /usr/share/yunohost/hooks/conf_regen/02-ssl init
-      bash /usr/share/yunohost/hooks/conf_regen/06-slapd init
-      bash /usr/share/yunohost/hooks/conf_regen/15-nginx init
+
+      # If apps/ is not empty, we're probably already installed in the past and
+      # something funky happened ...
+      if [ -d /etc/yunohost/apps/ ] && ls /etc/yunohost/apps/* 2>/dev/null
+      then
+          echo "Sounds like /etc/yunohost/installed mysteriously disappeared ... You should probably contact the Yunohost support ..."
+      else
+          bash /usr/share/yunohost/hooks/conf_regen/01-yunohost init
+          bash /usr/share/yunohost/hooks/conf_regen/02-ssl init
+          bash /usr/share/yunohost/hooks/conf_regen/06-slapd init
+          bash /usr/share/yunohost/hooks/conf_regen/15-nginx init
+      fi
   else
       echo "Regenerating configuration, this might take a while..."
       yunohost tools regen-conf --output-as none

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,7 +9,7 @@ do_configure() {
 
       # If apps/ is not empty, we're probably already installed in the past and
       # something funky happened ...
-      if [ -d /etc/yunohost/apps/ ] && ls /etc/yunohost/apps/* 2>/dev/null
+      if [ -d /etc/yunohost/apps/ ] && ls /etc/yunohost/apps/* >/dev/null 2>&1
       then
           echo "Sounds like /etc/yunohost/installed mysteriously disappeared ... You should probably contact the Yunohost support ..."
       else

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -249,6 +249,9 @@ def tools_postinstall(operation_logger, domain, password, ignore_dyndns=False,
     if os.path.isfile('/etc/yunohost/installed'):
         raise YunohostError('yunohost_already_installed')
 
+    if os.path.isdir("/etc/yunohost/apps") and os.listdir("/etc/yunohost/apps") != []:
+        raise YunohostError("It looks like you're trying to re-postinstall a system that was already working previously ... If you recently had some bug or issues with your installation, please first discuss with the team on how to fix the situation instead of savagely re-running the postinstall ...", raw_msg=True)
+
     # Check password
     if not force_password:
         assert_password_is_strong_enough("admin", password)


### PR DESCRIPTION
## The problem

Once more today, saw this issue where /etc/yunohost/installed mysteriously disappeared following some failed stuff ... (as well as yunohost-admin getting uninstalled ... why the hell ?!). Then user reinstalled yunohost-admin, and the webadmin was like "hey let's run the postinstall" which then miserably crashed

## Solution

Test at the beginning of the postinstall if /etc/yunohost/apps exists, and abort if there's at least one app folder inside ... That should be a decent indicator that the system was postinstalled in the past and something funky happened

## PR Status

Yolocommited

## How to test

Idk try to run postinstall with non-empty /etc/yunohost/apps
