### PR TITLE
Fix ynh_delete_file_checksum in helpers/config

### DIFF
--- a/helpers/config
+++ b/helpers/config
@@ -77,7 +77,7 @@ _ynh_app_config_apply_one() {
             if [[ "${!short_setting}" == "" ]]; then
                 ynh_backup_if_checksum_is_different --file="$bind_file"
                 ynh_secure_remove --file="$bind_file"
-                ynh_delete_file_checksum --file="$bind_file" --update_only
+                ynh_delete_file_checksum --file="$bind_file"
                 ynh_print_info --message="File '$bind_file' removed"
             else
                 ynh_backup_if_checksum_is_different --file="$bind_file"


### PR DESCRIPTION

## The problem

Config panel fails while deleting an uploaded file, while attempting to delete its checksum.

## Solution

no need for `--update_only` flag

## PR Status

Ready.

## How to test

Just. Do. It.