### PR TITLE
[fix] Lidswitch if no reboot

### DIFF
--- a/hooks/conf_regen/01-yunohost
+++ b/hooks/conf_regen/01-yunohost
@@ -221,7 +221,10 @@ do_post_regen() {
         systemctl restart ntp
     }
     [[ ! "$regen_conf_files" =~ "nftables.service.d/ynh-override.conf" ]] || systemctl daemon-reload
-    [[ ! "$regen_conf_files" =~ "login.conf.d/ynh-override.conf" ]] || systemctl daemon-reload
+    [[ ! "$regen_conf_files" =~ "login.conf.d/ynh-override.conf" ]] ||  {
+        systemctl daemon-reload
+        systemctl restart systemd-logind
+    }
     [[ ! "$regen_conf_files" =~ "yunohost-firewall.service" ]] || systemctl daemon-reload
     [[ ! "$regen_conf_files" =~ "yunohost-api.service" ]] || systemctl daemon-reload
 


### PR DESCRIPTION
## The problem

After doing the yunohost initial configuration (postinstall), the logind service is not restarted even if the logind lidswitch config has been updated. So if we close the lidswitch (before rebooting) the computer is suspended.

## Solution
Restart systemd-login in regen conf

## PR Status

Ready, but tested partially (i just restarted this service to make it work on an unrebooted laptop)

## How to test

...
