### PR TITLE
[fix] Force dependencies upgrade even if previous version is accepted

### DIFF
--- a/data/helpers.d/apt
+++ b/data/helpers.d/apt
@@ -425,6 +425,12 @@ ynh_install_extra_app_dependencies() {
     # Install requested dependencies from this extra repository.
     ynh_install_app_dependencies "$package"
 
+    # Force to upgrade to the last version...
+    # Without doing apt install, an already installed dep is not upgraded
+    local apps_auto_installed="$(apt-mark showauto $package)"
+    ynh_package_install "$package"
+    apt-mark auto $apps_auto_installed
+
     # Remove this extra repository after packages are installed
     ynh_remove_extra_repo --name=$app
 }


### PR DESCRIPTION
## The problem

We discovered several apps like onlyoffice and mautrix bridge had old dependencies on several instances.
The 

## Solution

We suggest to force the upgrade to the last version accepted thanks to this change in `ynh_install_extra_app_dependencies`
NB: currently it conserves the old configuration, so the package need to upgrade it by running ynh_add_config or by running dpkg-reconfigure. We could add an option in this helper to do it, but i am not sure what is the good idea.

## PR Status

Untested / need point of view

## How to test

With a repo with for example a top version of DEPENDENCY of 10
```
ynh_install_extra_app_dependencies --repo="SOME_REPO" --package="DEPENDENCY_NAME<=9"
ynh_install_extra_app_dependencies --repo="SOME_REPO" --package="DEPENDENCY_NAME"
dpkg -l | grep DEPENDENCY_NAME
```
