### PR TITLE
Escape username for ynh_user_exists

### DIFF
--- a/helpers/user
+++ b/helpers/user
@@ -17,7 +17,7 @@ ynh_user_exists() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    yunohost user list --output-as json --quiet | jq -e ".users.${username}" >/dev/null
+    yunohost user list --output-as json --quiet | jq -e ".users.\"${username}\"" >/dev/null
 }
 
 # Retrieve a YunoHost user information


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/2018

## Solution

Escape username when filtering with `jq`.

## PR Status

Ready, tested manually.

## How to test

...
