### PR TITLE
Trash ugly hack that merge services.yml every regenconf

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -2,8 +2,6 @@
 
 set -e
 
-services_path="/etc/yunohost/services.yml"
-
 do_init_regen() {
   if [[ $EUID -ne 0 ]]; then
     echo "You must be root to run this script" 1>&2
@@ -19,8 +17,6 @@ do_init_regen() {
     || echo "yunohost.org" > /etc/yunohost/current_host
 
   # copy default services and firewall
-  [[ -f $services_path ]] \
-    || cp services.yml "$services_path"
   [[ -f /etc/yunohost/firewall.yml ]] \
     || cp firewall.yml /etc/yunohost/firewall.yml
 
@@ -49,6 +45,9 @@ do_init_regen() {
   chmod 644 /etc/ssowat/conf.json.persistent
   chown root:root /etc/ssowat/conf.json.persistent
 
+  # Empty service conf
+  touch /etc/yunohost/services.yml
+
   mkdir -p /var/cache/yunohost/repo
   chown root:root /var/cache/yunohost
   chmod 700 /var/cache/yunohost
@@ -59,25 +58,9 @@ do_pre_regen() {
 
   cd /usr/share/yunohost/templates/yunohost
 
-  # update services.yml
-  if [[ -f $services_path ]]; then
-      tmp_services_path="${services_path}-tmp"
-      new_services_path="${services_path}-new"
-      cp "$services_path" "$tmp_services_path"
-      _update_services "$new_services_path" || {
-        mv "$tmp_services_path" "$services_path"
-        exit 1
-      }
-      if [[ -f $new_services_path ]]; then
-          # replace services.yml with new one
-          mv "$new_services_path" "$services_path"
-          mv "$tmp_services_path" "${services_path}-old"
-      else
-          rm -f "$tmp_services_path"
-      fi
-  else
-      cp services.yml /etc/yunohost/services.yml
-  fi
+  # Legacy code that can be removed once on bullseye
+  touch /etc/yunohost/services.yml
+  yunohost tools shell -c "from yunohost.service import _get_services, _save_services; _save_services(_get_services())"
 
   mkdir -p $pending_dir/etc/cron.d/
   mkdir -p $pending_dir/etc/cron.daily/
@@ -204,65 +187,6 @@ do_post_regen() {
   # Propagates changes in systemd service config overrides
   [[ ! "$regen_conf_files" =~ "ntp.service.d/ynh-override.conf" ]] || { systemctl daemon-reload; systemctl restart ntp; }
   [[ ! "$regen_conf_files" =~ "nftables.service.d/ynh-override.conf" ]] || systemctl daemon-reload
-}
-
-_update_services() {
-  python3 - << EOF
-import yaml
-
-
-with open('services.yml') as f:
-    new_services = yaml.safe_load(f)
-
-with open('/etc/yunohost/services.yml') as f:
-    services = yaml.safe_load(f) or {}
-
-updated = False
-
-
-for service, conf in new_services.items():
-    # remove service with empty conf
-    if conf is None:
-        if service in services:
-            print("removing '{0}' from services".format(service))
-            del services[service]
-            updated = True
-
-    # add new service
-    elif not services.get(service, None):
-        print("adding '{0}' to services".format(service))
-        services[service] = conf
-        updated = True
-
-    # update service conf
-    else:
-        conffiles = services[service].pop('conffiles', {})
-
-        # status need to be removed
-        if "status" not in conf and "status" in services[service]:
-            print("update '{0}' service status access".format(service))
-            del services[service]["status"]
-            updated = True
-
-        if services[service] != conf:
-            print("update '{0}' service".format(service))
-            services[service].update(conf)
-            updated = True
-
-        if conffiles:
-            services[service]['conffiles'] = conffiles
-
-        # Remove legacy /var/log/daemon.log and /var/log/syslog from log entries
-        # because they are too general. Instead, now the journalctl log is
-        # returned by default which is more relevant.
-        if "log" in services[service]:
-            if services[service]["log"] in ["/var/log/syslog", "/var/log/daemon.log"]:
-                del services[service]["log"]
-
-if updated:
-    with open('/etc/yunohost/services.yml-new', 'w') as f:
-        yaml.safe_dump(services, f, default_flow_style=False)
-EOF
 }
 
 FORCE=${2:-0}

--- a/src/yunohost/service.py
+++ b/src/yunohost/service.py
@@ -37,9 +37,12 @@ from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils.process import check_output
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import read_file, append_to_file, write_to_file
+from moulinette.utils.filesystem import read_file, append_to_file, write_to_file, read_yaml, write_to_yaml
 
 MOULINETTE_LOCK = "/var/run/moulinette_yunohost.lock"
+
+SERVICES_CONF = "/etc/yunohost/services.yml"
+SERVICES_CONF_BASE = "/usr/share/yunohost/templates/yunohost/services.yml"
 
 logger = getActionLogger("yunohost.service")
 
@@ -127,7 +130,8 @@ def service_add(
 
     try:
         _save_services(services)
-    except Exception:
+    except Exception as e:
+        logger.warning(e)
         # we'll get a logger.warning with more details in _save_services
         raise YunohostError("service_add_failed", service=name)
 
@@ -669,16 +673,18 @@ def _get_services():
 
     """
     try:
-        with open("/etc/yunohost/services.yml", "r") as f:
-            services = yaml.safe_load(f) or {}
+        services = read_yaml(SERVICES_CONF_BASE) or {}
+
+        # These are keys flagged 'null' in the base conf
+        legacy_keys_to_delete = [k for k, v in services.items() if v is None]
+
+        services.update(read_yaml(SERVICES_CONF) or {})
+
+        services = {name: infos
+                    for name, infos in services.items()
+                    if name not in legacy_keys_to_delete}
     except Exception:
         return {}
-
-    # some services are marked as None to remove them from YunoHost
-    # filter this
-    for key, value in list(services.items()):
-        if value is None:
-            del services[key]
 
     # Dirty hack to automatically find custom SSH port ...
     ssh_port_line = re.findall(
@@ -703,6 +709,13 @@ def _get_services():
             del services["postgresql"]["description"]
         services["postgresql"]["actual_systemd_service"] = "postgresql@11-main"
 
+    # Remove legacy /var/log/daemon.log and /var/log/syslog from log entries
+    # because they are too general. Instead, now the journalctl log is
+    # returned by default which is more relevant.
+    for infos in services.values():
+        if infos.get("log") in ["/var/log/syslog", "/var/log/daemon.log"]:
+            del infos["log"]
+
     return services
 
 
@@ -714,12 +727,26 @@ def _save_services(services):
         services -- A dict of managed services with their parameters
 
     """
-    try:
-        with open("/etc/yunohost/services.yml", "w") as f:
-            yaml.safe_dump(services, f, default_flow_style=False)
-    except Exception as e:
-        logger.warning("Error while saving services, exception: %s", e, exc_info=1)
-        raise
+
+    # Compute the diff with the base file
+    # such that /etc/yunohost/services.yml contains the minimal
+    # changes with respect to the base conf
+
+    conf_base = yaml.safe_load(open(SERVICES_CONF_BASE)) or {}
+
+    diff = {}
+
+    for service_name, service_infos in services.items():
+        service_conf_base = conf_base.get(service_name, {})
+        diff[service_name] = {}
+
+        for key, value in service_infos.items():
+            if service_conf_base.get(key) != value:
+                diff[service_name][key] = value
+
+    diff = {name: infos for name, infos in diff.items() if infos}
+
+    write_to_yaml(SERVICES_CONF, diff)
 
 
 def _tail(file, n):


### PR DESCRIPTION
## The problem

Not 100% sure why i'm doing this but I got triggered after seeing the ugly python-in-bash that merges the base service.yml in /etc/yunohost/service.yml

## Solution

Adopt the opposite strategy: /etc/yunohost/service.yml should only contain stuff that are specific to the instance

Therefore `_get_services()` read both /usr/share/yunohost/templates/yunohost/service.yml, and /etc/yunohost/services.yml, and merge these two

`_save_services()` computes the diff with respect to the base conf to only store the difference in /etc/yunohost/services.yml

Still require a small legacy code in the yunohost regenconf hook that can be removed after bullseye

## PR Status

Tested and working

## How to test

Run a yunohost regen conf and inspect the content of `/etc/yunohost/services.yml`

Validate that `yunohost service status` and `add/remove` still works properly
