### PR TITLE
Add passwd to be obfuscated

### DIFF
--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -427,7 +427,7 @@ class RedactingFormatter(Formatter):
             # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
             # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
             match = re.search(
-                r"(pwd|pass|password|passphrase|secret\w*|\w+key|token|PASSPHRASE)=(\S{3,})$",
+                r"(pwd|pass|passwd|password|passphrase|secret\w*|\w+key|token|PASSPHRASE)=(\S{3,})$",
                 record.strip(),
             )
             if (


### PR DESCRIPTION
## The problem

This [issue](https://github.com/YunoHost-Apps/mumbleserver_ynh/issues/44) for Mumbleserver shows logs with clear password on it. 

## Solution

Either change the password variable in mumbleserver or add `passwd` to obfuscated list.
