### PR TITLE
[fix] yunohost app search fail because of dictionary error

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -127,14 +127,15 @@ def app_search(string):
     catalog_of_apps = app_catalog()
 
     # Selecting apps according to a match in app name or description
+    matching_apps = {"apps": {}}
     for app in catalog_of_apps["apps"].items():
-        if not (
+        if (
             re.search(string, app[0], flags=re.IGNORECASE)
             or re.search(string, app[1]["description"], flags=re.IGNORECASE)
         ):
-            del catalog_of_apps["apps"][app[0]]
+            matching_apps["apps"][app[0]] = app[1]
 
-    return catalog_of_apps
+    return matching_apps
 
 
 # Old legacy function...


### PR DESCRIPTION
## The problem

The functionality brought by PR https://github.com/YunoHost/yunohost/pull/1070 is not working anymore since Python3 I think, because of an `RuntimeError: dictionary changed size during iteration` error.

## Solution

Use a new dictionary to store matching apps

## PR Status

Ready to review

## How to test

yunohost app search [string]
for example :
yunohost app search caldav
yunohost app search agendav
