### PR TITLE
Gotta escape \ during ynh_replace_vars

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -401,6 +401,7 @@ ynh_replace_vars () {
         match_string="__${one_var^^}__"
         match_string=${match_string//${delimit}/"\\${delimit}"}
         replace_string="${!one_var}"
+        replace_string=${replace_string//\\/\\\\}
         replace_string=${replace_string//${delimit}/"\\${delimit}"}
 
         # Actually replace (sed is used instead of ynh_replace_string to avoid triggering an epic amount of debug logs)


### PR DESCRIPTION
## The problem

c.f. the current issue in 4.2 where adding fail2ban config create weirds issue (cant compile regex)

## Solution

We need to escape possible \ in the strings we replace in templates.

I guess we don't do this in ynh_replace_string because it may be used for regexes etc, but in the context of ynh_add_config we probably always have fixed strings.

## PR Status

Tested on my side

## How to test

Try to install an app with fail2ban config, such as Nextcloud, with and without this fix
