### PR TITLE
[fix] Compute choices for the yunohost admin when installing an app

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -57,6 +57,7 @@ from yunohost.utils.config import (
     ask_questions_and_parse_answers,
     DomainQuestion,
     PathQuestion,
+    hydrate_questions_with_choices,
 )
 from yunohost.utils.i18n import _value_for_locale
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -677,6 +678,9 @@ def app_manifest(app):
     manifest, extracted_app_folder = _extract_app(app)
 
     shutil.rmtree(extracted_app_folder)
+
+    raw_questions = manifest.get("arguments", {}).get("install", [])
+    manifest['arguments']['install'] = hydrate_questions_with_choices(raw_questions)
 
     return manifest
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1114,7 +1114,7 @@ class DomainQuestion(Question):
             self.default = _get_maindomain()
 
         self.choices = {
-            domain: domain + " ★" if domain == self.default else ""
+            domain: domain + " ★" if domain == self.default else domain
             for domain in domain_list()["domains"]
         }
 
@@ -1178,7 +1178,7 @@ class UserQuestion(Question):
 
         if self.default is None:
             root_mail = "root@%s" % _get_maindomain()
-            for user in self.choices:
+            for user in self.choices.keys():
                 if root_mail in user_info(user).get("mail-aliases", []):
                     self.default = user
                     break

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1396,3 +1396,15 @@ def ask_questions_and_parse_answers(
         out.append(question)
 
     return out
+
+def hydrate_questions_with_choices(raw_questions: List) -> List:
+    out = []
+
+    for raw_question in raw_questions:
+        question = ARGUMENTS_TYPE_PARSERS[raw_question.get("type", "string")](raw_question)
+        if question.choices:
+            raw_question["choices"] = question.choices
+            raw_question["default"] = question.default
+        out.append(raw_question)
+
+    return out


### PR DESCRIPTION
## The problem

Domains and users appears empty when we install an app from the yunohost admin
This is a side effect of https://github.com/YunoHost/yunohost-admin/pull/426
Now, the admin doesn't compute choices and need them from the API

## Solution

Give `choices` to the yunohost admin through the manifest

## PR Status

Working on my side o/

## How to test

...
