### PR TITLE
[enh] Add settings to block webadmin from outside

### DIFF
--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -83,6 +83,13 @@ do_pre_regen() {
 
   done
 
+  export webadmin_allowlist_enabled=$(yunohost settings get security.webadmin.allowlist.enabled)
+  if [ "$webadmin_allowlist_enabled" == "True" ]
+  then
+    export webadmin_allowlist=$(yunohost settings get security.webadmin.allowlist)
+  fi
+  ynh_render_template "yunohost_admin.conf.inc" "${nginx_conf_dir}/yunohost_admin.conf.inc"
+  ynh_render_template "yunohost_api.conf.inc" "${nginx_conf_dir}/yunohost_api.conf.inc"
   ynh_render_template "yunohost_admin.conf" "${nginx_conf_dir}/yunohost_admin.conf"
   mkdir -p $nginx_conf_dir/default.d/
   cp "redirect_to_admin.conf" $nginx_conf_dir/default.d/

--- a/data/templates/nginx/yunohost_admin.conf.inc
+++ b/data/templates/nginx/yunohost_admin.conf.inc
@@ -6,6 +6,13 @@ location /yunohost/admin/ {
     default_type text/html;
     index index.html;
 
+    {% if webadmin_allowlist_enabled == "True" %}
+    {% for ip in webadmin_allowlist.split(',') %}
+    allow {{ ip }};
+    {% endfor %}
+    deny all;
+    {% endif %}
+
     more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; connect-src 'self' https://paste.yunohost.org wss://$host; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; object-src 'none'; img-src 'self' data:;";
     more_set_headers "Content-Security-Policy-Report-Only:";
 }

--- a/data/templates/nginx/yunohost_api.conf.inc
+++ b/data/templates/nginx/yunohost_api.conf.inc
@@ -6,6 +6,13 @@ location /yunohost/api/ {
     proxy_set_header Connection "upgrade";
     proxy_set_header Host $http_host;
 
+    {% if webadmin_allowlist_enabled == "True" %}
+    {% for ip in webadmin_allowlist.split(',') %}
+    allow {{ ip }};
+    {% endfor %}
+    deny all;
+    {% endif %}
+
     # Custom 502 error page
     error_page 502 /yunohost/api/error/502;
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -336,6 +336,8 @@
     "global_settings_setting_smtp_relay_port": "SMTP relay port",
     "global_settings_setting_smtp_relay_user": "SMTP relay user account",
     "global_settings_setting_smtp_relay_password": "SMTP relay host password",
+    "global_settings_setting_security_webadmin_allowlist_enabled": "Allow only some IPs to access the webadmin.",
+    "global_settings_setting_security_webadmin_allowlist": "IP adresses allowed to access the webadmin. Comma-separated.",
     "global_settings_setting_backup_compress_tar_archives": "When creating new backups, compress the archives (.tar.gz) instead of uncompressed archives (.tar). N.B. : enabling this option means create lighter backup archives, but the initial backup procedure will be significantly longer and heavy on CPU.",
     "global_settings_unknown_type": "Unexpected situation, the setting {setting:s} appears to have the type {unknown_type:s} but it is not a type supported by the system.",
     "good_practices_about_admin_password": "You are now about to define a new administration password. The password should be at least 8 characters long—though it is good practice to use a longer password (i.e. a passphrase) and/or to use a variation of characters (uppercase, lowercase, digits and special characters).",

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -100,6 +100,8 @@ DEFAULTS = OrderedDict(
         ("smtp.relay.password", {"type": "string", "default": ""}),
         ("backup.compress_tar_archives", {"type": "bool", "default": False}),
         ("ssowat.panel_overlay.enabled", {"type": "bool", "default": True}),
+        ("security.webadmin.allowlist.enabled", {"type": "bool", "default": False}),
+        ("security.webadmin.allowlist", {"type": "string", "default": ""}),
     ]
 )
 
@@ -391,6 +393,8 @@ def trigger_post_change_hook(setting_name, old_value, new_value):
 
 @post_change_hook("ssowat.panel_overlay.enabled")
 @post_change_hook("security.nginx.compatibility")
+@post_change_hook("security.webadmin.allowlist.enabled")
+@post_change_hook("security.webadmin.allowlist")
 def reconfigure_nginx(setting_name, old_value, new_value):
     if old_value != new_value:
         regen_conf(names=["nginx"])


### PR DESCRIPTION
## The problem

There's no way to allow webadmin access to some IP only.

https://github.com/YunoHost/issues/issues/1273

## Solution

This PR add settings to enable and set the allow-list. This setting modify nginx config (`yunohost_admin.conf.inc` and `yunohost_api.conf.inc` with regenconf.

The allow-list is a list of IP, coma separated.

## PR Status

Tested with ynh-dev and working :ok_hand:.

There's one thing I'm not happy with, when a user set the `security.webadmin.allowlist` with an incorrect value (`192.10.0.0.`), the nginx config is changed even if `nginx -t` fails.

I could add some regexp in `settings.py`, near the type checks, but I'm not really ok with this solution.

## How to test

Checkout this PR with ynh-dev and you can enable with :
```
yunohost settings set security.webadmin.allowlist -v True
yunohost settings set security.webadmin.allowlist -v "10.6.0.0/16,192.168.0.0/24"
```
Disable with 
```
yunohost settings set security.webadmin.allowlist -v True
```
