### PR TITLE
[dnsmasq] ensure interface is up

### DIFF
--- a/data/hooks/conf_regen/43-dnsmasq
+++ b/data/hooks/conf_regen/43-dnsmasq
@@ -28,7 +28,7 @@ do_pre_regen() {
     interfaces="$(ip -j addr show | jq -r '[.[].ifname]|join(" ")')"
     wireless_interfaces="lo"
     for dev in $(ls /sys/class/net); do
-        if [ -d "/sys/class/net/$dev/wireless" ]; then
+        if [ -d "/sys/class/net/$dev/wireless" ] && grep -q "up" "/sys/class/net/$dev/operstate"; then
             wireless_interfaces+=" $dev"
         fi
     done


### PR DESCRIPTION
## The problem

dnsmasq can't start if I [wlan0 interface is disabled](https://github.com/YunoHost-Apps/adguardhome_ynh/issues/34#issuecomment-1012405893)

## Solution

Check the content of the `operstate` file

## PR Status

Not really tested in the battlefield

## How to test

...
