### PR TITLE
Sane default permissions for files added using ynh_add_config and ynh_setup_source

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -330,7 +330,7 @@ ynh_add_config () {
     # (cp won't overwrite ownership / modes by default...)
     touch $destination
     chown root:root $destination
-    chmod 750 $destination
+    chmod 640 $destination
 
     cp -f "$template_path" "$destination"
 
@@ -725,11 +725,11 @@ _ynh_apply_default_permissions() {
     if [ -z "$ynh_requirements" ] || [ "$ynh_requirements" == "null" ] || dpkg --compare-versions $ynh_requirements ge 4.2
     then
         chmod o-rwx $target
+        chmod g-w $target
+        chown -R root:root $target
         if ynh_system_user_exists $app
         then
             chown $app:$app $target
-        else
-            chown root:root $target
         fi
     fi
 }

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -160,6 +160,11 @@ ynh_setup_source () {
     # Extract source into the app dir
     mkdir --parents "$dest_dir"
 
+    if [ -n "${final_path:-}" ] && [ "$dest_dir" == "$final_path" ]
+    then
+        _ynh_apply_default_permissions $dest_dir
+    fi
+
     if ! "$src_extract"
     then
         mv $src_filename $dest_dir
@@ -319,8 +324,17 @@ ynh_add_config () {
 
     ynh_backup_if_checksum_is_different --file="$destination"
 
+    # Make sure to set the permissions before we copy the file
+    # This is to cover a case where an attacker could have
+    # created a file beforehand to have control over it
+    # (cp won't overwrite ownership / modes by default...)
+    touch $destination
+    chown root:root $destination
+    chmod 750 $destination
+
     cp -f "$template_path" "$destination"
-    chown root: "$destination"
+
+    _ynh_apply_default_permissions $destination
 
     ynh_replace_vars --file="$destination"
 
@@ -684,4 +698,38 @@ ynh_compare_current_package_version() {
 
     # Return the return value of dpkg --compare-versions
     dpkg --compare-versions $current_version $comparison $version
+}
+
+# Check if we should enforce sane default permissions (= disable rwx for 'others')
+# on file/folders handled with ynh_setup_source and ynh_add_config
+#
+# [internal]
+#
+# Having a file others-readable or a folder others-executable(=enterable)
+# is a security risk comparable to "chmod 777"
+#
+# Configuration files may contain secrets. Or even just being able to enter a
+# folder may allow an attacker to do nasty stuff (maybe a file or subfolder has
+# some write permission enabled for 'other' and the attacker may edit the
+# content or create files as leverage for priviledge escalation ...)
+#
+# The sane default should be to set ownership to $app:$app.
+# In specific case, you may want to set the ownership to $app:www-data
+# for example if nginx needs access to static files.
+#
+_ynh_apply_default_permissions() {
+    local target=$1
+
+    local ynh_requirement=$(jq -r '.requirements.yunohost' $YNH_APP_BASEDIR/manifest.json)
+
+    if [ -z "$ynh_requirements" ] || [ "$ynh_requirements" == "null" ] || dpkg --compare-versions $ynh_requirements ge 4.2
+    then
+        chmod o-rwx $target
+        if ynh_system_user_exists $app
+        then
+            chown $app:$app $target
+        else
+            chown root:root $target
+        fi
+    fi
 }


### PR DESCRIPTION
## The problem

Today I was reading example_ynh and got mad after seeing some weird chown that I thought should be handled by the helpers directly instead of the packagers (at least we should have a decent default behavior)

After thinking about it, I realize that in many situations we probably have apps that do not correctly provide files or folders that may contain secrets .. hence they are world-readable and an attacker that has local a local shell on the machine could use this for privilege escalation.


Thing is, there seem to be a lot of focus on `chown` but it's easy to forget about `chmod` and the fact that by default files/folders are readable by `others` ... In fact, example_ynh currently recommends to `chown root: $final_path` ... This may sound like "SeCuRiTy HeLl Yeah !?" because you set the permission only to root, right ? **Wrong** ! If the owner/group is root, yet the `$app` user needs access, then it must be allowed through the `others` permissions ... which therefore means everybody else has access, too. There's simply no point to set `root` as the owner of a folder, except if nobody except root should be able to access it.

Thanksfully some packagers were careful enough to run some `chmod xx0` on critical files. But the current strategy is just plain wrong. It shouldn't be the packager to "restrict" permissions. Permissions should be restricted by default (least privileges), then the packager should allow specific access to specific files/folders.

Anyway, the whole thing ain't easy to fix because LeGaCy™ ... we can't just run `chown o-rwx /var/www/*` because : 
- `$app` should be owner of the appropriate folders, not root
- Yet the user `$app` may not even exists in the first place because not all apps call `ynh_system_user_create`
- In some cases, such as serving static files, `www-data` needs read access
- ... other edge cases I haven't thought about yet ...

## Solution

As part of a bunch of stuff to try to mitigate the entire mess, this PR tweaks `ynh_setup_source` and `ynh_add_config` such that it will run `chmod o-rwx` on every file added through `ynh_add_config`, and on the `$final_path` (during `ynh_setup_source` - can't apply it on every cases because `ynh_setup_source` is used for other things)

It also tries to set the ownership to `$app:$app` but then again, that's stupidly not that simple because as recommended by example_ynh, [`ynh_system_user_create` happens **after** `ynh_setup_source`](https://github.com/YunoHost/example_ynh/blob/master/scripts/install#L164) >_> ... So in that case it'll default to root:root ... (with a high likelyhood that the entire app won't work if the packager doesn't fix the permission manually, or moves ynh_system_user_create **before** ynh_setup_source ...

Anyway ... of course we can't apply all this behavior right away because that would probably break many apps ... So what I'm proposing is to check if the app requires yunohost >= 4.2 - such that only when the packager changes the manifest and supposedly trigger a fix on the CI will this change be effective ... and then the packager can fix the app ...

## PR Status

Yolocommited

## How to test

Zblerg idk, take for example hextris, tweak the manifest to require yunohost >= 4.2, check that permissions for /var/www/hextris are okay, same thing for a ynh_add_config usecase