### PR TITLE
[fix] Remove passphrase keyword from logs

### DIFF
--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -414,7 +414,7 @@ class RedactingFormatter(Formatter):
             # This matches stuff like db_pwd=the_secret or admin_password=other_secret
             # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
             # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
-            match = re.search(r'(pwd|pass|password|secret\w*|\w+key|token)=(\S{3,})$', record.strip())
+            match = re.search(r'(pwd|pass|password|passphrase|secret\w*|\w+key|token)=(\S{3,})$', record.strip())
             if match and match.group(2) not in self.data_to_redact and match.group(1) not in ["key", "manifest_key"]:
                 self.data_to_redact.append(match.group(2))
         except Exception as e:


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/borg-borg-server-deduplicated-encrypted-and-remote-backups/5006/29?u=ljf

## Solution

Add passphrase to the banned keywords list

## PR Status

Yolo PR

## How to test

Upgrade borg and search your password
