### PR TITLE
Able to replace sources

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -63,10 +63,11 @@ ynh_abort_if_errors() {
 
 # Download, check integrity, uncompress and patch the source from app.src
 #
-# usage: ynh_setup_source --dest_dir=dest_dir [--source_id=source_id] [--keep="file1 file2"]
+# usage: ynh_setup_source --dest_dir=dest_dir [--source_id=source_id] [--keep="file1 file2"] [--replace]
 # | arg: -d, --dest_dir=    - Directory where to setup sources
 # | arg: -s, --source_id=   - Name of the source, defaults to `app`
 # | arg: -k, --keep=        - Space-separated list of files/folders that will be backup/restored in $dest_dir, such as a config file you don't want to overwrite. For example 'conf.json secrets.json logs/'
+# | arg: -r, --replace=     - Remove previous sources before installing new sources
 #
 # This helper will read `conf/${source_id}.src`, download and install the sources.
 #
@@ -102,14 +103,16 @@ ynh_abort_if_errors() {
 ynh_setup_source() {
     # Declare an array to define the options of this helper.
     local legacy_args=dsk
-    local -A args_array=([d]=dest_dir= [s]=source_id= [k]=keep=)
+    local -A args_array=([d]=dest_dir= [s]=source_id= [k]=keep= [r]=replace=)
     local dest_dir
     local source_id
     local keep
+    local replace
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     source_id="${source_id:-app}"
     keep="${keep:-}"
+    replace="${replace:-0}"
 
     local src_file_path="$YNH_APP_BASEDIR/conf/${source_id}.src"
 
@@ -170,6 +173,10 @@ ynh_setup_source() {
                 cp --archive "$dest_dir/$stuff_to_keep" "$keep_dir/$stuff_to_keep"
             fi
         done
+    fi
+
+    if [ "$replace" -eq 1 ]; then
+        ynh_secure_remove --file="$dest_dir"
     fi
 
     # Extract source into the app dir

--- a/helpers/utils
+++ b/helpers/utils
@@ -63,11 +63,11 @@ ynh_abort_if_errors() {
 
 # Download, check integrity, uncompress and patch the source from app.src
 #
-# usage: ynh_setup_source --dest_dir=dest_dir [--source_id=source_id] [--keep="file1 file2"] [--replace]
-# | arg: -d, --dest_dir=    - Directory where to setup sources
-# | arg: -s, --source_id=   - Name of the source, defaults to `app`
-# | arg: -k, --keep=        - Space-separated list of files/folders that will be backup/restored in $dest_dir, such as a config file you don't want to overwrite. For example 'conf.json secrets.json logs/'
-# | arg: -r, --replace=     - Remove previous sources before installing new sources
+# usage: ynh_setup_source --dest_dir=dest_dir [--source_id=source_id] [--keep="file1 file2"] [--full_replace]
+# | arg: -d, --dest_dir=     - Directory where to setup sources
+# | arg: -s, --source_id=    - Name of the source, defaults to `app`
+# | arg: -k, --keep=         - Space-separated list of files/folders that will be backup/restored in $dest_dir, such as a config file you don't want to overwrite. For example 'conf.json secrets.json logs/'
+# | arg: -r, --full_replace= - Remove previous sources before installing new sources
 #
 # This helper will read `conf/${source_id}.src`, download and install the sources.
 #
@@ -103,16 +103,16 @@ ynh_abort_if_errors() {
 ynh_setup_source() {
     # Declare an array to define the options of this helper.
     local legacy_args=dsk
-    local -A args_array=([d]=dest_dir= [s]=source_id= [k]=keep= [r]=replace=)
+    local -A args_array=([d]=dest_dir= [s]=source_id= [k]=keep= [r]=full_replace=)
     local dest_dir
     local source_id
     local keep
-    local replace
+    local full_replace
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     source_id="${source_id:-app}"
     keep="${keep:-}"
-    replace="${replace:-0}"
+    full_replace="${full_replace:-0}"
 
     local src_file_path="$YNH_APP_BASEDIR/conf/${source_id}.src"
 
@@ -175,7 +175,7 @@ ynh_setup_source() {
         done
     fi
 
-    if [ "$replace" -eq 1 ]; then
+    if [ "$full_replace" -eq 1 ]; then
         ynh_secure_remove --file="$dest_dir"
     fi
 


### PR DESCRIPTION
## The problem

Sometimes during upgrade of an app we need to completly remove previous sources before installing the new ones

Some examples:

- https://github.com/YunoHost-Apps/agora_ynh/blob/3ce3213030bcc533205259c7737df4c213bbd6f7/scripts/upgrade#L71-L83
- https://github.com/YunoHost-Apps/chuwiki_ynh/blob/098937aadc6495bed4ff5858cd09bcbde3f3050e/scripts/upgrade#L74-L90
- https://github.com/YunoHost-Apps/shaarli_ynh/blob/445198c4c555d6a5adedfc54b9112264f2559328/scripts/upgrade#L74-L96
- https://github.com/YunoHost-Apps/discourse_ynh/blob/ec974723113fa8f984af8ab47d1cc99765ae6c2f/scripts/upgrade#L108-L174
- https://github.com/YunoHost-Apps/focalboard_ynh/blob/76ae13bb2e4c5bc4efde3d3081c92282c35ce405/scripts/upgrade#L84-L104

And as --keep is already implemented, we have a simple way to do so

## Solution

add an option for the ynh_setup_source helper to remove previous installed sources

## PR Status

Ready

## How to test

...
