### PR TITLE
[fix] Add backup for multimedia files

### DIFF
--- a/data/hooks/backup/18-data_multimedia
+++ b/data/hooks/backup/18-data_multimedia
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit hook on subcommand error or unset variable
+set -eu
+
+# Source YNH helpers
+source /usr/share/yunohost/helpers
+
+# Backup destination
+backup_dir="${1}/data/multimedia"
+
+if [ -e "/home/yunohost.multimedia/.nobackup" ]; then
+    exit 0
+fi
+
+# Backup multimedia directory
+ynh_backup --src_path="/home/yunohost.multimedia" --dest_path="${backup_dir}" --is_big --not_mandatory

--- a/data/hooks/restore/18-data_multimedia
+++ b/data/hooks/restore/18-data_multimedia
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Exit hook on subcommand error or unset variable
+set -eu
+
+# Source YNH helpers
+source /usr/share/yunohost/helpers
+
+ynh_restore_file --origin_path="/home/yunohost.multimedia" --not_mandatory


### PR DESCRIPTION
## The problem

Multimedia directory is not backup and i receive request from borg_ynh users about that

## Solution

Add a hook for saving multimedia directory

About legacy management, i don't know exactly what to do between:

- Nothing the multimedia dir is included by default after upgrade to the new yunohost version (could be problematic with daily backup on some instances)
- Create a migration (with an explanation and ability to skip) that deactivate the multimedia backup by creating a .nobackup inside this dir 
- Don't include by default this hook on yunohost backup create action

## PR Status

Ready

## How to test

...
