### PR TITLE
[fix] Avoid to delete --is-big unbackuped directories

### DIFF
--- a/helpers/backup
+++ b/helpers/backup
@@ -463,7 +463,7 @@ ynh_restore_upgradebackup() {
         # Check if an existing backup can be found before removing and restoring the application.
         if ynh_backup_archive_exists "$app_bck-pre-upgrade$backup_number"; then
             # Remove the application then restore it
-            yunohost app remove $app
+            REMOVE_CORE_ONLY=1 yunohost app remove $app
             # Restore the backup
             yunohost backup restore $app_bck-pre-upgrade$backup_number --apps $app --force --debug
             if [[ -d /etc/yunohost/apps/$app ]]


### PR DESCRIPTION
## The problem

Some apps like bozon declare the data_dir with --is-big in backup and remove this path in the remove script (without --purge option)
However, it doesn't make sense for bozon or similar apps (like lufi) to remove conditionnaly with the --purge option, cause if we remove the db, we have no interest to keep the files.

## Solution

I suggest to add here a REMOVE_CORE_ONLY option to use like BACKUP_CORE_ONLY. With this option if a user remove the app, unreusable big files will be deleted, but if it's the ynh_restore_upgradebackup helper that trigger the remove, we will keep the files to avoid to lose them before the restore operation...

## PR Status

Ready

## How to test

...
