### PR TITLE
fix backup_delete when compress_tar_archives is True

### DIFF
--- a/src/yunohost/backup.py
+++ b/src/yunohost/backup.py
@@ -2592,7 +2592,7 @@ def backup_delete(name):
     hook_callback("pre_backup_delete", args=[name])
 
     archive_file = "%s/%s.tar" % (ARCHIVES_PATH, name)
-    if os.path.exists(archive_file + ".gz"):
+    if not os.path.exists(archive_file) and os.path.exists(archive_file + ".gz"):
         archive_file += ".gz"
     info_file = "%s/%s.info.json" % (ARCHIVES_PATH, name)
 


### PR DESCRIPTION
## The problem

I have enable the `compress_tar_archives` parameter, and when I delete a backup, each time I want to upgrade an app or list backups I have the error:

> FileNotFoundError: [Errno 2] No such file or directory: '/home/yunohost.backup/archives/lxd-pre-upgrade2.tar'


## Solution

If the file `.tar` exists, it should be a symlink to the `.tar.gz`, which is managed here:
https://github.com/YunoHost/yunohost/blob/16dba79a3983b979a19de1701773a5440ae9766f/src/yunohost/backup.py#L2602-L2604

## PR Status

Tested on my server

## How to test

Enable compress_tar_archives:

> sudo yunohost settings set backup.compress_tar_archives -v 1

Create, remove, and then list backups
