### PR TITLE
Add push notification plugins

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -10,7 +10,7 @@ mail_uid = 500
 
 protocols = imap sieve {% if pop3_enabled == "True" %}pop3{% endif %}
 
-mail_plugins = $mail_plugins quota
+mail_plugins = $mail_plugins quota notify push_notification
 
 ###############################################################################
 


### PR DESCRIPTION
This is reasonably important for the performance of clients such as Delta Chat. The plugins are bundled with dovecot by default (see https://wiki2.dovecot.org/Plugins ) so this should not be disruptive.

## The problem

Clients can poll, but most are able to receive push notifications over imap as per RFC5423 ( https://datatracker.ietf.org/doc/html/rfc5423.html ). This improves the UX of IM-like clients considerably.

## Solution

Enable the notify and push_notification plugins.

## PR Status

...

## How to test

Start dovecot with the new config, connect with a client which can receive push notifications, compare apparent receipt time from a client perspective with the experience of a client doing polling instead and judge whether or not push is favourable.
