### PR TITLE
[enh] Tweak umask for SFTP

### DIFF
--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -84,7 +84,7 @@ Subsystem sftp internal-sftp
 
 # Apply following instructions to user with sftp perm only
 Match Group sftp.main,!ssh.main
-    ForceCommand internal-sftp
+    ForceCommand internal-sftp -u 0002
     # We can't restrict to /home/%u because the chroot base must be owned by root
     # So we chroot only on /home
     # See https://serverfault.com/questions/584986/bad-ownership-or-modes-for-chroot-directory-component
@@ -97,7 +97,7 @@ Match Group sftp.main,!ssh.main
     PermitUserRC no
 
 Match Group sftp.app,!ssh.app
-    ForceCommand internal-sftp
+    ForceCommand internal-sftp -u 0002
     ChrootDirectory %h
     AllowTcpForwarding no
     AllowStreamLocalForwarding no


### PR DESCRIPTION
## The problem

Via sftp when you load a file or a directory, the content uploaded has no group permission even if the parent dir has.
It's a bit shame if you want to share an app dir to a user like in this documentation PR https://github.com/YunoHost/doc/pull/1836/files

## Solution

Set an appropriate umask.

Alternatively, we could define umask by user through gcos in ldap... But it's more difficult.

## PR Status

Currently in testing on a true server with a true person. I wait a bit if this person get an issue.

## How to test

...
