### PR TITLE
Don't disable avahi-daemon by force in conf_regen

### DIFF
--- a/hooks/conf_regen/37-mdns
+++ b/hooks/conf_regen/37-mdns
@@ -53,9 +53,6 @@ do_post_regen() {
         systemctl daemon-reload
     fi
 
-    systemctl disable avahi-daemon.socket --quiet --now 2>/dev/null || true
-    systemctl disable avahi-daemon --quiet --now 2>/dev/null || true
-
     # Legacy stuff to enable the new yunomdns service on legacy systems
     if [[ -e /etc/avahi/avahi-daemon.conf ]] && grep -q 'yunohost' /etc/avahi/avahi-daemon.conf; then
         systemctl enable yunomdns --now --quiet


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/2115

## Solution

Just don't force-disable avahi. Everyone should have it disabled by default by now (unless they didn't do upgrades for more than a year), so let's just stop doing that.

If we want to be more specific, we could comment out the entire yunohost block in avahi config if it's still enabled, and in that case disable avahi service. But i don't think that's necessary because this behavior has been default for so long now.