### PR TITLE
configpanel: filter in AppQuestion

### DIFF
--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -14,7 +14,7 @@ i18n = "domain_config"
     [feature.app]
         [feature.app.default_app]
         type = "app"
-        filters = ["is_webapp"]
+        filter = "is_webapp"
         default = "_none"
     
     [feature.mail]

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -706,7 +706,7 @@ class Question:
         self.ask = question.get("ask", {"en": self.name})
         self.help = question.get("help")
         self.redact = question.get("redact", False)
-        self.filter = question.get("filter", [])
+        self.filter = question.get("filter", "true")
         # .current_value is the currently stored value
         self.current_value = question.get("current_value")
         # .value is the "proposed" value which we got from the user
@@ -1142,8 +1142,9 @@ class AppQuestion(Question):
         super().__init__(question, context, hooks)
 
         apps = app_list(full=True)["apps"]
-        
-        apps = [app for app in apps if evaluate_simple_js_expression(self.filter, context=app)]
+
+        if self.filter:
+            apps = [app for app in apps if evaluate_simple_js_expression(self.filter, context=app)]
 
         def _app_display(app):
             domain_path_or_id = f" ({app.get('domain_path', app['id'])})"

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -440,7 +440,7 @@ class ConfigPanel:
                     "step",
                     "accept",
                     "redact",
-                    "filters",
+                    "filter",
                 ],
                 "defaults": {},
             },
@@ -706,7 +706,7 @@ class Question:
         self.ask = question.get("ask", {"en": self.name})
         self.help = question.get("help")
         self.redact = question.get("redact", False)
-        self.filters = question.get("filters", [])
+        self.filter = question.get("filter", [])
         # .current_value is the currently stored value
         self.current_value = question.get("current_value")
         # .value is the "proposed" value which we got from the user
@@ -1142,12 +1142,12 @@ class AppQuestion(Question):
         super().__init__(question, context, hooks)
 
         apps = app_list(full=True)["apps"]
-        for _filter in self.filters:
-            apps = [app for app in apps if _filter in app and app[_filter]]
+        
+        apps = [app for app in apps if evaluate_simple_js_expression(self.filter, context=app)]
 
         def _app_display(app):
-            domain_path = f" ({app['domain_path']})" if "domain_path" in app else ""
-            return app["label"] + domain_path
+            domain_path_or_id = f" ({app.get('domain_path', app['id'])})"
+            return app["label"] + domain_path_or_id
 
         self.choices = {"_none": "---"}
         self.choices.update({app["id"]: _app_display(app) for app in apps})


### PR DESCRIPTION
`filter` is now a simple expression, this allow filtering apps by id.
In the case of https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh, the manifest.json would look like this
```json
{
"arguments": {
		"install": [
			{
				"name": "synapsenumber",
				"type": "app",
				"ask": {
					"en": "Choose the local Synapse instance to communicate with mautrix_whatsapp.",
					"fr": "Choisissez l'instance Synapse qui doit communiquer avec mautrix_whatsapp."
				},
				"filter": "match(id, 'synapse')"
			},
		]
}
```
and render in the webadmin like this:
![image](https://user-images.githubusercontent.com/36127788/151718289-f5431fb8-f05d-46f1-a1dc-98d1a26a5fb4.png)
