### PR TITLE
ci triggered only on file changed

### DIFF
--- a/.gitlab/ci/test.gitlab-ci.yml
+++ b/.gitlab/ci/test.gitlab-ci.yml
@@ -58,69 +58,105 @@ test-helpers:
   script:
     - cd tests
     - bash test_helpers.sh
+  only:
+    changes:
+      - data/helpers.d/*
 
 test-apps:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_apps.py
+  only:
+    changes:
+      - src/yunohost/app.py
 
 test-appscatalog:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_appscatalog.py
+  only:
+    changes:
+      - src/yunohost/app.py
 
 test-appurl:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_appurl.py
+  only:
+    changes:
+      - src/yunohost/app.py
 
 test-apps-arguments-parsing:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_apps_arguments_parsing.py
-
-test-backuprestore:
-  extends: .test-stage
-  script:
-    - cd src/yunohost
-    - python3 -m pytest tests/test_backuprestore.py
+  only:
+    changes:
+      - src/yunohost/app.py
 
 test-changeurl:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_changeurl.py
+  only:
+    changes:
+      - src/yunohost/app.py
+
+test-backuprestore:
+  extends: .test-stage
+  script:
+    - cd src/yunohost
+    - python3 -m pytest tests/test_backuprestore.py
+  only:
+    changes:
+      - src/yunohost/backup.py
 
 test-permission:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_permission.py
+  only:
+    changes:
+      - src/yunohost/permission.py
 
 test-settings:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_settings.py
+  only:
+    changes:
+      - src/yunohost/settings.py
 
 test-user-group:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_user-group.py
-    
+  only:
+    changes:
+      - src/yunohost/user.py
+
 test-regenconf:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_regenconf.py
+  only:
+    changes:
+      - src/yunohost/regenconf.py
 
 test-service:
   extends: .test-stage
   script:
     - cd src/yunohost
     - python3 -m pytest tests/test_service.py
+  only:
+    changes:
+      - src/yunohost/service.py


### PR DESCRIPTION
## The problem

The pipeline is slow. We could simply trigger jobs when the files involved change to speed it up.

## Solution

We could simply trigger jobs when the files involved change to speed it up. Keep `root-tests` and `full-tests` running all the time

Doc: https://docs.gitlab.com/ee/ci/yaml/#only--except
To be merged before https://github.com/YunoHost/yunohost/pull/1249

## PR Status

...

## How to test

...
