### PR TITLE
security: Enable proc-hidepid by default

### DIFF
--- a/hooks/conf_regen/01-yunohost
+++ b/hooks/conf_regen/01-yunohost
@@ -154,12 +154,7 @@ EOF
     cp yunohost-api.service ${pending_dir}/etc/systemd/system/yunohost-api.service
     cp yunohost-firewall.service ${pending_dir}/etc/systemd/system/yunohost-firewall.service
     cp yunoprompt.service ${pending_dir}/etc/systemd/system/yunoprompt.service
-
-    if [[ "$(yunohost settings get 'security.experimental.enabled')" == "True" ]]; then
-        cp proc-hidepid.service ${pending_dir}/etc/systemd/system/proc-hidepid.service
-    else
-        touch ${pending_dir}/etc/systemd/system/proc-hidepid.service
-    fi
+    cp proc-hidepid.service ${pending_dir}/etc/systemd/system/proc-hidepid.service
 
     mkdir -p ${pending_dir}/etc/dpkg/origins/
     cp dpkg-origins ${pending_dir}/etc/dpkg/origins/yunohost


### PR DESCRIPTION
## The problem

`ps -ef` (or more generally, access to `/proc`) may leak secret info

## Solution

Currently, the `hidepid` mechanism is only enabled via the experimental security setting

This proposes to enable it by default (since we're moving to Bullseye)

## PR Status

Yolocommited

## How to test

...
