### PR TITLE
[Fix] App diagnosis grep

### DIFF
--- a/data/hooks/diagnosis/80-apps.py
+++ b/data/hooks/diagnosis/80-apps.py
@@ -76,7 +76,7 @@ class AppDiagnoser(Diagnoser):
         for deprecated_helper in deprecated_helpers:
             if (
                 os.system(
-                    f"grep -nr -q '{deprecated_helper}' {app['setting_path']}/scripts/"
+                    f"grep -hr '{deprecated_helper}' {app['setting_path']}/scripts/ | grep -v -q '^\s*#'"
                 )
                 == 0
             ):


### PR DESCRIPTION
## The problem

The grep match the commented lines

For example: https://github.com/YunoHost-Apps/vaultwarden_ynh/blob/c233d94d76cae449630c59ce228b7a3c72f8fa12/scripts/ynh_handle_app_migration#L136

## Solution

Remove the commented lines

## PR Status

...

## How to test

...
