### PR TITLE
[fix] Write var in files with redundants keys

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -568,7 +568,7 @@ ynh_read_var_in_file() {
     var_part+='\s*'
 
     # Extract the part after assignation sign
-    local expression_with_comment="$(tail +$line_number ${file} | grep -i -o -P $var_part'\K.*$' || echo YNH_NULL | head -n1)"
+    local expression_with_comment="$((tail +$line_number ${file} | grep -i -o -P $var_part'\K.*$' || echo YNH_NULL) | head -n1)"
     if [[ "$expression_with_comment" == "YNH_NULL" ]]; then
         set -o xtrace # set -x
         echo YNH_NULL
@@ -647,7 +647,7 @@ ynh_write_var_in_file() {
     var_part+='\s*'
 
     # Extract the part after assignation sign
-    local expression_with_comment="$(tail +$line_number ${file} | grep -i -o -P $var_part'\K.*$' || echo YNH_NULL | head -n1)"
+    local expression_with_comment="$((tail +$line_number ${file} | grep -i -o -P $var_part'\K.*$' || echo YNH_NULL) | head -n1)"
     if [[ "$expression_with_comment" == "YNH_NULL" ]]; then
         set -o xtrace # set -x
         return 1


### PR DESCRIPTION
## The problem

With file like:
```
{
    "tic": {
        "toto": "titi"
    },
    "tac": {
        "toto": "tutu"
    },
```
This command fails
```
ynh_write_var_in_file --file=config.json --key=toto --value=tata --after="tic"
```

Here the kind of error messages:
```
sed: -e expression #1, char 173: unterminated `s' command
```

It's because `head -n1` is deactivated by the `|| echo YNH_NULL` just before... So we find several value in the key and get newline inside, so the sed command doesn't finish cause we insert a newline...

## Solution

Use parenthesis to avoid that

## PR Status

Waiting automatic test
Tested manually on mattermost config json file

## How to test

...
