### PR TITLE
Add support for Webgo Registrar DNS

### DIFF
--- a/share/registrar_list.toml
+++ b/share/registrar_list.toml
@@ -622,7 +622,14 @@
     [vultr.auth_token]
     type = "string"
     redact = true
-    
+
+[webgo]
+    [webgo.auth_username]
+    type = "string"
+
+    [webgo.auth_password]
+    type = "password"
+
 [yandex]
     [yandex.auth_token]
     type = "string"


### PR DESCRIPTION
## The problem

Recently added Provider "webgo" in lexicon-api leads to an stacktrace in yunohost (testing) when adding a domain which is registered there, since it is found by the lexicn-api, but is not in the yunohost registrar_list.
(I am also the author of the webgo provider for the lexicon-api)

## Solution

Add webgo Provider into registrar_list

## PR Status

Done

## How to test

I tested the whole implementation with about 20 Domains on webgo without any issue. 