### PR TITLE
appcatalog: do not fetch catalogs registered with no `url` (special case to be able to test app upgrades and stuff in dev envs)

### DIFF
--- a/src/app_catalog.py
+++ b/src/app_catalog.py
@@ -173,6 +173,9 @@ def _update_apps_catalog():
         mkdir(APPS_CATALOG_CACHE, mode=0o750, parents=True, uid="root")
 
     for apps_catalog in apps_catalog_list:
+        if apps_catalog["url"] is None:
+            continue
+            
         apps_catalog_id = apps_catalog["id"]
         actual_api_url = _actual_apps_catalog_api_url(apps_catalog["url"])
 


### PR DESCRIPTION
Do not fetch catalogs registered with no `url`

Required by https://github.com/YunoHost/ynh-dev/pull/66