### PR TITLE
Add a global setting to choose SSOwat's theme

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -424,6 +424,8 @@
     "global_settings_setting_ssh_password_authentication_help": "Allow password authentication for SSH",
     "global_settings_setting_ssh_port": "SSH port",
     "global_settings_setting_ssowat_panel_overlay_enabled": "Enable the small 'YunoHost' portal shortcut square on apps",
+    "global_settings_setting_portal_theme": "Portal theme",
+    "global_settings_setting_portal_theme_help": "More info regarding creating custom portal themes at https://yunohost.org/theming",
     "global_settings_setting_user_strength": "User password strength requirements",
     "global_settings_setting_user_strength_help": "These requirements are only enforced when initializing or changing the password",
     "global_settings_setting_webadmin_allowlist": "Webadmin IP allowlist",

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -144,7 +144,12 @@ name = "Other"
         [misc.portal.ssowat_panel_overlay_enabled]
         type = "boolean"
         default = true
-    
+
+        [misc.portal.portal_theme]
+        type = "select"
+        # Choices are loaded dynamically in the python code
+        default = "default"
+
     [misc.backup]
     name = "Backup"
         [misc.backup.backup_compress_tar_archives]

--- a/src/app.py
+++ b/src/app.py
@@ -1471,6 +1471,7 @@ def app_ssowatconf():
     """
     from yunohost.domain import domain_list, _get_maindomain, domain_config_get
     from yunohost.permission import user_permission_list
+    from yunohost.settings import settings_get
 
     main_domain = _get_maindomain()
     domains = domain_list()["domains"]
@@ -1550,6 +1551,7 @@ def app_ssowatconf():
         }
 
     conf_dict = {
+        "theme": settings_get("misc.portal.portal_theme"),
         "portal_domain": main_domain,
         "portal_path": "/yunohost/sso/",
         "additional_headers": {

--- a/src/settings.py
+++ b/src/settings.py
@@ -163,6 +163,20 @@ class SettingsConfigPanel(ConfigPanel):
                 logger.error(f"Post-change hook for setting failed : {e}")
                 raise
 
+    def _get_toml(self):
+
+        toml = super()._get_toml()
+
+        # Dynamic choice list for portal themes
+        THEMEDIR = "/usr/share/ssowat/portal/assets/themes/"
+        try:
+            themes = [d for d in os.listdir(THEMEDIR) if os.path.isdir(THEMEDIR + d)]
+        except Exception:
+            themes = ['unsplash', 'vapor', 'light', 'default', 'clouds']
+        toml["misc"]["portal"]["portal_theme"]["choices"] = themes
+
+        return toml
+
     def _load_current_values(self):
 
         super()._load_current_values()

--- a/src/settings.py
+++ b/src/settings.py
@@ -276,6 +276,11 @@ def trigger_post_change_hook(setting_name, old_value, new_value):
 #
 # ===========================================
 
+@post_change_hook("portal_theme")
+def regen_ssowatconf(setting_name, old_value, new_value):
+    if old_value != new_value:
+        from yunohost.app import app_ssowatconf
+        app_ssowatconf()
 
 @post_change_hook("ssowat_panel_overlay_enabled")
 @post_change_hook("nginx_redirect_to_https")


### PR DESCRIPTION
## The problem

Changing ssowat's theme is annoying, have to manually edit conf.json.persistent in /etc/ssowat

Also a rework of https://github.com/YunoHost/yunohost/pull/631

## Solution

Implement a global setting to choose the corresponding theme

## PR Status

Yolocommited, to be tested

## How to test

Check the webadmin to check if new setting is there, try to change it, see if it's propagated in /etc/ssowat/conf.json