### PR TITLE
Feature: Add postfix backup in yunohost hooks

### DIFF
--- a/data/hooks/backup/22-conf_mail
+++ b/data/hooks/backup/22-conf_mail
@@ -2,8 +2,9 @@
 
 source /usr/share/yunohost/helpers
 ynh_abort_if_errors
-YNH_CWD="${YNH_BACKUP_DIR%/}/conf/dkim"
+YNH_CWD="${YNH_BACKUP_DIR%/}/conf/mail"
 mkdir -p "$YNH_CWD"
 cd "$YNH_CWD"
 
 ynh_backup --src_path="/etc/dkim"
+ynh_backup --src_path="/etc/postfix"

--- a/data/hooks/restore/22-conf_mail
+++ b/data/hooks/restore/22-conf_mail
@@ -1,9 +1,16 @@
 #!/bin/bash
 
-backup_dir="$1/conf/dkim"
+backup_dir="$1/conf/mail"
 
 cp -a $backup_dir/etc/dkim/. /etc/dkim
 
 chown -R root:root /etc/dkim
 chown _rspamd:root /etc/dkim
 chown _rspamd:root /etc/dkim/*.mail.key
+
+cp -a $backup_dir/etc/postfix/. /etc/postfix
+chown -R root:root /etc/postfix
+
+cp -a $backup_dir/aliases /etc/aliases
+chown -R root:root /etc/aliases
+postalias /etc/aliases


### PR DESCRIPTION
## The problem

Today postfix configuration is not included in backups.
We need backups so i patched Yunohost code ans hope it will fit community needs

## Solution

Updated mail backup hook to add aliases and postfix configuration.

## PR Status

Review and approval needed.

## How to test

make a backup/restore