### PR TITLE
[fix] Postgresql migration

### DIFF
--- a/src/migrations/0023_postgresql_11_to_13.py
+++ b/src/migrations/0023_postgresql_11_to_13.py
@@ -58,7 +58,8 @@ class MyMigration(Migration):
             "LC_ALL=C pg_dropcluster --stop 13 main || true"
         )  # We do not trigger an exception if the command fails because that probably means cluster 13 doesn't exists, which is fine because it's created during the pg_upgradecluster)
         time.sleep(3)
-        self.runcmd("LC_ALL=C pg_upgradecluster -m upgrade 11 main")
+        self.runcmd("LC_ALL=C pg_upgradecluster -m upgrade 11 main || true")
+        time.sleep(3)
         self.runcmd("LC_ALL=C pg_dropcluster --stop 11 main")
         self.runcmd("systemctl start postgresql")
 


### PR DESCRIPTION

## The problem

The migration failed with:
```
could not stop old cluster, please do that manually
```

Here we have solved the issues by running each command of the migration manually:
```
root@sans-nuage:/opt/yunohost/searx# pg_lsclusters | grep -q '^11 '                                                                                                               
root@sans-nuage:/opt/yunohost/searx# echo $?                                                                                                                                      
0                                                                                                                                                                                 
root@sans-nuage:/opt/yunohost/searx# pg_lsclusters                                                                                                                                
Ver Cluster Port Status Owner    Data directory              Log file                                                                                                             
11  main    5432 down   postgres /var/lib/postgresql/11/main /var/log/postgresql/postgresql-11-main.log                                                                           
root@sans-nuage:/opt/yunohost/searx# systemctl stop postgresql                                                                                                                    
root@sans-nuage:/opt/yunohost/searx# LC_ALL=C pg_dropcluster --stop 13 main || true                                                                                               
Error: specified cluster does not exist                                                                                                                                           
root@sans-nuage:/opt/yunohost/searx# LC_ALL=C pg_upgradecluster -m upgrade 11 main                                                                                                
Restarting old cluster with restricted connections...                                                                                                                             
Notice: extra pg_ctl/postgres options given, bypassing systemctl for start operation                                                                                              
Stopping old cluster...                                                                                                                                                           
Creating new PostgreSQL cluster 13/main ...                                                                                                                                       
/usr/lib/postgresql/13/bin/initdb -D /var/lib/postgresql/13/main --auth-local peer --auth-host md5 --encoding UTF8 --lc-collate fr_FR.UTF-8 --lc-ctype fr_FR.UTF-8                
Les fichiers de ce système de bases de données appartiendront à l'utilisateur « postgres ».                                                                                       
Le processus serveur doit également lui appartenir.                                                                                                                               
                                                                                                                                                                                  
L'instance sera initialisée avec la locale « fr_FR.UTF-8 ».                                                                                                                       
La configuration de la recherche plein texte a été initialisée à « french ».                                                                                                      
                                                                                                                                                                                  
Les sommes de contrôle des pages de données sont désactivées.                                                                                                                     
                                                                                                                                                                                  
correction des droits sur le répertoire existant /var/lib/postgresql/13/main... ok                                                                                                
création des sous-répertoires... ok                                                                                                                                               
sélection de l'implémentation de la mémoire partagée dynamique...posix                                                                                                            
sélection de la valeur par défaut pour max_connections... 100
sélection de la valeur par défaut pour shared_buffers... 128MB
sélection du fuseau horaire par défaut... Europe/Paris
création des fichiers de configuration... ok
lancement du script bootstrap...ok
exécution de l'initialisation après bootstrap... ok
synchronisation des données sur disque... ok

Succès. Vous pouvez maintenant lancer le serveur de bases de données en utilisant :

    pg_ctlcluster 13 main start

Ver Cluster Port Status Owner    Data directory              Log file
13  main    5433 down   postgres /var/lib/postgresql/13/main /var/log/postgresql/postgresql-13-main.log                                                                           

/usr/lib/postgresql/13/bin/pg_upgrade -b /usr/lib/postgresql/11/bin -B /usr/lib/postgresql/13/bin -p 5432 -P 5433 -d /etc/postgresql/11/main -D /etc/postgresql/13/main           
Finding the real data directory for the source cluster      ok
Finding the real data directory for the target cluster      ok
Exécution de tests de cohérence
-------------------------------
Checking cluster versions                                   ok
Checking database user is the install user                  ok
Checking database connection settings                       ok
Checking for prepared transactions                          ok
Checking for system-defined composite types in user tables  ok
Checking for reg* data types in user tables                 ok
Checking for contrib/isn with bigint-passing mismatch       ok
Checking for tables WITH OIDS                               ok
Checking for invalid "sql_identifier" user columns          ok
Creating dump of global objects                             ok
Creating dump of database schemas
                                                            ok
Checking for presence of required libraries                 fatal

Votre installation référence des bibliothèques chargeables, mais manquantes sur
la nouvelle installation. Vous pouvez ajouter ces bibliothèques à la nouvelle
installation ou supprimer les fonctions les utilisant dans l'ancienne installation.
Une liste des biblioth_ques problématiques est disponible dans le fichier :
    loadable_libraries.txt

Échec, sortie
Error: pg_upgrade run failed. Logfiles are in /var/log/postgresql/pg_upgradecluster-11-13-main.C5e2                                                                               
Error during cluster dumping, removing new cluster
Cluster is not running.
Error: could not stop old cluster, please do that manually
root@sans-nuage:/opt/yunohost/searx# LC_ALL=C pg_dropcluster --stop 11 main
root@sans-nuage:/opt/yunohost/searx# systemctl start postgresql
root@sans-nuage:/opt/yunohost/searx# systemctl status postgresql
● postgresql.service - PostgreSQL RDBMS
     Loaded: loaded (/lib/systemd/system/postgresql.service; enabled; vendor preset: enabled)                                                                                     
     Active: active (exited) since Thu 2023-01-12 23:10:09 CET; 4s ago
    Process: 31054 ExecStart=/bin/true (code=exited, status=0/SUCCESS)
   Main PID: 31054 (code=exited, status=0/SUCCESS)

janv. 12 23:10:09 sans-nuage.fr systemd[1]: Starting PostgreSQL RDBMS...
janv. 12 23:10:09 sans-nuage.fr systemd[1]: Finished PostgreSQL RDBMS.
```

The migration log : https://paste.yunohost.org/raw/pexarufoci

## Solution

We think adding a true after `LC_ALL=C pg_upgradecluster -m upgrade 11 main ` could fix the issue.



## PR Status

Opinion needed

## How to test

...
