### PR TITLE
Several FIXME fix :rocket: 

### DIFF
--- a/hooks/conf_regen/12-metronome
+++ b/hooks/conf_regen/12-metronome
@@ -49,12 +49,8 @@ do_post_regen() {
     # retrieve variables
     main_domain=$(cat /etc/yunohost/current_host)
 
-    # FIXME : small optimization to do to avoid calling a yunohost command ...
-    # maybe another env variable like YNH_MAIN_DOMAINS idk
-    domain_list=$(yunohost domain list --exclude-subdomains --output-as plain --quiet)
-
     # create metronome directories for domains
-    for domain in $domain_list; do
+    for domain in $YNH_MAIN_DOMAINS; do
         mkdir -p "/var/lib/metronome/${domain//./%2e}/pep"
         # http_upload directory must be writable by metronome and readable by nginx
         mkdir -p "/var/xmpp-upload/${domain}/upload"

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -735,6 +735,10 @@ app:
                     full: --full
                     help: Display all details, including the app manifest and various other infos
                     action: store_true
+                -u:
+                    full: --upgradable
+                    help: List only apps that can upgrade to a newer version
+                    action: store_true
 
         ### app_info()
         info:

--- a/src/regenconf.py
+++ b/src/regenconf.py
@@ -140,6 +140,7 @@ def regen_conf(
     # though kinda tight-coupled to the postinstall logic :s
     if os.path.exists("/etc/yunohost/installed"):
         env["YNH_DOMAINS"] = " ".join(domain_list()["domains"])
+        env["YNH_MAIN_DOMAINS"] = " ".join(domain_list(exclude_subdomains=True)["domains"])
 
     pre_result = hook_callback("conf_regen", names, pre_callback=_pre_call, env=env)
 

--- a/src/tools.py
+++ b/src/tools.py
@@ -37,8 +37,8 @@ from moulinette.utils.process import call_async_output
 from moulinette.utils.filesystem import read_yaml, write_to_yaml, cp, mkdir, rm
 
 from yunohost.app import (
-    app_info,
     app_upgrade,
+    app_list
 )
 from yunohost.app_catalog import (
     _initialize_apps_catalog_system,
@@ -56,8 +56,6 @@ from yunohost.utils.packages import (
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.log import is_unit_operation, OperationLogger
 
-# FIXME this is a duplicate from apps.py
-APPS_SETTING_PATH = "/etc/yunohost/apps/"
 MIGRATIONS_STATE_PATH = "/etc/yunohost/migrations.yaml"
 
 logger = getActionLogger("yunohost.tools")
@@ -391,47 +389,12 @@ def tools_update(target=None):
         except YunohostError as e:
             logger.error(str(e))
 
-        upgradable_apps = list(_list_upgradable_apps())
+        upgradable_apps = list(app_list(upgradable=True)["apps"])
 
     if len(upgradable_apps) == 0 and len(upgradable_system_packages) == 0:
         logger.info(m18n.n("already_up_to_date"))
 
     return {"system": upgradable_system_packages, "apps": upgradable_apps}
-
-
-def _list_upgradable_apps():
-
-    app_list_installed = os.listdir(APPS_SETTING_PATH)
-    for app_id in app_list_installed:
-
-        app_dict = app_info(app_id, full=True)
-
-        if app_dict["upgradable"] == "yes":
-
-            # FIXME : would make more sense for these infos to be computed
-            # directly in app_info and used to check the upgradability of
-            # the app...
-            current_version = app_dict.get("manifest", {}).get("version", "?")
-            current_commit = app_dict.get("settings", {}).get("current_revision", "?")[
-                :7
-            ]
-            new_version = (
-                app_dict.get("from_catalog", {}).get("manifest", {}).get("version", "?")
-            )
-            new_commit = (
-                app_dict.get("from_catalog", {}).get("git", {}).get("revision", "?")[:7]
-            )
-
-            if current_version == new_version:
-                current_version += " (" + current_commit + ")"
-                new_version += " (" + new_commit + ")"
-
-            yield {
-                "id": app_id,
-                "label": app_dict["label"],
-                "current_version": current_version,
-                "new_version": new_version,
-            }
 
 
 @is_unit_operation()
@@ -466,7 +429,7 @@ def tools_upgrade(operation_logger, target=None):
 
         # Make sure there's actually something to upgrade
 
-        upgradable_apps = [app["id"] for app in _list_upgradable_apps()]
+        upgradable_apps = [app["id"] for app in app_list(upgradable=True)["apps"]]
 
         if not upgradable_apps:
             logger.info(m18n.n("apps_already_up_to_date"))

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -289,6 +289,8 @@ class ConfigPanel:
                 question_class = ARGUMENTS_TYPE_PARSERS[option.get("type", "string")]
                 # FIXME : maybe other properties should be taken from the question, not just choices ?.
                 option["choices"] = question_class(option).choices
+                option["default"] = question_class(option).default
+                option["pattern"] = question_class(option).pattern
             else:
                 result[key] = {"ask": ask}
                 if "current_value" in option:
@@ -603,7 +605,7 @@ class ConfigPanel:
         }
 
     @property
-    def future_values(self):  # TODO put this in ConfigPanel ?
+    def future_values(self):
         return {**self.values, **self.new_values}
 
     def __getattr__(self, name):

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -706,7 +706,7 @@ class Question:
         self.ask = question.get("ask", {"en": self.name})
         self.help = question.get("help")
         self.redact = question.get("redact", False)
-        self.filter = question.get("filter", "true")
+        self.filter = question.get("filter", None)
         # .current_value is the currently stored value
         self.current_value = question.get("current_value")
         # .value is the "proposed" value which we got from the user


### PR DESCRIPTION
## The problem

I got distracted by some FIXME :fearful: 

## Solution

Some small fixes...okwell that was small at some point
* `yunohost domain list -output-as plain` also print `#main` and `#domain`, use the command in metronome regen-conf create some unnecessary files. => Create a new env `YNH_MAIN_DOMAINS` for regen-conf.
* Add `default` and `pattern` in the `yunohost <thing> config get --full`. `default` is used in the webadmin, especially in `select`s. I don't think we use `pattern` yet but this could be usefull
* Move the `_list_upgradable_apps` logic from `tools.py` to `app.py`. Also added `yunohost app list --upgradable` in the actionmap because why not ? :rocket: 

## PR Status

Tested locally

## How to test

```
yunohost tools regen-conf metronome --debug

yunohost domain config get domain.tld --full

# Install some old app version
yunohost app install https://github.com/YunoHost-Apps/20euros_ynh/tree/f8c5f11894b7d0579bea6d583a776ada9de4a6b8
yunohost tools update apps
yunohost app list --upgradable
yunohost tools upgrade apps
```
