### PR TITLE
[fix] Several long-standing issues with UPnP port forwarding from issue #1463

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1292,7 +1292,6 @@ firewall:
                         - enable
                         - disable
                         - status
-                        - reload
                     nargs: "?"
                     default: status
                 --no-refresh:


### PR DESCRIPTION

## The problem
See issue #1463
...

## Solution
Fixes local firewall rules to allow discovery of SSDP servers.
No longer disables UPnP forwarding when refreshing fails.
No longer disables UPnP forwarding on system reboot.
Cron job runs every 10 minutes to refresh the router tables more
promptly after the system or router reboots.
Removes the deprecated UPnP "reload" option.

...

## PR Status
Works on my system (yunohost 4.2.0 testing) behind a home router. Others need to check it works with their networks.
...

## How to test

...
