### PR TITLE
Saving app's venv in a requirements file, in order to regenerate it

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -507,6 +507,7 @@
     "migration_0018_failed_to_reset_legacy_rules": "Failed to reset legacy iptables rules: {error}",
     "migration_0019_add_new_attributes_in_ldap": "Add new attributes for permissions in LDAP database",
     "migration_0019_slapd_config_will_be_overwritten": "It looks like you manually edited the slapd configuration. For this critical migration, YunoHost needs to force the update of the slapd configuration. The original files will be backuped in {conf_backup_folder}.",
+	"migration_0021_venv_regen_failed": "The virtual environment '{venv}' failed to regenerate, you probably need to run the command `yunohost app upgrade --force`",
     "migration_0021_start" : "Starting migration to Bullseye",
     "migration_0021_patching_sources_list": "Patching the sources.lists...",
     "migration_0021_main_upgrade": "Starting main upgrade...",

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -71,7 +71,7 @@ def _rebuild_venvs():
             if status!=0:
                 logger.warning(m18n.n("venv_regen_failed", venv=venv))
             else:
-                rm(venv+VENV_REQUIREMENTS_SUFFIX, recursive=True)
+                rm(venv+VENV_REQUIREMENTS_SUFFIX)
         else:
             logger.warning(m18n.n("venv_regen_failed", venv=venv))
 

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -30,7 +30,6 @@ N_CURRENT_YUNOHOST = 4
 N_NEXT_DEBAN = 11
 N_NEXT_YUNOHOST = 11
 
-VENV_BACKUP_SUFFIX = "_BACKUP_VENV"
 VENV_REQUIREMENTS_SUFFIX = "_req.txt"
 VENV_IGNORE = "ynh_migration_no_regen"
 
@@ -64,15 +63,7 @@ def _rebuild_venvs():
 
     venvs = _get_all_venvs("/opt/")+_get_all_venvs("/var/www/")
     for venv in venvs:
-        # Create a backup of the venv, in case there's a problem
-        if os.path.isdir(venv+VENV_BACKUP_SUFFIX):
-            rm(venv+VENV_BACKUP_SUFFIX, recursive=True)
-        backup = True
-        try:
-            cp(venv, venv+VENV_BACKUP_SUFFIX, recursive=True)
-        except:
-            backup = False
-        if backup and os.path.isfile(venv+VENV_REQUIREMENTS_SUFFIX):
+        if os.path.isfile(venv+VENV_REQUIREMENTS_SUFFIX):
             # Recreate the venv
             rm(venv, recursive=True)
             os.system(f"python -m venv {venv}")

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -35,6 +35,7 @@ VENV_REQUIREMENTS_SUFFIX = "_req.txt"
 VENV_IGNORE = "VENVNOREGEN"
 
 def _get_all_venvs(dir,level=0,maxlevel=2):
+    # Using os functions instead of glob, because glob doesn't support hidden folders, and we need recursion with a fixed depth
     result = []
     for file in os.listdir(dir):
         path = os.path.join(dir,file)

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -58,7 +58,7 @@ def _get_all_venvs(dir, level=0, maxlevel=3):
     return result
 
 
-def _generate_requirements():
+def _backup_pip_freeze_for_python_app_venvs():
     """
         Generate a requirements file for all python virtual env located inside /opt/ and /var/www/
     """
@@ -112,7 +112,7 @@ class MyMigration(Migration):
         # Get requirements of the different venvs from python apps
         #
 
-        _generate_requirements()
+        _backup_pip_freeze_for_python_app_venvs()
 
         #
         # Run apt update

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -31,7 +31,6 @@ N_NEXT_DEBAN = 11
 N_NEXT_YUNOHOST = 11
 
 VENV_REQUIREMENTS_SUFFIX = ".requirements_backup_for_bullseye_upgrade.txt"
-VENV_IGNORE = "ynh_migration_no_regen"
 
 
 def _get_all_venvs(dir, level=0, maxlevel=3):
@@ -48,8 +47,6 @@ def _get_all_venvs(dir, level=0, maxlevel=3):
     for file in os.listdir(dir):
         path = os.path.join(dir, file)
         if os.path.isdir(path):
-            if os.path.isfile(os.path.join(path, VENV_IGNORE)):
-                continue
             activatepath = os.path.join(path,"bin", "activate")
             if os.path.isfile(activatepath):
                 content = read_file(activatepath)

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -33,7 +33,7 @@ N_NEXT_YUNOHOST = 11
 VENV_REQUIREMENTS_SUFFIX = "_req.txt"
 VENV_IGNORE = "ynh_migration_no_regen"
 
-def _get_all_venvs(dir,level=0,maxlevel=2):
+def _get_all_venvs(dir,level=0,maxlevel=3):
     # Using os functions instead of glob, because glob doesn't support hidden folders, and we need recursion with a fixed depth
     result = []
     for file in os.listdir(dir):

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -85,11 +85,11 @@ def _rebuild_venvs():
             os.system(f"python -m venv {venv}")
             status = os.system(f"bash -c 'source {venv}/bin/activate && pip install -r {venv}{VENV_REQUIREMENTS_SUFFIX} && deactivate'")
             if status != 0:
-                logger.warning(m18n.n("venv_regen_failed", venv=venv))
+                logger.warning(m18n.n("migration_0021_venv_regen_failed", venv=venv))
             else:
                 rm(venv + VENV_REQUIREMENTS_SUFFIX)
         else:
-            logger.warning(m18n.n("venv_regen_failed", venv=venv))
+            logger.warning(m18n.n("migration_0021_venv_regen_failed", venv=venv))
 
 
 class MyMigration(Migration):

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -69,7 +69,7 @@ def _generate_requirements():
     venvs = _get_all_venvs("/opt/") + _get_all_venvs("/var/www/")
     for venv in venvs:
         # Generate a requirements file from venv
-        os.system(f"bash -c 'source {venv}/bin/activate && pip freeze > {venv}{VENV_REQUIREMENTS_SUFFIX} && deactivate'")
+        os.system(f"{venv}/bin/pip freeze > {venv}{VENV_REQUIREMENTS_SUFFIX}")
 
 
 def _rebuild_venvs():

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -44,7 +44,7 @@ def _get_all_venvs(dir,level=0,maxlevel=3):
             activatepath = os.path.join(path,"bin","activate")
             if os.path.isfile(activatepath):
                 content = read_file(activatepath)
-                if "VIRTUAL_ENV" and "PYTHONHOME" in content:
+                if ("VIRTUAL_ENV" in content) and ("PYTHONHOME" in content):
                     result.append(path)
                     continue
             if level<maxlevel:

--- a/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
+++ b/src/yunohost/data_migrations/0021_migrate_to_bullseye.py
@@ -83,7 +83,7 @@ def _rebuild_venvs():
             # Recreate the venv
             rm(venv, recursive=True)
             os.system(f"python -m venv {venv}")
-            status = os.system(f"bash -c 'source {venv}/bin/activate && pip install -r {venv}{VENV_REQUIREMENTS_SUFFIX} && deactivate'")
+            status = os.system(f"{venv}/bin/pip install -r {venv}{VENV_REQUIREMENTS_SUFFIX}")
             if status != 0:
                 logger.warning(m18n.n("migration_0021_venv_regen_failed", venv=venv))
             else:


### PR DESCRIPTION
## The problem

After migrating, the old virtual env for python apps ( located in /opt/ ) is no longer valid

## Solution

Before upgrading, the migration script now creates a requirements file listing the different dependancies.
After upgrading the packages, the script deletes and recreates the virtual env from the generated requirements file

## PR Status

Draft