### PR TITLE
Fix OCSP stapling ... but using tech giant resolvers :|

### DIFF
--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -54,7 +54,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
-    resolver 127.0.0.1 127.0.1.1 valid=300s;
+    resolver 8.8.8.8 valid=300s;
     resolver_timeout 5s;
     {% endif %}
 
@@ -110,7 +110,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
-    resolver 127.0.0.1 127.0.1.1 valid=300s;
+    resolver 8.8.8.8 valid=300s;
     resolver_timeout 5s;
     {% endif %}
 

--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -54,7 +54,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
-    resolver 8.8.8.8 valid=300s;
+    resolver 1.1.1.1 9.9.9.9 valid=300s;
     resolver_timeout 5s;
     {% endif %}
 
@@ -110,7 +110,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
-    resolver 8.8.8.8 valid=300s;
+    resolver 1.1.1.1 9.9.9.9 valid=300s;
     resolver_timeout 5s;
     {% endif %}
 


### PR DESCRIPTION
## The problem

OCSP stapling is in fact broken because nginx complains in the log file : 

`r3.o.lencr.org could not be resolved (110: Operation timed out) while requesting certificate status, responder: r3.o.lencr.org, certificate: "/etc/yunohost/certs/domain.tld/crt.pem"`

Also related to : https://github.com/YunoHost/issues/issues/1099

## Solution

I don't know why, but Nginx doesnt like 127.0.0.1 as a resolver, despite the fact that dnsmasq listens on 0.0.0.0:53 and a `dig` request on 127.0.0.1 does work ...

Using Google resolver works, but this is probably not what we want, so opening as draft PR only

## PR Status

Using Google resolver works, but this is probably not what we want, so opening as draft PR only


## How to test

`openssl s_client -connect domain.tld:443 -status | grep OCSP` 

should display:

```
OCSP response: 
OCSP Response Data:
    OCSP Response Status: successful (0x0)
```
