### PR TITLE
Simplify regen conf scripts

### DIFF
--- a/data/hooks/conf_regen/01-yunohost
+++ b/data/hooks/conf_regen/01-yunohost
@@ -211,23 +211,4 @@ do_post_regen() {
   fi
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/02-ssl
+++ b/data/hooks/conf_regen/02-ssl
@@ -48,8 +48,6 @@ regen_local_ca() {
     popd
 }
 
-
-
 do_init_regen() {
 
   LOGFILE=/tmp/yunohost-ssl-init
@@ -121,23 +119,4 @@ do_post_regen() {
   fi
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/03-ssh
+++ b/data/hooks/conf_regen/03-ssh
@@ -48,20 +48,4 @@ do_post_regen() {
     systemctl restart ssh
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/06-slapd
+++ b/data/hooks/conf_regen/06-slapd
@@ -199,23 +199,4 @@ objectClass: top"
   done
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/09-nslcd
+++ b/data/hooks/conf_regen/09-nslcd
@@ -22,23 +22,4 @@ do_post_regen() {
     || systemctl restart nslcd
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/10-apt
+++ b/data/hooks/conf_regen/10-apt
@@ -54,20 +54,4 @@ do_post_regen() {
   update-alternatives --set php /usr/bin/php7.3
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/12-metronome
+++ b/data/hooks/conf_regen/12-metronome
@@ -70,20 +70,4 @@ do_post_regen() {
     || systemctl restart metronome
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/15-nginx
+++ b/data/hooks/conf_regen/15-nginx
@@ -149,23 +149,4 @@ do_post_regen() {
   pgrep nginx && systemctl reload nginx || { journalctl --no-pager --lines=10 -u nginx >&2; exit 1; }
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/19-postfix
+++ b/data/hooks/conf_regen/19-postfix
@@ -80,20 +80,4 @@ do_post_regen() {
 
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/25-dovecot
+++ b/data/hooks/conf_regen/25-dovecot
@@ -63,20 +63,4 @@ do_post_regen() {
   systemctl restart dovecot
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/31-rspamd
+++ b/data/hooks/conf_regen/31-rspamd
@@ -59,20 +59,4 @@ do_post_regen() {
   systemctl -q restart rspamd.service 
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -69,18 +69,4 @@ do_post_regen() {
     || systemctl restart mysql
 }
 
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/34-mysql
+++ b/data/hooks/conf_regen/34-mysql
@@ -69,8 +69,6 @@ do_post_regen() {
     || systemctl restart mysql
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
 
 case "$1" in
   pre)

--- a/data/hooks/conf_regen/35-redis
+++ b/data/hooks/conf_regen/35-redis
@@ -10,20 +10,4 @@ do_post_regen() {
   chown -R redis:adm /var/log/redis
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/37-mdns
+++ b/data/hooks/conf_regen/37-mdns
@@ -61,23 +61,4 @@ do_post_regen() {
     || systemctl restart yunomdns
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -80,20 +80,4 @@ do_post_regen() {
   systemctl restart dnsmasq
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/46-nsswitch
+++ b/data/hooks/conf_regen/46-nsswitch
@@ -22,23 +22,4 @@ do_post_regen() {
     || systemctl restart unscd
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  init)
-    do_init_regen
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/data/hooks/conf_regen/52-fail2ban
+++ b/data/hooks/conf_regen/52-fail2ban
@@ -27,20 +27,4 @@ do_post_regen() {
     || systemctl reload fail2ban
 }
 
-FORCE=${2:-0}
-DRY_RUN=${3:-0}
-
-case "$1" in
-  pre)
-    do_pre_regen $4
-    ;;
-  post)
-    do_post_regen $4
-    ;;
-  *)
-    echo "hook called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-exit 0
+do_$1_regen ${@:2}

--- a/src/yunohost/regenconf.py
+++ b/src/yunohost/regenconf.py
@@ -105,13 +105,9 @@ def regen_conf(
     else:
         filesystem.mkdir(PENDING_CONF_DIR, 0o755, True)
 
-    # Format common hooks arguments
-    common_args = [1 if force else 0, 1 if dry_run else 0]
-
     # Execute hooks for pre-regen
-    pre_args = [
-        "pre",
-    ] + common_args
+    # element 2 and 3 with empty string is because of legacy...
+    pre_args = ["pre", "", ""]
 
     def _pre_call(name, priority, path, args):
         # create the pending conf directory for the category
@@ -417,9 +413,8 @@ def regen_conf(
         return result
 
     # Execute hooks for post-regen
-    post_args = [
-        "post",
-    ] + common_args
+    # element 2 and 3 with empty string is because of legacy...
+    post_args = ["post", "", ""]
 
     def _pre_call(name, priority, path, args):
         # append coma-separated applied changes for the category


### PR DESCRIPTION
## The problem

Regenconf is confusing enough, we don't need those 'FORCE' and 'DRY_RUN' args which are in fact never used, nor that ugly `case`

## Solution

Just call `do_$1_regen ${@:2}`

## PR Status

Yolocommited

## How to test

...
