### PR TITLE
[fix] Diagnosis dns query taking an awful amount of time because of timeout

### DIFF
--- a/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/data/templates/dnsmasq/plain/resolv.dnsmasq.conf
@@ -23,11 +23,6 @@ nameserver 185.233.100.100
 nameserver 2a0c:e300::100
 nameserver 185.233.100.101
 nameserver 2a0c:e300::101
-# (FR) gozmail / grifon
-nameserver 80.67.190.200
-nameserver 2a00:5884:8218::1
-# (DE) FoeBud / Digital Courage
-nameserver 85.214.20.141
 # (DE) CCC Berlin
 nameserver 195.160.173.53
 # (DE) AS250

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -176,7 +176,7 @@ def dig(
     # In diagnosis dnsrecords, with 10 domains this means at least 12min, too long.
     resolver.timeout = 1.0
     # resolver.lifetime is the timeout for resolver.query()
-    # By default set it to 7 seconds to allow 6 resolvers to be unreachable.
+    # By default set it to 5 seconds to allow 4 resolvers to be unreachable.
     resolver.lifetime = timeout
     try:
         answers = resolver.query(qname, rdtype)

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -169,7 +169,15 @@ def dig(
     resolver = dns.resolver.Resolver(configure=False)
     resolver.use_edns(0, 0, edns_size)
     resolver.nameservers = resolvers
-    resolver.timeout = timeout
+    # resolver.timeout is used to trigger the next DNS query on resolvers list.
+    # In python-dns 1.16, this value is set to 2.0. However, this means that if
+    # the 3 first dns resolvers in list are down, we wait 6 seconds before to
+    # run the DNS query to a DNS resolvers up...
+    # In diagnosis dnsrecords, with 10 domains this means at least 12min, too long.
+    resolver.timeout = 1.0
+    # resolver.lifetime is the timeout for resolver.query()
+    # By default set it to 7 seconds to allow 6 resolvers to be unreachable.
+    resolver.lifetime = timeout
     try:
         answers = resolver.query(qname, rdtype)
     except (


### PR DESCRIPTION
## The problem

With 10 domains, and if shuffle of dns query put some down DNS resolver, we could wait diagnosis too much.

## Solution

We have used resolver.timeout instead of resolver.lifetime...
https://www.dnspython.org/docs/1.16.0/dns.resolver-pysrc.html

Remove some "blinker" resolvers.

## PR Status

Ready

## How to test

...
