### PR TITLE
Allow tilde in username/organization for repo URLs

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -79,7 +79,7 @@ re_app_instance_name = re.compile(
 )
 
 APP_REPO_URL = re.compile(
-    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?tree/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
+    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./~]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?tree/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
 )
 
 APP_FILES_TO_COPY = [

--- a/src/yunohost/tests/test_appurl.py
+++ b/src/yunohost/tests/test_appurl.py
@@ -70,6 +70,7 @@ def test_repo_url_definition():
     )
     assert _is_app_repo_url("https://github.com/YunoHost-Apps/foobar_ynh/tree/1.23.4")
     assert _is_app_repo_url("git@github.com:YunoHost-Apps/foobar_ynh.git")
+    assert _is_app_repo_url("https://git.super.host/~max/foobar_ynh")
 
     assert not _is_app_repo_url("github.com/YunoHost-Apps/foobar_ynh")
     assert not _is_app_repo_url("http://github.com/YunoHost-Apps/foobar_ynh")


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/1931
Some Git forges like SourceHut use tildes `~` to refer to usernames.

## Solution

Allow tildes in the app repo URL regex.

## PR Status

Regex tested but not "live".

## How to test

`yunohost app install https://git.sr.ht/~michalr/convos_ynh`
🤞 