### PR TITLE
Force utf8 for char set in mysql database

### DIFF
--- a/data/helpers.d/mysql
+++ b/data/helpers.d/mysql
@@ -89,7 +89,7 @@ ynh_mysql_execute_file_as_root() {
 ynh_mysql_create_db() {
     local db=$1
 
-    local sql="CREATE DATABASE ${db};"
+    local sql="CREATE DATABASE ${db} CHARACTER SET = 'utf8';"
 
     # grant all privilegies to user
     if [[ $# -gt 1 ]]


### PR DESCRIPTION
Fix issue https://github.com/YunoHost-Apps/seafile_ynh/issues/77

## The problem

https://github.com/YunoHost-Apps/seafile_ynh/issues/77

## Solution

Force char set to UTF8

## PR Status

Not tested but hope that it might fix the issue

## How to test

...
