### PR TITLE
chore: update actions version to use node 16 version

### DIFF
--- a/.github/workflows/n_updater.yml
+++ b/.github/workflows/n_updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run the updater script


### PR DESCRIPTION
## The problem

Node 12 version is deprecated since April 2022.

> Node.js 12 actions are deprecated. For more information see: [github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2

## Solution

 This PR is here to update actions to use Node 16 instead.

## PR Status

...

## How to test

...
