### PR TITLE
enh-PostgreSQL helpers for multidatabases handling

### DIFF
--- a/helpers/postgresql
+++ b/helpers/postgresql
@@ -143,6 +143,41 @@ ynh_psql_dump_db() {
     sudo --login --user=postgres pg_dump "$database"
 }
 
+# Dump all existing PostgreSQL databases associated with a given user
+#
+# usage: ynh_psql_dump_all_user_dbs --db_user=db_user [--app=app]
+# | arg: -u, --db_user=    - the PostgreSQL role/user of which to remove all owned databases
+# | arg: -a, --app=     - the application id to tag the dump with
+#
+# Requires YunoHost version 3.5.0 or higher.
+ynh_psql_dump_all_user_dbs() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=ua
+    local -A args_array=([u]=db_user= [a]=app=)
+    local db_user
+    local app
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    app="${app:-}"
+	
+	local dbs_to_dump=$(ynh_psql_list_user_dbs $db_user)
+	if [ -n "$dbs_to_dump" ]; then	   # Check that the list of database(s) is not empty 
+		
+		local db_name
+		for db_name in $dbs_to_dump   # Iterate through the list of database(s) to dump. Note: this would fail in case databases names would contain space character or characters such as "*". IFS parsing method would then be required. 
+		do
+			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
+				ynh_psql_dump_db $db_name > "$app-$db_name-dump.sql" # Dump the database to a filename format of app-db_name-dump.sql, or of db_name-dump.sql if app parameter was not supplied  
+				ynh_print_info --message="Dumped database $db_name associated to role $db_user"
+			else
+				ynh_print_warn --message="Database $db_name not found"
+			fi
+		done
+	else 
+		ynh_print_warn --message="No associated database to role $db_user was found"
+	fi
+}
+
 # Create a user
 #
 # [internal]

--- a/helpers/postgresql
+++ b/helpers/postgresql
@@ -302,3 +302,24 @@ ynh_psql_test_if_first_run() {
 
     yunohost tools regen-conf postgresql
 }
+
+# List all existing PostgreSQL databases associated with a given user
+#
+# [internal]
+#
+# usage: ynh_psql_list_user_dbs db_user
+# | arg: db_user  - the PostgreSQL role/user of which to list all owned databases
+#
+# Requires YunoHost version 3.5.0 or higher.
+ynh_psql_list_user_dbs() {
+    local db_user=$1
+	
+    if ynh_psql_user_exists --user=$db_user; then # Check that the db_user exists
+        local sql="COPY (SELECT datname FROM pg_database JOIN pg_authid ON pg_database.datdba = pg_authid.oid WHERE rolname = '${db_user}') TO STDOUT"
+        local dbs_list=$(ynh_psql_execute_as_root --sql="$sql") # Fetch database(s) associated to role $db_user as a string using space as delimiter (ex: "db1 db2 db3 db4")
+        echo "$dbs_list"
+    else
+        ynh_print_err --message="User \'$db_user\' does not exist"
+        echo ""
+    fi
+}

--- a/helpers/postgresql
+++ b/helpers/postgresql
@@ -178,6 +178,56 @@ ynh_psql_dump_all_user_dbs() {
 	fi
 }
 
+# Restore all dumped PostgreSQL databases for the given app
+#
+# usage: ynh_psql_restore_all_app_dbs_dumps --db_user=db_user [--db_user_pwd=db_user_pwd]
+# | arg: -u, --db_user=    		- the PostgreSQL role/user which will own the restored databases. If not existing, it will be created.
+# | arg: -p, --db_user_pwd= 	- the password associated to the PostgreSQL role/user which will own the databases. If not existing, it will be generated and saved to the app's config file.
+#	
+# SQL dump files to restore must be named according to this format "app_id-db_name-dump.sql" (e.g. "noalyss-account_repository-dump.sql") and be located in the app folder 
+# The filename format requirement is so in order to match the files dumped using ynh_psql_dump_all_user_dbs --user=user --app=app (with both parameters specified).
+# 
+# Requires YunoHost version 3.5.0 or higher.
+ynh_psql_restore_all_app_dbs_dumps(){
+    # Declare an array to define the options of this helper.
+    local legacy_args=up
+    local -A args_array=([u]=db_user= [p]=db_user_pwd=)
+    local db_user
+    local db_user_pwd
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"	
+	
+	if [ -z "$app" ]; then
+		ynh_die --message="No global app_ID variable defined in the script"
+	fi
+
+	ynh_psql_test_if_first_run  # Make sure PSQL is installed
+	
+	local filename
+	for filename in *-dump.sql	# Loop among all files ending with "-dump.sql" in the current folder  
+	do	
+		local db_name
+		db_name="${filename#${app}-}"							# Remove "$app-" prefix from filename string to parse db_name. Will do nothing if there is no match.
+		db_name="${db_name%-dump.sql}"							# Remove "-dump.sql" suffix from filename string to parse db_name. Will do nothing if there is no match.
+		db_name=$(ynh_sanitize_dbid --db_name="$db_name")
+		
+		if [[ "${filename#${app}-}" = "$filename" || -z "$db_name" ]] ; then  	# Check whether app_ID is included in filename OR $db_name is empty
+			ynh_print_warn --message="File ignored: $filename. Filename not matching expected format (appID-db_name-dump.sql)"
+			continue												
+		else														
+		    db_user_pwd="${db_user_pwd:-}"
+			if [ -z "$db_user_pwd" ]; then 
+				db_user_pwd=$(ynh_app_setting_get --app=$app --key=psqlpwd) 				# Try to retrieve db_user_pwd from the app's settings. It may prove empty during the first loop, but will get populated before the second loop by ynh_psql_setup_db() below.   
+			fi
+			
+			ynh_psql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_user_pwd	# Check that the db_user exists or create it generating a random password and then create an empty database named $db_name.  
+			ynh_psql_execute_file_as_root --file="./${filename}" --database=$db_name		# Restore the dabatase from the corresponding dump file
+			
+			ynh_print_info --message="Restored database $db_name, owned by PostgreSQL user $db_user"
+		fi
+	done	
+}
+
 # Create a user
 #
 # [internal]

--- a/helpers/postgresql
+++ b/helpers/postgresql
@@ -285,6 +285,40 @@ ynh_psql_remove_db() {
     fi
 }
 
+# Remove all existing PostgreSQL databases associated with a given user
+#
+# usage: ynh_psql_remove_all_user_dbs --db_user=db_user
+# | arg: -u, --db_user=    - the PostgreSQL role/user of which to remove all owned databases
+#
+# This can be useful to prepare the removal of a given user.
+#
+# Requires YunoHost version 3.5.0 or higher.
+ynh_psql_remove_all_user_dbs() {
+    # Declare an array to define the options of this helper.
+    local legacy_args=u
+    local -A args_array=([u]=db_user=)
+    local db_user
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+	
+	local dbs_to_drop=$(ynh_psql_list_user_dbs $db_user) 
+	if [ -n "$dbs_to_drop" ]; then	   # Check that the list of database(s) is not empty 
+		
+		local db_name
+		for db_name in $dbs_to_drop   # Iterate through the list of database(s) to remove. Note: this would fail in case databases names would contain space character or characters such as "*". IFS parsing method would then be required. 
+		do
+			if ynh_psql_database_exists --database=$db_name; then # Check if the database exists
+				ynh_psql_drop_db $db_name                         # Remove the database
+				ynh_print_info --message="Removed database $db_name associated to role $db_user"
+			else
+				ynh_print_warn --message="Database $db_name not found"
+			fi
+		done
+	else 
+		ynh_print_warn --message="No associated database to role $db_user was found"
+	fi
+}
+
 # Create a master password and set up global settings
 #
 # [internal]


### PR DESCRIPTION
## The problem

Facing the case of the broken app package [Noalyss](https://github.com/YunoHost-Apps/noalyss_ynh) (accounting solution), it happens that this app would need more than one PostgreSQL database to work. As a matter of fact this particular app is designed to require: 
- 1 database to store global settings
- 1 database per accounting ruleset (2 by default, total number up to the user)
- 1 database per accounting project (total number up to the user)

All databases are created by the app via the dedicated rolename assigned to it (e.g. here "noalyss"). However, a script is needed to correctly backup, restore, and delete those multiple databases which only have in common the fact of being owned by the rolename associated to the app.

## Solution

4 helpers were created:
- `ynh_psql_list_user_dbs()` is an internal helper (meant to be used by the 3 others helpers below) which returns the list of databases associated to the specified PostgreSQL rolename as a string combining names separated with a space (it is assumed that no database name will ever contain space).
- `ynh_psql_remove_all_user_dbs()` loops within the list of databases associated to the given rolename and drops them all (it is assumed that no database name will ever contain space or asterisk).
- `ynh_psql_dump_all_user_dbs()` loops within the list of databases associated to the given rolename and dumps them all in the current folder, naming each file as a combination of app_id, db_name, and a "-dump.sql" suffix (it is assumed that no database name will ever contain space or asterisk).
- `ynh_psql_restore_all_app_dbs_dumps()` loops among all the files in the current folder with a filename ending with the suffix "-dump.sql" and restore the ones matching the app_id of the app being restored (it is assumed that the dumps to be restored follow the filename template defined in the previous helper).

## PR Status

Helpers are ready and [already implemented](https://github.com/oleole39/noalyss_ynh/blob/standard-install-fixed/scripts/_common.sh#L75) as functions limited to the Noalyss app's scope in the fixed package [currently being reviewed](https://github.com/YunoHost-Apps/noalyss_ynh/pull/39) for this app. As such they have been tested on a VPS running Debian and YNH 11.6 stable and worked as expected.

**The goal of this PR is to turn these functions into helpers so that they could be used by other apps.**
They have not been tested as such in a Yunohost custom build, since trying to create the required build environment happened to be complicated for my dev machine (no snap, limited disk space for a Virtualbox machine).

This PR would also take the [docs on helpers](https://yunohost.org/en/packaging_apps_helpers) to be regenerated. 
 
## How to test

Functions can be tested easily installing [this branch](https://github.com/oleole39/noalyss_ynh/tree/standard-install-fixed) of Noalyss package as a custom app - following install instructions till the end, then backup the app, remove it and eventually restore it and see that after restoration you still have access to the app with the credentials defined during the initial installation.  
Between each step you can list PostgreSQL databases on the test YNH server to note what is happening to them (not knowing YNH server's postgres user password, I have to log first as root as indicated below):
```
su -
sudo -u -i postgres
psql -l 
```
As global helpers, a custom build is required and call examples can be found in the backup/restore/remove scripts of the fixed Noalyss package's branch indicated hereinabove. 
