### PR TITLE
App Config Panel : Don't restrict choices if there's no choices specified

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -703,7 +703,8 @@ class Question:
         self.default = question.get("default", None)
         self.optional = question.get("optional", False)
         self.visible = question.get("visible", None)
-        self.choices = question.get("choices", [])
+        # Don't restrict choices if there's none specified
+        self.choices = question.get("choices", None)
         self.pattern = question.get("pattern", self.pattern)
         self.ask = question.get("ask", {"en": self.name})
         self.help = question.get("help")


### PR DESCRIPTION
## The problem

Currently, if you have an app config panel that uses tags without restricting choices ( for example, `borg`'s one, with it's `app` field ), the web-admin will still use the component `TagsSelectizeItem` instead of `TagsItem` , making the option unchangeable from the web-admin.

This is due to the fact that the web-admin request the `--full` version of the config panel, and this returns by default an empty list for the choices, instead of `None`.

## Solution

Simply change the default from an empty list to `None`

## PR Status

Ready to merge ? I was trying to think of edge cases where this could break something, but couldn't find one.
