### PR TITLE
Apply realpath to find mounted points to unmount

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2658,7 +2658,7 @@ def _recursive_umount(directory):
     points_to_umount = [
         line.split(" ")[2]
         for line in mount_lines
-        if len(line) >= 3 and line.split(" ")[2].startswith(directory)
+        if len(line) >= 3 and line.split(" ")[2].startswith(os.path.realpath(directory))
     ]
 
     everything_went_fine = True


### PR DESCRIPTION


## The problem
Bindings created by some backup methods appears with their 'real' path in /etc/mtab, that may differ from the original /home/yunohost.backup/tmp/auto_xxx that is passed to _recursive_umount().

Traced as https://github.com/YunoHost/issues/issues/1809#issue-899123573

## Solution
This fix applies realpath to the 'directory' parameter passed to _recursive_umount().
Tested OK on my own instance, where backups with Borg were failing (except the first one after a reboot) because of this issue (it was unable to clean temporary dir).



