### PR TITLE
Make changed variables' old values available in config panels scripts

### DIFF
--- a/helpers/config
+++ b/helpers/config
@@ -90,6 +90,7 @@ _ynh_app_config_apply_one() {
 
         # Save value in app settings
         elif [[ "$bind" == "settings" ]]; then
+            declare -g "old_$short_setting"=$(ynh_app_setting_get --app=$app --key=$short_setting)
             ynh_app_setting_set --app=$app --key=$short_setting --value="${!short_setting}"
             ynh_print_info --message="Configuration key '$short_setting' edited in app settings"
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost-Apps/my_webapp_ynh/pull/82

PHP versions management is hindered partially because the variables' new values are already set when a config panel script is launched.

## Solution

In any ways, we should have the old variable values available at old_${variable}.

## PR Status

"Meh"

## How to test

Just. Do. It.
