### PR TITLE
[mdns] Set the StandardOutput to journal

### DIFF
--- a/conf/mdns/yunomdns.service
+++ b/conf/mdns/yunomdns.service
@@ -8,7 +8,7 @@ Group=mdns
 Type=simple
 Environment=PYTHONUNBUFFERED=1
 ExecStart=/usr/bin/yunomdns
-StandardOutput=syslog
+StandardOutput=journal
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## The problem

After upgrade to bullseye the service complains:

```
Standard output type syslog is obsolete, automatically updating to journal.
Please update your unit file, and consider removing the setting altogether.
```

## Solution

Follow the advice.

## PR Status

Ready, minor decision.

## How to test

Just. Do. It!
