### PR TITLE
Make grep lazy

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -382,7 +382,7 @@ ynh_replace_vars () {
     # Replace others variables
 
     # List other unique (__ __) variables in $file
-    local uniques_vars=( $(grep -o '__[A-Z0-9_]*__' $file | sort --unique | sed "s@__\([^.]*\)__@\L\1@g" ))
+    local uniques_vars=( $(grep -oP '__[A-Z0-9_]+?__' $file | sort --unique | sed "s@__\([^.]*\)__@\L\1@g" ))
 
     # Do the replacement
     local delimit=@


### PR DESCRIPTION
## The problem

ynh_add_config is unable to manage something like `__DOMAIN____PATH_URL__`
CF [Job #502 wikijs (PR #134, example)](https://ci-apps-dev.yunohost.org/ci/job/502)

The corresponding lines of the script:
https://github.com/YunoHost-Apps/wikijs_ynh/blob/2a8db83a45f9ebdd9c03b461827f45a81b50db3b/scripts/install#L185-L191

And the file on which ynh_add_config is applyed:
https://github.com/YunoHost-Apps/wikijs_ynh/blob/example/conf/ldap_message

## Solution

Make finding the `unique_vars` lazy

## PR Status

Tested

## How to test

Actual fail with https://github.com/YunoHost-Apps/wikijs_ynh/tree/example :
https://paste.yunohost.org/savilagari.sql

the with lazy grep https://github.com/YunoHost-Apps/wikijs_ynh/pull/135:
https://paste.yunohost.org/aqukotiher.sql


