### PR TITLE
Remove src filename

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -194,6 +194,7 @@ ynh_setup_source () {
         else
             ynh_die --message="Archive format unrecognized."
         fi
+        ynh_secure_remove --file="$src_filename"
     fi
 
     # Apply patches

--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -176,6 +176,7 @@ ynh_setup_source () {
         else
             unzip -quo $src_filename -d "$dest_dir"
         fi
+        ynh_secure_remove --file="$src_filename"
     else
         local strip=""
         if [ "$src_in_subdir" != "false" ]

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -3638,7 +3638,7 @@ def _patch_legacy_helpers(app_folder):
 
         try:
             content = read_file(filename)
-        except Exception:
+        except MoulinetteError:
             continue
         
         replaced_stuff = False

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1761,7 +1761,7 @@ def app_action_run(operation_logger, app, action, args=None):
     if action_declaration.get("cwd"):
         cwd = action_declaration["cwd"].replace("$app", app)
     else:
-        cwd = "/etc/yunohost/apps/" + app
+        cwd = os.path.join(APPS_SETTING_PATH, app)
 
     retcode = hook_exec(
         path,
@@ -3636,7 +3636,11 @@ def _patch_legacy_helpers(app_folder):
         if not os.path.isfile(filename):
             continue
 
-        content = read_file(filename)
+        try:
+            content = read_file(filename)
+        except Exception:
+            continue
+        
         replaced_stuff = False
         show_warning = False
 


### PR DESCRIPTION
## The problem

After upgrade an app a copy of all scripts/* files into `/etc/yunohost/apps/$app/scripts` is performed.
If the app download (with the `ynh_setup_source` helper or not) a file in .tar.gz we can't remove it anymore with an error like:

```
root@domain:/ynh-dev# yunohost app remove lxd --debug
59   DEBUG initializing base actions map parser for cli
59   DEBUG loading actions map namespace 'yunohost'
60   DEBUG building parser...
67   DEBUG building parser took 0.006s
67   DEBUG acquiring lock...
73   DEBUG lock has been acquired
78   DEBUG loading python module yunohost.app took 0.005s
78   DEBUG processing action [406724.1]: yunohost.app.remove with args={'app': 'lxd'}
82   INFO Removing lxd...
171  INFO The operation 'Remove the 'lxd' app' could not be completed. Please share the full log of this operation using the command 'yunohost log share 20210316-152627-app_remove-lxd' to get help
178  DEBUG action [406724.1] executed in 0.100s
179  DEBUG lock has been released
179  ERROR Unknown error while trying to read file /etc/yunohost/apps/lxd/scripts/go.x86-64.tar.gz (reason: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte)
```

## Solution

In `ynh_setup_source` remove the downloaded file if it's extracted
In `_patch_legacy_helpers` , if read_file fails, continue to the next file

## PR Status

Half tested

## How to test

Install and upgrade (it's important to upgrade because install is not managed in the same way) lxd, and try to remove it
