### PR TITLE
Define YNH_APP_BASEDIR to be able to properly point to conf folder depending on the app script we're running

### DIFF
--- a/data/helpers.d/fail2ban
+++ b/data/helpers.d/fail2ban
@@ -87,7 +87,7 @@ port = __PORTS__
 filter = __APP__
 logpath = __LOGPATH__
 maxretry = __MAX_RETRY__
-" > ../conf/f2b_jail.conf
+" > $YNH_APP_BASEDIR/conf/f2b_jail.conf
 
        echo "
 [INCLUDES]
@@ -95,11 +95,11 @@ before = common.conf
 [Definition]
 failregex = __FAILREGEX__
 ignoreregex =
-" > ../conf/f2b_filter.conf
+" > $YNH_APP_BASEDIR/conf/f2b_filter.conf
     fi
 
-    ynh_add_config --template="../conf/f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
-    ynh_add_config --template="../conf/f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
+    ynh_add_config --template="$YNH_APP_BASEDIR/conf/f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
+    ynh_add_config --template="$YNH_APP_BASEDIR/conf/f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 

--- a/data/helpers.d/nginx
+++ b/data/helpers.d/nginx
@@ -22,12 +22,12 @@ ynh_add_nginx_config () {
 
     if [ "${path_url:-}" != "/" ]
     then
-        ynh_replace_string --match_string="^#sub_path_only" --replace_string="" --target_file="../conf/nginx.conf"
+        ynh_replace_string --match_string="^#sub_path_only" --replace_string="" --target_file="$YNH_APP_BASEDIR/conf/nginx.conf"
     else
-        ynh_replace_string --match_string="^#root_path_only" --replace_string="" --target_file="../conf/nginx.conf"
+        ynh_replace_string --match_string="^#root_path_only" --replace_string="" --target_file="$YNH_APP_BASEDIR/conf/nginx.conf"
     fi
 
-    ynh_add_config --template="../conf/nginx.conf" --destination="$finalnginxconf"
+    ynh_add_config --template="$YNH_APP_BASEDIR/conf/nginx.conf" --destination="$finalnginxconf"
 
 
     ynh_systemd_action --service_name=nginx --action=reload

--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -153,10 +153,7 @@ ynh_add_fpm_config () {
     if [ $use_template -eq 1 ]
     then
         # Usage 1, use the template in conf/php-fpm.conf
-        local phpfpm_path="../conf/php-fpm.conf"
-        if [ ! -e "$phpfpm_path" ]; then
-            phpfpm_path="../settings/conf/php-fpm.conf"	# Into the restore script, the PHP-FPM template is not at the same place
-        fi
+        local phpfpm_path="$YNH_APP_BASEDIR/conf/php-fpm.conf"
         # Make sure now that the template indeed exists
         [ -e "$phpfpm_path" ] || ynh_die --message="Unable to find template to configure PHP-FPM."
     else
@@ -169,7 +166,7 @@ ynh_add_fpm_config () {
         # Define the values to use for the configuration of PHP.
         ynh_get_scalable_phpfpm --usage=$usage --footprint=$footprint
 
-        local phpfpm_path="../conf/php-fpm.conf"
+        local phpfpm_path="$YNH_APP_BASEDIR/conf/php-fpm.conf"
         echo "
 [__APP__]
 
@@ -204,18 +201,18 @@ pm.process_idle_timeout = 10s
         fi
 
         # Concatene the extra config.
-        if [ -e ../conf/extra_php-fpm.conf ]; then
-            cat ../conf/extra_php-fpm.conf >> "$phpfpm_path"
+        if [ -e $YNH_APP_BASEDIR/conf/extra_php-fpm.conf ]; then
+            cat $YNH_APP_BASEDIR/conf/extra_php-fpm.conf >> "$phpfpm_path"
         fi
     fi
 
     local finalphpconf="$fpm_config_dir/pool.d/$app.conf"
     ynh_add_config --template="$phpfpm_path" --destination="$finalphpconf"
 
-    if [ -e "../conf/php-fpm.ini" ]
+    if [ -e "$YNH_APP_BASEDIR/conf/php-fpm.ini" ]
     then
         ynh_print_warn --message="Packagers ! Please do not use a separate php ini file, merge your directives in the pool file instead."
-        ynh_add_config --template="../conf/php-fpm.ini" --destination="$fpm_config_dir/conf.d/20-$app.ini"
+        ynh_add_config --template="$YNH_APP_BASEDIR/conf/php-fpm.ini" --destination="$fpm_config_dir/conf.d/20-$app.ini"
     fi
 
     if [ $dedicated_service -eq 1 ]
@@ -228,7 +225,7 @@ pid = /run/php/php__PHPVERSION__-fpm-__APP__.pid
 error_log = /var/log/php/fpm-php.__APP__.log
 syslog.ident = php-fpm-__APP__
 include = __FINALPHPCONF__
-" > ../conf/php-fpm-$app.conf
+" > $YNH_APP_BASEDIR/conf/php-fpm-$app.conf
 
         ynh_add_config --template="../config/php-fpm-$app.conf" --destination="$globalphpconf"
 
@@ -245,7 +242,7 @@ ExecReload=/bin/kill -USR2 \$MAINPID
 
 [Install]
 WantedBy=multi-user.target
-" > ../conf/$fpm_service
+" > $YNH_APP_BASEDIR/conf/$fpm_service
 
         # Create this dedicated PHP-FPM service
         ynh_add_systemd_config --service=$fpm_service --template=$fpm_service

--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -22,7 +22,7 @@ ynh_add_systemd_config () {
     local service="${service:-$app}"
     local template="${template:-systemd.service}"
 
-    ynh_add_config --template="../conf/$template" --destination="/etc/systemd/system/$service.service"
+    ynh_add_config --template="$YNH_APP_BASEDIR/conf/$template" --destination="/etc/systemd/system/$service.service"
 
     systemctl enable $service --quiet
     systemctl daemon-reload

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_APP_BASEDIR=$([[ "$(basename $0)" =~ ^backup|restore$ ]] && echo '../settings' || echo '..')
+
 # Handle script crashes / failures
 #
 # [internal]
@@ -112,12 +114,7 @@ ynh_setup_source () {
     ynh_handle_getopts_args "$@"
     source_id="${source_id:-app}" # If the argument is not given, source_id equals "app"
 
-    local src_file_path="$YNH_CWD/../conf/${source_id}.src"
-    # In case of restore script the src file is in an other path.
-    # So try to use the restore path if the general path point to no file.
-    if [ ! -e "$src_file_path" ]; then
-        src_file_path="$YNH_CWD/../settings/conf/${source_id}.src"
-    fi
+    local src_file_path="$YNH_APP_BASEDIR/conf/${source_id}.src"
 
     # Load value from configuration file (see above for a small doc about this file
     # format)
@@ -309,10 +306,8 @@ ynh_add_config () {
     ynh_handle_getopts_args "$@"
     local template_path
 
-    if [ -f "../conf/$template" ]; then
-        template_path="../conf/$template"
-    elif [ -f "../settings/conf/$template" ]; then
-        template_path="../settings/conf/$template"
+    if [ -f "$YNH_APP_BASEDIR/conf/$template" ]; then
+        template_path="$YNH_APP_BASEDIR/conf/$template"
     elif [ -f "$template" ]; then
         template_path=$template
     else

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -704,9 +704,7 @@ class BackupManager:
         settings_dir = os.path.join(self.work_dir, "apps", app, "settings")
 
         logger.info(m18n.n("app_start_backup", app=app))
-        tmp_script = (
-            None  # This is to make sure the var exists later in the 'finally' ...
-        )
+        tmp_folder = tempfile.mkdtemp()
         try:
             # Prepare backup directory for the app
             filesystem.mkdir(tmp_app_bkp_dir, 0o750, True, uid="admin")
@@ -715,8 +713,8 @@ class BackupManager:
             shutil.copytree(app_setting_path, settings_dir)
 
             # Copy app backup script in a temporary folder and execute it
-            _, tmp_script = tempfile.mkstemp(prefix="backup_")
             app_script = os.path.join(app_setting_path, "scripts/backup")
+            tmp_script = os.path.join(tmp_folder, "backup")
             subprocess.call(["install", "-Dm555", app_script, tmp_script])
 
             hook_exec(
@@ -752,8 +750,8 @@ class BackupManager:
 
         # Remove tmp files in all situations
         finally:
-            if tmp_script:
-                filesystem.rm(tmp_script, force=True)
+            if tmp_folder and os.path.exists(tmp_folder):
+                shutil.rmtree(tmp_folder)
             filesystem.rm(env_dict["YNH_BACKUP_CSV"], force=True)
 
     #


### PR DESCRIPTION
## The problem

c.f. regressions mentioned in https://github.com/YunoHost/issues/issues/1732

Some conf file were not found because of the usage of the new ynh_add_config trying to use some file in ../conf in the context of backup/restore scripts

## Solution

Define a new variable YNH_APP_BASEDIR which points to `..` or `../settings` depending if we're in backup/restore context or not, to simplify the handling of this issue

Had to make sure that the backup script was indeed called "backup" when we actually run it

## PR Status

Tested and working on my side

## How to test

Install/backup an app