### PR TITLE
[fix] Config panel nested bind statements

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -513,7 +513,7 @@ ynh_read_var_in_file() {
     # Get the line number after which we search for the variable
     local line_number=1
     if [[ -n "$after" ]]; then
-        line_number=$(grep -n $after $file | cut -d: -f1)
+        line_number=$(grep -m1 -n $after $file | cut -d: -f1)
         if [[ -z "$line_number" ]]; then
             set -o xtrace # set -x
             return 1
@@ -591,7 +591,7 @@ ynh_write_var_in_file() {
     # Get the line number after which we search for the variable
     local line_number=1
     if [[ -n "$after" ]]; then
-        line_number=$(grep -n $after $file | cut -d: -f1)
+        line_number=$(grep -m1 -n $after $file | cut -d: -f1)
         if [[ -z "$line_number" ]]; then
             set -o xtrace # set -x
             return 1


### PR DESCRIPTION
## The problem

When using the bind option in `config_panel.toml` with a values like `"encryption>allow:__FINALPATH__/config.yaml"` the config panel won't load and will be broken.

## Solution

Use `-m1` parameter to Limit the number of grep matches to 1 here:
https://github.com/YunoHost/yunohost/blob/e4369274fa3379c279de4c8b6a19a85e06040805/helpers/utils#L517
and here:
https://github.com/YunoHost/yunohost/blob/e4369274fa3379c279de4c8b6a19a85e06040805/helpers/utils#L595

To avoid the following `tail` statements from breaking:
https://github.com/YunoHost/yunohost/blob/e4369274fa3379c279de4c8b6a19a85e06040805/helpers/utils#L547
https://github.com/YunoHost/yunohost/blob/e4369274fa3379c279de4c8b6a19a85e06040805/helpers/utils#L626

More info in the bug report: [#2003
](https://github.com/YunoHost/issues/issues/2003#top)
## PR Status

Ready

## How to test

Use any existing app that has a config panel, edit one of the entries and try to use a nested option like seen above.
Make sure that the string actually exists in the referenced config file.
