### PR TITLE
domain_info: Some apps don't have path

### DIFF
--- a/src/domain.py
+++ b/src/domain.py
@@ -156,7 +156,7 @@ def domain_info(domain):
         settings = _get_app_settings(app)
         if settings.get("domain") == domain:
             apps.append(
-                {"name": app_info(app)["name"], "id": app, "path": settings["path"]}
+                {"name": app_info(app)["name"], "id": app, "path": settings.get("path", "")}
             )
 
     return {


### PR DESCRIPTION
 domain_info: Some apps don't have path (non-web apps like synapse/borg), it triggers a KeyError.


## The problem

Domain info page does not load for some domains

## Solution

Fix the backend

## PR Status

FIXME: should I default to "" (domain root ?) or `None` (should be properly understood by the frontend) ?

## How to test

Install synapse on a domain, try to go on the domain info page.
