### PR TITLE
Always activate time when running inside CI tests

### DIFF
--- a/helpers/logging
+++ b/helpers/logging
@@ -250,7 +250,7 @@ ynh_script_progression() {
     weight=${weight:-1}
     
     # Always activate time when running inside CI tests
-    if [$PACKAGE_CHECK_EXEC -eq 1]; then
+    if [ $PACKAGE_CHECK_EXEC -eq 1 ]; then
     	time=${time:-1}
     else
     	time=${time:-0}

--- a/helpers/logging
+++ b/helpers/logging
@@ -248,7 +248,14 @@ ynh_script_progression() {
     # Re-disable xtrace, ynh_handle_getopts_args set it back
     set +o xtrace # set +x
     weight=${weight:-1}
-    time=${time:-0}
+    
+    # Always activate time when running inside CI tests
+    if [$PACKAGE_CHECK_EXEC -eq 1]; then
+    	time=${time:-1}
+    else
+    	time=${time:-0}
+    fi
+
     last=${last:-0}
 
     # Get execution time since the last $base_time


### PR DESCRIPTION
## The problem

To adjust the weight parameter, you need to use the --time argument of ynh_script_progression and then need to remove it, and that for every occurrence. Sure, using an alias or a regular expression may help, but configuring the script may provide a more efficient way to alleviate this task.

## Solution

The time is now always displayed when the scripts (install, backup, upgrade, etc.) are run in the CI environment while it can still be manually set while running outside.

## How to test

I did not test my commit.
