### PR TITLE
[enh] Add SNI support for postfix and dovecot

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -21,6 +21,11 @@ ssl = required
 
 ssl_cert = </etc/yunohost/certs/{{ main_domain }}/crt.pem
 ssl_key = </etc/yunohost/certs/{{ main_domain }}/key.pem
+{% for domain in domain_list.split() %}{% if domain != main_domain %}
+local_name {{ domain }} {
+  ssl_cert = </etc/yunohost/certs/{{ domain }}/crt.pem
+  ssl_key = </etc/yunohost/certs/{{ domain }}/key.pem
+}{% endif %}{% endfor %}
 
 # curl https://ssl-config.mozilla.org/ffdhe2048.txt > /path/to/dhparam
 ssl_dh = </usr/share/yunohost/ffdhe2048.pem

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -23,8 +23,11 @@ smtpd_use_tls = yes
 
 smtpd_tls_security_level = may
 smtpd_tls_auth_only = yes
-smtpd_tls_cert_file = /etc/yunohost/certs/{{ main_domain }}/crt.pem
-smtpd_tls_key_file = /etc/yunohost/certs/{{ main_domain }}/key.pem
+smtpd_tls_chain_files =
+    /etc/yunohost/certs/{{ main_domain }}/key.pem,
+    /etc/yunohost/certs/{{ main_domain }}/crt.pem
+
+tls_server_chain_sni_maps = hash:/etc/postfix/sni
 
 {% if compatibility == "intermediate" %}
 # generated 2020-08-18, Mozilla Guideline v5.6, Postfix 3.4.14, OpenSSL 1.1.1d, intermediate configuration

--- a/conf/postfix/sni
+++ b/conf/postfix/sni
@@ -1,0 +1,2 @@
+{% for domain in domain_list.split() %}{{ domain }} /etc/yunohost/certs/{{ domain }}/key.pem /etc/yunohost/certs/{{ domain }}/crt.pem
+{% endfor %}

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -46,6 +46,7 @@ do_pre_regen() {
     export main_domain
     export domain_list="$YNH_DOMAINS"
     ynh_render_template "main.cf" "${postfix_dir}/main.cf"
+    ynh_render_template "sni" "${postfix_dir}/sni"
 
     cat postsrsd \
         | sed "s/{{ main_domain }}/${main_domain}/g" \
@@ -72,6 +73,8 @@ do_post_regen() {
         chown postfix:root /etc/postfix/sasl_passwd*
         postmap /etc/postfix/sasl_passwd
     fi
+
+    postmap -F hash:/etc/postfix/sni
 
     [[ -z "$regen_conf_files" ]] \
         || { systemctl restart postfix && systemctl restart postsrsd; }

--- a/hooks/conf_regen/25-dovecot
+++ b/hooks/conf_regen/25-dovecot
@@ -18,6 +18,7 @@ do_pre_regen() {
 
     export pop3_enabled="$(yunohost settings get 'pop3.enabled')"
     export main_domain=$(cat /etc/yunohost/current_host)
+    export domain_list="$YNH_DOMAINS"
 
     ynh_render_template "dovecot.conf" "${dovecot_dir}/dovecot.conf"
 


### PR DESCRIPTION
## The problem

In a multi-domain context, postfix and dovecot always serve the main domain SSL certificates. This cause issue when users try to connect with a secondary domain.
- Fix https://github.com/YunoHost/issues/issues/1301

## Solution

- Enable SNI support in postfix and dovecot.
Configuration from https://doc.dovecot.org/configuration_manual/dovecot_ssl_configuration/#with-client-tls-sni-server-name-indication-support and http://www.postfix.org/postconf.5.html#tls_server_sni_maps

## PR Status

- Works great with Thunderbird o/
- Maybe need testing on other mail clients but idk

## How to test

- Pull this PR with `ynh-dev`
- Add 2 or more domains on YunoHost
- Create a user with a main on a secondary domain
- Try to log from a mail client
- Try to send a mail
