### PR TITLE
[fix] Avoid admin part of apps to be reachable from visitors

### DIFF
--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -13,7 +13,6 @@ from yunohost.app import (
 )
 from yunohost.permission import (
     permission_create,
-    user_permission_list,
     user_permission_update,
     permission_sync_to_user,
 )

--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -280,7 +280,7 @@ def migrate_legacy_permission_settings(app=None):
                 auth_header=True,
                 label=legacy_permission_label(app, "protected"),
                 show_tile=False,
-                allowed=user_permission_list()["permissions"][app + ".main"]["allowed"],
+                allowed=[],
                 protected=True,
                 sync_perm=False,
             )


### PR DESCRIPTION
## The problem

Some apps have an admin part , we want this part to be protected. The current migration code could accidentally expose publicly this part.

## Solution

Don't give the admin permission to the same user with main permissions

## PR Status

Ready

## How to test

...
