### PR TITLE
allow cert installation when failing diagnostics are ignored

### DIFF
--- a/src/yunohost/certificate.py
+++ b/src/yunohost/certificate.py
@@ -881,13 +881,13 @@ def _check_domain_is_ready_for_ACME(domain):
     if not dnsrecords.get("status") in [
         "SUCCESS",
         "WARNING",
-    ]:  # Warning is for missing IPv6 record which ain't critical for ACME
+    ] and not dnsrecords.get("ignored"):  # Warning is for missing IPv6 record which ain't critical for ACME
         raise YunohostValidationError(
             "certmanager_domain_dns_ip_differs_from_public_ip", domain=domain
         )
 
     # Check if domain seems to be accessible through HTTP?
-    if not httpreachable.get("status") == "SUCCESS":
+    if not httpreachable.get("status") == "SUCCESS" and not dnsrecords.get("ignored"):
         raise YunohostValidationError(
             "certmanager_domain_http_not_working", domain=domain
         )

--- a/src/yunohost/diagnosis.py
+++ b/src/yunohost/diagnosis.py
@@ -465,9 +465,9 @@ class Diagnoser:
         new_report = {"id": self.id_, "cached_for": self.cache_duration, "items": items}
 
         self.logger_debug("Updating cache %s" % self.cache_file)
-        self.write_cache(new_report)
         Diagnoser.i18n(new_report)
         add_ignore_flag_to_issues(new_report)
+        self.write_cache(new_report)
 
         errors = [
             item


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1813

## Solution

- include `ignored` state in diagnosis cache
- check the `ignored` state when deciding whether to throw an error in cert creation

## PR Status

ready for review

## How to test

see linked issue for reproduction steps.
