### PR TITLE
Add postfix SASL login failure to a fail2ban jail

### DIFF
--- a/conf/fail2ban/postfix-sasl.conf
+++ b/conf/fail2ban/postfix-sasl.conf
@@ -1,0 +1,6 @@
+# Fail2Ban filter for postfix authentication failures
+[INCLUDES]
+before = common.conf
+[Definition]
+_daemon = postfix/smtpd
+failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$

--- a/conf/fail2ban/yunohost-jails.conf
+++ b/conf/fail2ban/yunohost-jails.conf
@@ -8,6 +8,13 @@ enabled = true
 [postfix]
 enabled = true
 
+[sasl]
+enabled  = true
+port     = smtp
+filter   = postfix-sasl
+logpath  = /var/log/mail.log
+maxretry = 5
+
 [dovecot]
 enabled = true
 

--- a/hooks/conf_regen/52-fail2ban
+++ b/hooks/conf_regen/52-fail2ban
@@ -14,6 +14,7 @@ do_pre_regen() {
     mkdir -p "${fail2ban_dir}/jail.d"
 
     cp yunohost.conf "${fail2ban_dir}/filter.d/yunohost.conf"
+    cp postfix-sasl.conf "${fail2ban_dir}/filter.d/postfix-sasl.conf"
     cp jail.conf "${fail2ban_dir}/jail.conf"
 
     export ssh_port="$(yunohost settings get 'security.ssh.ssh_port')"


### PR DESCRIPTION
in order to prevent those 
```
Aug 31 22:23:52 hostxyz postfix/smtpd[38697]: warning: unknown[192.168.xx.xx]: SASL LOGIN authentication failed: authentication failure
Aug 31 22:23:52 hostxyz postfix/smtpd[38697]: lost connection after AUTH from unknown[192.168.xx.xx]
```

## The problem

Too many login failures not taken into accounts by fail2ban

## Solution

Apply jail conf and filter conf

## PR Status

...

## How to test

...
