### PR TITLE
Removes nginx Content-Security-Policy overrides

### DIFF
--- a/conf/nginx/security.conf.inc
+++ b/conf/nginx/security.conf.inc
@@ -45,7 +45,6 @@ header_filter_by_lua_block {
     ngx.header["Content-Security-Policy"] = "upgrade-insecure-requests"
   end
 }
-more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
 {% endif %}
 
 # Disable the disaster privacy thing that is FLoC

--- a/conf/nginx/security.conf.inc
+++ b/conf/nginx/security.conf.inc
@@ -31,6 +31,23 @@ more_set_headers "X-Download-Options : noopen";
 more_set_headers "X-Permitted-Cross-Domain-Policies : none";
 more_set_headers "X-Frame-Options : SAMEORIGIN";
 
+# Here we add a generic CSP headers only if the app doesn't define it.
+# NB: if the <meta tag is used the most restrictive rules will be used
+{% if experimental == "True" %}
+header_filter_by_lua_block {
+  if ngx.header["Content-Security-Policy"] == nil or ngx.header["Content-Security-Policy"] == "" then
+    ngx.header["Content-Security-Policy"] = "upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'"
+  end
+}
+{% else %}
+header_filter_by_lua_block {
+  if ngx.header["Content-Security-Policy"] == nil or ngx.header["Content-Security-Policy"] == "" then
+    ngx.header["Content-Security-Policy"] = "upgrade-insecure-requests"
+  end
+}
+more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
+{% endif %}
+
 # Disable the disaster privacy thing that is FLoC
 {% if experimental == "True" %}
 more_set_headers "Permissions-Policy : fullscreen=(), geolocation=(), payment=(), accelerometer=(), battery=(), magnetometer=(), usb=(), interest-cohort=()";

--- a/conf/nginx/security.conf.inc
+++ b/conf/nginx/security.conf.inc
@@ -25,12 +25,6 @@ ssl_dhparam /usr/share/yunohost/ffdhe2048.pem;
 # Follows the Web Security Directives from the Mozilla Dev Lab and the Mozilla Obervatory + Partners
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security
 # https://observatory.mozilla.org/
-{% if experimental == "True" %}
-more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
-{% else %}
-more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
-{% endif %}
 more_set_headers "X-Content-Type-Options : nosniff";
 more_set_headers "X-XSS-Protection : 1; mode=block";
 more_set_headers "X-Download-Options : noopen";


### PR DESCRIPTION
## The problem
Different web apps use different features of the browser environment, so each web app must have its own Content Security Policy.  These directives override the CSP set be the app server itself - they will break some web apps and open security holes in others.  https://github.com/openresty/headers-more-nginx-module#more_set_headers

Setting default_src or any of the other *_src directives to data: or 'unsafe-inline' disables key XSS protection. It's hardly a security policy at all.  Content-Security-Policy-Report-Only is useless without a report-uri (and probably a report-to) directive, pointing to a host that accepts violation reports for your domain: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri

...

## Solution

Remove the nginx directives, and let each app server set its own CSP.

...

## PR Status

...

## How to test

Install Armadietto, and with the current nginx config, observe that 
1. The Content-Security-Policy header is set by the nginx config
2. Some browsers complain about the Content-Security-Policy-Report-Only header without a report-uri directive.

Remote the nginx directives, restart and observe
1. Armadietto sets a strict Content-Security-Policy
2. No browser complaints about a Content-Security-Policy-Report-Only header without a report-uri directive.

...
