### PR TITLE
[fix] hotspot config panel fails in webadmin

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -651,10 +651,19 @@ class ConfigPanel:
                         raw_msg=True,
                     )
             value = self.values[option["name"]]
+            
+            # Allow to use value instead of current_value in app config script.
+            # For example hotspot used it...
+            # See https://github.com/YunoHost/yunohost/pull/1546
+            if isinstance(value, dict) and "value" in value and "current_value" not in value:
+                value["current_value"] = value["value"]
+            
             # In general, the value is just a simple value.
             # Sometimes it could be a dict used to overwrite the option itself
             value = value if isinstance(value, dict) else {"current_value": value}
             option.update(value)
+            
+            self.values[option["id"]] = value.get("current_value")
 
         return self.values
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -682,7 +682,7 @@ class ConfigPanel:
                 section
                 and section.get("visible")
                 and not evaluate_simple_js_expression(
-                    section["visible"], context=self.new_values
+                    section["visible"], context=self.future_values
                 )
             ):
                 continue

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -653,6 +653,7 @@ class ConfigPanel:
             value = self.values[option["name"]]
             
             # Allow to use value instead of current_value in app config script.
+            # e.g. apps may write `echo 'value: "foobar"'` in the config file (which is more intuitive that `echo 'current_value: "foobar"'`
             # For example hotspot used it...
             # See https://github.com/YunoHost/yunohost/pull/1546
             if isinstance(value, dict) and "value" in value and "current_value" not in value:


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/2099

## Solution

1. Use future_values instead of new_values (new_values includes only changed new values, instead of future_values, that includes all values updated with the already answered questions)
2. After hydrating the questions, make sure to overwrite each self.values[OPTION_ID] by a simple value and not a structured data

## PR Status

Ready (just tested on a server by copying the change manually not with ynh-dev)

## How to test

Install hotspot and try to activate an hotspot
