### PR TITLE
Enhance yunomdns service startup

### DIFF
--- a/conf/mdns/yunomdns.service
+++ b/conf/mdns/yunomdns.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=YunoHost mDNS service
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 User=mdns


### PR DESCRIPTION
## The problem

I had the service start before it was able to list any interface.

## Solution

Make it rely on network-online.target instead of network.target

## PR Status

Done, ready to test, tested locally.

## How to test

...
