### PR TITLE
Tweak ynh_systemd_action message : echo -n is pointless

### DIFF
--- a/data/helpers.d/systemd
+++ b/data/helpers.d/systemd
@@ -145,11 +145,8 @@ ynh_systemd_action() {
                 ynh_print_info --message="The service $service_name has correctly executed the action ${action}."
                 break
             fi
-            if [ $i -eq 3 ]; then
-                echo -n "Please wait, the service $service_name is ${action}ing" >&2
-            fi
-            if [ $i -ge 3 ]; then
-                echo -n "." >&2
+            if [ $i -eq 30 ]; then
+                echo "(this may take some time)" >&2
             fi
             sleep 1
         done


### PR DESCRIPTION
## The problem

systemd action helper supposedly displays a message to warn that `the service xxx is starting` with a bunch of dots at the end as the script waits for the operation to finish or timeout

Except it's using `echo -n`, which doesn't flush the output and doesn't interface properly with the way Yunohost handle messages, thus the message is only displayed *after* the completion/timeout, which is pointless

## Solution

Just display a "this is gonna take some time" message when we reach 30 sec

## PR Status

Yolocommited

## How to test

Idk start a service that doesn't really start
