### PR TITLE
[fix] Put a & into a config var

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -658,6 +658,7 @@ ynh_write_var_in_file() {
     endline=${expression_with_comment#"$expression"}
     endline="$(echo "$endline" | sed 's/\\/\\\\/g')"
     value="$(echo "$value" | sed 's/\\/\\\\/g')"
+    value=${value//&/"\&"}
     local first_char="${expression:0:1}"
     delimiter=$'\001'
     if [[ "$first_char" == '"' ]]; then


### PR DESCRIPTION
## The problem
This doesn't work due to the & char... cause in sed it means something
```
ynh_write_var_in_file --file=/var/www/mattermost/config/config.json --key=DataSource '--value=postgres://mattermost:**********@localhost:5432/mattermost?sslmode=disable&connect_timeout=10'
```

## Solution

Escape it like in ynh_replace_string

## PR Status

Ready

## How to test

...
