### PR TITLE
Add a global setting to disable root login on local network

### DIFF
--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -57,11 +57,7 @@ UsePAM yes
 
 # PLEASE: if you wish to force everybody to authenticate using ssh keys, run this command:
 # yunohost settings set security.ssh.ssh_password_authentication -v no
-{% if password_authentication == "False" %}
-PasswordAuthentication no
-{% else %}
-#PasswordAuthentication yes
-{% endif %}
+PasswordAuthentication {{ password_authentication }}
 
 # Post-login stuff
 Banner /etc/issue.net
@@ -103,7 +99,7 @@ Match Group sftp.app,!ssh.app
     AllowStreamLocalForwarding no
     PermitTunnel no
     PermitUserRC no
-    PasswordAuthentication yes
+    PasswordAuthentication {{ password_authentication }}
 
 # root login is allowed on local networks
 # It's meant to be a backup solution in case LDAP is down and

--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -100,11 +100,11 @@ Match Group sftp.app,!ssh.app
     PermitTunnel no
     PermitUserRC no
     PasswordAuthentication {{ password_authentication }}
-
+{% if allow_root_on_localnet == "true" %}
 # root login is allowed on local networks
 # It's meant to be a backup solution in case LDAP is down and
 # user admin can't be used...
 # If the server is a VPS, it's expected that the owner of the
 # server has access to a web console through which to log in.
 Match Address 192.168.0.0/16,10.0.0.0/8,172.16.0.0/12,169.254.0.0/16,fe80::/10,fd00::/8
-    PermitRootLogin yes
+    PermitRootLogin yes{% endif %}

--- a/hooks/conf_regen/03-ssh
+++ b/hooks/conf_regen/03-ssh
@@ -18,6 +18,7 @@ do_pre_regen() {
     export compatibility="$(yunohost settings get 'security.ssh.ssh_compatibility')"
     export port="$(yunohost settings get 'security.ssh.ssh_port')"
     export password_authentication="$(yunohost settings get 'security.ssh.ssh_password_authentication')"
+    export allow_root_on_localnet="$(yunohost settings get 'security.ssh.ssh_allow_root_on_localnet')"
     export ssh_keys
     export ipv6_enabled
     ynh_render_template "sshd_config" "${pending_dir}/etc/ssh/sshd_config"

--- a/locales/en.json
+++ b/locales/en.json
@@ -423,6 +423,8 @@
     "global_settings_setting_ssh_compatibility_help": "Compatibility vs. security tradeoff for the SSH server. Affects the ciphers (and other security-related aspects). See https://infosec.mozilla.org/guidelines/openssh for more info.",
     "global_settings_setting_ssh_password_authentication": "Password authentication",
     "global_settings_setting_ssh_password_authentication_help": "Allow password authentication for SSH",
+    "global_settings_setting_ssh_allow_root_on_localnet": "Permit root from localnet",
+    "global_settings_setting_ssh_allow_root_on_localnet_help": "Allow root login from the local network",
     "global_settings_setting_ssh_port": "SSH port",
     "global_settings_setting_ssowat_panel_overlay_enabled": "Enable the small 'YunoHost' portal shortcut square on apps",
     "global_settings_setting_portal_theme": "Portal theme",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -664,6 +664,7 @@
     "global_settings_setting_postfix_compatibility_help": "Compromis 'compatibilité versus sécurité' pour le serveur Postfix. Affecte les cryptogrammes utilisés (et d'autres aspects liés à la sécurité)",
     "global_settings_setting_ssh_compatibility_help": "Compromis 'compatibilité versus sécurité' pour le serveur SSH. Affecte les cryptogrammes utilisés (et d'autres aspects liés à la sécurité).",
     "global_settings_setting_ssh_password_authentication_help": "Autoriser l'authentification par mot de passe pour SSH",
+    "global_settings_setting_ssh_allow_root_on_localnet_help": "Permettre la connexion de l'utilisateur root depuis le réseau local",
     "global_settings_setting_ssh_port": "Port SSH",
     "global_settings_setting_webadmin_allowlist_help": "Adresses IP autorisées à accéder à la webadmin. Elles doivent être séparées par une virgule.",
     "global_settings_setting_webadmin_allowlist_enabled_help": "Autoriser seulement certaines IP à accéder à la webadmin.",

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -42,6 +42,8 @@ name = "Security"
         [security.ssh.ssh_password_authentication]
         type = "boolean"
         default = true
+        yes = "yes"
+        no = "no"
 
     [security.nginx]
     name = "NGINX (web server)"

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -45,6 +45,12 @@ name = "Security"
         yes = "yes"
         no = "no"
 
+        [security.ssh.ssh_allow_root_on_localnet]
+        type = "boolean"
+        default = true
+        yes = "true"
+        no = "false"
+
     [security.nginx]
     name = "NGINX (web server)"
         [security.nginx.nginx_redirect_to_https]


### PR DESCRIPTION
## The problem

- Fix and improve handling of PasswordAuthentication option
- Add a setting for PermitRootLogin usage on local network

## Solution

- Directly use the value of ssh_password_authentication
- Add ssh_allow_root_on_localnet to manage the last part of the SSH template

## PR Status

First release and review

## How to test

Play with the ssh settings.
