### PR TITLE
Message stays compliant in each locale with --apps deprecation

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -613,7 +613,7 @@
     "tools_upgrade_cant_unhold_critical_packages": "Konnte für die kritischen Pakete das Flag 'hold' nicht aufheben...",
     "tools_upgrade_cant_hold_critical_packages": "Konnte für die kritischen Pakete das Flag 'hold' nicht setzen...",
     "tools_upgrade_cant_both": "Kann das Upgrade für das System und die Applikation nicht gleichzeitig durchführen",
-    "tools_upgrade_at_least_one": "Bitte geben Sie '--apps' oder '--system' an",
+    "tools_upgrade_at_least_one": "Bitte geben Sie 'apps' oder 'system' an",
     "this_action_broke_dpkg": "Diese Aktion hat unkonfigurierte Pakete verursacht, welche durch dpkg/apt (die Paketverwaltungen dieses Systems) zurückgelassen wurden... Sie können versuchen dieses Problem zu lösen, indem Sie 'sudo apt install --fix-broken' und/oder 'sudo dpkg --configure -a' ausführen.",
     "update_apt_cache_failed": "Kann den Cache von APT (Debians Paketmanager) nicht aktualisieren. Hier ist ein Auszug aus den sources.list-Zeilen, die helfen könnten, das Problem zu identifizieren:\n{sourceslist}",
     "tools_upgrade_special_packages_completed": "YunoHost-Paketupdate beendet.\nDrücke [Enter], um zurück zur Kommandoziele zu kommen",

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -234,7 +234,7 @@
     "service_stop_failed": "Ne povis maldaŭrigi la servon '{service}'\n\nLastatempaj servaj protokoloj: {logs}",
     "unbackup_app": "App '{app}' ne konserviĝos",
     "updating_apt_cache": "Akirante haveblajn ĝisdatigojn por sistemaj pakoj…",
-    "tools_upgrade_at_least_one": "Bonvolu specifi '--apps' aŭ '--system'",
+    "tools_upgrade_at_least_one": "Bonvolu specifi 'apps' aŭ 'system'",
     "service_already_stopped": "La servo '{service}' jam ĉesis",
     "tools_upgrade_cant_both": "Ne eblas ĝisdatigi ambaŭ sistemon kaj programojn samtempe",
     "restore_extracting": "Eltirante bezonatajn dosierojn el la ar theivo…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -211,7 +211,7 @@
     "tools_upgrade_cant_unhold_critical_packages": "No se pudo liberar los paquetes críticos…",
     "tools_upgrade_cant_hold_critical_packages": "No se pudieron retener los paquetes  críticos…",
     "tools_upgrade_cant_both": "No se puede actualizar el sistema y las aplicaciones al mismo tiempo",
-    "tools_upgrade_at_least_one": "Especifique «--apps», o «--system»",
+    "tools_upgrade_at_least_one": "Especifique «apps», o «system»",
     "this_action_broke_dpkg": "Esta acción rompió dpkg/APT(los gestores de paquetes del sistema)…  Puede tratar de solucionar este problema conectando mediante SSH y ejecutando `sudo dpkg --configure -a`.",
     "service_reloaded_or_restarted": "El servicio '{service}' fue recargado o reiniciado",
     "service_reload_or_restart_failed": "No se pudo recargar o reiniciar el servicio «{service}»\n\nRegistro de servicios recientes:{logs}",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -527,7 +527,7 @@
     "service_restarted": "'{service}' zerbitzua berrabiarazi da",
     "service_start_failed": "Ezin izan da '{service}' zerbitzua abiarazi\n\nZerbitzuen azken erregistroak: {logs}",
     "ssowat_conf_updated": "SSOwat ezarpenak eguneratu dira",
-    "tools_upgrade_at_least_one": "Mesedez, zehaztu '--apps' edo '--system'",
+    "tools_upgrade_at_least_one": "Mesedez, zehaztu 'apps' edo 'system'",
     "tools_upgrade_cant_both": "Ezin dira sistema eta aplikazioak une berean eguneratu",
     "update_apt_cache_failed": "Ezin da APT Debian-en pakete kudeatzailearen cachea eguneratu. Hemen dituzu sources.list fitxategiaren lerroak, arazoa identifikatzeko baliagarria izan dezakezuna:\n{sourceslist}",
     "update_apt_cache_warning": "Zerbaitek huts egin du APT Debian-en pakete kudeatzailearen cachea eguneratzean. Hemen dituzu sources.list fitxategiaren lerroak, arazoa identifikatzeko baliagarria izan dezakezuna:\n{sourceslist}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -339,7 +339,7 @@
     "regenconf_failed": "Impossible de régénérer la configuration pour la ou les catégorie(s) : '{categories}'",
     "regenconf_pending_applying": "Applique la configuration en attente pour la catégorie '{category}'...",
     "service_regen_conf_is_deprecated": "'yunohost service regen-conf' est obsolète ! Veuillez plutôt utiliser 'yunohost tools regen-conf' à la place.",
-    "tools_upgrade_at_least_one": "Veuillez spécifier '--apps' ou '--system'",
+    "tools_upgrade_at_least_one": "Veuillez spécifier 'apps' ou 'system'",
     "tools_upgrade_cant_both": "Impossible de mettre à niveau le système et les applications en même temps",
     "tools_upgrade_cant_hold_critical_packages": "Impossibilité d'ajouter le drapeau 'hold' pour les paquets critiques...",
     "tools_upgrade_regular_packages": "Mise à jour des paquets du système (non liés a YunoHost)...",

--- a/locales/oc.json
+++ b/locales/oc.json
@@ -341,7 +341,7 @@
     "service_reload_or_restart_failed": "Impossible de recargar o reaviar lo servici « {service} »\n\nJornal d’audit recent : {logs}",
     "regenconf_file_kept_back": "S’espèra que lo fichièr de configuracion « {conf} » siá suprimit per regen-conf (categoria {category} mas es estat mantengut.",
     "this_action_broke_dpkg": "Aquesta accion a copat dpkg/apt (los gestionaris de paquets del sistèma)… Podètz ensajar de resòlver aqueste problèma en vos connectant amb SSH e executant « sudo dpkg --configure -a ».",
-    "tools_upgrade_at_least_one": "Especificatz --apps O --system",
+    "tools_upgrade_at_least_one": "Especificatz apps O system",
     "tools_upgrade_cant_unhold_critical_packages": "Se pòt pas quitar de manténer los paquets critics…",
     "tools_upgrade_regular_packages": "Actualizacion dels paquets « normals » (pas ligats a YunoHost)…",
     "tools_upgrade_special_packages": "Actualizacion dels paquets « especials » (ligats a YunoHost)…",


### PR DESCRIPTION
## The problem

![image](https://user-images.githubusercontent.com/16349417/146548788-a5ca317a-ed2c-41ed-907b-c82674ca1a55.png)

## Solution

Just remove the --apps from all locales :)

## How to test

`# yunohst tools upgrade`