### PR TITLE
Not need to force $YNH_APP_BASEDIR

### DIFF
--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -99,8 +99,8 @@ ignoreregex =
 " >$YNH_APP_BASEDIR/conf/f2b_filter.conf
     fi
 
-    ynh_add_config --template="$YNH_APP_BASEDIR/conf/f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
-    ynh_add_config --template="$YNH_APP_BASEDIR/conf/f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
+    ynh_add_config --template="f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
+    ynh_add_config --template="f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 

--- a/helpers/nginx
+++ b/helpers/nginx
@@ -20,7 +20,7 @@ ynh_add_nginx_config() {
 
     local finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 
-    ynh_add_config --template="$YNH_APP_BASEDIR/conf/nginx.conf" --destination="$finalnginxconf"
+    ynh_add_config --template="nginx.conf" --destination="$finalnginxconf"
 
     if [ "${path_url:-}" != "/" ]; then
         ynh_replace_string --match_string="^#sub_path_only" --replace_string="" --target_file="$finalnginxconf"

--- a/helpers/php
+++ b/helpers/php
@@ -192,7 +192,7 @@ pm.process_idle_timeout = 10s
 
     if [ -e "$YNH_APP_BASEDIR/conf/php-fpm.ini" ]; then
         ynh_print_warn --message="Packagers ! Please do not use a separate php ini file, merge your directives in the pool file instead."
-        ynh_add_config --template="$YNH_APP_BASEDIR/conf/php-fpm.ini" --destination="$fpm_config_dir/conf.d/20-$app.ini"
+        ynh_add_config --template="php-fpm.ini" --destination="$fpm_config_dir/conf.d/20-$app.ini"
     fi
 
     if [ $dedicated_service -eq 1 ]; then
@@ -206,7 +206,7 @@ syslog.ident = php-fpm-__APP__
 include = __FINALPHPCONF__
 " >$YNH_APP_BASEDIR/conf/php-fpm-$app.conf
 
-        ynh_add_config --template="$YNH_APP_BASEDIR/conf/php-fpm-$app.conf" --destination="$globalphpconf"
+        ynh_add_config --template="php-fpm-$app.conf" --destination="$globalphpconf"
 
         # Create a config for a dedicated PHP-FPM service for the app
         echo "[Unit]

--- a/helpers/systemd
+++ b/helpers/systemd
@@ -23,7 +23,7 @@ ynh_add_systemd_config() {
     service="${service:-$app}"
     template="${template:-systemd.service}"
 
-    ynh_add_config --template="$YNH_APP_BASEDIR/conf/$template" --destination="/etc/systemd/system/$service.service"
+    ynh_add_config --template="$template" --destination="/etc/systemd/system/$service.service"
 
     systemctl enable $service --quiet
     systemctl daemon-reload


### PR DESCRIPTION
## The problem

Able to define a specific path for some files ie outside of `/conf`

## Solution

ynh_add_config directly handle the `$YNH_APP_BASEDIR/conf/` at https://github.com/YunoHost/yunohost/blob/551095aa7098c2ad4a8dbc9348cf80e4b5400f83/helpers/utils#L364-L370

and allow to define a specific path

So removing it from the helpers

## PR Status

Ready

## How to test

...
