### PR TITLE
[DRAFT] make IP.YUNOHOST.ORG redundant

### DIFF
--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -6,6 +6,9 @@ set -e
 do_pre_regen() {
   pending_dir=$1
 
+  declare -a ip_yuno=(ip.yunohost.org 0-ip.yunohost.org)
+  declare -a ip_yuno6=(ip.yunohost.org 0-ip6.yunohost.org)
+
   cd /usr/share/yunohost/templates/dnsmasq
 
   # create directory for pending conf
@@ -22,10 +25,30 @@ do_pre_regen() {
   cat plain/resolv.dnsmasq.conf | grep "^nameserver" | shuf > ${pending_dir}/etc/resolv.dnsmasq.conf
 
   # retrieve variables
-  ipv4=$(curl -s -4 https://ip.yunohost.org 2>/dev/null || true)
-  ynh_validate_ip4 "$ipv4" || ipv4='127.0.0.1'
-  ipv6=$(curl -s -6 https://ip6.yunohost.org 2>/dev/null || true)
-  ynh_validate_ip6 "$ipv6" || ipv6=''
+  # Retrieve status first and then connect
+
+  ###### IPV4 #######
+
+  trouve=0
+  for i in "${!ip_yuno[@]}" ; do
+    if [ $(curl --connect-timeout 5 -o -I -L -s -w "%{http_code}" "${ip_yuno[$i]}" 2> /dev/null) -eq 200 ] && [ $trouve -ne 0 ]; then
+      ipv4=$(curl -s -4 "${ip_yuno[$i]}" 2>/dev/null || true)
+      ynh_validate_ip4 "$ipv4" || ipv4='127.0.0.1'
+      trouve=1
+    fi
+  done
+
+  ###### IPV6 #######
+
+  trouve=0
+
+  for i in "${!ip_yuno6[@]}" ; do
+    if [ $(curl --connect-timeout 5 -o -I -L -s -w "%{http_code}" "${ip6_yuno[$i]}" 2> /dev/null) -eq 200 ] && [ $trouve -ne 0 ]; then
+      ipv6=$(curl -s -6 "${ip_yuno6[$i]}" 2>/dev/null || true)
+      ynh_validate_ip6 "$ipv6" || ipv6=''
+      trouve=1
+    fi
+  done
 
   export ipv4
   export ipv6

--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -7,7 +7,7 @@ do_pre_regen() {
   pending_dir=$1
 
   declare -a ip_yuno=(ip.yunohost.org 0-ip.yunohost.org)
-  declare -a ip_yuno6=(ip.yunohost.org 0-ip6.yunohost.org)
+  declare -a ip_yuno6=(ip6.yunohost.org 0-ip6.yunohost.org)
 
   cd /usr/share/yunohost/templates/dnsmasq
 

--- a/data/hooks/diagnosis/10-ip.py
+++ b/data/hooks/diagnosis/10-ip.py
@@ -204,7 +204,7 @@ class IPDiagnoser(Diagnoser):
 
     def get_public_ip(self, protocol=4):
 
-        # FIXME - TODO : here we assume that DNS resolution for ip.yunohost.org is working
+        # FIXME - TODO : The best would be to make it configurable
         # but if we want to be able to diagnose DNS resolution issues independently from
         # internet connectivity, we gotta rely on fixed IPs first....
 
@@ -215,15 +215,19 @@ class IPDiagnoser(Diagnoser):
             protocol
         )
 
-        url = "https://ip%s.yunohost.org" % ("6" if protocol == 6 else "")
+        ip_url_yunohost_tab = ["https://ip%s.yunohost.org" % (protocol if protocol != 4 else ""), "https://0-ip%s.yunohost.org" % (protocol if protocol != 4 else "")]
 
-        try:
-            return download_text(url, timeout=30).strip()
-        except Exception as e:
-            self.logger_debug(
-                "Could not get public IPv%s : %s" % (str(protocol), str(e))
-            )
-            return None
+        # Check URLS
+        for url in ip_url_yunohost_tab:
+            try:
+                return download_text(url, timeout=10).strip()
+            except Exception as e:
+                self.logger_debug(
+                    "Could not get public IPv%s from %s : %s" % (str(protocol), url, str(e))
+                )
+
+        return None
+
 
 
 def main(args, env, loggers):

--- a/src/yunohost/utils/network.py
+++ b/src/yunohost/utils/network.py
@@ -54,7 +54,7 @@ def get_public_ip(protocol=4):
 
 
 def get_public_ip_from_remote_server(protocol=4):
-    """Retrieve the public IP address from ip.yunohost.org"""
+    """Retrieve the public IP address from ip.yunohost.org or another Server"""
 
     # We can know that ipv6 is not available directly if this file does not exists
     if protocol == 6 and not os.path.exists("/proc/net/if_inet6"):
@@ -82,14 +82,19 @@ def get_public_ip_from_remote_server(protocol=4):
         )
         return None
 
-    url = "https://ip%s.yunohost.org" % (protocol if protocol != 4 else "")
-    logger.debug("Fetching IP from %s " % url)
+    ip_url_yunohost_tab = ["https://ip%s.yunohost.org" % (protocol if protocol != 4 else ""), "https://0-ip%s.yunohost.org" % (protocol if protocol != 4 else "")]
 
-    try:
-        return download_text(url, timeout=30).strip()
-    except Exception as e:
-        logger.debug("Could not get public IPv%s : %s" % (str(protocol), str(e)))
-        return None
+    # Check URLS
+    for url in ip_url_yunohost_tab:
+        logger.debug("Fetching IP from %s " % url)
+        try:
+            return download_text(url, timeout=30).strip()
+        except Exception as e:
+            self.logger_debug(
+                "Could not get public IPv%s from %s : %s" % (str(protocol), url, str(e))
+            )
+
+    return None
 
 
 def get_network_interfaces():


### PR DESCRIPTION
## The problem

If ip.yunohost.org is down, ip verification failed for all servers.

## Solution

Host different instances of ip.yunohost.org and make it redundant.

## PR Status

DRAFT

## How to test

...

## Prerequisites
0-ip.yunohost.org and 0-ip6.yunohost.org exist.
