### PR TITLE
ynh_systemd_action: Fix case where service is already stopped

### DIFF
--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -88,6 +88,12 @@ ynh_systemd_action() {
     log_path="${log_path:-/var/log/$service_name/$service_name.log}"
     timeout=${timeout:-300}
 
+    # Manage case of service already stopped
+    if [ "$action" == "stop" ] && ! systemctl is-active --quiet $service_name
+    then
+        return 0
+    fi
+
     # Start to read the log
     if [[ -n "$line_match" ]]
     then


### PR DESCRIPTION
## The problem

When upgrading an app, if the service is stopped or broken and the upgrade has `ynh_systemd_action --service_name=$app --action="stop"` with`--line_match="SOMETHING"`, the upgrade will fail because the line_math won't complete

## Solution

having `ynh_systemd_action` checkingf if the service is already stopped

## PR Status

Ready

## How to test

choose an app with an upgrade step `ynh_systemd_action --service_name=$app --action="stop" --line_match="SOMETHING"` => for example pleroma, mobilizon, wikijs, etc ...
install a previous version of the app on a fresh yunohost
stop the app service
try to upgrade, it will fail

install a previous version of the app on a fresh yunohost
stop the app service
apply the patch
try to upgrade, it will work ...


