### PR TITLE
avoid to retrieve final path in the config panel scripts

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -1766,7 +1766,6 @@ class AppConfigPanel(ConfigPanel):
             default_script = """#!/bin/bash
 source /usr/share/yunohost/helpers
 ynh_abort_if_errors
-final_path=$(ynh_app_setting_get $app final_path)
 ynh_app_config_run $1
 """
             write_to_file(config_script, default_script)
@@ -1774,11 +1773,13 @@ ynh_app_config_run $1
         # Call config script to extract current values
         logger.debug(f"Calling '{action}' action from config script")
         app_id, app_instance_nb = _parse_app_instance_name(self.app)
+        settings = _get_app_settings(app_id)
         env.update(
             {
                 "app_id": app_id,
                 "app": self.app,
                 "app_instance_nb": str(app_instance_nb),
+                "final_path": settings.get("final_path", "")
             }
         )
 


### PR DESCRIPTION
## The problem

For now, we have to get [the value of final_path](https://github.com/YunoHost/test_apps/blob/6c9cf102006ae5bd05e078e1bac8526de91acf3a/config_app_ynh/scripts/config#L17) when we define a config panel script

## Solution

Define it in the core

## PR Status

...

## How to test

...
