### PR TITLE
[enh] add header to disallow FLoC

### DIFF
--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -33,6 +33,9 @@ more_set_headers "X-Download-Options : noopen";
 more_set_headers "X-Permitted-Cross-Domain-Policies : none";
 more_set_headers "X-Frame-Options : SAMEORIGIN";
 
+# Disable the disaster privacy thing that is FLoC
+more_set_headers "Permissions-Policy : interest-cohort=()";
+
 # Disable gzip to protect against BREACH
 # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)
 gzip off;


### PR DESCRIPTION
## The problem

Google is starting to use FLoC and it's a privacy nightmare, see https://www.eff.org/deeplinks/2021/03/google-testing-its-controversial-new-ad-targeting-tech-millions-browsers-heres

## Solution

While destroying google would be a great thing in the meantime we can apparently disallow it using a nginx header, see https://diaspodon.fr/@etienne/106070042112522839

## PR Status

Tested on my prod and used https://securityheaders.com linked in the toot to see if it is working and the website is happy.

## How to test

Apply the patch on your local nginx conf, reload nginx and check the headers or use security headers.
