### PR TITLE
[fix] App search : dictionary changed size

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -125,16 +125,14 @@ def app_search(string):
 
     # Retrieve a simple dict listing all apps
     catalog_of_apps = app_catalog()
-
+    result = {"apps": {}}
     # Selecting apps according to a match in app name or description
     for app in catalog_of_apps["apps"].items():
-        if not (
-            re.search(string, app[0], flags=re.IGNORECASE)
-            or re.search(string, app[1]["description"], flags=re.IGNORECASE)
-        ):
-            del catalog_of_apps["apps"][app[0]]
+        if re.search(string, app[0], flags=re.IGNORECASE) \
+           or re.search(string, app[1]["description"], flags=re.IGNORECASE):
+            result["apps"][app[0]] = app
 
-    return catalog_of_apps
+    return result
 
 
 # Old legacy function...


### PR DESCRIPTION
## The problem

```
root@pentesting:~# yunohost app search unattended
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 72, in <module>
    parser=parser
  File "/usr/lib/moulinette/yunohost/__init__.py", line 25, in cli
    ret = moulinette.cli(args, output_as=output_as, timeout=timeout, top_parser=parser)
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 120, in cli
    args, output_as=output_as, timeout=timeout
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 502, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 600, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/app.py", line 130, in app_search
    for app in catalog_of_apps["apps"].items():
RuntimeError: dictionary changed size during iteration
```

## Solution

Use an intermediate dico

## PR Status

Ready

## How to test

yunohost app search unattended
