### PR TITLE
Fix let's encrypt certificat generation

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -598,7 +598,7 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
         subdomain = "xmpp-upload." + domain
         xmpp_records = Diagnoser.get_cached_report("dnsrecords", item={"domain": domain, "category": "xmpp"}).get("data") or {}
         if xmpp_records.get("CNAME:xmpp-upload") == "OK":
-            csr.add_extensions([crypto.X509Extension("subjectAltName", False, "DNS:" + subdomain)])
+            csr.add_extensions([crypto.X509Extension("subjectAltName".encode('utf8'), False, ("DNS:" + subdomain).encode('utf8'))])
         else:
             logger.warning(m18n.n('certmanager_warning_subdomain_dns_record', subdomain=subdomain, domain=domain))
 
@@ -615,7 +615,7 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     csr_file = output_folder + domain + ".csr"
     logger.debug("Saving to %s.", csr_file)
 
-    with open(csr_file, "w") as f:
+    with open(csr_file, "wb") as f:
         f.write(crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr))
 
 
@@ -726,9 +726,8 @@ def _generate_key(destination_path):
     k = crypto.PKey()
     k.generate_key(crypto.TYPE_RSA, KEY_SIZE)
 
-    with open(destination_path, "w") as f:
+    with open(destination_path, "wb") as f:
         f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
-
 
 def _set_permissions(path, user, group, permissions):
     uid = pwd.getpwnam(user).pw_uid


### PR DESCRIPTION
## The problem
Can't install let's encrypt certificat, error message is
```
2375 DEBUG To view the log of the operation 'Regenerate system configurations 'dnsmasq'', use the command 'yunohost log show 20210127-094059-regen_conf-dnsmasq20210127-094059-regen_conf-dnsmasq'
2375 DEBUG + exit 0
2394 DEBUG Prepare key and certificate signing request (CSR) for domain.tld...
2625 ERROR Certificate installation for domain.tld failed !
Exception: write() argument must be str, not bytes
```


## Solution
- Encode str to bytes when necessary
- Open file in binary mode to write bytes 


## PR Status



## How to test
Tested on new install from ynh-dev
`yunohost domain cert-install domain.tld`
or
`yunohost domain cert-install domain.tld --force`
