### PR TITLE
ynh_local_curl: temporarily auto-add visitors if needed

### DIFF
--- a/data/helpers.d/utils
+++ b/data/helpers.d/utils
@@ -290,8 +290,18 @@ ynh_local_curl() {
     chown root $cookiefile
     chmod 700 $cookiefile
 
+    # Temporarily enable visitors if needed...
+    local visitors_enabled=$(ynh_permission_has_user "main" "visitors" && echo yes || echo no)
+    if [[ $visitors_enabled == "no" ]]; then
+        ynh_permission_update --permission "main" --add "visitors"
+    fi
+
     # Curl the URL
     curl --silent --show-error --insecure --location --header "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar $cookiefile --cookie $cookiefile
+
+    if [[ $visitors_enabled == "no" ]]; then
+        ynh_permission_update --permission "main" --remove "visitors"
+    fi
 }
 
 # Create a dedicated config file from a template


### PR DESCRIPTION
## The problem

Some apps have to temporarily enable visitors to the main permission to run ynh_local_curl, this is boring as hell, makes the code more complex that it needs to be

## Solution

Just temporarily enable visitors during every curl call

Idk if this is too brutal or not, maybe we could decide to add a new option like `--temporarily-enable-visitors` idk

## PR Status

Yolocommited

## How to test

Zblerg try to reproduce the scenario where the app ain't publicly exposed and need to perform a curl ...
