### PR TITLE
[fix] reorder diagnosers

### DIFF
--- a/src/diagnosis.py
+++ b/src/diagnosis.py
@@ -656,9 +656,9 @@ class Diagnoser:
 def _list_diagnosis_categories():
 
     paths = glob.glob(os.path.dirname(__file__) + "/diagnosers/??-*.py")
-    names = sorted(
-        [os.path.basename(path)[: -len(".py")].split("-")[-1] for path in paths]
-    )
+    names = [name.split("-")[-1] for name in sorted(
+        [os.path.basename(path)[: -len(".py")] for path in paths]
+    )]
 
     return names
 


### PR DESCRIPTION
## The problem

Fix https://github.com/YunoHost/issues/issues/1967

## Solution

Some list tricks :sunglasses: 

## PR Status

Not truly tested but should work great!
This is `names` :
```
['basesystem', 'ip', 'dnsrecords', 'ports', 'web', 'mail', 'services', 'systemresources', 'regenconf', 'apps']
```

## How to test

Run those diagnosis! 
