### PR TITLE
[fix] Automatically call ynh_clean_check_starting when ynh_systemd_action fails

### DIFF
--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -58,7 +58,7 @@ ynh_remove_systemd_config () {
 # usage: ynh_systemd_action [--service_name=service_name] [--action=action] [ [--line_match="line to match"] [--log_path=log_path] [--timeout=300] [--length=20] ]
 # | arg: -n, --service_name= - Name of the service to start. Default : $app
 # | arg: -a, --action=       - Action to perform with systemctl. Default: start
-# | arg: -l, --line_match=   - Line to match - The line to find in the log to attest the service have finished to boot. If not defined it don't wait until the service is completely started. WARNING: When using --line_match, you should always add `ynh_clean_check_starting` into your `ynh_clean_setup` at the beginning of the script. Otherwise, tail will not stop in case of failure of the script. The script will then hang forever.
+# | arg: -l, --line_match=   - Line to match - The line to find in the log to attest the service have finished to boot. If not defined it don't wait until the service is completely started.
 # | arg: -p, --log_path=     - Log file - Path to the log file. Default : /var/log/$app/$app.log
 # | arg: -t, --timeout=      - Timeout - The maximum time to wait before ending the watching. Default : 300 seconds.
 # | arg: -e, --length=       - Length of the error log : Default : 20
@@ -117,6 +117,7 @@ ynh_systemd_action() {
         then
             ynh_exec_err tail --lines=$length "$log_path"
         fi
+        ynh_clean_check_starting
         return 1
     fi
 
@@ -161,9 +162,8 @@ ynh_systemd_action() {
 }
 
 # Clean temporary process and file used by ynh_check_starting
-# (usually used in ynh_clean_setup scripts)
 #
-# usage: ynh_clean_check_starting
+# [internal]
 #
 # Requires YunoHost version 3.5.0 or higher.
 ynh_clean_check_starting () {
@@ -174,7 +174,7 @@ ynh_clean_check_starting () {
     fi
     if [ -n "$templog" ]
     then
-        ynh_secure_remove "$templog" 2>&1
+        ynh_secure_remove --file="$templog" 2>&1
     fi
 }
 


### PR DESCRIPTION
## The problem

- We use `ynh_systemd_action` in some helpers, which requires calling `ynh_clean_check_starting` in the exit function
- `ynh_clean_check_starting` tries to kill remains process created by `ynh_systemd_action`, but variables used to store the pid is in the local scope, idk how this ever work. https://github.com/YunoHost/yunohost/blob/1d3380415eca14ea9291d3b29fbf326111077e68/data/helpers.d/systemd#L96 https://github.com/YunoHost/yunohost/blob/1d3380415eca14ea9291d3b29fbf326111077e68/data/helpers.d/systemd#L89

https://github.com/YunoHost/yunohost/blob/1d3380415eca14ea9291d3b29fbf326111077e68/data/helpers.d/systemd#L170-L178

## Solution

Call `ynh_clean_check_starting` just before returning 1
Set `ynh_clean_check_starting` as internal. Packagers shouldn't handle our mess :-)

## PR Status

...

## How to test

...
