### PR TITLE
[metronome] activate module pubsub

### DIFF
--- a/data/templates/metronome/metronome.cfg.lua
+++ b/data/templates/metronome/metronome.cfg.lua
@@ -32,6 +32,7 @@ modules_enabled = {
 		"private"; -- Private XML storage (for room bookmarks, etc.)
 		"vcard"; -- Allow users to set vCards
 		"pep"; -- Allows setting of mood, tune, etc.
+		"pubsub";  -- Publish-subscribe XEP-0060
 		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
 		"bidi"; -- Enables Bidirectional Server-to-Server Streams.
  


### PR DESCRIPTION
## The problem

Pub sub XEP060 allow several features see https://xmpp.org/extensions/xep-0060.html
Some problems happens when not activated:
- Avatars are not synchronized when contacts are not connected
- OMEMO need PUBSUB XEP060 and XEP0163 to correctly exchange keys https://xmpp.org/extensions/xep-0384.html#intro-overview 

## Solution

Activate the module

## PR Status

Config done, PENDING approval

## How to test

publish a new avatar, see if it synchronize with other device
connect a new user with a new device, disconnect it talk to him/her with OMEMO activated. message should be correctly encrypted even for the disconnected devices.
