### PR TITLE
[metronome/xmpp] deactivate stanza mention optimization / have quick notification in chat group

### DIFF
--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -95,6 +95,10 @@ allow_registration = false
 -- Use LDAP storage backend for all stores
 storage = "ldap"
 
+-- stanza optimization
+csi_config_queue_all_muc_messages_but_mentions = false;
+
+
 -- Logging configuration
 log = {
 	info = "/var/log/metronome/metronome.log"; -- Change 'info' to 'debug' for verbose logging


### PR DESCRIPTION
## The problem

As XMPP client encrypt the messages, optimization on server side like "dont forward the message to inactive client only if there is their name in the message's content" does not work.

## Solution

deactivate the optimization

## PR Status

PENDING test

## How to test

- Open your preferred client, put it in the background, wait to see "signaling client is inactive"
- Send an encrypted message to a group containing the first user
- Wait for the message to arrive. It should arrive really late

- Apply the change
- The message should arrive quickly