### PR TITLE
[fix] hook restore multimedia

### DIFF
--- a/data/hooks/restore/18-data_multimedia
+++ b/data/hooks/restore/18-data_multimedia
@@ -6,4 +6,6 @@ set -eu
 # Source YNH helpers
 source /usr/share/yunohost/helpers
 
-ynh_restore_file --origin_path="/home/yunohost.multimedia" --not_mandatory
+backup_dir="data/multimedia"
+
+ynh_restore_file --origin_path="${backup_dir}" --dest_path="/home/yunohost.multimedia" --not_mandatory


### PR DESCRIPTION
## The problem

The restore of the multimedia folders doesn't work because we backup it with:
https://github.com/YunoHost/yunohost/blob/6854f23cca74fad1b131f5bdec7d92c7cc62aec4/data/hooks/backup/18-data_multimedia#L10

But during the restore, the script will search for something like `home/yunohost.multimedia`

Here some logs:

> 9272 DEBUG + ynh_restore_file --origin_path=/home/yunohost.multimedia --not_mandatory
9272 DEBUG + local legacy_args=odm
9273 DEBUG + args_array=([o]=origin_path= [d]=dest_path= [m]=not_mandatory)
9273 DEBUG + local -A args_array
9273 DEBUG + local origin_path
9273 DEBUG + local dest_path
9273 DEBUG + local not_mandatory
9273 DEBUG + ynh_handle_getopts_args --origin_path=/home/yunohost.multimedia --not_mandatory
9273 DEBUG + set +o xtrace
9306 DEBUG + origin_path=/home/yunohost.multimedia
9306 DEBUG + dest_path=/home/yunohost.multimedia
9306 DEBUG + not_mandatory=1
9306 DEBUG + local archive_path=/home/yunohost.backup/tmp/20211130-111701/home/yunohost.multimedia
9306 DEBUG + '[' '!' -d /home/yunohost.backup/tmp/20211130-111701/home/yunohost.multimedia ']'
9306 DEBUG + '[' '!' -f /home/yunohost.backup/tmp/20211130-111701/home/yunohost.multimedia ']'
9307 DEBUG + '[' '!' -L /home/yunohost.backup/tmp/20211130-111701/home/yunohost.multimedia ']'
9307 DEBUG + '[' 1 == 0 ']'
9307 DEBUG + return 0

Corresponding to this: https://github.com/YunoHost/yunohost/blob/6854f23cca74fad1b131f5bdec7d92c7cc62aec4/data/helpers.d/backup#L253-L261

## Solution

Reuse the `data/multimedia` for the restore hook

## PR Status

Tested in yoloprod during a migration

## How to test

...
