### PR TITLE
[Enh]Multimedia helper: check home folder

### DIFF
--- a/data/helpers.d/multimedia
+++ b/data/helpers.d/multimedia
@@ -32,8 +32,9 @@ ynh_multimedia_build_main_dir() {
         ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
         # Création du lien symbolique dans le home de l'utilisateur.
         #link will only be created if the home directory of the user exists and if it's located in '/home' folder
-        if [[ -d "$(getent passwd $user | cut -d: -f6)" && "$(getent passwd $user | cut -d: -f6 | grep home)" ]]; then
-            ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+        home="$(getent passwd $user | cut -d: -f6)"
+        if [[ -d "$home" && "$(echo "$home" | grep home)" ]]; then
+            ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
         fi
         # Propriétaires des dossiers utilisateurs.
         chown -R $user "$MEDIA_DIRECTORY/$user"

--- a/data/helpers.d/multimedia
+++ b/data/helpers.d/multimedia
@@ -31,7 +31,10 @@ ynh_multimedia_build_main_dir() {
         mkdir -p "$MEDIA_DIRECTORY/$user/eBook"
         ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
         # Création du lien symbolique dans le home de l'utilisateur.
-        ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+        #link will only be created if the home directory of the user exists and if it's located in '/home' folder
+        if [[ -d "$(getent passwd $user | cut -d: -f6)" && "$(getent passwd $user | cut -d: -f6 | grep home)" ]]; then
+            ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+        fi
         # Propriétaires des dossiers utilisateurs.
         chown -R $user "$MEDIA_DIRECTORY/$user"
     done

--- a/data/helpers.d/multimedia
+++ b/data/helpers.d/multimedia
@@ -32,9 +32,9 @@ ynh_multimedia_build_main_dir() {
         ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
         # Création du lien symbolique dans le home de l'utilisateur.
         #link will only be created if the home directory of the user exists and if it's located in '/home' folder
-        home="$(getent passwd $user | cut -d: -f6)"
-        if [[ -d "$home" && "$(echo "$home" | grep /home/)" ]]; then
-            ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
+        local user_home="$(getent passwd $user | cut -d: -f6 | grep '^/home/')"
+        if [[ -d "$user_home" ]]; then
+            ln -sfn "$MEDIA_DIRECTORY/$user" "$user_home/Multimedia"
         fi
         # Propriétaires des dossiers utilisateurs.
         chown -R $user "$MEDIA_DIRECTORY/$user"

--- a/data/helpers.d/multimedia
+++ b/data/helpers.d/multimedia
@@ -33,7 +33,7 @@ ynh_multimedia_build_main_dir() {
         # Création du lien symbolique dans le home de l'utilisateur.
         #link will only be created if the home directory of the user exists and if it's located in '/home' folder
         home="$(getent passwd $user | cut -d: -f6)"
-        if [[ -d "$home" && "$(echo "$home" | grep home)" ]]; then
+        if [[ -d "$home" && "$(echo "$home" | grep /home/)" ]]; then
             ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
         fi
         # Propriétaires des dossiers utilisateurs.

--- a/data/hooks/post_user_create/ynh_multimedia
+++ b/data/hooks/post_user_create/ynh_multimedia
@@ -17,7 +17,7 @@ ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
 # Création du lien symbolique dans le home de l'utilisateur.
 #link will only be created if the home directory of the user exists and if it's located in '/home' folder
 home="$(getent passwd $user | cut -d: -f6)"
-if [[ -d "$home" && "$(echo "$home" | grep home)" ]]; then
+if [[ -d "$home" && "$(echo "$home" | grep /home/)" ]]; then
     ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
 fi
 # Propriétaires des dossiers utilisateurs.

--- a/data/hooks/post_user_create/ynh_multimedia
+++ b/data/hooks/post_user_create/ynh_multimedia
@@ -15,7 +15,11 @@ mkdir -p "$MEDIA_DIRECTORY/$user/Video"
 mkdir -p "$MEDIA_DIRECTORY/$user/eBook"
 ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
 # Création du lien symbolique dans le home de l'utilisateur.
-ln -sfn "$MEDIA_DIRECTORY/$user" "/home/$user/Multimedia"
+#link will only be created if the home directory of the user exists and if it's located in '/home' folder
+home="$(getent passwd $user | cut -d: -f6)"
+if [[ -d "$home" && "$(echo "$home" | grep home)" ]]; then
+    ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
+fi
 # Propriétaires des dossiers utilisateurs.
 chown -R $user "$MEDIA_DIRECTORY/$user"
 

--- a/data/hooks/post_user_create/ynh_multimedia
+++ b/data/hooks/post_user_create/ynh_multimedia
@@ -16,9 +16,9 @@ mkdir -p "$MEDIA_DIRECTORY/$user/eBook"
 ln -sfn "$MEDIA_DIRECTORY/share" "$MEDIA_DIRECTORY/$user/Share"
 # Création du lien symbolique dans le home de l'utilisateur.
 #link will only be created if the home directory of the user exists and if it's located in '/home' folder
-home="$(getent passwd $user | cut -d: -f6)"
-if [[ -d "$home" && "$(echo "$home" | grep /home/)" ]]; then
-    ln -sfn "$MEDIA_DIRECTORY/$user" "$home/Multimedia"
+local user_home="$(getent passwd $user | cut -d: -f6 | grep '^/home/')"
+if [[ -d "$user_home" ]]; then
+    ln -sfn "$MEDIA_DIRECTORY/$user" "$user_home/Multimedia"
 fi
 # Propriétaires des dossiers utilisateurs.
 chown -R $user "$MEDIA_DIRECTORY/$user"


### PR DESCRIPTION
## The problem
When multimedia helpers create symbolic link to home folder of a user, it does not check if the user indeed has a home folder, which gives [this problem](https://forum.yunohost.org/t/calibre-web-manage-your-ebooks/6499/94) in case there is not and fail install/upgrade script.

## Solution
add a check in the helper and in the post_user_create hook that will:
1/check that the folder used as home in /etc/passwd exists
2/ check that this folder is located in /home/ folder
In this case, symbolic link is created, otherwise, only folders located in /home/yunohost.multimedia/$user are created/
...

## PR Status
Well, I tested it locally to check if helpers and hooks still works, and it seems that yes... I don't know what else to do?

