### PR TITLE
WIP: rewrite the CLI/API interface using Typer+FastAPI

### DIFF
--- a/bin/yunohost-fastapi
+++ b/bin/yunohost-fastapi
@@ -1,0 +1,33 @@
+#! /usr/bin/python3
+
+import os
+import typer
+import uvicorn
+
+os.environ["INTERFACE"] = "api"
+
+
+def main(
+    host: str = typer.Option("127.0.0.1", "--host", "-h", help="Host to listen on", rich_help_panel="Server configuration"),
+    port: int = typer.Option(6787, "--port", "-p", help="Port to listen on", rich_help_panel="Server configuration"),
+    debug: bool = typer.Option(False, "--debug", help="Set log level to DEBUG"),
+    reload: bool = typer.Option(False, "--reload", hidden=True),
+    reload_dirs: list[str] = typer.Option([], hidden=True)
+):
+    """
+    Run the YunoHost API to manage your server.
+    """
+    uvicorn.run(
+        "yunohost.__init_:create_interface",
+        factory=True,
+        host=host,
+        port=port,
+        log_level="info" if not debug else "debug",
+        reload=reload,
+        reload_dirs=reload_dirs,
+        root_path="/yunohost/api",
+    )
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/bin/yunohost-fastapi
+++ b/bin/yunohost-fastapi
@@ -18,7 +18,7 @@ def main(
     Run the YunoHost API to manage your server.
     """
     uvicorn.run(
-        "yunohost.__init_:create_interface",
+        "yunohost.__init_:create_api_interface",
         factory=True,
         host=host,
         port=port,

--- a/bin/yunohost-typer
+++ b/bin/yunohost-typer
@@ -13,7 +13,7 @@ if os.environ["PATH"] != default_path:
 
 if __name__ == "__main__":
 
-    from yunohost.__init_ import create_interface
+    from yunohost.__init_ import create_cli_interface
 
     if os.geteuid() != 0:
         sys.stderr.write(
@@ -22,5 +22,5 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    app = create_interface()
+    app = create_cli_interface()
     app()

--- a/bin/yunohost-typer
+++ b/bin/yunohost-typer
@@ -1,0 +1,26 @@
+#! /usr/bin/python3
+
+import os
+import sys
+
+os.environ["INTERFACE"] = "cli"
+
+# Stupid PATH management because sometimes (e.g. some cron job) PATH is only /usr/bin:/bin ...
+default_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+if os.environ["PATH"] != default_path:
+    os.environ["PATH"] = default_path + ":" + os.environ["PATH"]
+
+
+if __name__ == "__main__":
+
+    from yunohost.__init_ import create_interface
+
+    if os.geteuid() != 0:
+        sys.stderr.write(
+            "\033[1;31mError:\033[0m yunohost command must be "
+            "run as root or with sudo.\n"
+        )
+        sys.exit(1)
+
+    app = create_interface()
+    app()

--- a/src/__init_.py
+++ b/src/__init_.py
@@ -1,10 +1,46 @@
+import logging
+from rich.logging import RichHandler
 from yunohost.interface import Interface
+from yunohost.user import user, group, permission
 
-from yunohost.user import app as user_app
+from moulinette import m18n
+from moulinette.interfaces.cli import get_locale
 
 
-def create_interface():
+def create_cli_interface():
+    init_i18n()
+    init_logging(interface="cli")
+
     app = Interface(root=True)
-    app.add(user_app)
+
+    user.add(group)
+    user.add(permission)
+    app.add(user)
 
     return app.instance
+
+
+def create_api_interface():
+    init_i18n()
+    init_logging(interface="cli")
+
+    app = Interface(root=True)
+    # Intermediate router to have distincts categories in swagger
+    user_sub = Interface(prefix="/users")
+    user_sub.add(user)
+    user_sub.add(group)
+    user_sub.add(permission)
+    app.add(user_sub)
+
+    return app.instance
+
+
+def init_i18n():
+    m18n.set_locales_dir("/usr/share/yunohost/locales/")
+    m18n.set_locale(get_locale())
+
+
+def init_logging(interface="cli", debug=False, quiet=False, logdir="/var/log/yunohost"):
+    logging.basicConfig(
+        level="NOTSET", format="%(message)s", handlers=[RichHandler(show_time=False)]
+    )

--- a/src/__init_.py
+++ b/src/__init_.py
@@ -1,0 +1,10 @@
+from yunohost.interface import Interface
+
+from yunohost.user import app as user_app
+
+
+def create_interface():
+    app = Interface(root=True)
+    app.add(user_app)
+
+    return app.instance

--- a/src/__init_.py
+++ b/src/__init_.py
@@ -1,21 +1,24 @@
-import logging
-from rich.logging import RichHandler
+import os
 from yunohost.interface import Interface
-from yunohost.user import user, group, permission
 
 from moulinette import m18n
 from moulinette.interfaces.cli import get_locale
+from moulinette.utils.log import configure_logging
 
 
 def create_cli_interface():
     init_i18n()
     init_logging(interface="cli")
 
+    from yunohost.user import user, group, permission
+    from yunohost.log import log
+
     app = Interface(root=True)
 
     user.add(group)
     user.add(permission)
     app.add(user)
+    app.add(log)
 
     return app.instance
 
@@ -24,6 +27,9 @@ def create_api_interface():
     init_i18n()
     init_logging(interface="cli")
 
+    from yunohost.user import user, group, permission
+    from yunohost.log import log
+
     app = Interface(root=True)
     # Intermediate router to have distincts categories in swagger
     user_sub = Interface(prefix="/users")
@@ -31,6 +37,7 @@ def create_api_interface():
     user_sub.add(group)
     user_sub.add(permission)
     app.add(user_sub)
+    app.add(log)
 
     return app.instance
 
@@ -41,6 +48,63 @@ def init_i18n():
 
 
 def init_logging(interface="cli", debug=False, quiet=False, logdir="/var/log/yunohost"):
-    logging.basicConfig(
-        level="NOTSET", format="%(message)s", handlers=[RichHandler(show_time=False)]
-    )
+    engine = "typer" if interface == "cli" else "fastapi"
+    logfile = os.path.join(logdir, f"yunohost-{engine}-{interface}.log")
+
+    if not os.path.isdir(logdir):
+        os.makedirs(logdir, 0o750)
+
+    logging_configuration = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "console": {
+                "format": "%(relativeCreated)-5d %(levelname)-8s %(name)s %(funcName)s - %(message)s"
+            },
+            "tty-debug": {"format": "%(relativeCreated)-4d %(message)s"},
+            "precise": {
+                "format": "%(asctime)-15s %(levelname)-8s %(name)s %(funcName)s - %(message)s"
+            },
+        },
+        "filters": {
+            "action": {
+                "()": "moulinette.utils.log.ActionFilter",
+            },
+        },
+        "handlers": {
+            "cli": {
+                "level": "DEBUG" if debug else "INFO",
+                "()": "rich.logging.RichHandler",
+                "show_time": False,
+                # "formatter": "tty-debug" if debug else "",
+            },
+            "api": {
+                "level": "DEBUG" if debug else "INFO",
+                "class": "moulinette.interfaces.api.APIQueueHandler",
+            },
+            "file": {
+                "class": "logging.FileHandler",
+                "formatter": "precise",
+                "filename": logfile,
+                # "filters": ["action"],
+            },
+        },
+        "loggers": {
+            "yunohost": {
+                "level": "DEBUG",
+                "handlers": ["file", interface] if not quiet else ["file"],
+                "propagate": False,
+            },
+            "moulinette": {
+                "level": "DEBUG",
+                "handlers": ["file", interface] if not quiet else ["file"],
+                "propagate": False,
+            },
+        },
+        "root": {
+            "level": "DEBUG",
+            "handlers": ["file", interface] if debug else ["file"],
+        },
+    }
+
+    configure_logging(logging_configuration)

--- a/src/__init_.py
+++ b/src/__init_.py
@@ -56,7 +56,7 @@ def init_logging(interface="cli", debug=False, quiet=False, logdir="/var/log/yun
 
     logging_configuration = {
         "version": 1,
-        "disable_existing_loggers": True,
+        "disable_existing_loggers": False,
         "formatters": {
             "console": {
                 "format": "%(relativeCreated)-5d %(levelname)-8s %(name)s %(funcName)s - %(message)s"

--- a/src/hook.py
+++ b/src/hook.py
@@ -25,6 +25,7 @@ from glob import iglob
 from importlib import import_module
 
 from moulinette import m18n, Moulinette
+from yunohost.interface import Interface, InterfaceKind
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils import log
 from moulinette.utils.filesystem import read_yaml, cp
@@ -409,7 +410,7 @@ def _hook_exec_bash(path, args, chdir, env, user, return_format, loggers):
         env = {}
     env["YNH_CWD"] = chdir
 
-    env["YNH_INTERFACE"] = Moulinette.interface.type
+    env["YNH_INTERFACE"] = Interface.kind.value
 
     stdreturn = os.path.join(tempfile.mkdtemp(), "stdreturn")
     with open(stdreturn, "w") as f:
@@ -511,7 +512,7 @@ def hook_exec_with_script_debug_if_failure(*args, **kwargs):
             error = error_message_if_script_failed
             logger.error(error_message_if_failed(error))
             failure_message_with_debug_instructions = operation_logger.error(error)
-            if Moulinette.interface.type != "api":
+            if Interface.kind is not InterfaceKind.API:
                 operation_logger.dump_script_log_extract_for_debugging()
     # Script got manually interrupted ...
     # N.B. : KeyboardInterrupt does not inherit from Exception

--- a/src/interface/__init__.py
+++ b/src/interface/__init__.py
@@ -1,6 +1,9 @@
 import os
 
+from yunohost.interface.base import InterfaceKind
+
 if os.environ.get("INTERFACE", "cli") == "cli":
-    from yunohost.interface.cli import Interface  # noqa
+    from yunohost.interface.cli import Interface
 else:
-    from yunohost.interface.api import Interface  # noqa
+    from yunohost.interface.api import Interface
+

--- a/src/interface/__init__.py
+++ b/src/interface/__init__.py
@@ -1,9 +1,11 @@
 import os
 
-from yunohost.interface.base import InterfaceKind
+from yunohost.interface.base import InterfaceKind, Field
 
-if os.environ.get("INTERFACE", "cli") == "cli":
+if os.environ.get("INTERFACE") == "cli":
     from yunohost.interface.cli import Interface
-else:
+elif os.environ.get("INTERFACE") == "api":
     from yunohost.interface.api import Interface
-
+else:
+    # FIXME for Moulinette to work
+    from yunohost.interface.base import BaseInterface as Interface

--- a/src/interface/__init__.py
+++ b/src/interface/__init__.py
@@ -1,0 +1,6 @@
+import os
+
+if os.environ.get("INTERFACE", "cli") == "cli":
+    from yunohost.interface.cli import Interface  # noqa
+else:
+    from yunohost.interface.api import Interface  # noqa

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -67,7 +67,7 @@ class Interface(BaseInterface):
     def add(self, interface: Interface):
         assert isinstance(interface.instance, fastapi.APIRouter)
         self.instance.include_router(
-            interface.instance, prefix=f"/{interface.name}", tags=[interface.name]
+            interface.instance, prefix=interface.prefix, tags=[interface.name] if interface.name else []
         )
 
     def prepare_params(

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -134,6 +134,11 @@ class Interface(BaseInterface):
                         else ...  # required
                     )
 
+                    pattern = param_kwargs.pop("pattern", None)
+                    if pattern:
+                        # FIXME for now throw generic error (need to catch and update text)
+                        param_kwargs["regex"] = pattern
+
                     if param_kwargs.pop("file", False):
                         new_param = param.replace(
                             annotation=fastapi.UploadFile,

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import inspect
+import types
+import fastapi
+import pydantic
+import uvicorn
+
+from typing import Optional, Union
+
+
+def snake_to_camel_case(snake: str) -> str:
+    return "".join(word.title() for word in snake.split("_"))
+
+
+def get_path_param(route: str) -> Optional[str]:
+    last_path = route.split("/")[-1]
+    if last_path and "{" in last_path:
+        return last_path.strip("{}")
+    return None
+
+
+def alter_params_for_body(
+    parameters, as_body, as_body_except
+) -> list[Union[list[inspect.Parameter], inspect.Parameter]]:
+    if as_body_except:
+        body_params = []
+        rest = []
+        for param in parameters:
+            if param.name not in as_body_except:
+                body_params.append(param)
+            else:
+                rest.append(param)
+        return [body_params, *rest]
+
+    if as_body:
+        return [parameters]
+
+    return parameters
+
+
+def params_to_body(
+    params: list[inspect.Parameter], func_name: str
+) -> inspect.Parameter:
+    model = pydantic.create_model(
+        snake_to_camel_case(func_name),
+        **{
+            param.name: (
+                param.annotation,
+                param.default if param.default != param.empty else ...,
+            )
+            for param in params
+        },
+    )
+
+    return inspect.Parameter(
+        func_name.split("_")[0],
+        inspect.Parameter.POSITIONAL_ONLY,
+        default=...,
+        annotation=model,
+    )
+
+
+class Interface:
+    type = "api"
+
+    instance: Union[fastapi.FastAPI, fastapi.APIRouter]
+    name: str
+
+    def __init__(self, root: bool = False, name: Optional[str] = None):
+        self.instance = fastapi.FastAPI() if root else fastapi.APIRouter()
+        self.name = "root" if root else name or ""
+
+    def add(self, interface: Interface):
+        assert isinstance(interface.instance, fastapi.APIRouter)
+        self.instance.include_router(
+            interface.instance, prefix=f"/{interface.name}", tags=[interface.name]
+        )
+
+    def run(self, host="127.0.0.1", port=6787, debug=False, reload=False):
+        uvicorn.run(
+            self.instance,
+            host=host,
+            port=port,
+            log_level="info" if not debug else "debug",
+            reload=reload,
+            root_path="/yunohost/api",
+        )
+
+    def cli(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def api(
+        self,
+        route: str,
+        method: str = "get",
+        as_body: bool = False,
+        as_body_except: Optional[list[str]] = None,
+        **kwargs,
+    ):
+        as_body = as_body if not as_body_except else True
+
+        def decorator(func):
+            signature = inspect.signature(func)
+            override_params = []
+            params = alter_params_for_body(
+                signature.parameters.values(), as_body, as_body_except
+            )
+            path_param = get_path_param(route)
+
+            for param in params:
+                if isinstance(param, list):
+                    override_params.append(params_to_body(param, func.__name__))
+                else:
+                    default_kwargs = kwargs.get(param.name, {})
+                    default_cls = (
+                        fastapi.Path if param.name == path_param else fastapi.Query
+                    )
+
+                    if param.default is None:
+                        default_value = default_cls(None, **default_kwargs)
+                    elif param.default is param.empty:
+                        default_value = default_cls(..., **default_kwargs)
+                    else:
+                        default_value = default_cls(param.default, **default_kwargs)
+
+                    override_params.append(param.replace(default=default_value))
+
+            route_func = getattr(self.instance, method)(route)
+            override_signature = signature.replace(parameters=tuple(override_params))
+
+            if as_body:
+
+                def body_to_args_back(*args, **kwargs):
+                    new_kwargs = {}
+                    for kwarg, value in kwargs.items():
+                        if issubclass(type(value), pydantic.BaseModel):
+                            new_kwargs = value.dict() | new_kwargs
+                        else:
+                            new_kwargs[kwarg] = value
+                    return func(*args, **new_kwargs)
+
+                body_to_args_back.__name__ = func.__name__
+                body_to_args_back.__signature__ = override_signature
+                route_func(body_to_args_back)
+            else:
+                func_copy = types.FunctionType(
+                    func.__code__,
+                    func.__globals__,
+                    func.__name__,
+                    func.__defaults__,
+                    func.__closure__,
+                )
+                func_copy.__signature__ = override_signature
+                route_func(func_copy)
+
+            return func
+
+        return decorator

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -1,52 +1,46 @@
-from __future__ import annotations
+from __future__ import (
+    annotations,
+)  # Enable self reference a class in its own method arguments
 
 import inspect
-import types
+import re
 import fastapi
 import pydantic
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
+from yunohost.interface.base import (
+    BaseInterface,
+    InterfaceKind,
+    merge_dicts,
+    get_params_doc,
+    override_function,
+)
 
 
 def snake_to_camel_case(snake: str) -> str:
     return "".join(word.title() for word in snake.split("_"))
 
 
-def get_path_param(route: str) -> Optional[str]:
-    last_path = route.split("/")[-1]
-    if last_path and "{" in last_path:
-        return last_path.strip("{}")
-    return None
-
-
-def alter_params_for_body(
-    parameters, as_body, as_body_except
-) -> list[Union[list[inspect.Parameter], inspect.Parameter]]:
-    if as_body_except:
-        body_params = []
-        rest = []
-        for param in parameters:
-            if param.name not in as_body_except:
-                body_params.append(param)
-            else:
-                rest.append(param)
-        return [body_params, *rest]
-
-    if as_body:
-        return [parameters]
-
-    return parameters
+def parse_api_route(route: str) -> list[str]:
+    return re.findall(r"{(\w+)}", route)
 
 
 def params_to_body(
-    params: list[inspect.Parameter], func_name: str
+    params: list[inspect.Parameter],
+    data: dict[str, Any],
+    doc: dict[str, Any],
+    func_name: str,
 ) -> inspect.Parameter:
     model = pydantic.create_model(
         snake_to_camel_case(func_name),
         **{
             param.name: (
                 param.annotation,
-                param.default if param.default != param.empty else ...,
+                pydantic.Field(
+                    param.default if param.default != param.empty else ...,
+                    description=doc.get(param.name, None),
+                    **data.get(param.name, {}),
+                ),
             )
             for param in params
         },
@@ -60,15 +54,15 @@ def params_to_body(
     )
 
 
-class Interface:
-    type = "api"
+class Interface(BaseInterface):
+    kind = InterfaceKind.API
 
     instance: Union[fastapi.FastAPI, fastapi.APIRouter]
     name: str
 
-    def __init__(self, root: bool = False, name: Optional[str] = None):
+    def __init__(self, root: bool = False, **kwargs):
+        super().__init__(root=root, **kwargs)
         self.instance = fastapi.FastAPI() if root else fastapi.APIRouter()
-        self.name = "root" if root else name or ""
 
     def add(self, interface: Interface):
         assert isinstance(interface.instance, fastapi.APIRouter)
@@ -76,11 +70,28 @@ class Interface:
             interface.instance, prefix=f"/{interface.name}", tags=[interface.name]
         )
 
-    def cli(self, *args, **kwargs):
-        def decorator(func):
-            return func
+    def prepare_params(
+        self,
+        params: list[inspect.Parameter],
+        as_body: bool,
+        as_body_except: Optional[list[str]] = None,
+    ) -> list[Union[list[inspect.Parameter], inspect.Parameter]]:
+        params = self.filter_params(params)
 
-        return decorator
+        if as_body_except:
+            body_params = []
+            rest = []
+            for param in params:
+                if param.name not in as_body_except:
+                    body_params.append(param)
+                else:
+                    rest.append(param)
+            return [body_params, *rest]
+
+        if as_body:
+            return [params]
+
+        return params
 
     def api(
         self,
@@ -88,38 +99,40 @@ class Interface:
         method: str = "get",
         as_body: bool = False,
         as_body_except: Optional[list[str]] = None,
-        **kwargs,
+        **extra_data,
     ):
         as_body = as_body if not as_body_except else True
 
         def decorator(func):
             signature = inspect.signature(func)
             override_params = []
-            params = alter_params_for_body(
+            params = self.prepare_params(
                 signature.parameters.values(), as_body, as_body_except
             )
-            path_param = get_path_param(route)
+            local_data = merge_dicts(self.local_data, extra_data)
+            params_doc = get_params_doc(func.__doc__)
+            paths = parse_api_route(route)
 
             for param in params:
                 if isinstance(param, list):
-                    override_params.append(params_to_body(param, func.__name__))
+                    override_params.append(
+                        params_to_body(param, local_data, params_doc, func.__name__)
+                    )
                 else:
-                    default_kwargs = kwargs.get(param.name, {})
-                    default_cls = (
-                        fastapi.Path if param.name == path_param else fastapi.Query
+                    param_kwargs = local_data.get(param.name, {})
+                    param_kwargs["description"] = params_doc.get(param.name, None)
+                    param_default = (
+                        param.default
+                        if not param.default == param.empty
+                        else ...  # required
                     )
 
-                    if param.default is None:
-                        default_value = default_cls(None, **default_kwargs)
-                    elif param.default is param.empty:
-                        default_value = default_cls(..., **default_kwargs)
+                    if param.name in paths:
+                        param_default = fastapi.Path(param_default, **param_kwargs)
                     else:
-                        default_value = default_cls(param.default, **default_kwargs)
+                        param_default = fastapi.Query(param_default, **param_kwargs)
 
-                    override_params.append(param.replace(default=default_value))
-
-            route_func = getattr(self.instance, method)(route)
-            override_signature = signature.replace(parameters=tuple(override_params))
+                    override_params.append(param.replace(default=param_default))
 
             if as_body:
 
@@ -132,19 +145,18 @@ class Interface:
                             new_kwargs[kwarg] = value
                     return func(*args, **new_kwargs)
 
-                body_to_args_back.__name__ = func.__name__
-                body_to_args_back.__signature__ = override_signature
-                route_func(body_to_args_back)
-            else:
-                func_copy = types.FunctionType(
-                    func.__code__,
-                    func.__globals__,
-                    func.__name__,
-                    func.__defaults__,
-                    func.__closure__,
+                route_func = override_function(
+                    func, signature, override_params, decorator=body_to_args_back
                 )
-                func_copy.__signature__ = override_signature
-                route_func(func_copy)
+            else:
+                route_func = override_function(func, signature, override_params)
+
+            summary = func.__doc__.split("\n\n")[0] if func.__doc__ else None
+            getattr(self.instance, method)(
+                route, summary=summary, deprecated=local_data.get("deprecated")
+            )(route_func)
+
+            self.clear_local_data()
 
             return func
 

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -69,7 +69,7 @@ class Interface(BaseInterface):
             override_params = []
             body_fields = {}
             for param, field in self.build_fields(
-                Interface, params, annotations, doc, positional_params
+                params, annotations, doc, positional_params
             ):
 
                 if field and field.extra.get("file"):
@@ -117,7 +117,7 @@ class Interface(BaseInterface):
                     # FIXME replace dummy error information
                     raise fastapi.exceptions.RequestValidationError(
                         [
-                            pydantic.errors.ErrorWrapper(
+                            pydantic.error_wrappers.ErrorWrapper(
                                 ValueError(e.strerror), ("query", "test")
                             )
                         ]

--- a/src/interface/api.py
+++ b/src/interface/api.py
@@ -4,7 +4,6 @@ import inspect
 import types
 import fastapi
 import pydantic
-import uvicorn
 
 from typing import Optional, Union
 
@@ -75,16 +74,6 @@ class Interface:
         assert isinstance(interface.instance, fastapi.APIRouter)
         self.instance.include_router(
             interface.instance, prefix=f"/{interface.name}", tags=[interface.name]
-        )
-
-    def run(self, host="127.0.0.1", port=6787, debug=False, reload=False):
-        uvicorn.run(
-            self.instance,
-            host=host,
-            port=port,
-            log_level="info" if not debug else "debug",
-            reload=reload,
-            root_path="/yunohost/api",
         )
 
     def cli(self, *args, **kwargs):

--- a/src/interface/base.py
+++ b/src/interface/base.py
@@ -1,0 +1,94 @@
+import inspect
+import types
+import re
+
+from enum import Enum
+from typing import Any, Callable, Optional, TypeVar
+
+ViewFunc = TypeVar("ViewFunc")
+
+
+class InterfaceKind(Enum):
+    API = "api"
+    CLI = "cli"
+
+
+def pass_func(func: ViewFunc) -> ViewFunc:
+    return func
+
+
+def merge_dicts(*dicts: dict[str, Any]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+
+    for dict_ in dicts:
+        for key, value in dict_.items():
+            if key not in merged or isinstance(merged[key], (str, int, float, bool)):
+                merged[key] = value
+            else:
+                merged[key] |= value
+
+    return merged
+
+
+def get_params_doc(docstring: Optional[str]) -> dict[str, str]:
+    if not docstring:
+        return {}
+
+    return {
+        param_name: param_desc
+        for param_name, param_desc in re.findall(
+            r"- \*\*(\w+)\*\*: (.*)", docstring, re.MULTILINE
+        )
+    }
+
+
+def override_function(
+    func: Callable,
+    func_signature: inspect.Signature,
+    new_params: list[inspect.Parameter],
+    decorator: Optional[Callable] = None,
+    name: Optional[str] = None,
+    doc: Optional[str] = None,
+) -> Callable:
+    returned_func = decorator or types.FunctionType(
+        func.__code__,
+        func.__globals__,
+        func.__name__,
+        func.__defaults__,
+        func.__closure__,
+    )
+    returned_func.__name__ = name or func.__name__
+    returned_func.__doc__ = doc or func.__doc__
+    returned_func.__signature__ = func_signature.replace(parameters=tuple(new_params))
+
+    return returned_func
+
+
+class BaseInterface:
+    kind: InterfaceKind
+    local_data: dict[str, Any] = {}
+
+    def __init__(self, root: bool = False, name: str = "", help: str = ""):
+        self.name = "root" if root else name or ""
+        self.help = help
+
+    def __call__(self, *args, **kwargs):
+        self.local_data = kwargs
+        return pass_func
+
+    def clear_local_data(self):
+        self.local_data = {}
+
+    def filter_params(self, params: list[inspect.Parameter]) -> list[inspect.Parameter]:
+        private = self.local_data.get("private", [])
+
+        if private:
+            return [param for param in params if param.name not in private]
+
+        return params
+
+    def api(self, *args, **kwargs):
+        return pass_func
+
+    def cli(self, *args, **kwargs):
+        return pass_func

--- a/src/interface/base.py
+++ b/src/interface/base.py
@@ -1,9 +1,29 @@
+from __future__ import (
+    annotations,
+)  # Enable self reference a class in its own method arguments
+
 import inspect
 import types
 import re
 
 from enum import Enum
-from typing import Any, Callable, Optional, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Optional,
+    TypeVar,
+    Union,
+    get_origin,
+    get_args,
+)
+
+import pydantic
+
+from yunohost.interface.types import PrivateParam
+
 
 ViewFunc = TypeVar("ViewFunc")
 
@@ -42,9 +62,12 @@ def get_params_doc(docstring: Optional[str]) -> dict[str, str]:
     }
 
 
-def validate_pattern(pattern: str, value: str, name: str):
+def validate_pattern(pattern: str, value: str, name: Optional[str] = None):
+
     if not re.match(pattern, value, re.UNICODE):
-        raise ValueError(f"'{value}' does'nt match pattern '{pattern}'")
+        error = name if name else "'{value}' does'nt match pattern '{pattern}'"
+        raise ValueError(error.format(value=value, pattern=pattern))
+
     return value
 
 
@@ -65,7 +88,7 @@ def override_function(
     )
     returned_func.__name__ = name or func.__name__
     returned_func.__doc__ = doc or func.__doc__
-    returned_func.__signature__ = func_signature.replace(parameters=tuple(new_params))
+    returned_func.__signature__ = func_signature.replace(parameters=tuple(new_params))  # type: ignore
 
     return returned_func
 
@@ -92,16 +115,160 @@ class BaseInterface:
     def clear_local_data(self):
         self.local_data = {}
 
-    def filter_params(self, params: list[inspect.Parameter]) -> list[inspect.Parameter]:
-        private = self.local_data.get("private", [])
+    @staticmethod
+    def build_fields(
+        cls,
+        params: Iterable[inspect.Parameter],
+        annotations: dict[str, Any],
+        doc: dict[str, str],
+        positional_params: list[str],
+    ) -> Iterator[tuple[inspect.Parameter, Optional[pydantic.fields.FieldInfo]]]:
 
-        return [
-            param for param in params
-            if param.name not in private and param.name != "operation_logger"
-        ]
+        for param in params:
+            annotation = annotations[param.name]
+            field: Optional[pydantic.fields.FieldInfo] = None
+            description = doc.get(param.name, None)
+
+            if get_origin(annotation) is Annotated:
+                annotation, field = get_args(annotation)
+
+                if get_origin(field) is PrivateParam:
+                    field = None
+                elif isinstance(field, pydantic.fields.FieldInfo):
+                    update_field_from_annotation(
+                        field,
+                        param.default,
+                        name=param.name,
+                        description=description,
+                        positional=param.name in positional_params,
+                    )
+                else:
+                    raise Exception(
+                        "Views function paramaters can only be 'Annotated[Any, PrivateParam | Param]' but found '{new_param}'"
+                    )
+
+            else:
+                field = Field(
+                    param.default,
+                    name=param.name,
+                    description=description,
+                    positional=param.name in positional_params,
+                )
+
+            param = param.replace(annotation=annotation)
+
+            yield param, field
 
     def api(self, *args, **kwargs):
         return pass_func
 
     def cli(self, *args, **kwargs):
         return pass_func
+
+
+def Field(
+    default: Any = ...,
+    *,
+    name: Optional[str] = None,
+    positional: bool = False,
+    param_decls: Optional[list[str]] = None,
+    deprecated: bool = False,
+    description: Optional[str] = None,
+    hidden: bool = False,
+    pattern: Optional[Union[str, tuple[str, str]]] = None,
+    ask: Union[str, bool] = False,
+    confirm: bool = False,
+    redac: bool = False,
+    file: bool = False,
+    panel: Optional[str] = None,
+    example: Optional[str] = None,
+    # default_factory: Optional[NoArgAnyCallable] = None,
+    # alias: str = None,
+    # title: str = None,
+    # exclude: Union['AbstractSetIntStr', 'MappingIntStrAny', Any] = None,
+    # include: Union['AbstractSetIntStr', 'MappingIntStrAny', Any] = None,
+    # const: bool = None,
+    # gt: float = None,
+    # ge: float = None,
+    # lt: float = None,
+    # le: float = None,
+    # multiple_of: float = None,
+    # allow_inf_nan: bool = None,
+    # max_digits: int = None,
+    # decimal_places: int = None,
+    # min_items: int = None,
+    # max_items: int = None,
+    # unique_items: bool = None,
+    # min_length: int = None,
+    # max_length: int = None,
+    # allow_mutation: bool = True,
+    # discriminator: str = None,
+    # repr: bool = True,
+    **kwargs: Any,
+) -> pydantic.fields.FieldInfo:
+
+    pattern_name = None
+    if isinstance(pattern, tuple):
+        pattern_name, pattern = pattern
+
+    return pydantic.fields.Field(
+        default=... if default is inspect.Parameter.empty else default,
+        # default_factory=default_factory,
+        # alias=alias,
+        # title=title,
+        description=description,  # type: ignore
+        # exclude=exclude,
+        # include=include,
+        # const=const,
+        # gt=gt,
+        # ge=ge,
+        # lt=lt,
+        # le=le,
+        # multiple_of=multiple_of,
+        # allow_inf_nan=allow_inf_nan,
+        # max_digits=max_digits,
+        # decimal_places=decimal_places,
+        # min_items=min_items,
+        # max_items=max_items,
+        # unique_items=unique_items,
+        # min_length=min_length,
+        # max_length=max_length,
+        # allow_mutation=allow_mutation,
+        regex=pattern,  # type: ignore
+        # discriminator=discriminator,
+        # repr=repr,
+        # Yunohost custom
+        name=name,
+        param_decls=param_decls,
+        positional=positional,
+        deprecated=deprecated,
+        hidden=hidden,
+        # Typer Option only
+        ask=False if deprecated else ask,
+        confirm=confirm,
+        redac=redac,
+        # Type
+        file=file,
+        # Rich
+        panel=panel,
+        pattern_name=pattern_name,
+        example=example,
+        # **kwargs,
+    )
+
+
+def update_field_from_annotation(
+    field: pydantic.fields.FieldInfo,
+    default: Any,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    positional: bool = False,
+):
+    field.default = ... if default is inspect.Parameter.empty else default
+    if name:
+        field.extra["name"] = name
+    if description:
+        field.description = description
+    if positional:
+        field.extra["positional"] = positional
+        field.extra["ask"] = False

--- a/src/interface/base.py
+++ b/src/interface/base.py
@@ -42,6 +42,12 @@ def get_params_doc(docstring: Optional[str]) -> dict[str, str]:
     }
 
 
+def validate_pattern(pattern: str, value: str, name: str):
+    if not re.match(pattern, value, re.UNICODE):
+        raise ValueError(f"'{value}' does'nt match pattern '{pattern}'")
+    return value
+
+
 def override_function(
     func: Callable,
     func_signature: inspect.Signature,
@@ -89,10 +95,10 @@ class BaseInterface:
     def filter_params(self, params: list[inspect.Parameter]) -> list[inspect.Parameter]:
         private = self.local_data.get("private", [])
 
-        if private:
-            return [param for param in params if param.name not in private]
-
-        return params
+        return [
+            param for param in params
+            if param.name not in private and param.name != "operation_logger"
+        ]
 
     def api(self, *args, **kwargs):
         return pass_func

--- a/src/interface/base.py
+++ b/src/interface/base.py
@@ -68,9 +68,16 @@ class BaseInterface:
     kind: InterfaceKind
     local_data: dict[str, Any] = {}
 
-    def __init__(self, root: bool = False, name: str = "", help: str = ""):
+    def __init__(
+        self,
+        root: bool = False,
+        name: str = "",
+        help: str = "",
+        prefix: str = "",
+    ):
         self.name = "root" if root else name or ""
         self.help = help
+        self.prefix = prefix
 
     def __call__(self, *args, **kwargs):
         self.local_data = kwargs

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -25,7 +25,7 @@ from yunohost.interface.base import (
     merge_dicts,
     get_params_doc,
     override_function,
-    validate_pattern
+    validate_pattern,
 )
 from yunohost.utils.error import YunohostValidationError
 
@@ -40,7 +40,7 @@ def print_as_yaml(data: Any):
     rprint(Syntax(data, "yaml", background_color="default"))
 
 
-def pattern_validator(pattern: str, name: str):
+def pattern_validator(pattern: str, name: Optional[str]):
     def inner_validator(ctx: typer.Context, param_: typer.CallbackParam, value: str):
         if ctx.resilient_parsing:
             return
@@ -72,16 +72,21 @@ class Interface(BaseInterface):
             rprint(content)
         else:
             from moulinette import Moulinette
+
             Moulinette.display(content)
 
     @staticmethod
     def prompt(ask: str, is_password=False, confirm=False, **kwargs):
         if os.environ.get("INTERFACE") == "cli":
-            return typer.prompt(ask, hide_input=is_password, confirmation_prompt=confirm)
+            return typer.prompt(
+                ask, hide_input=is_password, confirmation_prompt=confirm
+            )
         else:
             from moulinette import Moulinette
-            return Moulinette.prompt(ask, is_password=is_password, confirm=confirm, **kwargs)
 
+            return Moulinette.prompt(
+                ask, is_password=is_password, confirm=confirm, **kwargs
+            )
 
     def cli(self, command_def: str, **extra_data):
         def decorator(func: Callable):

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -2,6 +2,7 @@ from __future__ import (
     annotations,
 )  # Enable self reference a class in its own method arguments
 
+import os
 import inspect
 import typer
 import yaml
@@ -43,6 +44,23 @@ class Interface(BaseInterface):
         self.instance.add_typer(
             interface.instance, name=interface.name, help=interface.help
         )
+
+    @staticmethod
+    def display(content: str):
+        if os.environ.get("INTERFACE") == "cli":
+            rprint(content)
+        else:
+            from moulinette import Moulinette
+            Moulinette.display(content)
+
+    @staticmethod
+    def prompt(ask: str, is_password=False, confirm=False, **kwargs):
+        if os.environ.get("INTERFACE") == "cli":
+            return typer.prompt(ask, hide_input=is_password, confirmation_prompt=confirm)
+        else:
+            from moulinette import Moulinette
+            return Moulinette.prompt(ask, is_password=is_password, confirm=confirm, **kwargs)
+
 
     def cli(self, command_def: str, **extra_data):
         def decorator(func: Callable):

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -80,9 +80,14 @@ class Interface(BaseInterface):
                 override_params.append(param.replace(default=param_default))
 
             def hook_results(*args, **kwargs):
-                results = func(*args, **kwargs)
-                print_as_yaml(results)
-                return results
+                try:
+                    results = func(*args, **kwargs)
+                    print_as_yaml(results)
+                    return results
+                except YunohostValidationError as e:
+                    raise typer.BadParameter(e.strerror)
+                except:
+                    raise
 
             command_func = override_function(
                 func,

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import inspect
+import typer
+import yaml
+
+from typing import Any, Optional
+from rich import print as rprint
+from rich.syntax import Syntax
+
+
+def parse_cli_command(command: str) -> tuple[str, list[str]]:
+    command, *args = command.split(" ")
+    return (command, [arg.strip("{}") for arg in args])
+
+
+def print_as_yaml(data: Any):
+    data = yaml.dump(data, default_flow_style=False)
+    rprint(Syntax(data, "yaml", background_color="default"))
+
+
+class Interface:
+    type = "cli"
+
+    instance: typer.Typer
+    name: str
+
+    def __init__(self, root: bool = False, name: Optional[str] = None):
+        self.instance = typer.Typer()
+        self.name = "root" if root else name or ""
+
+    def add(self, interface: Interface):
+        self.instance.add_typer(interface.instance, name=interface.name)
+
+    def run(self):
+        self.instance()
+
+    def cli(self, command_def: str, **kwargs):
+        def decorator(func):
+            signature = inspect.signature(func)
+            override_params = []
+            command, args = parse_cli_command(command_def)
+
+            for param in signature.parameters.values():
+
+                # Auto setup typer Argument or Option kwargs
+                default_kwargs = kwargs.get(param.name, {})
+                # if param.name not in args and not default_kwargs.get("hidden", False):
+                #     default_kwargs["prompt"] = True
+                if param.name == "password":
+                    default_kwargs["confirmation_prompt"] = True
+                    default_kwargs["hide_input"] = True
+
+                # Define new default value for typer
+                default_cls = typer.Argument if param.name in args else typer.Option
+                if param.default is None:
+                    default_value = default_cls(None, **default_kwargs)
+                elif param.default is param.empty:
+                    default_value = default_cls(..., **default_kwargs)
+                else:
+                    default_value = default_cls(param.default, **default_kwargs)
+
+                override_params.append(param.replace(default=default_value))
+
+            def hook_results(*args, **kwargs):
+                results = func(*args, **kwargs)
+                print_as_yaml(results)
+                return results
+
+            hook_results.__name__ = func.__name__
+            hook_results.__signature__ = signature.replace(
+                parameters=tuple(override_params)
+            )
+            self.instance.command(command)(hook_results)
+
+            return func
+
+        return decorator
+
+    def api(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -102,7 +102,7 @@ class Interface(BaseInterface):
             override_params = []
 
             for param, field in self.build_fields(
-                Interface, params, annotations, doc, positional_params
+                params, annotations, doc, positional_params
             ):
                 forward_params.append(param)
 

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -11,7 +11,7 @@ from rich.syntax import Syntax
 
 def parse_cli_command(command: str) -> tuple[str, list[str]]:
     command, *args = command.split(" ")
-    return (command, [arg.strip("{}") for arg in args])
+    return command, [arg.strip("{}") for arg in args]
 
 
 def print_as_yaml(data: Any):
@@ -31,9 +31,6 @@ class Interface:
 
     def add(self, interface: Interface):
         self.instance.add_typer(interface.instance, name=interface.name)
-
-    def run(self):
-        self.instance()
 
     def cli(self, command_def: str, **kwargs):
         def decorator(func):

--- a/src/interface/types.py
+++ b/src/interface/types.py
@@ -1,0 +1,15 @@
+from __future__ import (
+    annotations,
+)  # Enable self reference a class in its own method arguments
+
+from typing import Annotated, Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+class PrivateParam(Generic[T]):
+    ...
+
+
+Private = Annotated[T, PrivateParam[T]]

--- a/src/user.py
+++ b/src/user.py
@@ -63,15 +63,15 @@ FIELDS_FOR_IMPORT = {
 ADMIN_ALIASES = ["root", "admin", "admins", "webmaster", "postmaster", "abuse"]
 
 DepreciatedField = Field(deprecated=True)
-UsernameField = Field(pattern=("pattern_username", r"^[a-z0-9_]+$"), example="username")
+UsernameField = Field(regex=("pattern_username", r"^[a-z0-9_]+$"), example="username")
 FullnameField = Field(
     param_decls=["-F"],
     ask=True,
-    pattern=("pattern_fullname", r"^([^\W\d_]{1,30}[ ,.'-]{0,3})+$"),
+    regex=("pattern_fullname", r"^([^\W\d_]{1,30}[ ,.'-]{0,3})+$"),
     example="Camille Dupont",
 )
 DomainField = Field(
-    pattern=(
+    regex=(
         "pattern_domain",
         r"^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})$",
     ),
@@ -81,7 +81,7 @@ PasswordField = Field(
     ask=True,
     confirm=True,
     redac=True,
-    pattern=("pattern_password", r"^.{3,}$"),
+    regex=("pattern_password", r"^.{3,}$"),
     example="secret_password",
 )
 MailboxQuotaField = Field(pattern=("pattern_mailbox_quota", r"^(\d+[bkMGT])|0$"))


### PR DESCRIPTION
## POC of using typer + fastapi for managing cli commands + api endpoints


## PR Status
Very POC
- simple commands ok
- type checking ok for basic types
- help from docstring

## Todo
- custom prompt

## How to test

```
# To test api
systemctl stop yunohost-api
yunohost-fastapi --reload --reload-dirs /ynh-dev/yunohost
```
Go to https://{LXC_IP}/yunohost/api/docs

```
for cli
yunohost-typer --help
```

regular `yunohost` and `yunohost-api` should still ~work to compare with