### PR TITLE
Fix variable not found when using appv2

### DIFF
--- a/helpers/php
+++ b/helpers/php
@@ -156,7 +156,7 @@ ynh_add_fpm_config() {
 user = __APP__
 group = __APP__
 
-chdir = __FINALPATH__
+chdir = __INSTALL_DIR__
 
 listen = /var/run/php/php__PHPVERSION__-fpm-__APP__.sock
 listen.owner = www-data
@@ -474,9 +474,9 @@ YNH_COMPOSER_VERSION=${YNH_COMPOSER_VERSION:-$YNH_DEFAULT_COMPOSER_VERSION}
 
 # Execute a command with Composer
 #
-# usage: ynh_composer_exec [--phpversion=phpversion] [--workdir=$final_path] --commands="commands"
+# usage: ynh_composer_exec [--phpversion=phpversion] [--workdir=$install_dir] --commands="commands"
 # | arg: -v, --phpversion - PHP version to use with composer
-# | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
+# | arg: -w, --workdir - The directory from where the command will be executed. Default $install_dir.
 # | arg: -c, --commands - Commands to execute.
 #
 # Requires YunoHost version 4.2 or higher.
@@ -489,7 +489,7 @@ ynh_composer_exec() {
     local commands
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
-    workdir="${workdir:-$final_path}"
+    workdir="${workdir:-$install_dir}"
     phpversion="${phpversion:-$YNH_PHP_VERSION}"
 
     COMPOSER_HOME="$workdir/.composer" COMPOSER_MEMORY_LIMIT=-1 \
@@ -499,9 +499,9 @@ ynh_composer_exec() {
 
 # Install and initialize Composer in the given directory
 #
-# usage: ynh_install_composer [--phpversion=phpversion] [--workdir=$final_path] [--install_args="--optimize-autoloader"] [--composerversion=composerversion]
+# usage: ynh_install_composer [--phpversion=phpversion] [--workdir=$install_dir] [--install_args="--optimize-autoloader"] [--composerversion=composerversion]
 # | arg: -v, --phpversion - PHP version to use with composer
-# | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
+# | arg: -w, --workdir - The directory from where the command will be executed. Default $install_dir.
 # | arg: -a, --install_args - Additional arguments provided to the composer install. Argument --no-dev already include
 # | arg: -c, --composerversion - Composer version to install
 #
@@ -516,7 +516,7 @@ ynh_install_composer() {
     local composerversion
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
-    workdir="${workdir:-$final_path}"
+    workdir="${workdir:-$install_dir}"
     phpversion="${phpversion:-$YNH_PHP_VERSION}"
     install_args="${install_args:-}"
     composerversion="${composerversion:-$YNH_COMPOSER_VERSION}"


### PR DESCRIPTION
## The problem

when using `ynh_add_fpm_config` and `ynh_install_composer` we get the error `$finalpath` and `$final_path` not found.

## Solution

Replace by the new variable used in manifest v2: `$install_dir`

## PR Status

...

## How to test

...
