### PR TITLE
Content Security Policies Report-Only and Websockets

### DIFF
--- a/conf/nginx/security.conf.inc
+++ b/conf/nginx/security.conf.inc
@@ -29,7 +29,7 @@ ssl_dhparam /usr/share/yunohost/ffdhe2048.pem;
 more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
 {% else %}
 more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
-more_set_headers "Content-Security-Policy-Report-Only : default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
+more_set_headers "Content-Security-Policy-Report-Only : default-src https: wss: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
 {% endif %}
 more_set_headers "X-Content-Type-Options : nosniff";
 more_set_headers "X-XSS-Protection : 1; mode=block";


### PR DESCRIPTION
Add the `wss:` field so that Nginx does not create warning when using Websocket over TLS.

This modification only affects the `Report-Only` part of the CSP, that takes care of creating warnings in the logs.

## The problem

Many worrying warnings are created in Nginx logs. Those warnings are useless and counter intuitive.

Warning example (fr only sorry):
```
Content Security Policy: Les paramètres de la page ont empêché le chargement d’une ressource à wss://your.website.tld (« default-src »). Un rapport CSP est en cours d’envoi.
```

## Solution

Add the `wss` directive in the "Report-Only" CSP config to allow WSS requests

## PR Status

Ready to merge :+1: 

## How to test

![We do it live](https://media.giphy.com/media/q7UpJegIZjsk0/giphy.gif)
