### PR TITLE
[enh] by default be very strict on the Permissions-Policy header

### DIFF
--- a/data/templates/nginx/security.conf.inc
+++ b/data/templates/nginx/security.conf.inc
@@ -33,8 +33,8 @@ more_set_headers "X-Download-Options : noopen";
 more_set_headers "X-Permitted-Cross-Domain-Policies : none";
 more_set_headers "X-Frame-Options : SAMEORIGIN";
 
-# Disable the disaster privacy thing that is FLoC
-more_set_headers "Permissions-Policy : interest-cohort=()";
+# Disable most possible leaking things by default including the horrible FLoC
+more_set_headers "Permissions-Policy : fullscreen=(), geolocation=(), display-capture=(), gyroscope=(), ambient-light-sensor=(), payment=(), accelerometer=(), battery=(), camera=(), microphone=(), magnetometer=(), usb=(), interest-cohort=(), publickey-credentials-get=()";
 
 # Disable gzip to protect against BREACH
 # Read https://trac.nginx.org/nginx/ticket/1720 (text/html cannot be disabled!)


### PR DESCRIPTION
## The problem

I'm not 100% sure about this one.

By setting the Permissions-Policy header we can create a very strict policy for the browser and avoiding leaking a lot of information that are opened by default. This will prevent the app from accessing them including rogue javascript or things like that that could leak them.

On the downside, this will force every app developers for which apps needs some permissions to explicitly allow them thus breaking the feature of some apps that are already working, so : communications, temporary bugs etc ... I'm not sure if it's worth it?

Reference https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy

## PR Status

Working on my prod.

## How to test

Apply the patch on your prod and reload nginx then look at the headers.
