### PR TITLE
[fix] manpage generation

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -403,7 +403,7 @@ user:
                             help: The key to be added
                         -c:
                             full: --comment
-                            help: Optionnal comment about the key
+                            help: Optional comment about the key
 
                 ### user_ssh_keys_remove()
                 remove-key:

--- a/doc/manpage.template
+++ b/doc/manpage.template
@@ -93,7 +93,7 @@ usage: yunohost {{ name }} {{ '{' }}{{ ",".join(value["actions"].keys()) }}{{ '}
 {# each subcategory #}
 {% for subcategory_name, subcategory in value.get("subcategories", {}).items() %}
 {% for action, action_value in subcategory["actions"].items() %}
-.SS "yunohost {{ subcategory_name }} {{ name }} {{ action }} \
+.SS "yunohost {{ name }} {{ subcategory_name }} {{ action }} \
 {% for argument_name, argument_value in action_value.get("arguments", {}).items() %}\
 {% set required=(not str(argument_name).startswith("-")) or argument_value.get("extra", {}).get("required", False) %}\
 {% if not required %}[{% endif %}\


### PR DESCRIPTION
https://forum.yunohost.org/t/yunohost-manpage-misplaced-subcategory/15986

When looking at the yunohost manpage (v4.2.4), the subcategories are placed before the name of the command… This solves the issue for me.