### PR TITLE
Proof of concept for multiple-admins auth

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -481,7 +481,7 @@
     "migrations_to_be_ran_manually":  "Migration {id} has to be run manually. Please go to Tools → Migrations on the webadmin page, or run `yunohost tools migrations run`.",
     "not_enough_disk_space": "Not enough free space on '{path}'",
     "invalid_number": "Must be a number",
-    "invalid_password": "Invalid password",
+    "invalid_credentials": "Invalid credentials",
     "operation_interrupted": "The operation was manually interrupted?",
     "packages_upgrade_failed": "Could not upgrade all the packages",
     "password_listed": "This password is among the most used passwords in the world. Please choose something more unique.",

--- a/src/yunohost/authenticators/ldap_admin.py
+++ b/src/yunohost/authenticators/ldap_admin.py
@@ -9,34 +9,44 @@ import time
 from moulinette import m18n
 from moulinette.authentication import BaseAuthenticator
 from yunohost.utils.error import YunohostError
+from yunohost.utils.ldap import _get_ldap_interface
+
 
 logger = logging.getLogger("yunohost.authenticators.ldap_admin")
+
+LDAP_URI = "ldap://localhost:389"
+ADMIN_GROUP = "cn=admins,ou=groups,dc=yunohost,dc=org"
+AUTH_DN = "uid={uid},ou=users,dc=yunohost,dc=org"
 
 class Authenticator(BaseAuthenticator):
 
     name = "ldap_admin"
 
     def __init__(self, *args, **kwargs):
-        self.uri = "ldap://localhost:389"
-        self.basedn = "dc=yunohost,dc=org"
-        self.admindn = "cn=admin,dc=yunohost,dc=org"
+        pass
 
     def _authenticate_credentials(self, credentials=None):
 
-        # TODO : change authentication format
-        # to support another dn to support multi-admins
+        admins = _get_ldap_interface().search(ADMIN_GROUP, attrs=["memberUid"])[0]["memberUid"]
+
+        uid, password = credentials.split(":", 1)
+
+        if uid not in admins:
+            raise YunohostError("invalid_credentials")
+
+        dn = AUTH_DN.format(uid=uid)
 
         def _reconnect():
             con = ldap.ldapobject.ReconnectLDAPObject(
-                self.uri, retry_max=10, retry_delay=0.5
+                LDAP_URI, retry_max=10, retry_delay=0.5
             )
-            con.simple_bind_s(self.admindn, credentials)
+            con.simple_bind_s(dn, password)
             return con
 
         try:
             con = _reconnect()
         except ldap.INVALID_CREDENTIALS:
-            raise YunohostError("invalid_password")
+            raise YunohostError("invalid_credentials")
         except ldap.SERVER_DOWN:
             # ldap is down, attempt to restart it before really failing
             logger.warning(m18n.n("ldap_server_is_down_restart_it"))
@@ -56,9 +66,11 @@ class Authenticator(BaseAuthenticator):
             logger.warning("Error during ldap authentication process: %s", e)
             raise
         else:
-            if who != self.admindn:
-                raise YunohostError(f"Not logged with the appropriate identity ? Found {who}, expected {self.admindn} !?", raw_msg=True)
+            if who != dn:
+                raise YunohostError(f"Not logged with the appropriate identity ? Found {who}, expected {dn} !?", raw_msg=True)
         finally:
             # Free the connection, we don't really need it to keep it open as the point is only to check authentication...
             if con:
                 con.unbind_s()
+
+        return {"username": uid}

--- a/src/yunohost/user.py
+++ b/src/yunohost/user.py
@@ -46,6 +46,12 @@ logger = getActionLogger("yunohost.user")
 
 def user_list(fields=None):
 
+    from moulinette.interfaces.api import Session
+
+    print("Currently logged with:")
+    print(Session.get_infos())
+    print(Session.get_infos()["ldap_admin"]["username"])
+
     from yunohost.utils.ldap import _get_ldap_interface
 
     user_attrs = {


### PR DESCRIPTION
## The problem

Having a single is problematic for many reasons

Also we want to get rid of the weird "admin" special user because it creates confusion, etc

## Solution

Have an "admins" group containing multiple user

So far, this only demonstrates the ability to : 
- have multiple users being to authenticate on the admin/api
- accessing what's the current logged-in username (not super useful here, but useful for other projects such as the-future-portal/user-api-to-replace-part-of-ssowat)

Stuff not covered:
- ... everything else such as all the modifications in other pieces of code, and legacy migration

## PR Status

Tested and working, but much work still to be done

## How to test

- One has to first manually adds yunohost users to the `admins` group. From a yunohost shell: `ldap.update("cn=admins,ou=groups", {"memberUid": ["admin", "johndoe"]})`
- Then in the yunohost admin, login by putting in the password field : `johndoe:The_Actual_Password` (to be replaced later with two different input fields instead of this hack)
- Go to the user list to see the `print()` in `user_list()` demonstrating that we can access the currently logged in username