### PR TITLE
[enh] Add level 0 bullseye apps to disclaimer

### DIFF
--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2509,7 +2509,7 @@ def unstable_apps():
         if not infos.get("from_catalog") or infos.get("from_catalog").get("state") in [
             "inprogress",
             "notworking",
-        ] or infos["id"] in deprecated_apps:
+        ] or infos["id"] in deprecated_apps or infos.get("from_catalog").get("level") == 0:
             output.append(infos["id"])
 
     return output

--- a/src/yunohost/app.py
+++ b/src/yunohost/app.py
@@ -2506,10 +2506,10 @@ def unstable_apps():
 
     for infos in app_list(full=True)["apps"]:
 
-        if not infos.get("from_catalog") or infos.get("from_catalog").get("state") in [
+        if not infos.get("from_catalog") or infos.get("from_catalog", {}).get("state") in [
             "inprogress",
             "notworking",
-        ] or infos["id"] in deprecated_apps or infos.get("from_catalog").get("level") == 0:
+        ] or infos["id"] in deprecated_apps or infos.get("from_catalog", {}).get("level") == 0:
             output.append(infos["id"])
 
     return output


### PR DESCRIPTION
## The problem

It seems ffsync is not displayed in disclaimer for bullseye migration

## Solution

Check if the apps as a level 0 and warn in disclaimer.

## PR Status

Done (untested)

## How to test

...
