### PR TITLE
tools_postinstall: list all partitions (not only physical ones)

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -219,7 +219,7 @@ def tools_postinstall(
         )
 
     # Check there's at least 10 GB on the rootfs...
-    disk_partitions = sorted(psutil.disk_partitions(), key=lambda k: k.mountpoint)
+    disk_partitions = sorted(psutil.disk_partitions(all=True), key=lambda k: k.mountpoint)
     main_disk_partitions = [d for d in disk_partitions if d.mountpoint in ["/", "/var"]]
     main_space = sum(
         psutil.disk_usage(d.mountpoint).total for d in main_disk_partitions


### PR DESCRIPTION
This allows special installation cases such as in a container, where disk_partitions(all=False) would not show virtual mount points.

## The problem

When installing in a container, the postinstall step will complain about disk not being big enough. Actually, disk_partitions() only returns those mount points:
```
>>> psutil.disk_partitions()
[sdiskpart(device='/dev/mapper/luks-4e999104-04dc-4395-af70-0ce456540e15', mountpoint='/sys/fs/cgroup', fstype='ext4', opts='rw,nosuid,nodev,noatime', maxfile=255, maxpath=4096)]
```

## Solution
all=True tells psutils to show all mountpoints, including virtual ones and non-physical partitions. We actually filter the returned list for the mountpoints / and /var, so there's no downside to this change.

## PR Status

Working

## How to test
Install Yunohost in a podman container and enjoy
