### PR TITLE
[fix] Missing migration

### DIFF
--- a/src/migrations/0027_ssowat_regenconf.py
+++ b/src/migrations/0027_ssowat_regenconf.py
@@ -1,0 +1,21 @@
+from moulinette.utils.log import getActionLogger
+
+from yunohost.tools import Migration
+
+logger = getActionLogger("yunohost.migration")
+
+
+class MyMigration(Migration):
+    """
+    Regen SSOwat conf to add remote_user_var_in_nginx_conf properties
+    """
+
+    introduced_in_version = "11.1"  # FIXME?
+    dependencies = []
+
+    def run(self, *args):
+        from yunohost.app import app_ssowatconf
+        app_ssowatconf()
+
+    def run_after_system_restore(self):
+        self.run()


### PR DESCRIPTION
## The problem

SSOwat conf is not regen after the upgrade and `remote_user_var_in_nginx_conf` are missing

## Solution

Trigger once with a migration

Alternative solution not implemented: regen at each debian package upgrade ?

## PR Status

Opinion needed
Untested (i have an issue with my ynh-dev)

## How to test

...
