### PR TITLE
[fix] set .ssh folder permissions to 600

### DIFF
--- a/src/yunohost/ssh.py
+++ b/src/yunohost/ssh.py
@@ -64,6 +64,7 @@ def user_ssh_add_key(username, key, comment):
             parents=True,
             uid=user["uid"][0],
         )
+        chmod(os.path.join(user["homeDirectory"][0], ".ssh"), 0o600)
 
         # create empty file to set good permissions
         write_to_file(authorized_keys_file, "")


### PR DESCRIPTION
## The problem

`.ssh/` is created with `777` and break publickey authentication.

Fix YunoHost/issues#1770

## Solution

Set permissions to 600.

I use `chmod()` instead of setting `mode=0o600` in `mkdir()` in hope this will magically fix someone's folder.

## PR Status

Tested with ynh-dev. :ok_hand:

## How to test

Use `yunohost user ssh add-key`
