### PR TITLE
[fix] Avoid warning and use safeloader

### DIFF
--- a/data/actionsmap/yunohost_completion.py
+++ b/data/actionsmap/yunohost_completion.py
@@ -32,7 +32,7 @@ def get_dict_actions(OPTION_SUBTREE, category):
 with open(ACTIONSMAP_FILE, "r") as stream:
 
     # Getting the dictionary containning what actions are possible per category
-    OPTION_TREE = yaml.load(stream)
+    OPTION_TREE = yaml.safe_load(stream)
 
     CATEGORY = [
         category for category in OPTION_TREE.keys() if not category.startswith("_")

--- a/data/helpers.d/setting
+++ b/data/helpers.d/setting
@@ -86,7 +86,7 @@ key, value = os.environ['KEY'], os.environ.get('VALUE', None)
 setting_file = "/etc/yunohost/apps/%s/settings.yml" % app
 assert os.path.exists(setting_file), "Setting file %s does not exists ?" % setting_file
 with open(setting_file) as f:
-    settings = yaml.load(f)
+    settings = yaml.safe_load(f)
 if action == "get":
     if key in settings:
         print(settings[key])
@@ -96,7 +96,7 @@ else:
             del settings[key]
     elif action == "set":
         if key in ['redirected_urls', 'redirected_regex']:
-            value = yaml.load(value)
+            value = yaml.safe_load(value)
         settings[key] = value
     else:
         raise ValueError("action should either be get, set or delete")

--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -212,10 +212,10 @@ import yaml
 
 
 with open('services.yml') as f:
-    new_services = yaml.load(f)
+    new_services = yaml.safe_load(f)
 
 with open('/etc/yunohost/services.yml') as f:
-    services = yaml.load(f) or {}
+    services = yaml.safe_load(f) or {}
 
 updated = False
 

--- a/doc/generate_manpages.py
+++ b/doc/generate_manpages.py
@@ -26,14 +26,14 @@ ACTIONSMAP_FILE = os.path.join(THIS_SCRIPT_DIR, "../data/actionsmap/yunohost.yml
 
 
 def ordered_yaml_load(stream):
-    class OrderedLoader(yaml.Loader):
+    class OrderedLoader(yaml.SafeLoader):
         pass
 
     OrderedLoader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         lambda loader, node: OrderedDict(loader.construct_pairs(node)),
     )
-    return yaml.safe_load(stream, OrderedLoader)
+    return yaml.load(stream, OrderedLoader)
 
 
 def main():

--- a/doc/generate_manpages.py
+++ b/doc/generate_manpages.py
@@ -33,7 +33,7 @@ def ordered_yaml_load(stream):
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         lambda loader, node: OrderedDict(loader.construct_pairs(node)),
     )
-    return yaml.load(stream, OrderedLoader)
+    return yaml.safe_load(stream, OrderedLoader)
 
 
 def main():

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1518,7 +1518,7 @@ def app_setting(app, key, value=None, delete=False):
     # SET
     else:
         if key in ["redirected_urls", "redirected_regex"]:
-            value = yaml.load(value)
+            value = yaml.safe_load(value)
         app_settings[key] = value
 
     _set_app_settings(app, app_settings)
@@ -2175,7 +2175,7 @@ def _get_app_settings(app_id):
         )
     try:
         with open(os.path.join(APPS_SETTING_PATH, app_id, "settings.yml")) as f:
-            settings = yaml.load(f)
+            settings = yaml.safe_load(f)
         # If label contains unicode char, this may later trigger issues when building strings...
         # FIXME: this should be propagated to read_yaml so that this fix applies everywhere I think...
         settings = {k: v for k, v in settings.items()}

--- a/src/yunohost/firewall.py
+++ b/src/yunohost/firewall.py
@@ -179,7 +179,7 @@ def firewall_list(raw=False, by_ip_version=False, list_forwarded=False):
 
     """
     with open(FIREWALL_FILE) as f:
-        firewall = yaml.load(f)
+        firewall = yaml.safe_load(f)
     if raw:
         return firewall
 

--- a/src/yunohost/regenconf.py
+++ b/src/yunohost/regenconf.py
@@ -444,7 +444,7 @@ def _get_regenconf_infos():
     """
     try:
         with open(REGEN_CONF_FILE, "r") as f:
-            return yaml.load(f)
+            return yaml.safe_load(f)
     except Exception:
         return {}
 

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -670,7 +670,7 @@ def _get_services():
     """
     try:
         with open("/etc/yunohost/services.yml", "r") as f:
-            services = yaml.load(f) or {}
+            services = yaml.safe_load(f) or {}
     except Exception:
         return {}
 

--- a/tests/test_actionmap.py
+++ b/tests/test_actionmap.py
@@ -2,4 +2,4 @@ import yaml
 
 
 def test_yaml_syntax():
-    yaml.load(open("data/actionsmap/yunohost.yml"))
+    yaml.safe_load(open("data/actionsmap/yunohost.yml"))

--- a/tests/test_i18n_keys.py
+++ b/tests/test_i18n_keys.py
@@ -108,7 +108,7 @@ def find_expected_string_keys():
         yield m
 
     # Keys for the actionmap ...
-    for category in yaml.load(open("data/actionsmap/yunohost.yml")).values():
+    for category in yaml.safe_load(open("data/actionsmap/yunohost.yml")).values():
         if "actions" not in category.keys():
             continue
         for action in category["actions"].values():


### PR DESCRIPTION
## The problem
Cron flood my email since ??? with things like:
```
/usr/lib/moulinette/yunohost/service.py:673: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

## Solution

Even if our yaml are not really untrusted it could be safer to load these yaml with the SafeLoader.

I tried with BaseLoader however there are some important differences:
```
Python 3.6.9 (default, Jan 26 2021, 15:33:00) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import yaml
>>> yaml.safe_load("5.10")
5.1
>>> yaml.load("5.10", Loader=yaml.BaseLoader)
'5.10'
>>> yaml.load("5.10")
5.1
```

safe_load is a shortcut for `yaml.load("5.10", Loader=yaml.SafeLoader)`

## PR Status
Not yet tested

## How to test

...
