### PR TITLE
Fixing ___APP__

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -382,7 +382,7 @@ ynh_replace_vars () {
     # Replace others variables
 
     # List other unique (__ __) variables in $file
-    local uniques_vars=( $(grep -oP '__[A-Z0-9_]+?__' $file | sort --unique | sed "s@__\([^.]*\)__@\L\1@g" ))
+    local uniques_vars=( $(grep -oP '__[A-Z0-9]+?[A-Z0-9_]*?[A-Z0-9]*?__' $file | sort --unique | sed "s@__\([^.]*\)__@\L\1@g" ))
 
     # Do the replacement
     local delimit=@


### PR DESCRIPTION
## The problem

using ynh_add_config, `___APP__` is retrieved as `___APP__` instead of `__APP__`like at [Job #492 peertube (PR #204, example)](https://ci-apps-dev.yunohost.org/ci/job/492)

## Solution

Making grep more accurate using [https://www.rexegg.com/regex-quantifiers.html](https://www.rexegg.com/regex-quantifiers.html)

- starting with `__`
- `[A-Z0-9]+?` lazy one or more of `[A-Z0-9]`
- `[A-Z0-9_]*?` lazy zero or more of `[A-Z0-9_]`
- `[A-Z0-9]*?` lazy zero or more of `[A-Z0-9]`
- ending with `__`

Will do a good match on :
`___APP__` => `__APP__`
`__DB_USER__` => `__DB_USER__`
`__DOMAIN____PATH_URL__` => `__DOMAIN__` and `__PATH_URL__`
`__BC__` => `__BC__`
`__A__` => `__A__`
`__YNH_NODE_LOAD_PATH__` => `__YNH_NODE_LOAD_PATH__`
`__APP_____DOMAIN__` => `__APP__` and `__DOMAIN__`

## PR Status

Ready

## How to test

Create a text file named test, write some samples and execute `grep -oP '__[A-Z0-9]+?[A-Z0-9_]*?[A-Z0-9]*?__' ./test`
