### PR TITLE
Ability to "list" domain as a tree structure, + add a new domain_info endpoint

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -450,7 +450,7 @@ domain:
         ### domain_info()
         info:
             action_help: Get domain aggredated data
-            api: GET /domains/<domains>
+            api: GET /domains/<domain>
             arguments:
                 domain:
                     help: Domain to check

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -449,12 +449,13 @@ domain:
 
         ### domain_info()
         info:
-            action_help: Get domains aggredated data
+            action_help: Get domain aggredated data
             api: GET /domains/<domains>
             arguments:
-                domains:
-                    help: Domains to check
-                    nargs: "*"
+                domain:
+                    help: Domain to check
+                    extra:
+                        pattern: *pattern_domain
 
         ### domain_add()
         add:

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -447,6 +447,15 @@ domain:
                     help: Display domains as a tree
                     action: store_true
 
+        ### domain_info()
+        info:
+            action_help: Get domains aggredated data
+            api: GET /domains/<domains>
+            arguments:
+                domains:
+                    help: Domains to check
+                    nargs: "*"
+
         ### domain_add()
         add:
             action_help: Create a custom domain

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -443,6 +443,9 @@ domain:
                 --exclude-subdomains:
                     help: Filter out domains that are obviously subdomains of other declared domains
                     action: store_true
+                --tree:
+                    help: Display domains as a tree
+                    action: store_true
 
         ### domain_add()
         add:

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -90,13 +90,13 @@ i18n = "domain_config"
         [cert.cert.acme_eligible_explain]
         type = "alert"
         style = "warning"
-        visible = "acme_eligible == false"
+        visible = "acme_eligible == false || acme_elligible == null"
 
         [cert.cert.cert_no_checks]
         ask = "Ignore diagnosis checks"
         type = "boolean"
         default = false
-        visible = "acme_eligible == false"
+        visible = "acme_eligible == false || acme_elligible == null"
 
         [cert.cert.cert_install]
         type = "button"

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -5,12 +5,13 @@ i18n = "domain_config"
 # Other things we may want to implement in the future:
 #
 # - maindomain handling
-# - default app
 # - autoredirect www in nginx conf
 # - ?
 #
 
 [feature]
+name = "Features"
+
     [feature.app]
         [feature.app.default_app]
         type = "app"
@@ -46,6 +47,7 @@ i18n = "domain_config"
         default = 0
 
 [dns]
+name = "DNS"
 
     [dns.registrar]
     optional = true
@@ -61,6 +63,7 @@ i18n = "domain_config"
 
 
 [cert]
+name = "Certificate"
 
     [cert.status]
     name = "Status"

--- a/src/certificate.py
+++ b/src/certificate.py
@@ -98,9 +98,13 @@ def certificate_status(domains, full=False):
         if full:
             try:
                 _check_domain_is_ready_for_ACME(domain)
-                status["ACME_eligible"] = True
-            except Exception:
-                status["ACME_eligible"] = False
+                status["acme_status"] = 'eligible'
+            except Exception as e:
+                if e.key == 'certmanager_domain_not_diagnosed_yet':
+                    status["acme_status"] = 'unknown'
+                else:
+                    status["acme_status"] = 'ineligible'
+
 
         del status["domain"]
         certificates[domain] = status

--- a/src/certificate.py
+++ b/src/certificate.py
@@ -98,12 +98,12 @@ def certificate_status(domains, full=False):
         if full:
             try:
                 _check_domain_is_ready_for_ACME(domain)
-                status["acme_status"] = 'eligible'
+                status["ACME_eligible"] = True
             except Exception as e:
                 if e.key == 'certmanager_domain_not_diagnosed_yet':
-                    status["acme_status"] = 'unknown'
+                    status["ACME_eligible"] = None   # = unknown status
                 else:
-                    status["acme_status"] = 'ineligible'
+                    status["ACME_eligible"] = False
 
 
         del status["domain"]

--- a/src/certificate.py
+++ b/src/certificate.py
@@ -798,7 +798,7 @@ def _check_domain_is_ready_for_ACME(domain):
         or {}
     )
 
-    parent_domain = _get_parent_domain_of(domain)
+    parent_domain = _get_parent_domain_of(domain, return_self=True)
 
     dnsrecords = (
         Diagnoser.get_cached_report(

--- a/src/domain.py
+++ b/src/domain.py
@@ -167,6 +167,7 @@ def domain_info(domain):
         "registrar": registrar,
         "apps": apps,
         "main": _get_maindomain() == domain,
+        "topest_parent": _get_parent_domain_of(domain, return_self=True, topest=True),
         # TODO : add parent / child domains ?
     }
 
@@ -188,15 +189,17 @@ def _list_subdomains_of(parent_domain):
     return out
 
 
-def _get_parent_domain_of(domain, return_self=True):
+def _get_parent_domain_of(domain, return_self=True, topest=False):
 
     _assert_domain_exists(domain)
 
-    domains = _get_domains()
-    while "." in domain:
-        domain = domain.split(".", 1)[1]
-        if domain in domains:
-            return domain
+    domains = _get_domains(exclude_subdomains=topest)
+
+    domain_ = domain
+    while "." in domain_:
+        domain_ = domain_.split(".", 1)[1]
+        if domain_ in domains:
+            return domain_
 
     return domain if return_self else None
 

--- a/src/domain.py
+++ b/src/domain.py
@@ -24,7 +24,7 @@
     Manage domains
 """
 import os
-from typing import List, Any
+from typing import List
 from collections import OrderedDict
 
 from moulinette import m18n, Moulinette

--- a/src/domain.py
+++ b/src/domain.py
@@ -25,6 +25,7 @@
 """
 import os
 from typing import List, Any
+from collections import OrderedDict
 
 from moulinette import m18n, Moulinette
 from moulinette.core import MoulinetteError
@@ -99,7 +100,6 @@ def domain_list(exclude_subdomains=False, tree=False):
         tree -- Display domains as a hierarchy tree
 
     """
-    from collections import OrderedDict
 
     domains = _get_domains(exclude_subdomains)
     main = _get_maindomain()
@@ -128,80 +128,37 @@ def domain_list(exclude_subdomains=False, tree=False):
     return {"domains": result, "main": main}
 
 
-def domain_info(domains):
+def domain_info(domain):
     """
-    Print aggregate data about domains (all by default)
+    Print aggregate data for a specific domain
 
     Keyword argument:
-        domains     -- Domains to be checked
-
+        domain     -- Domain to be checked
     """
 
-    from collections import OrderedDict
     from yunohost.app import app_info
     from yunohost.dns import _get_registar_settings
-    from yunohost.utils.dns import is_special_use_tld
 
-    # If no domains given, consider all yunohost domains
-    if domains == []:
-        domains = _get_domains()
-    # Else, validate that yunohost knows the domains given
-    else:
-        for domain in domains:
-            _assert_domain_exists(domain)
+    _assert_domain_exists(domain)
 
-    def get_dns_config(domain):
-        if is_special_use_tld(domain):
-            return {"method": "none"}
+    registrar, _ = _get_registar_settings(domain)
+    certificate = domain_cert_status([domain], full=True)["certificates"][domain]
 
-        registrar, registrar_credentials = _get_registar_settings(domain)
-
-        if not registrar or registrar == "None":  # yes it's None as a string
-            return {"method": "manual", "semi_auto_status": "unavailable"}
-        if registrar == "parent_domain":
-            return {"method": "handled_in_parent"}
-        if registrar == "yunohost":
-            return {"method": "auto", "registrar": registrar}
-        if not all(registrar_credentials.values()):
-            return {
-                "method": "manual",
-                "semi_auto_status": "activable",
-                "registrar": registrar,
-            }
-
-        return {
-            "method": "semi_auto",
-            "registrar": registrar,
-            "semi_auto_status": "activated",
-        }
-
-    certs = domain_cert_status(domains, full=True)["certificates"]
-    apps = {domain: [] for domain in domains}
-
+    apps = []
     for app in _installed_apps():
         settings = _get_app_settings(app)
-        if settings["domain"] in domains:
-            apps[settings["domain"]].append(
+        if settings.get("domain") == domain:
+            apps.append(
                 {"name": app_info(app)["name"], "id": app, "path": settings["path"]}
             )
 
-    result = OrderedDict()
-    for domain in domains:
-        result[domain] = OrderedDict(
-            {
-                "certificate": {
-                    "authority": certs[domain]["CA_type"]["code"],
-                    "validity": certs[domain]["validity"],
-                    "acme_status": certs[domain]["acme_status"],
-                },
-                "dns": get_dns_config(domain),
-            }
-        )
-
-        if apps[domain]:
-            result[domain]["apps"] = apps[domain]
-
-    return {"domains": result}
+    return {
+        "certificate": certificate,
+        "registrar": registrar,
+        "apps": apps,
+        "main": _get_maindomain() == domain,
+        # TODO : add parent / child domains ?
+    }
 
 
 def _assert_domain_exists(domain):

--- a/src/domain.py
+++ b/src/domain.py
@@ -192,7 +192,7 @@ def domain_info(domains):
                 "certificate": {
                     "authority": certs[domain]["CA_type"]["code"],
                     "validity": certs[domain]["validity"],
-                    "ACME_eligible": certs[domain]["ACME_eligible"],
+                    "acme_status": certs[domain]["acme_status"],
                 },
                 "dns": get_dns_config(domain),
             }

--- a/src/domain.py
+++ b/src/domain.py
@@ -221,21 +221,6 @@ def _list_subdomains_of(parent_domain):
     return out
 
 
-# def _get_parent_domain_of(domain):
-#
-#     _assert_domain_exists(domain)
-#
-#     if "." not in domain:
-#         return domain
-#
-#     parent_domain = domain.split(".", 1)[-1]
-#     if parent_domain not in _get_domains():
-#         return domain  # Domain is its own parent
-#
-#     else:
-#         return _get_parent_domain_of(parent_domain)
-
-
 def _get_parent_domain_of(domain, return_self=True):
 
     _assert_domain_exists(domain)


### PR DESCRIPTION
- rework a bit the cache logic for domains and maindomain to keep only raw data
- add `--tree` arg to `yunohost domain list` to display a hierarchical tree of domains and subdomains
- add `yunohost domain info` to get aggregate data about dns configuration, cert status and apps installed on domain

## PR Status
Draft

## How to test

```bash
yunohost domain list --tree
yunohost domain info
yunohost domain info mydomain.tld
```

`yunohost domain list --tree` should return something like:
```yaml
domains: 
  dmn.ynh-dns-test.fr: 
    my.dmn.ynh-dns-test.fr: 
    my.long.sub.dmn.ynh-dns-test.fr: 
  testy.ynh-dns-test.fr: 
  ynh.local: 
    main.sub.ynh.local: 
main: ynh.local
```

`yunohost domain info` should return something like:
```yaml
domains: 
  dmn.ynh-dns-test.fr: 
    certificate: 
      acme_status: unknown
      authority: self-signed
      validity: 3645
    dns: 
      method: manual
      registrar: godaddy
      semi_auto_status: activable
  my.dmn.ynh-dns-test.fr: 
    certificate: 
      acme_status: ineligible
      authority: self-signed
      validity: 3645
    dns: 
      method: handled_in_parent
  ynh.local: 
    certificate: 
      acme_status: unknown
      authority: self-signed
      validity: 3639
    dns: 
      method: none
    apps: 
      0: 
        id: 20euros
        name: 20 euros
        path: /20euros
      1: 
        id: config_app
        name: Config panel test app
        path: /
  main.sub.ynh.local: 
    certificate: 
      acme_status: unknown
      authority: self-signed
      validity: 3649
    dns: 
      method: none
```