### PR TITLE
Use jq / output-as json to get info from yunohost commands instead of scraping with grep

### DIFF
--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -399,6 +399,15 @@ ynh_delete_file_checksum () {
     ynh_app_setting_delete --app=$app --key=$checksum_setting_name
 }
 
+# Checks a backup archive exists
+#
+# [internal]
+#
+ynh_backup_archive_exists () {
+    yunohost backup list --output-as json --quiet \
+        | jq -e --arg archive "$1" '.archives | index($archive)' >/dev/null
+}
+
 # Make a backup in case of failed upgrade
 #
 # usage:
@@ -423,7 +432,7 @@ ynh_backup_before_upgrade () {
     if [ "$NO_BACKUP_UPGRADE" -eq 0 ]
     then
         # Check if a backup already exists with the prefix 1
-        if yunohost backup list | grep --quiet $app_bck-pre-upgrade1
+        if ynh_backup_archive_exists "$app_bck-pre-upgrade1"
         then
             # Prefix becomes 2 to preserve the previous backup
             backup_number=2
@@ -435,7 +444,7 @@ ynh_backup_before_upgrade () {
         if [ "$?" -eq 0 ]
         then
             # If the backup succeeded, remove the previous backup
-            if yunohost backup list | grep --quiet $app_bck-pre-upgrade$old_backup_number
+            if ynh_backup_archive_exists "$app_bck-pre-upgrade$old_backup_number"
             then
                 # Remove the previous backup only if it exists
                 yunohost backup delete $app_bck-pre-upgrade$old_backup_number > /dev/null
@@ -467,7 +476,7 @@ ynh_restore_upgradebackup () {
     if [ "$NO_BACKUP_UPGRADE" -eq 0 ]
     then
         # Check if an existing backup can be found before removing and restoring the application.
-        if yunohost backup list | grep --quiet $app_bck-pre-upgrade$backup_number
+        if ynh_backup_archive_exists "$app_bck-pre-upgrade$backup_number"
         then
             # Remove the application then restore it
             yunohost app remove $app

--- a/data/helpers.d/permission
+++ b/data/helpers.d/permission
@@ -185,7 +185,8 @@ ynh_permission_exists() {
     local permission
     ynh_handle_getopts_args "$@"
 
-    yunohost user permission list --short | grep --word-regexp --quiet "$app.$permission"
+    yunohost user permission list --output-as json --quiet \
+        | jq -e --arg perm "$app.$permission" '.permissions[$perm]' >/dev/null
 }
 
 # Redefine the url associated to a permission
@@ -366,7 +367,8 @@ ynh_permission_has_user() {
         return 1
     fi
 
-    yunohost user permission info "$app.$permission" | grep --word-regexp --quiet "$user"
+    yunohost user permission info "$app.$permission" --output-as json --quiet \
+       | jq -e --arg user $user '.corresponding_users | index($user)' >/dev/null
 }
 
 # Check if a legacy permissions exist

--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -17,7 +17,7 @@ ynh_user_exists() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    yunohost user list --output-as json | grep --quiet "\"username\": \"${username}\""
+    yunohost user list --output-as json --quiet | jq -e ".users.${username}" >/dev/null
 }
 
 # Retrieve a YunoHost user information
@@ -39,7 +39,7 @@ ynh_user_get_info() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    yunohost user info "$username" --output-as plain | ynh_get_plain_key "$key"
+    yunohost user info "$username" --output-as json --quiet | jq -r ".$key"
 }
 
 # Get the list of YunoHost users
@@ -51,8 +51,7 @@ ynh_user_get_info() {
 #
 # Requires YunoHost version 2.4.0 or higher.
 ynh_user_list() {
-    yunohost user list --output-as plain --quiet \
-        | awk '/^##username$/{getline; print}'
+    yunohost user list --output-as json --quiet | jq -r ".users | keys[]"
 }
 
 # Check if a user exists on the system

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -504,12 +504,7 @@ ynh_secure_remove () {
 #
 # [internal]
 #
-# example: yunohost user info tata --output-as plain | ynh_get_plain_key mail
-#
-# usage: ynh_get_plain_key key [subkey [subsubkey ...]]
-# | ret: string - the key's value
-#
-# Requires YunoHost version 2.2.4 or higher.
+# (Deprecated, use --output-as json and jq instead)
 ynh_get_plain_key() {
     local prefix="#"
     local founded=0


### PR DESCRIPTION
## The problem

Idk while debugging stuff on ci-apps-unstable, realized we have many helpers relying on dirty scraping with grep

## Solution

Use `jq` for robustness ... that's not trivial but at least json is a better interface between programs and less prone to stupid edge case like grepping stuff you weren't expecting ...

## PR Status

Tested and working on my side

## How to test

Zblerg idk i just ran commands manually
