### PR TITLE
Add a --dry-run option to backup_create to fetch an estimate of the backup size

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -890,6 +890,9 @@ backup:
                 --apps:
                     help: List of application names to backup (or all if none given)
                     nargs: "*"
+                --dry-run:
+                    help: "'Simulate' the backup and return the size details per item to backup"
+                    action: store_true
 
         ### backup_restore()
         restore:

--- a/locales/en.json
+++ b/locales/en.json
@@ -93,6 +93,7 @@
     "backup_copying_to_organize_the_archive": "Copying {size:s}MB to organize the archive",
     "backup_couldnt_bind": "Could not bind {src:s} to {dest:s}.",
     "backup_created": "Backup created",
+    "backup_create_size_estimation": "The archive will contain about {size} of data.",
     "backup_creation_failed": "Could not create the backup archive",
     "backup_csv_addition_failed": "Could not add files to backup into the CSV file",
     "backup_csv_creation_failed": "Could not create the CSV file needed for restoration",

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -793,25 +793,28 @@ class BackupManager:
             self.size_details["apps"][app_key] = 0
 
         for row in self.paths_to_backup:
-            if row["dest"] != "info.json":
-                size = disk_usage(row["source"])
+            if row["dest"] == "info.json":
+                continue
 
-                # Add size to apps details
-                splitted_dest = row["dest"].split("/")
-                category = splitted_dest[0]
-                if category == "apps":
-                    for app_key in self.apps_return:
-                        if row["dest"].startswith("apps/" + app_key):
-                            self.size_details["apps"][app_key] += size
-                            break
-                # OR Add size to the correct system element
-                elif category == "data" or category == "conf":
-                    for system_key in self.system_return:
-                        if row["dest"].startswith(system_key.replace("_", "/")):
-                            self.size_details["system"][system_key] += size
-                            break
+            size = disk_usage(row["source"])
 
-                self.size += size
+            # Add size to apps details
+            splitted_dest = row["dest"].split("/")
+            category = splitted_dest[0]
+            if category == "apps":
+                for app_key in self.apps_return:
+                    if row["dest"].startswith("apps/" + app_key):
+                        self.size_details["apps"][app_key] += size
+                        break
+
+            # OR Add size to the correct system element
+            elif category == "data" or category == "conf":
+                for system_key in self.system_return:
+                    if row["dest"].startswith(system_key.replace("_", "/")):
+                        self.size_details["system"][system_key] += size
+                        break
+
+            self.size += size
 
         return self.size
 

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -538,8 +538,8 @@ class BackupManager:
         # Add unlisted files from backup tmp dir
         self._add_to_list_to_backup("backup.csv")
         self._add_to_list_to_backup("info.json")
-        if len(self.apps_return) > 0:
-            self._add_to_list_to_backup("apps")
+        for app in self.apps_return.keys():
+            self._add_to_list_to_backup(f"apps/{app}")
         if os.path.isdir(os.path.join(self.work_dir, "conf")):
             self._add_to_list_to_backup("conf")
         if os.path.isdir(os.path.join(self.work_dir, "data")):

--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2138,7 +2138,7 @@ class CustomBackupMethod(BackupMethod):
 @is_unit_operation()
 def backup_create(
     operation_logger,
-    name=None, description=None, methods=[], output_directory=None, system=[], apps=[]
+    name=None, description=None, methods=[], output_directory=None, system=[], apps=[], dry_run=False
 ):
     """
     Create a backup local archive
@@ -2220,8 +2220,15 @@ def backup_create(
     # Collect files to be backup (by calling app backup script / system hooks)
     backup_manager.collect_files()
 
+    if dry_run:
+        return {
+            "size": backup_manager.size,
+            "size_details": backup_manager.size_details
+        }
+
     # Apply backup methods on prepared files
     logger.info(m18n.n("backup_actually_backuping"))
+    logger.info(m18n.n("backup_create_size_estimation", size=binary_to_human(backup_manager.size) + "B"))
     backup_manager.backup()
 
     logger.success(m18n.n("backup_created"))


### PR DESCRIPTION
## The problem

Going to the backup creation interface, there's no clue provided about the size of the to-be-created backup (which may also provide some clue about the time it'll take to create the archive, c.f. people backing up 100+GB of data)

## Solution

Add a --dry-run option, meant to be used by the webadmin. Maybe we can implement a "Simulate" button or something on the webadmin that would add size annotations in the view. (We probably want this to be only triggered manually by the user because the dry-run ain't trivial, you still have to run all the app scripts to obtain the information of what's to be backedup, and there's also db dumps in the process)

## PR Status

Tested and working on my side

## How to test

Run `yunohost backup create --dry-run`
