### PR TITLE
[fix] Enable pop3 settings make dovecot failed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends}, ${misc:Depends}
  , slapd, ldap-utils, sudo-ldap, libnss-ldapd, unscd, libpam-ldapd
  , dnsmasq, resolvconf, libnss-myhostname
  , postfix, postfix-ldap, postfix-policyd-spf-perl, postfix-pcre
- , dovecot-core, dovecot-ldap, dovecot-lmtpd, dovecot-managesieved, dovecot-antispam
+ , dovecot-core, dovecot-ldap, dovecot-lmtpd, dovecot-managesieved, dovecot-antispam, dovecot-pop3d
  , rspamd, opendkim-tools, postsrsd, procmail, mailutils
  , redis-server
  , acl


### PR DESCRIPTION
## The problem

When we enable dovecot pop3 on sans-nuage.fr, the dovecot fail with error:
```
Fatal: service(pop3) access(/usr/lib/dovecot/pop3) failed: No such file or directory
```

## Solution

Install `dovecot-pop3d` package

## PR Status

Ready

## How to test

...
