### PR TITLE
helpers: fix quoting issue in new ynh_install_apps helper

### DIFF
--- a/helpers/apps
+++ b/helpers/apps
@@ -32,7 +32,7 @@ ynh_install_apps() {
 		then
 			# Retrieve the arguments of the app (part after ?)
 			local one_argument=$(cut -d "?" -f2- <<< "$one_app_and_its_args")
-			[ ! -z "$one_argument" ] && one_argument="--args \"$one_argument\""
+			[ ! -z "$one_argument" ] && one_argument="--args $one_argument"
 			
 			# Install the app with its arguments
 			yunohost app install $one_app $one_argument


### PR DESCRIPTION
keeping the `\"`

`yunohost app install $one_app $one_argument`

will be

`yunohost app install galette --args "'domain=domain2.tld&path=/galette&is_public=1&admin=yalh&password=**********&database=mysql'"` 

with too much quotes