### PR TITLE
Add route to fetch app manifest for custom app installs in a forge-agnostic way

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -608,6 +608,14 @@ app:
                 string:
                     help: Return matching app name or description with "string"
 
+        ### app_manifest()
+        manifest:
+            action_help: Return the manifest of a given app from the manifest, or from a remote git repo
+            api: GET /apps/manifest
+            arguments:
+                app:
+                    help: Name, local path or git URL of the app to fetch the manifest of
+
         fetchlist:
             deprecated: true
 
@@ -679,7 +687,7 @@ app:
                     help: Do not ask confirmation if the app is not safe to use (low quality, experimental or 3rd party)
                     action: store_true
 
-        ### app_remove() TODO: Write help
+        ### app_remove()
         remove:
             action_help: Remove app
             api: DELETE /apps/<app>

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -610,7 +610,7 @@ app:
 
         ### app_manifest()
         manifest:
-            action_help: Return the manifest of a given app from the manifest, or from a remote git repo
+            action_help: Return the manifest of a given app from the catalog, or from a remote git repo
             api: GET /apps/manifest
             arguments:
                 app:

--- a/data/templates/nginx/plain/yunohost_admin.conf.inc
+++ b/data/templates/nginx/plain/yunohost_admin.conf.inc
@@ -6,6 +6,6 @@ location /yunohost/admin/ {
     default_type text/html;
     index index.html;
 
-    more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; connect-src 'self' https://raw.githubusercontent.com https://paste.yunohost.org wss://$host; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; object-src 'none'; img-src 'self' data:;";
+    more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; connect-src 'self' https://paste.yunohost.org wss://$host; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; object-src 'none'; img-src 'self' data:;";
     more_set_headers "Content-Security-Policy-Report-Only:";
 }

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -786,6 +786,21 @@ def app_upgrade(app=[], url=None, file=None, force=False):
     logger.success(m18n.n("upgrade_complete"))
 
 
+def app_manifest(app):
+
+    raw_app_list = _load_apps_catalog()["apps"]
+
+    if app in raw_app_list or ("@" in app) or ("http://" in app) or ("https://" in app):
+        manifest, extracted_app_folder = _fetch_app_from_git(app)
+    elif os.path.exists(app):
+        manifest, extracted_app_folder = _extract_app_from_file(app)
+    else:
+        raise YunohostValidationError("app_unknown")
+
+    shutil.rmtree(extracted_app_folder)
+
+    return manifest
+
 @is_unit_operation()
 def app_install(
     operation_logger,


### PR DESCRIPTION
## The problem

c.f. https://github.com/YunoHost/issues/issues/1117

Currently, custom app install work by fetching **from the client** the raw manifest.json. This was good enough so far but recently break after I started advising removing the superflous ask strings ... But also it worked with tight-coupling to raw.githubuserstuff.com, etc

## Solution

Add a `yunohost app manifest foobar`, which can also be fed an url, and is meant to be used by the API such that the backends fetch the manifest in a forge-agnostic way.

## PR Status

Tested and working on my side

## How to test

c.f. corresponding PR on yunohost-admin
