### PR TITLE
Prevent the installation of apache2 ...

### DIFF
--- a/data/hooks/conf_regen/10-apt
+++ b/data/hooks/conf_regen/10-apt
@@ -15,6 +15,31 @@ Package: $package
 Pin: origin \"packages.sury.org\" 
 Pin-Priority: -1" >> "${pending_dir}/etc/apt/preferences.d/extra_php_version"
     done
+
+        echo "
+# Yes !
+# This is what's preventing you from installing apache2 !
+#
+# Maybe take two fucking minutes to realize that if you try to install
+# apache2, this will break nginx and break the entire YunoHost ecosystem.
+# on your server.
+#
+# So, *NO*
+# DO NOT do this.
+# DO NOT remove these lines.
+#
+# I warned you. I WARNED YOU! But did you listen to me?
+# Oooooh, noooo. You knew it all, didn't you?
+
+Package: apache2
+Pin: release *
+Pin-Priority: -1
+
+Package: apache2-bin
+Pin: release *
+Pin-Priority: -1
+" >> "${pending_dir}/etc/apt/preferences.d/forbid_apache2"
+
 }
 
 do_post_regen() {

--- a/data/hooks/conf_regen/10-apt
+++ b/data/hooks/conf_regen/10-apt
@@ -38,7 +38,15 @@ Pin-Priority: -1
 Package: apache2-bin
 Pin: release *
 Pin-Priority: -1
-" >> "${pending_dir}/etc/apt/preferences.d/forbid_apache2"
+
+# Also yes, bind9 will conflict with dnsmasq.
+# Same story than for apache2.
+# Don't fucking install it.
+
+Package: bind9
+Pin: release *
+Pin-Priority: -1
+" >> "${pending_dir}/etc/apt/preferences.d/ban_packages"
 
 }
 


### PR DESCRIPTION
## The problem

Apparently people don't give a shit about the goddamn apt trying to tell you that installing apache2 will remove yunohost and you should not do this. And they type the "Yes, do as I say!" or whatever without wondering what the fuck. And then everything explode like apt warned.

## Solution

Fucking pin the goddamn apache2 package. Same for bind9 because who knows what users are capable of.

## PR Status

Tested on my side

## How to test

Run the regen conf for `apt`, then try to install apache2 / apache2-bin / bind9
