### PR TITLE
Add ssh.app, sftp.app groups to cover my_webapp and borg needing ssh access

### DIFF
--- a/data/helpers.d/user
+++ b/data/helpers.d/user
@@ -92,10 +92,11 @@ ynh_system_group_exists() {
 
 # Create a system user
 #
-# usage: ynh_system_user_create --username=user_name [--home_dir=home_dir] [--use_shell]
+# usage: ynh_system_user_create --username=user_name [--home_dir=home_dir] [--use_shell] [--groups="group1 group2"]
 # | arg: -u, --username=    - Name of the system user that will be create
 # | arg: -h, --home_dir=    - Path of the home dir for the user. Usually the final path of the app. If this argument is omitted, the user will be created without home
 # | arg: -s, --use_shell    - Create a user using the default login shell if present. If this argument is omitted, the user will be created with /usr/sbin/nologin shell
+# | arg: -g, --groups       - Add the user to system groups. Typically meant to add the user to the ssh.app / sftp.app group (e.g. for borgserver, my_webapp)
 #
 # Create a nextcloud user with no home directory and /usr/sbin/nologin login shell (hence no login capability) :
 # ```
@@ -110,14 +111,17 @@ ynh_system_group_exists() {
 ynh_system_user_create () {
     # Declare an array to define the options of this helper.
     local legacy_args=uhs
-    local -A args_array=( [u]=username= [h]=home_dir= [s]=use_shell )
+    local -A args_array=( [u]=username= [h]=home_dir= [s]=use_shell [g]=groups= )
     local username
     local home_dir
     local use_shell
+    local groups
+
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     use_shell="${use_shell:-0}"
     home_dir="${home_dir:-}"
+    groups="${groups:-}"
 
     if ! ynh_system_user_exists "$username"	# Check if the user exists on the system
     then	# If the user doesn't exist
@@ -135,6 +139,12 @@ ynh_system_user_create () {
         fi
         useradd $user_home_dir --system --user-group $username $shell || ynh_die --message="Unable to create $username system account"
     fi
+
+    local group
+    for group in $groups
+    do
+        usermod -a -G "$group" "$username"
+    done
 }
 
 # Delete a system user

--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -187,6 +187,10 @@ do_post_regen() {
   [[ ! -e /etc/yunohost/hooks.d ]] || (chown root /etc/yunohost/hooks.d && chmod 700 /etc/yunohost/hooks.d)
   [[ ! -e /etc/yunohost/apps ]] || (chown root /etc/yunohost/apps && chmod 700 /etc/yunohost/apps)
 
+  # Create ssh.app and sftp.app groups if they don't exist yet
+  grep -q '^ssh.app:' /etc/group || groupadd ssh.app
+  grep -q '^sftp.app:' /etc/group || groupadd sftp.app
+
   # Propagates changes in systemd service config overrides
   [[ ! "$regen_conf_files" =~ "ntp.service.d/ynh-override.conf" ]] || { systemctl daemon-reload; systemctl restart ntp; }
   [[ ! "$regen_conf_files" =~ "nftables.service.d/ynh-override.conf" ]] || systemctl daemon-reload

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -65,7 +65,7 @@ ClientAliveInterval 60
 AcceptEnv LANG LC_*
 
 # Disallow user without ssh or sftp permissions
-AllowGroups ssh.main sftp.main admins root
+AllowGroups ssh.main sftp.main ssh.app sftp.app admins root
 
 # Allow users to create tunnels or forwarding
 AllowTcpForwarding yes


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1784

## Solution

Introduce new ssh.app and sftp.app groups

Apps can add their system user to this group by adding for example `--groups="ssh.app"` to `ynh_system_user_create`

## PR Status

Tested and working on my side
Though we'll have to create PR to propagate that change on borg, restic, my_webapp

## How to test

Zblerg idk, run the regen-conf, run the unit test for ynh_system_user_create, try to connect with the created user
