### PR TITLE
remove created permission if error

### DIFF
--- a/src/yunohost/permission.py
+++ b/src/yunohost/permission.py
@@ -457,22 +457,26 @@ def permission_create(
             "permission_creation_failed", permission=permission, error=e
         )
 
-    permission_url(
-        permission,
-        url=url,
-        add_url=additional_urls,
-        auth_header=auth_header,
-        sync_perm=False,
-    )
+    try:
+        permission_url(
+            permission,
+            url=url,
+            add_url=additional_urls,
+            auth_header=auth_header,
+            sync_perm=False,
+        )
 
-    new_permission = _update_ldap_group_permission(
-        permission=permission,
-        allowed=allowed,
-        label=label,
-        show_tile=show_tile,
-        protected=protected,
-        sync_perm=sync_perm,
-    )
+        new_permission = _update_ldap_group_permission(
+            permission=permission,
+            allowed=allowed,
+            label=label,
+            show_tile=show_tile,
+            protected=protected,
+            sync_perm=sync_perm,
+        )
+    except:
+        permission_delete(permission, force=True)
+        raise
 
     logger.debug(m18n.n("permission_created", permission=permission))
     return new_permission


### PR DESCRIPTION
## The problem

I'm trying to fix the `backup_wordpress_from_3p8` test and I hit another bug:

Trying to restore the backup:

```
# yunohost backup restore backup
Do you really want to restore an already installed system? [y/N]: y
Info: Preparing archive for restoration...
Info: Restoring wordpress...
Info: The operation 'Create permission 'wordpress'' could not be completed. Please share the full log of this operation using the command 'yunohost log share 20210917-155022-permission_create-wordpress' to get help
Error: Could not restore wordpress: Something unexpected went wrong: 
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/backup.py", line 1452, in _restore_app
    sync_perm=False,
  File "/usr/lib/moulinette/yunohost/log.py", line 417, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/permission.py", line 466, in permission_create
    sync_perm=False,
  File "/usr/lib/moulinette/yunohost/log.py", line 417, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/permission.py", line 535, in permission_url
    url = _validate_and_sanitize_permission_url(url, app_main_path, app)
  File "/usr/lib/moulinette/yunohost/permission.py", line 941, in _validate_and_sanitize_permission_url
    _assert_no_conflicting_apps(domain, path, ignore_app=app)
  File "/usr/lib/moulinette/yunohost/app.py", line 2532, in _assert_no_conflicting_apps
    conflicts = _get_conflicting_apps(domain, path, ignore_app)
  File "/usr/lib/moulinette/yunohost/app.py", line 2508, in _get_conflicting_apps
    raise YunohostValidationError("domain_name_unknown", domain=domain)
yunohost.utils.error.YunohostValidationError: Domain 'yolo.test' unknown
```
... crap! the domain yolo.test is not added to my ynh-dev. Ok i'll add it and run the restore again:

```
# yunohost backup restore backup
Info: Preparing archive for restoration...
Info: Restoring wordpress...
Error: Could not restore wordpress: Something unexpected went wrong: 
Traceback (most recent call last):
  File "/usr/lib/moulinette/yunohost/backup.py", line 1452, in _restore_app
    sync_perm=False,
  File "/usr/lib/moulinette/yunohost/log.py", line 417, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/moulinette/yunohost/permission.py", line 412, in permission_create
    raise YunohostValidationError("permission_already_exist", permission=permission)
yunohost.utils.error.YunohostValidationError: Permission 'wordpress.main' already exists
```

The permission is not removed if the `permission_create` crash.

## Solution

Remove a permission if there is an error during the creation

## PR Status

...

## How to test

...
