### PR TITLE
[fix] Be able to redo postinstall after 128+ chars password

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -71,7 +71,10 @@ def tools_adminpw(new_password, check_strength=True):
 
     """
     from yunohost.user import _hash_user_password
-    from yunohost.utils.password import assert_password_is_strong_enough
+    from yunohost.utils.password import (
+        assert_password_is_strong_enough,
+        assert_password_is_compatible
+    )
     import spwd
 
     if check_strength:

--- a/src/tools.py
+++ b/src/tools.py
@@ -50,7 +50,7 @@ from yunohost.utils.packages import (
     _list_upgradable_apt_packages,
     ynh_packages_version,
 )
-from yunohost.utils.error import YunohostError, YunohostValidationError
+from yunohost.utils.error import yunohosterror, yunohostvalidationerror
 from yunohost.log import is_unit_operation, OperationLogger
 
 MIGRATIONS_STATE_PATH = "/etc/yunohost/migrations.yaml"
@@ -77,10 +77,7 @@ def tools_adminpw(new_password, check_strength=True):
     if check_strength:
         assert_password_is_strong_enough("admin", new_password)
 
-    # UNIX seems to not like password longer than 127 chars ...
-    # e.g. SSH login gets broken (or even 'su admin' when entering the password)
-    if len(new_password) >= 127:
-        raise YunohostValidationError("admin_password_too_long")
+    assert_password_is_compatible(new_password)
 
     new_hash = _hash_user_password(new_password)
 
@@ -226,6 +223,8 @@ def tools_postinstall(
         raise YunohostValidationError("postinstall_low_rootfsspace")
 
     # Check password
+    assert_password_is_compatible(password)
+
     if not force_password:
         assert_password_is_strong_enough("admin", password)
 

--- a/src/tools.py
+++ b/src/tools.py
@@ -50,7 +50,7 @@ from yunohost.utils.packages import (
     _list_upgradable_apt_packages,
     ynh_packages_version,
 )
-from yunohost.utils.error import yunohosterror, yunohostvalidationerror
+from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.log import is_unit_operation, OperationLogger
 
 MIGRATIONS_STATE_PATH = "/etc/yunohost/migrations.yaml"

--- a/src/user.py
+++ b/src/user.py
@@ -143,7 +143,10 @@ def user_create(
 
     from yunohost.domain import domain_list, _get_maindomain, _assert_domain_exists
     from yunohost.hook import hook_callback
-    from yunohost.utils.password import assert_password_is_strong_enough
+    from yunohost.utils.password import (
+        assert_password_is_strong_enough,
+        assert_password_is_compatible
+    )
     from yunohost.utils.ldap import _get_ldap_interface
 
     # Ensure compatibility and sufficiently complex password

--- a/src/user.py
+++ b/src/user.py
@@ -369,7 +369,10 @@ def user_update(
     """
     from yunohost.domain import domain_list, _get_maindomain
     from yunohost.app import app_ssowatconf
-    from yunohost.utils.password import assert_password_is_strong_enough
+    from yunohost.utils.password import (
+        assert_password_is_strong_enough,
+        assert_password_is_compatible
+    )
     from yunohost.utils.ldap import _get_ldap_interface
     from yunohost.hook import hook_callback
 

--- a/src/user.py
+++ b/src/user.py
@@ -146,7 +146,8 @@ def user_create(
     from yunohost.utils.password import assert_password_is_strong_enough
     from yunohost.utils.ldap import _get_ldap_interface
 
-    # Ensure sufficiently complex password
+    # Ensure compatibility and sufficiently complex password
+    assert_password_is_compatible(password)
     assert_password_is_strong_enough("user", password)
 
     # Validate domain used for email address/xmpp account
@@ -414,7 +415,8 @@ def user_update(
             change_password = Moulinette.prompt(
                 m18n.n("ask_password"), is_password=True, confirm=True
             )
-        # Ensure sufficiently complex password
+        # Ensure compatibility and sufficiently complex password
+        assert_password_is_compatible(password)
         assert_password_is_strong_enough("user", change_password)
 
         new_attr_dict["userPassword"] = [_hash_user_password(change_password)]

--- a/src/utils/password.py
+++ b/src/utils/password.py
@@ -47,7 +47,25 @@ STRENGTH_LEVELS = [
 ]
 
 
+def assert_password_is_compatible(password):
+    """
+    UNIX seems to not like password longer than 127 chars ...
+    e.g. SSH login gets broken (or even 'su admin' when entering the password)
+    """
+
+    if len(password) >= 127:
+
+        # Note that those imports are made here and can't be put
+        # on top (at least not the moulinette ones)
+        # because the moulinette needs to be correctly initialized
+        # as well as modules available in python's path.
+        from yunohost.utils.error import YunohostValidationError
+
+        raise YunohostValidationError("admin_password_too_long")
+
+
 def assert_password_is_strong_enough(profile, password):
+
     PasswordValidator(profile).validate(password)
 
 


### PR DESCRIPTION
## The problem
When someone do the postinstall with a 128+ char password, the person gets a message about the need for a 127- char password.
However when the person retry to postinstall, the postinstall is half made.So the second time it says  "The domain already exists" so the person have to reinstall or use the unknown reset script on https://github.com/YunoHost/yunoScripts/blob/master/resetPostinstall.sh

## Solution

Do the check before to make changes.

In more i have added the checks on user account (not just admin) cause user account could have ssh permission too now.

## PR Status

Untested

## How to test

...
