### PR TITLE
Update mysql sort_buffer_size value

### DIFF
--- a/data/templates/mysql/my.cnf
+++ b/data/templates/mysql/my.cnf
@@ -30,7 +30,7 @@ skip-external-locking
 key_buffer_size = 16K
 max_allowed_packet = 16M
 table_open_cache = 4
-sort_buffer_size = 64K
+sort_buffer_size = 256K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K


### PR DESCRIPTION
Consider this PR more as a question...

## The problem

 Nextcloud v22.1.0 complains during install of not having enough `sort_buffer_size`

```
137239 INFO WARNING -   SQLSTATE[HY001]: Memory allocation error: 1038 Out of sort memory, consider
137239 INFO WARNING -    increasing server sort buffer size
```
https://ci-apps-dev.yunohost.org/ci/job/2624

## Solution

Increase mysql `sort_buffer_size` to 256k

## La citation

Puisque ces mystères nous dépassent, feignons d'en être l'organisateur.

jean Cocteau, *Les Mariés de la Tour Eiffel*