### PR TITLE
Enforce chmod 644(-rw-r--r--) on logrotate configuration files

### DIFF
--- a/helpers/logrotate
+++ b/helpers/logrotate
@@ -90,6 +90,7 @@ $logfile {
 EOF
     mkdir --parents $(dirname "$logfile")                              # Create the log directory, if not exist
     cat ${app}-logrotate | $customtee /etc/logrotate.d/$app >/dev/null # Append this config to the existing config file, or replace the whole config file (depending on $customtee)
+    chmod 644 /etc/logrotate.d/$app
 }
 
 # Remove the app's logrotate config.


### PR DESCRIPTION
## The problem

Some logrotate files are created as `-rw-rw-rw-`. This is really bad.

Also, obviously, logrotate doesn't want to use a configuration file that anyone in the world can write. Good boi.

## Solution

We can just ensure the files are correctly chmod in the logrotate helper.

