### PR TITLE
fix app upgrade

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -507,7 +507,7 @@ def app_upgrade(app=[], url=None, file=None, force=False, no_safety_backup=False
             logger.warning(m18n.n("custom_app_url_required", app=app_instance_name))
             continue
         elif app_dict["upgradable"] == "yes" or force:
-            new_app_src = app_dict["id"]
+            new_app_src = app_dict["manifest"]["id"]
         else:
             logger.success(m18n.n("app_already_up_to_date", app=app_instance_name))
             continue


### PR DESCRIPTION
## The problem

In 4.3.1.1, when i try to upgrade Searx i have this error message:

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/api.py", line 497, in process
    ret = self.actionsmap.process(arguments, timeout=30, route=_route)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 597, in process
    return func(**arguments)
  File "/usr/lib/moulinette/yunohost/app.py", line 511, in app_upgrade
    new_app_src = app_dict["id"]
KeyError: 'id'
```

When i run the function `app_dict = app_info("searx", full=True)`, I can isolate several `id`s fields:

```json
{
    "manifest": {
        "id": "searx"
    },
    "settings": {
        "id": "searx"
    },
    "from_catalog": {
        "id": "searx",
        "manifest": {
            "id": "searx"
        }
    }
}
```

## Solution

Use the manifest's one, but I'm not sure if we want that one or another.

How the ci didn't catch that case?!

## PR Status

...

## How to test

...
