### PR TITLE
Fix dump_script_log_extract_for_debugging 

### DIFF
--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -42,12 +42,36 @@ from yunohost.utils.packages import get_ynh_package_version
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.filesystem import read_file, read_yaml
 
+logger = getActionLogger("yunohost.log")
+
 CATEGORIES_PATH = "/var/log/yunohost/categories/"
 OPERATIONS_PATH = "/var/log/yunohost/categories/operation/"
 METADATA_FILE_EXT = ".yml"
 LOG_FILE_EXT = ".log"
 
-logger = getActionLogger("yunohost.log")
+BORING_LOG_LINES = [
+    r"set [+-]x$",
+    r"set [+-]o xtrace$",
+    r"set [+-]o errexit$",
+    r"set [+-]o nounset$",
+    r"trap '' EXIT",
+    r"local \w+$",
+    r"local exit_code=(1|0)$",
+    r"local legacy_args=.*$",
+    r"local -A args_array$",
+    r"args_array=.*$",
+    r"ret_code=1",
+    r".*Helper used in legacy mode.*",
+    r"ynh_handle_getopts_args",
+    r"ynh_script_progression",
+    r"sleep 0.5",
+    r"'\[' (1|0) -eq (1|0) '\]'$",
+    r"\[?\['? -n '' '?\]\]?$",
+    r"rm -rf /var/cache/yunohost/download/$",
+    r"type -t ynh_clean_setup$",
+    r"DEBUG - \+ echo '",
+    r"DEBUG - \+ exit (1|0)$",
+]
 
 
 def log_list(limit=None, with_details=False, with_suboperations=False):
@@ -163,30 +187,7 @@ def log_show(
     if filter_irrelevant:
 
         def _filter(lines):
-            filters = [
-                r"set [+-]x$",
-                r"set [+-]o xtrace$",
-                r"set [+-]o errexit$",
-                r"set [+-]o nounset$",
-                r"trap '' EXIT",
-                r"local \w+$",
-                r"local exit_code=(1|0)$",
-                r"local legacy_args=.*$",
-                r"local -A args_array$",
-                r"args_array=.*$",
-                r"ret_code=1",
-                r".*Helper used in legacy mode.*",
-                r"ynh_handle_getopts_args",
-                r"ynh_script_progression",
-                r"sleep 0.5",
-                r"'\[' (1|0) -eq (1|0) '\]'$",
-                r"\[?\['? -n '' '?\]\]?$",
-                r"rm -rf /var/cache/yunohost/download/$",
-                r"type -t ynh_clean_setup$",
-                r"DEBUG - \+ echo '",
-                r"DEBUG - \+ exit (1|0)$",
-            ]
-            filters = [re.compile(f) for f in filters]
+            filters = [re.compile(f) for f in BORING_LOG_LINES]
             return [
                 line
                 for line in lines
@@ -738,19 +739,7 @@ class OperationLogger(object):
         with open(self.log_path, "r") as f:
             lines = f.readlines()
 
-        filters = [
-            r"set [+-]x$",
-            r"set [+-]o xtrace$",
-            r"local \w+$",
-            r"local legacy_args=.*$",
-            r".*Helper used in legacy mode.*",
-            r"args_array=.*$",
-            r"local -A args_array$",
-            r"ynh_handle_getopts_args",
-            r"ynh_script_progression",
-        ]
-
-        filters = [re.compile(f_) for f_ in filters]
+        filters = [re.compile(f_) for f_ in BORING_LOG_LINES]
 
         lines_to_display = []
 

--- a/src/yunohost/log.py
+++ b/src/yunohost/log.py
@@ -753,8 +753,16 @@ class OperationLogger(object):
         filters = [re.compile(f_) for f_ in filters]
 
         lines_to_display = []
-        for line in lines:
 
+        # The logs may contain multiple ynh_exit_properly (backup + upgrade e.g)
+        # We want to get the last one.
+        rev_lines = reversed(lines)
+        for line in rev_lines:
+            if line.endswith("+ ynh_exit_properly") or " + ynh_die " in line:
+                lines_to_display.append(line)
+                break
+
+        for line in rev_lines:
             if ": " not in line.strip():
                 continue
 
@@ -768,10 +776,10 @@ class OperationLogger(object):
 
             lines_to_display.append(line)
 
-            if line.endswith("+ ynh_exit_properly") or " + ynh_die " in line:
+            if len(lines_to_display) > 20:
                 break
-            elif len(lines_to_display) > 20:
-                lines_to_display.pop(0)
+
+        lines_to_display.reverse()
 
         logger.warning(
             "Here's an extract of the logs before the crash. It might help debugging the error:"


### PR DESCRIPTION
## The problem

When a failure occurs during the upgrade, the first ynh_exit is catched. That will be the one during the backup. So the logs abstract does not contain the code execution of the failure.

## Solution
Find the last ynh_exit in the logs by using a reversed iterator of the lines.

## PR Status

UNTESTED only for review.

## How to test

Try to upgrade an app whose upgrade script fails (after backup).
