### PR TITLE
[enh] - Force destination to be replaced

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -316,7 +316,7 @@ ynh_add_config () {
 
     ynh_backup_if_checksum_is_different --file="$destination"
 
-    cp "$template_path" "$destination"
+    cp -f "$template_path" "$destination"
     chown root: "$destination"
 
     ynh_replace_vars --file="$destination"


### PR DESCRIPTION
## The problem

When using ynh_add_config, if destination file already exist, it's not overwritten

## Solution

just forcing

## PR Status

Ready

## How to test

...
