### PR TITLE
Fix flag case sensitivity in dovecot and rspamd sieve filter

### DIFF
--- a/conf/dovecot/dovecot.sieve
+++ b/conf/dovecot/dovecot.sieve
@@ -1,4 +1,4 @@
 require "fileinto"; 
-    if header :contains "X-Spam-Flag" "YES" { 
+    if header :contains "X-Spam-Flag" "Yes" { 
         fileinto "Junk"; 
     }

--- a/conf/rspamd/rspamd.sieve
+++ b/conf/rspamd/rspamd.sieve
@@ -1,4 +1,4 @@
 require ["fileinto"];
-if header :is "X-Spam" "yes" {
+if header :is "X-Spam" "Yes" {
     fileinto "Junk";
 }


### PR DESCRIPTION
AFAIK this value is case sensitive. It is written as "Yes" in rspamd/milter_headers.conf