### PR TITLE
Composer without limit

### DIFF
--- a/data/helpers.d/php
+++ b/data/helpers.d/php
@@ -581,7 +581,7 @@ ynh_composer_exec () {
     workdir="${workdir:-$final_path}"
     phpversion="${phpversion:-$YNH_PHP_VERSION}"
 
-    COMPOSER_HOME="$workdir/.composer" \
+    COMPOSER_HOME="$workdir/.composer" COMPOSER_MEMORY_LIMIT=-1 \
         php${phpversion} "$workdir/composer.phar" $commands \
         -d "$workdir" --quiet --no-interaction
 }


### PR DESCRIPTION
## The problem

Sometime composer doesn't have enough memory:
- Fix https://github.com/YunoHost-Apps/pixelfed_ynh/issues/145
- https://forum.yunohost.org/t/installation-drupal-impossible/16683

## Solution

Increase memory limit: https://joshtronic.com/2020/05/25/increase-memory-list-for-composer/

## PR Status

Ready

## How to test

...
