### PR TITLE
Don't resolve symlinks while transforming backup path to absolute.

### DIFF
--- a/data/helpers.d/backup
+++ b/data/helpers.d/backup
@@ -113,7 +113,7 @@ ynh_backup() {
 
     # Transform the source path as an absolute path
     # If it's a dir remove the ending /
-    src_path=$(realpath "$src_path")
+    src_path=$(realpath --no-symlink "$src_path")
 
     # If there is no destination path, initialize it with the source path
     # relative to "/".


### PR DESCRIPTION
This fixes backup/restore scripts. 

If you're backuping /lib/systemd/system/jellyfin.service but /lib is a symlink to /usr/lib, the path stored in the backup will be /usr/lib/systemd/system/jellyfin.service.
Thus restoring will not find the file and will fail.

THIS MAY BREAK SOME RESTORE SCRIPTS that would use this bug as a feature.
