### PR TITLE
[fix] Better support for non latin domain name

### DIFF
--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -115,6 +115,9 @@ def domain_add(operation_logger, domain, dyndns=False):
     # See: https://forum.yunohost.org/t/invalid-domain-causes-diagnosis-web-to-fail-fr-on-demand/11765
     domain = domain.lower()
 
+    # Non-latin characters (e.g. café.com => xn--caf-dma.com)
+    domain = domain.encode('idna').decode('utf-8')
+
     # DynDNS domain
     if dyndns:
 


### PR DESCRIPTION
## The problem

https://yunohost.org/en/administrate/overview/domains#non-latin-characters

## Solution

Add an automatic conversion.
Here i do it just on add action. It could be made on all action with a domain argument AND reconvert the domain when it is displayed, however i think this PR is a minimal fix for this issue.

## PR Status

Tested in ynh-dev by adding domain café.com via cli.
Waiting automated test


## How to test

...
