### PR TITLE
[enh] Accept attachment of 25MB instead of 21,8MB

### DIFF
--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -91,7 +91,7 @@ inet_interfaces = all
 
 #### Fit to the maximum message size to 25mb, more than allowed by GMail or Yahoo ####
 # /!\ This size is the size of the attachment in base64. 
-# Base64_SIZE = ORIGINAL_SIZE * 1,37 *1024*1024 + 980
+# BASE64_SIZE_IN_BYTE = ORIGINAL_SIZE_IN_MEGABYTE * 1,37 *1024*1024 + 980
 # See https://serverfault.com/questions/346895/postfix-mail-size-counting
 message_size_limit = 35914708
 

--- a/data/templates/postfix/main.cf
+++ b/data/templates/postfix/main.cf
@@ -89,8 +89,11 @@ mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = all
 
-#### Fit to the maximum message size to 30mb, more than allowed by GMail or Yahoo ####
-message_size_limit = 31457280
+#### Fit to the maximum message size to 25mb, more than allowed by GMail or Yahoo ####
+# /!\ This size is the size of the attachment in base64. 
+# Base64_SIZE = ORIGINAL_SIZE * 1,37 *1024*1024 + 980
+# See https://serverfault.com/questions/346895/postfix-mail-size-counting
+message_size_limit = 35914708
 
 # Virtual Domains Control
 virtual_mailbox_domains = ldap:/etc/postfix/ldap-domains.cf


### PR DESCRIPTION
## The problem

YunoHost refuses email attachment bigger than 21,8MB

## Solution

Take into account the base64 transformation

## PR Status

Ready

## How to test

Send an email with a 24MB attachment
