### PR TITLE
Set YNH_APP_BASEDIR as an absolute path

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-YNH_APP_BASEDIR=$([[ "$(basename $0)" =~ ^backup|restore$ ]] && echo '../settings' || echo '..')
+YNH_APP_BASEDIR=$(realpath $([[ "$(basename $0)" =~ ^backup|restore$ ]] && echo '../settings' || echo '..'))
 
 # Handle script crashes / failures
 #


### PR DESCRIPTION
Ping @alexAubin :)
As a relative path that may lead to problems when ynh_setup_source is called after a `cd`.