### PR TITLE
[fix] sort_buffer_size too small to make nextcloud work

### DIFF
--- a/data/templates/mysql/my.cnf
+++ b/data/templates/mysql/my.cnf
@@ -30,7 +30,7 @@ skip-external-locking
 key_buffer_size = 16K
 max_allowed_packet = 16M
 table_open_cache = 4
-sort_buffer_size = 256K
+sort_buffer_size = 4M
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K


### PR DESCRIPTION
## The problem

Nextcloud can install with the previous settings, however it display an error page on some real servers.

## Solution

Increase to the config used in debian mariadb package
https://github.com/MariaDB/server/blob/10.3/debian/additions/my.cnf#L56

## PR Status
Ready tested on sans-nuage.fr

## How to test

...
