### PR TITLE
Move some tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
   - tests
   - lint
   - doc
+  - translation
 
 default:
   tags:

--- a/.gitlab/ci/test.gitlab-ci.yml
+++ b/.gitlab/ci/test.gitlab-ci.yml
@@ -58,7 +58,7 @@ test-i18n-keys:
     changes:
       - locales/*
 
-test-i18n-keys:
+test-translation-format-consistency:
   extends: .test-stage
   script:
     - python3 -m pytest tests tests/test_translation_format_consistency.py

--- a/.gitlab/ci/test.gitlab-ci.yml
+++ b/.gitlab/ci/test.gitlab-ci.yml
@@ -50,10 +50,29 @@ full-tests:
     reports:
       junit: report.xml
 
-root-tests:
+test-i18n-keys:
   extends: .test-stage
   script:
-    - python3 -m pytest tests
+    - python3 -m pytest tests tests/test_i18n_keys.py
+  only:
+    changes:
+      - locales/*
+
+test-i18n-keys:
+  extends: .test-stage
+  script:
+    - python3 -m pytest tests tests/test_translation_format_consistency.py
+  only:
+    changes:
+      - locales/*
+
+test-actionmap:
+  extends: .test-stage
+  script:
+    - python3 -m pytest tests tests/test_actionmap.py
+  only:
+    changes:
+      - data/actionsmap/*.yml
 
 test-helpers:
   extends: .test-stage

--- a/.gitlab/ci/test.gitlab-ci.yml
+++ b/.gitlab/ci/test.gitlab-ci.yml
@@ -37,6 +37,8 @@ full-tests:
     - yunohost tools postinstall -d domain.tld -p the_password --ignore-dyndns --force-diskspace
   script:
     - python3 -m pytest --cov=yunohost tests/ src/yunohost/tests/ --junitxml=report.xml
+    - cd tests
+    - bash test_helpers.sh
   needs:
       - job: build-yunohost
         artifacts: true

--- a/.gitlab/ci/translation.gitlab-ci.yml
+++ b/.gitlab/ci/translation.gitlab-ci.yml
@@ -1,0 +1,24 @@
+########################################
+# TRANSLATION
+########################################
+
+remove-stale-translated-strings:
+  stage: translation
+  image: "before-install"
+  needs: []
+  before_script:
+    - apt-get update -y && apt-get install git hub -y
+    - git config --global user.email "yunohost@yunohost.org"
+    - git config --global user.name "$GITHUB_USER"
+  script:
+    - cd tests # Maybe move this script location to another folder?
+    # create a local branch that will overwrite distant one
+    - git checkout -b "ci-remove-stale-translated-strings-${CI_COMMIT_REF_NAME}" --no-track
+    - python remove_stale_translated_strings.py
+    - '[ $(git diff | wc -l) != 0 ] || exit 0'  # stop if there is nothing to commit
+    - git commit -am "[CI] Remove stale translated strings" || true
+    - git push -f origin "ci-remove-stale-translated-strings-${CI_COMMIT_REF_NAME}":"ci-remove-stale-translated-strings-${CI_COMMIT_REF_NAME}"
+    - hub pull-request -m "[CI] Remove stale translated strings" -b Yunohost:dev -p || true # GITHUB_USER and GITHUB_TOKEN registered here https://gitlab.com/yunohost/yunohost/-/settings/ci_cd
+  only:
+    changes:
+      - locales/*


### PR DESCRIPTION
## Solution

- run the translation stage + tests on the translation keys only when the locale files have changed
- automatically run `remove_stale_translated_strings.py` (should we move this script to the `locales` folder?)
- split root-tests
- run test_helpers in full-tests

## PR Status

...

## How to test

...
