### PR TITLE
[enh] Manage SSH PasswordAuthentication setting

### DIFF
--- a/data/hooks/conf_regen/03-ssh
+++ b/data/hooks/conf_regen/03-ssh
@@ -26,6 +26,7 @@ do_pre_regen() {
     # Support different strategy for security configurations
     export compatibility="$(yunohost settings get 'security.ssh.compatibility')"
     export port="$(yunohost settings get 'security.ssh.port')"
+    export password_authentication="$(yunohost settings get 'security.ssh.password_authentication')"
     export ssh_keys
     export ipv6_enabled
     ynh_render_template "sshd_config" "${pending_dir}/etc/ssh/sshd_config"

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -2,6 +2,8 @@
 # by YunoHost
 
 Protocol 2
+# PLEASE: to change ssh port properly in YunoHost, use this command
+# yunohost settings set security.ssh.port -v <port>
 Port {{ port }}
 
 {% if ipv6_enabled == "true" %}ListenAddress ::{% endif %}
@@ -53,9 +55,13 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 UsePAM yes
 
-# Change to no to disable tunnelled clear text passwords
-# (i.e. everybody will need to authenticate using ssh keys)
+# PLEASE: to force everybody to authenticate using ssh keys, run this command:
+# yunohost settings set security.ssh.password_authentication -v no
+{% if password_authentication == "True" %}
 #PasswordAuthentication yes
+{% else %}
+PasswordAuthentication no
+{% endif %}
 
 # Post-login stuff
 Banner /etc/issue.net

--- a/data/templates/ssh/sshd_config
+++ b/data/templates/ssh/sshd_config
@@ -2,7 +2,7 @@
 # by YunoHost
 
 Protocol 2
-# PLEASE: to change ssh port properly in YunoHost, use this command
+# PLEASE: if you wish to change the ssh port properly in YunoHost, use this command:
 # yunohost settings set security.ssh.port -v <port>
 Port {{ port }}
 
@@ -55,12 +55,12 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 UsePAM yes
 
-# PLEASE: to force everybody to authenticate using ssh keys, run this command:
+# PLEASE: if you wish to force everybody to authenticate using ssh keys, run this command:
 # yunohost settings set security.ssh.password_authentication -v no
-{% if password_authentication == "True" %}
-#PasswordAuthentication yes
-{% else %}
+{% if password_authentication == "False" %}
 PasswordAuthentication no
+{% else %}
+#PasswordAuthentication yes
 {% endif %}
 
 # Post-login stuff

--- a/locales/en.json
+++ b/locales/en.json
@@ -382,7 +382,7 @@
     "global_settings_setting_security_password_user_strength": "User password strength",
     "global_settings_setting_security_postfix_compatibility": "Compatibility vs. security tradeoff for the Postfix server. Affects the ciphers (and other security-related aspects)",
     "global_settings_setting_security_ssh_compatibility": "Compatibility vs. security tradeoff for the SSH server. Affects the ciphers (and other security-related aspects)",
-    "global_settings_setting_security_ssh_password_authentication": "Password authentication allowed",
+    "global_settings_setting_security_ssh_password_authentication": "Allow password authentication for SSH",
     "global_settings_setting_security_ssh_port": "SSH port",
     "global_settings_setting_security_webadmin_allowlist": "IP adresses allowed to access the webadmin. Comma-separated.",
     "global_settings_setting_security_webadmin_allowlist_enabled": "Allow only some IPs to access the webadmin.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -382,6 +382,7 @@
     "global_settings_setting_security_password_user_strength": "User password strength",
     "global_settings_setting_security_postfix_compatibility": "Compatibility vs. security tradeoff for the Postfix server. Affects the ciphers (and other security-related aspects)",
     "global_settings_setting_security_ssh_compatibility": "Compatibility vs. security tradeoff for the SSH server. Affects the ciphers (and other security-related aspects)",
+    "global_settings_setting_security_ssh_password_authentication": "Password authentication allowed",
     "global_settings_setting_security_ssh_port": "SSH port",
     "global_settings_setting_security_webadmin_allowlist": "IP adresses allowed to access the webadmin. Comma-separated.",
     "global_settings_setting_security_webadmin_allowlist_enabled": "Allow only some IPs to access the webadmin.",

--- a/src/yunohost/settings.py
+++ b/src/yunohost/settings.py
@@ -82,6 +82,10 @@ DEFAULTS = OrderedDict(
             {"type": "int", "default": 22},
         ),
         (
+            "security.ssh.password_authentication",
+            {"type": "bool", "default": True},
+        ),
+        (
             "security.nginx.redirect_to_https",
             {
                 "type": "bool",
@@ -420,6 +424,7 @@ def reconfigure_nginx_and_yunohost(setting_name, old_value, new_value):
 
 
 @post_change_hook("security.ssh.compatibility")
+@post_change_hook("security.ssh.password_authentication")
 def reconfigure_ssh(setting_name, old_value, new_value):
     if old_value != new_value:
         regen_conf(names=["ssh"])


### PR DESCRIPTION
## The problem

People want to disable password auth with ssh (especially with the new diagnosis alert about fail2ban tentative).
https://forum.yunohost.org/t/high-number-of-authentication-failures-recently/18026/3?u=ljf

## Solution

Allow to do:
```
yunohost settings set security.ssh.password_authentication -v no
```

## PR Status
Ready

## How to test
If you have not modified your ssh conf:
```
yunohost settings set security.ssh.password_authentication -v no
```
