### PR TITLE
domains: propagate mail/xmpp enable/disable toggle to actual system configs

### DIFF
--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -6,7 +6,7 @@ map $http_upgrade $connection_upgrade {
 server {
     listen 80;
     listen [::]:80;
-    server_name {{ domain }} xmpp-upload.{{ domain }};
+    server_name {{ domain }}{% if xmpp_enabled != "True" %} xmpp-upload.{{ domain }}{% endif %};
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 
@@ -16,9 +16,11 @@ server {
         alias /tmp/.well-known/ynh-diagnosis/;
     }
 
+    {% if mail_enabled == "True" %}
     location ^~ '/.well-known/autoconfig/mail/' {
         alias /var/www/.well-known/{{ domain }}/autoconfig/mail/;
     }
+    {% endif %}
 
     {# Note that this != "False" is meant to be failure-safe, in the case the redrect_to_https would happen to contain empty string or whatever value. We absolutely don't want to disable the HTTPS redirect *except* when it's explicitly being asked to be disabled. #}
     {% if redirect_to_https != "False" %}
@@ -58,9 +60,11 @@ server {
     resolver_timeout 5s;
     {% endif %}
 
+    {% if mail_enabled == "True" %}
     location ^~ '/.well-known/autoconfig/mail/' {
         alias /var/www/.well-known/{{ domain }}/autoconfig/mail/;
     }
+    {% endif %}
 
     access_by_lua_file /usr/share/ssowat/access.lua;
 
@@ -75,6 +79,7 @@ server {
     error_log /var/log/nginx/{{ domain }}-error.log;
 }
 
+{% if xmpp_enabled == "True" %}
 # vhost dedicated to XMPP http_upload
 server {
     listen 443 ssl http2;
@@ -117,3 +122,4 @@ server {
     access_log /var/log/nginx/xmpp-upload.{{ domain }}-access.log;
     error_log /var/log/nginx/xmpp-upload.{{ domain }}-error.log;
 }
+{% endif %}

--- a/hooks/conf_regen/12-metronome
+++ b/hooks/conf_regen/12-metronome
@@ -26,8 +26,14 @@ do_pre_regen() {
         | sed "s/{{ main_domain }}/${main_domain}/g" \
             >"${metronome_dir}/metronome.cfg.lua"
 
-    # add domain conf files
+    # Trick such that old conf files are flagged as to remove
     for domain in $YNH_DOMAINS; do
+        touch "${metronome_conf_dir}/${domain}.cfg.lua"
+    done
+
+    # add domain conf files
+    domain_list="$(yunohost domain list --features xmpp --output-as json | jq -r ".domains[]")"
+    for domain in $domain_list; do
         cat domain.tpl.cfg.lua \
             | sed "s/{{ domain }}/${domain}/g" \
                 >"${metronome_conf_dir}/${domain}.cfg.lua"

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -73,6 +73,8 @@ do_pre_regen() {
     cert_status=$(yunohost domain cert status --json)
 
     # add domain conf files
+    xmpp_domain_list="$(yunohost domain list --features xmpp --output-as json | jq -r ".domains[]")"
+    mail_domain_list="$(yunohost domain list --features mail_in mail_out --output-as json | jq -r ".domains[]")"
     for domain in $YNH_DOMAINS; do
         domain_conf_dir="${nginx_conf_dir}/${domain}.d"
         mkdir -p "$domain_conf_dir"
@@ -84,9 +86,24 @@ do_pre_regen() {
         export domain_cert_ca=$(echo $cert_status \
             | jq ".certificates.\"$domain\".CA_type" \
             | tr -d '"')
+        if echo "$xmpp_domain_list" | grep -q "^$domain$"
+        then
+            export xmpp_enabled="True"
+        else
+            export xmpp_enabled="False"
+        fi
+        if echo "$mail_domain_list" | grep -q "^$domain$"
+        then
+            export mail_enabled="True"
+        else
+            export mail_enabled="False"
+        fi
 
         ynh_render_template "server.tpl.conf" "${nginx_conf_dir}/${domain}.conf"
-        ynh_render_template "autoconfig.tpl.xml" "${mail_autoconfig_dir}/config-v1.1.xml"
+        if [ $mail_enabled == "True" ]
+        then
+            ynh_render_template "autoconfig.tpl.xml" "${mail_autoconfig_dir}/config-v1.1.xml"
+        fi
 
         touch "${domain_conf_dir}/yunohost_local.conf" # Clean legacy conf files
 

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -46,13 +46,13 @@ do_pre_regen() {
         cat <<<"[${relay_host}]:${relay_port} ${relay_user}:${relay_password}" >${postfix_dir}/sasl_passwd
     fi
     export main_domain
-    export domain_list="$YNH_DOMAINS"
+    export domain_list="$(yunohost domain list --features mail_in mail_out --output-as json | jq -r ".domains[]" | tr '\n' ' ')"
     ynh_render_template "main.cf" "${postfix_dir}/main.cf"
     ynh_render_template "sni" "${postfix_dir}/sni"
 
     cat postsrsd \
         | sed "s/{{ main_domain }}/${main_domain}/g" \
-        | sed "s/{{ domain_list }}/${YNH_DOMAINS}/g" \
+        | sed "s/{{ domain_list }}/${domain_list}/g" \
             >"${default_dir}/postsrsd"
 
     # adapt it for IPv4-only hosts

--- a/hooks/conf_regen/25-dovecot
+++ b/hooks/conf_regen/25-dovecot
@@ -18,7 +18,7 @@ do_pre_regen() {
 
     export pop3_enabled="$(yunohost settings get 'email.pop3.pop3_enabled')"
     export main_domain=$(cat /etc/yunohost/current_host)
-    export domain_list="$YNH_DOMAINS"
+    export domain_list="$(yunohost domain list --features mail_in mail_out --output-as json | jq -r ".domains[]" | tr '\n' ' ')"
 
     ynh_render_template "dovecot.conf" "${dovecot_dir}/dovecot.conf"
 

--- a/hooks/conf_regen/31-rspamd
+++ b/hooks/conf_regen/31-rspamd
@@ -26,7 +26,8 @@ do_post_regen() {
     chown _rspamd /etc/dkim
 
     # create DKIM key for domains
-    for domain in $YNH_DOMAINS; do
+    domain_list="$(yunohost domain list --features mail_in mail_out --output-as json | jq -r ".domains[]" | tr '\n' ' ')"
+    for domain in $domain_list; do
         domain_key="/etc/dkim/${domain}.mail.key"
         [ ! -f "$domain_key" ] && {
             # We use a 1024 bit size because nsupdate doesn't seem to be able to

--- a/locales/en.json
+++ b/locales/en.json
@@ -337,7 +337,6 @@
     "domain_config_cert_summary_selfsigned": "WARNING: Current certificate is self-signed. Browsers will display a spooky warning to new visitors!",
     "domain_config_cert_validity": "Validity",
     "domain_config_default_app": "Default app",
-    "domain_config_features_disclaimer": "So far, enabling/disabling mail or XMPP features only impact the recommended and automatic DNS configuration, not system configurations!",
     "domain_config_mail_in": "Incoming emails",
     "domain_config_mail_out": "Outgoing emails",
     "domain_config_xmpp": "Instant messaging (XMPP)",

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -462,6 +462,9 @@ domain:
                 --tree:
                     help: Display domains as a tree
                     action: store_true
+                --features:
+                    help: List only domains with features enabled (xmpp, mail_in, mail_out)
+                    nargs: "*"
 
         ### domain_info()
         info:

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -1,14 +1,6 @@
 version = "1.0"
 i18n = "domain_config"
 
-#
-# Other things we may want to implement in the future:
-#
-# - maindomain handling
-# - autoredirect www in nginx conf
-# - ?
-#
-
 [feature]
 name = "Features"
 
@@ -19,12 +11,6 @@ name = "Features"
         default = "_none"
 
     [feature.mail]
-    #services = ['postfix', 'dovecot']
-
-        [feature.mail.features_disclaimer]
-        type = "alert"
-        style = "warning"
-        icon = "warning"
 
         [feature.mail.mail_out]
         type = "boolean"
@@ -34,31 +20,18 @@ name = "Features"
         type = "boolean"
         default = 1
 
-        #[feature.mail.backup_mx]
-        #type = "tags"
-        #default = []
-        #pattern.regexp = '^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})$'
-        #pattern.error = "pattern_error"
-
     [feature.xmpp]
 
         [feature.xmpp.xmpp]
         type = "boolean"
         default = 0
+        help = "NB: some XMPP features will require that you update your DNS records and regenerate your Lets Encrypt certificate to be enabled"
 
 [dns]
 name = "DNS"
 
     [dns.registrar]
     # This part is automatically generated in DomainConfigPanel
-
-#   [dns.advanced]
-#
-#        [dns.advanced.ttl]
-#        type = "number"
-#        min = 0
-#        default = 3600
-
 
 [cert]
 name = "Certificate"

--- a/src/certificate.py
+++ b/src/certificate.py
@@ -568,10 +568,10 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
     # Set the domain
     csr.get_subject().CN = domain
 
-    from yunohost.domain import domain_list
+    from yunohost.domain import domain_list, domain_config_get
 
-    # For "parent" domains, include xmpp-upload subdomain in subject alternate names
-    if domain in domain_list(exclude_subdomains=True)["domains"]:
+    # If XMPP is enabled for this domain, add xmpp-upload domain
+    if domain_config_get(domain, key="feature.xmpp.xmpp") == 1:
         subdomain = "xmpp-upload." + domain
         xmpp_records = (
             Diagnoser.get_cached_report(

--- a/src/domain.py
+++ b/src/domain.py
@@ -98,7 +98,7 @@ def _get_domains(exclude_subdomains=False):
     return domain_list_cache
 
 
-def domain_list(exclude_subdomains=False, tree=False):
+def domain_list(exclude_subdomains=False, tree=False, features=[]):
     """
     List domains
 
@@ -110,6 +110,14 @@ def domain_list(exclude_subdomains=False, tree=False):
 
     domains = _get_domains(exclude_subdomains)
     main = _get_maindomain()
+
+    if features:
+        domains_filtered = []
+        for domain in domains:
+            config = domain_config_get(domain, key="feature", export=True)
+            if any(config.get(feature) == 1 for feature in features):
+                domains_filtered.append(domain)
+        domains = domains_filtered
 
     if not tree:
         return {"domains": domains, "main": main}
@@ -544,6 +552,30 @@ class DomainConfigPanel(ConfigPanel):
             and self.future_values["default_app"] != self.values["default_app"]
         ):
             app_ssowatconf()
+
+        stuff_to_regen_conf = []
+        if (
+            "xmpp" in self.future_values
+            and self.future_values["xmpp"] != self.values["xmpp"]
+        ):
+            stuff_to_regen_conf.append("nginx")
+            stuff_to_regen_conf.append("metronome")
+
+        if (
+            "mail_in" in self.future_values
+            and self.future_values["mail_in"] != self.values["mail_in"]
+        ) or (
+            "mail_out" in self.future_values
+            and self.future_values["mail_out"] != self.values["mail_out"]
+        ):
+            if "nginx" not in stuff_to_regen_conf:
+                stuff_to_regen_conf.append("nginx")
+            stuff_to_regen_conf.append("postfix")
+            stuff_to_regen_conf.append("dovecot")
+            stuff_to_regen_conf.append("rspamd")
+
+        if stuff_to_regen_conf:
+            regen_conf(names=stuff_to_regen_conf)
 
     def _get_toml(self):
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/1028

## Solution

Propagate the existing mail/xmpp toggle to actual system configs during regen conf

## PR Status

Kinda tested on my side

## How to test

Run ` yunohost domain config set your.domain.tld feature` and enable/disable some feature, check the impact on system confs
