### PR TITLE
[fix] Avoid to suspend server if we close lidswitch

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -135,6 +135,16 @@ Conflicts=yunohost-firewall.service
 ConditionFileIsExecutable=!/etc/init.d/yunohost-firewall
 ConditionPathExists=!/etc/systemd/system/multi-user.target.wants/yunohost-firewall.service
 EOF
+
+  # Don't suspend computer on LidSwitch
+  mkdir -p ${pending_dir}/etc/systemd/logind.conf.d/
+  cat > ${pending_dir}/etc/systemd/logind.conf.d/yunohost.conf << EOF
+[Login]
+HandleLidSwitch=ignore
+HandleLidSwitchDocked=ignore
+HandleLidSwitchExternalPower=ignore
+EOF
+
 }
 
 do_post_regen() {

--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -138,7 +138,7 @@ EOF
 
   # Don't suspend computer on LidSwitch
   mkdir -p ${pending_dir}/etc/systemd/logind.conf.d/
-  cat > ${pending_dir}/etc/systemd/logind.conf.d/yunohost.conf << EOF
+  cat > ${pending_dir}/etc/systemd/logind.conf.d/ynh-override.conf << EOF
 [Login]
 HandleLidSwitch=ignore
 HandleLidSwitchDocked=ignore


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/mettre-lecran-en-veille/14675/18

## Solution

...

## PR Status

This settings has been tested by bykepunk in /etc/systemd/logind.conf. The same in /etc/systemd/logind.conf.d has not been tested but documentation speak about it (don't know if [login] should be added!)



## How to test

...
