### PR TITLE
(TBD) Don't raise an exception if legacy permission migration fails

### DIFF
--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -879,7 +879,7 @@ def _validate_and_sanitize_permission_url(url, app_base_path, app):
         path = "/" + path
 
         if domain.replace("%", "").replace("\\", "") not in domains:
-            raise YunohostError("domain_name_unknown", domain=domain)
+            raise YunohostError("domain_name_unknown", domain=domain.replace("%", "").replace("\\", ""))
 
         validate_regex(path)
 

--- a/src/yunohost/utils/legacy.py
+++ b/src/yunohost/utils/legacy.py
@@ -251,27 +251,41 @@ def migrate_legacy_permission_settings(app=None):
         protected_urls += ["re:" + regex for regex in _setting("protected_regex")]
 
         if skipped_urls != []:
-            permission_create(
-                app + ".legacy_skipped_uris",
-                additional_urls=skipped_urls,
-                auth_header=False,
-                label=legacy_permission_label(app, "skipped"),
-                show_tile=False,
-                allowed="visitors",
-                protected=True,
-                sync_perm=False,
-            )
+            try:
+                permission_create(
+                    app + ".legacy_skipped_uris",
+                    additional_urls=skipped_urls,
+                    auth_header=False,
+                    label=legacy_permission_label(app, "skipped"),
+                    show_tile=False,
+                    allowed="visitors",
+                    protected=True,
+                    sync_perm=False,
+                )
+            except YunohostError as e:
+                if e.key == "domain_name_unknown":
+                    logger.error("Failed to create legacy permission %s : %e" % (app + ".legacy_skipped_uris", str(e)))
+                else:
+                    raise
+
         if unprotected_urls != []:
-            permission_create(
-                app + ".legacy_unprotected_uris",
-                additional_urls=unprotected_urls,
-                auth_header=True,
-                label=legacy_permission_label(app, "unprotected"),
-                show_tile=False,
-                allowed="visitors",
-                protected=True,
-                sync_perm=False,
-            )
+            try:
+                permission_create(
+                    app + ".legacy_unprotected_uris",
+                    additional_urls=unprotected_urls,
+                    auth_header=True,
+                    label=legacy_permission_label(app, "unprotected"),
+                    show_tile=False,
+                    allowed="visitors",
+                    protected=True,
+                    sync_perm=False,
+                )
+            except YunohostError as e:
+                if e.key == "domain_name_unknown":
+                    logger.error("Failed to create legacy permission %s : %e" % (app + ".legacy_unprotected_uris", str(e)))
+                else:
+                    raise
+
         if protected_urls != []:
             permission_create(
                 app + ".legacy_protected_uris",


### PR DESCRIPTION
## The problem

Follow-up of several stories where the legacy permission migration failed because either:
- weird regexes where `.` was replaced by `-` (or viceversa) for reasons
- the domain doesn't exists anymore because people used `change_url` and the script did not propagate the change to the regex...

Then the entire migration (or backup restore) explodes and the user has to manually fix the setting file ...

## Solution

Do not miserably fail if the reason for failure is domain unknown

## PR Status

Yolocommited, not tested

## How to test

Zblerg
