### PR TITLE
Allow apps to be installed on a path sharing a common base, eg /foo and /foo2

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2508,11 +2508,7 @@ def _get_conflicting_apps(domain, path, ignore_app=None):
         for p, a in apps_map[domain].items():
             if a["id"] == ignore_app:
                 continue
-            if path == p:
-                conflicts.append((p, a["id"], a["label"]))
-            # We also don't want conflicts with other apps starting with
-            # same name
-            elif path.startswith(p) or p.startswith(path):
+            if path == p or path == "/" or p == "/":
                 conflicts.append((p, a["id"], a["label"]))
 
     return conflicts


### PR DESCRIPTION
## The problem

Fix https://github.com/YunoHost/issues/issues/1974
Fix https://github.com/YunoHost/issues/issues/1178

## Solution

Allow to install apps on `/foo2` even if there's already an app on `/foo`

It's not clear to me if there's any drawback doing this ... It seems to me that there was not actual reason to forbid this and may just have been a mythological "uh maybe nginx won't like it" but I dont see why it would ...

## PR Status

Yolocomitted

## How to test

Try to install hextris on one /hextris, then another on /hextris2