### PR TITLE
[fix] Remove warning to user (transfered in linter)

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1269,10 +1269,6 @@ def app_addaccess(apps, users=[]):
     """
     from yunohost.permission import user_permission_update
 
-    logger.warning(
-        "/!\\ Packagers ! This app is using the legacy permission system. Please use the new helpers ynh_permission_{create,url,update,delete} and the 'visitors' group to manage permissions."
-    )
-
     output = {}
     for app in apps:
         permission = user_permission_update(
@@ -1294,10 +1290,6 @@ def app_removeaccess(apps, users=[]):
     """
     from yunohost.permission import user_permission_update
 
-    logger.warning(
-        "/!\\ Packagers ! This app is using the legacy permission system. Please use the new helpers ynh_permission_{create,url,update,delete} and the 'visitors' group to manage permissions."
-    )
-
     output = {}
     for app in apps:
         permission = user_permission_update(app + ".main", remove=users)
@@ -1315,11 +1307,7 @@ def app_clearaccess(apps):
 
     """
     from yunohost.permission import user_permission_reset
-
-    logger.warning(
-        "/!\\ Packagers ! This app is using the legacy permission system. Please use the new helpers ynh_permission_{create,url,update,delete} and the 'visitors' group to manage permissions."
-    )
-
+    
     output = {}
     for app in apps:
         permission = user_permission_reset(app + ".main")
@@ -1447,9 +1435,6 @@ def app_setting(app, key, value=None, delete=False):
 
         # SET
         else:
-            logger.warning(
-                "/!\\ Packagers! This app is still using the skipped/protected/unprotected_uris/regex settings which are now obsolete and deprecated... Instead, you should use the new helpers 'ynh_permission_{create,urls,update,delete}' and the 'visitors' group to initialize the public/private access. Check out the documentation at the bottom of yunohost.org/groups_and_permissions to learn how to use the new permission mechanism."
-            )
 
             urls = value
             # If the request is about the root of the app (/), ( = the vast majority of cases)


### PR DESCRIPTION
## The problem

Some end users received warning dedicated to packagers.

## Solution

Remove it. 
Those warnings are in linter
 - [x] skipped https://github.com/YunoHost/package_linter/blob/master/package_linter.py#L1472
 - [x] yunohost app XXXaccess https://github.com/YunoHost/package_linter/blob/master/package_linter.py#L1437

## PR Status


## How to test

...
