### PR TITLE
Drop some YAGNI in dyndns.py + improve resilience w.r.t. ns0 / ns1 being down

### DIFF
--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1483,9 +1483,6 @@ dyndns:
         subscribe:
             action_help: Subscribe to a DynDNS service
             arguments:
-                --subscribe-host:
-                    help: Dynette HTTP API to subscribe to
-                    default: "dyndns.yunohost.org"
                 -d:
                     full: --domain
                     help: Full domain to subscribe with
@@ -1499,9 +1496,6 @@ dyndns:
         update:
             action_help: Update IP on DynDNS platform
             arguments:
-                --dyn-host:
-                    help: Dynette DNS server to inform
-                    default: "dyndns.yunohost.org"
                 -d:
                     full: --domain
                     help: Full domain to update

--- a/data/actionsmap/yunohost.yml
+++ b/data/actionsmap/yunohost.yml
@@ -1501,12 +1501,6 @@ dyndns:
                     help: Full domain to update
                     extra:
                         pattern: *pattern_domain
-                -k:
-                    full: --key
-                    help: Public DNS key
-                -i:
-                    full: --ipv4
-                    help: IP address to send
                 -f:
                     full: --force
                     help: Force the update (for debugging only)
@@ -1515,9 +1509,6 @@ dyndns:
                     full: --dry-run
                     help: Only display the generated zone
                     action: store_true
-                -6:
-                    full: --ipv6
-                    help: IPv6 address to send
 
         ### dyndns_installcron()
         installcron:

--- a/locales/en.json
+++ b/locales/en.json
@@ -349,7 +349,6 @@
     "dpkg_is_broken": "You cannot do this right now because dpkg/APT (the system package managers) seems to be in a broken state... You can try to solve this issue by connecting through SSH and running `sudo apt install --fix-broken` and/or `sudo dpkg --configure -a`.",
     "dpkg_lock_not_available": "This command can't be run right now because another program seems to be using the lock of dpkg (the system package manager)",
     "dyndns_could_not_check_available": "Could not check if {domain} is available on {provider}.",
-    "dyndns_could_not_check_provide": "Could not check if {provider} can provide {domain}.",
     "dyndns_domain_not_provided": "DynDNS provider {provider} cannot provide domain {domain}.",
     "dyndns_ip_update_failed": "Could not update IP address to DynDNS",
     "dyndns_ip_updated": "Updated your IP on DynDNS",

--- a/src/yunohost/domain.py
+++ b/src/yunohost/domain.py
@@ -167,15 +167,16 @@ def domain_add(operation_logger, domain, dyndns=False):
     # DynDNS domain
     if dyndns:
 
-        from yunohost.dyndns import _dyndns_provides, _guess_current_dyndns_domain
+        from yunohost.utils.dns import is_yunohost_dyndns_domain
+        from yunohost.dyndns import _guess_current_dyndns_domain
 
         # Do not allow to subscribe to multiple dyndns domains...
-        if _guess_current_dyndns_domain("dyndns.yunohost.org") != (None, None):
+        if _guess_current_dyndns_domain() != (None, None):
             raise YunohostValidationError("domain_dyndns_already_subscribed")
 
         # Check that this domain can effectively be provided by
         # dyndns.yunohost.org. (i.e. is it a nohost.me / noho.st)
-        if not _dyndns_provides("dyndns.yunohost.org", domain):
+        if not is_yunohost_dyndns_domain(domain):
             raise YunohostValidationError("domain_dyndns_root_unknown")
 
     operation_logger.start()

--- a/src/yunohost/dyndns.py
+++ b/src/yunohost/dyndns.py
@@ -203,6 +203,16 @@ def dyndns_update(
 
         key = keys[0]
 
+    # Get current IPv4 and IPv6
+    ipv4 = get_public_ip()
+    ipv6 = get_public_ip(6)
+
+    if ipv4 is None and ipv6 is None:
+        logger.debug(
+            "No ipv4 nor ipv6 ?! Sounds like the server is not connected to the internet, or the ip.yunohost.org infrastructure is down somehow"
+        )
+        return
+
     # Extract 'host', e.g. 'nohost.me' from 'foo.nohost.me'
     host = domain.split(".")[1:]
     host = ".".join(host)
@@ -259,18 +269,8 @@ def dyndns_update(
     old_ipv4 = resolve_domain(domain, "A")
     old_ipv6 = resolve_domain(domain, "AAAA")
 
-    # Get current IPv4 and IPv6
-    ipv4 = get_public_ip()
-    ipv6 = get_public_ip(6)
-
     logger.debug("Old IPv4/v6 are (%s, %s)" % (old_ipv4, old_ipv6))
     logger.debug("Requested IPv4/v6 are (%s, %s)" % (ipv4, ipv6))
-
-    if ipv4 is None and ipv6 is None:
-        logger.debug(
-            "No ipv4 nor ipv6 ?! Sounds like the server is not connected to the internet, or the ip.yunohost.org infrastructure is down somehow"
-        )
-        return
 
     # no need to update
     if (not force and not dry_run) and (old_ipv4 == ipv4 and old_ipv6 == ipv6):

--- a/src/yunohost/tools.py
+++ b/src/yunohost/tools.py
@@ -45,7 +45,6 @@ from yunohost.app_catalog import (
     _update_apps_catalog,
 )
 from yunohost.domain import domain_add
-from yunohost.dyndns import _dyndns_available, _dyndns_provides
 from yunohost.firewall import firewall_upnp
 from yunohost.service import service_start, service_enable
 from yunohost.regenconf import regen_conf
@@ -205,11 +204,11 @@ def tools_postinstall(
         password -- YunoHost admin password
 
     """
+    from yunohost.dyndns import _dyndns_available
+    from yunohost.utils.dns import is_yunohost_dyndns_domain
     from yunohost.utils.password import assert_password_is_strong_enough
     from yunohost.domain import domain_main_domain
     import psutil
-
-    dyndns_provider = "dyndns.yunohost.org"
 
     # Do some checks at first
     if os.path.isfile("/etc/yunohost/installed"):
@@ -235,33 +234,28 @@ def tools_postinstall(
     if not force_password:
         assert_password_is_strong_enough("admin", password)
 
-    if not ignore_dyndns:
-        # Check if yunohost dyndns can handle the given domain
-        # (i.e. is it a .nohost.me ? a .noho.st ?)
-        try:
-            is_nohostme_or_nohost = _dyndns_provides(dyndns_provider, domain)
-        # If an exception is thrown, most likely we don't have internet
-        # connectivity or something. Assume that this domain isn't manageable
-        # and inform the user that we could not contact the dyndns host server.
-        except Exception:
-            logger.warning(
-                m18n.n("dyndns_provider_unreachable", provider=dyndns_provider)
-            )
-            is_nohostme_or_nohost = False
+    # If this is a nohost.me/noho.st, actually check for availability
+    if not ignore_dyndns and is_yunohost_dyndns_domain(domain):
+        # (Except if the user explicitly said he/she doesn't care about dyndns)
+        if ignore_dyndns:
+            dyndns = False
+        # Check if the domain is available...
+        else:
+            try:
+                available = _dyndns_available(domain)
+            # If an exception is thrown, most likely we don't have internet
+            # connectivity or something. Assume that this domain isn't manageable
+            # and inform the user that we could not contact the dyndns host server.
+            except Exception:
+                logger.warning(
+                    m18n.n("dyndns_provider_unreachable", provider="dyndns.yunohost.org")
+                )
 
-        # If this is a nohost.me/noho.st, actually check for availability
-        if is_nohostme_or_nohost:
-            # (Except if the user explicitly said he/she doesn't care about dyndns)
-            if ignore_dyndns:
-                dyndns = False
-            # Check if the domain is available...
-            elif _dyndns_available(dyndns_provider, domain):
+            if available:
                 dyndns = True
             # If not, abort the postinstall
             else:
                 raise YunohostValidationError("dyndns_unavailable", domain=domain)
-        else:
-            dyndns = False
     else:
         dyndns = False
 


### PR DESCRIPTION
## The problem

Boring stuff in dyndns.py like the ability to specify a custom dyndns host ... and ability to specify what ipv4/ipv6 to push on dyndns update ...

Also lack of resilience when ns0.yunohost.org is down .. because it's mapped to dyndns.yunohost.org and hmpf

## Solution

We don't need those, drop them to simplify the code ...

\+ add ns1.yunohost.org for resolver redundancy

## PR Status

Yolocommited

## How to test

Zblerg try to subscribe / update a test dyndns domain
