### PR TITLE
configpanels: config_get should return possible choices for domain, user questions (and other dynamic-choices questions)

### DIFF
--- a/src/tests/test_app_config.py
+++ b/src/tests/test_app_config.py
@@ -19,6 +19,7 @@ from yunohost.app import (
     app_config_set,
     app_ssowatconf,
 )
+from yunohost.user import user_create, user_delete
 
 from yunohost.utils.error import YunohostError, YunohostValidationError
 
@@ -101,12 +102,16 @@ def config_app(request):
 
 def test_app_config_get(config_app):
 
+    user_create("alice", "Alice", "White", _get_maindomain(), "test123Ynh")
+
     assert isinstance(app_config_get(config_app), dict)
     assert isinstance(app_config_get(config_app, full=True), dict)
     assert isinstance(app_config_get(config_app, export=True), dict)
     assert isinstance(app_config_get(config_app, "main"), dict)
     assert isinstance(app_config_get(config_app, "main.components"), dict)
     assert app_config_get(config_app, "main.components.boolean") == "0"
+
+    user_delete("alice")
 
 
 def test_app_config_nopanel(legacy_app):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -285,8 +285,10 @@ class ConfigPanel:
                 ask = m18n.n(self.config["i18n"] + "_" + option["id"])
 
             if mode == "full":
-                # edit self.config directly
                 option["ask"] = ask
+                question_class = ARGUMENTS_TYPE_PARSERS[option.get("type", "string")]
+                # FIXME : maybe other properties should be taken from the question, not just choices ?.
+                option["choices"] = question_class(option).choices
             else:
                 result[key] = {"ask": ask}
                 if "current_value" in option:
@@ -1109,7 +1111,7 @@ class DomainQuestion(Question):
         if self.default is None:
             self.default = _get_maindomain()
 
-        self.choices = domain_list()["domains"]
+        self.choices = {domain: domain + ' ★' if domain == self.default else '' for domain in domain_list()['domains']}
 
     @staticmethod
     def normalize(value, option={}):
@@ -1134,7 +1136,9 @@ class UserQuestion(Question):
         from yunohost.domain import _get_maindomain
 
         super().__init__(question, context, hooks)
-        self.choices = list(user_list()["users"].keys())
+
+        self.choices = {username: f"{infos['fullname']} ({infos['mail']})"
+                        for username, infos in user_list()["users"].items()}
 
         if not self.choices:
             raise YunohostValidationError(


### PR DESCRIPTION
## The problem

Running `yunohost foobar config get --full` doesn't return the list of choices for domain, user or other "dynamic-choices" questions.

As a result, the yunohost admin has some specific logic to fill the choices with pretty display values (eg adding a star for main domain, or display user with their fullname and email). But that logic could and should be handled by the core

## Solution

during the `get()`, questions constructors are never called ... but they probably should ... but I don't have every edge case in mind to know if that's an issue

## PR Status

Testing and working on my side, but to be discussed about edge cases

## How to test

Add dummy domain/user questions to the domain config panel
