### PR TITLE
[fix] Remove SPFB cause this dnsbl make false positive compared to we…

### DIFF
--- a/data/other/dnsbl_list.yml
+++ b/data/other/dnsbl_list.yml
@@ -164,12 +164,6 @@
   ipv4: false
   ipv6: true
   domain: false
-- name: SPFBL.net RBL 
-  dns_server: dnsbl.spfbl.net
-  website: https://spfbl.net/en/dnsbl/
-  ipv4: true
-  ipv6: true
-  domain: true
 - name: Suomispam Blacklist 
   dns_server: bl.suomispam.net 
   website: http://suomispam.net/ 


### PR DESCRIPTION
…b version !

## The problem
```
A user on chat: THANK You!! you have no idea how many times i re-read that line.
Diagnosis is all green except for 1 issue in the Email section...        Your IP or domain 192.64.116.184 is blacklisted on SPFBL.net RBL
After identifying why you are listed and fixed it, feel free to ask for your IP or domaine to be removed on https://spfbl.net/en/dnsbl/
DNSBL – SPFBL.net
Descubra aqui mais detalhes sobre a primeira DNSBL brasileira. Find out more details about the first Brazilian DNSBL.
Occasionally the diagnosis provides a link:  https://matrix.spfbl.net/192.64.116.184
DNSBL check page
New query Check result of IP 192.64.116.184 Found an email server running at this address: < multiadventures.ca > service's FQDN. This email server is currently clean.
To my noob eyes...when I click that link and see... "This email server is currently clean." is a good sign?
```
## Solution

Remove spfbl

## PR Status

Ready

## How to test

...
