### PR TITLE
WIP: Use pydantic for config panels and app install 

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1207,6 +1207,7 @@ settings:
             arguments:
                 key:
                     help: Settings key
+                    nargs: '?'
                 -f:
                     full: --full
                     help: Display all details (meant to be used by the API)

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -5,10 +5,10 @@ i18n = "domain_config"
 name = "Features"
 
     [feature.app]
+
         [feature.app.default_app]
         type = "app"
         filter = "is_webapp"
-        default = "_none"
 
     [feature.mail]
 
@@ -44,28 +44,30 @@ name = "Certificate"
         [cert.cert.cert_validity]
         type = "number"
         readonly = true
-        visible = "false"
+        visible = false
         # Automatically filled by DomainConfigPanel
 
         [cert.cert.cert_issuer]
         type = "string"
+        readonly = true
         visible = false
         # Automatically filled by DomainConfigPanel
 
         [cert.cert.acme_eligible]
         type = "boolean"
+        readonly = true
         visible = false
         # Automatically filled by DomainConfigPanel
 
         [cert.cert.acme_eligible_explain]
         type = "alert"
         style = "warning"
-        visible = "acme_eligible == false || acme_eligible == null"
+        visible = "!acme_eligible"
 
         [cert.cert.cert_no_checks]
         type = "boolean"
         default = false
-        visible = "acme_eligible == false || acme_eligible == null"
+        visible = "!acme_eligible"
 
         [cert.cert.cert_install]
         type = "button"

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -73,7 +73,6 @@ name = "Security"
         type = "tags"
         visible = "webadmin_allowlist_enabled"
         optional = true
-        default = ""
 
     [security.root_access]
     name = "Change root password"
@@ -107,7 +106,7 @@ name = "Email"
         [email.pop3.pop3_enabled]
         type = "boolean"
         default = false
-    
+
     [email.smtp]
     name = "SMTP"
         [email.smtp.smtp_allow_ipv6]
@@ -117,7 +116,7 @@ name = "Email"
         [email.smtp.smtp_relay_enabled]
         type = "boolean"
         default = false
-        
+
         [email.smtp.smtp_relay_host]
         type = "string"
         default = ""
@@ -134,7 +133,7 @@ name = "Email"
         default = ""
         optional = true
         visible="smtp_relay_enabled"
-        
+
         [email.smtp.smtp_relay_password]
         type = "password"
         default = ""

--- a/src/app.py
+++ b/src/app.py
@@ -1411,7 +1411,7 @@ def app_remove(operation_logger, app, purge=False, force_workdir=None):
 
     for domain in domain_list()["domains"]:
         if domain_config_get(domain, "feature.app.default_app") == app:
-            domain_config_set(domain, "feature.app.default_app", "_none")
+            domain_config_set(domain, "feature.app.default_app", None)
 
     if ret == 0:
         logger.success(m18n.n("app_removed", app=app))
@@ -1448,7 +1448,7 @@ def app_makedefault(operation_logger, app, domain=None, undo=False):
     operation_logger.start()
 
     if undo:
-        domain_config_set(domain, "feature.app.default_app", "_none")
+        domain_config_set(domain, "feature.app.default_app", None)
     else:
         domain_config_set(domain, "feature.app.default_app", app)
 
@@ -1701,7 +1701,7 @@ def app_ssowatconf():
 
     for domain in domains:
         default_app = domain_config_get(domain, "feature.app.default_app")
-        if default_app != "_none" and _is_installed(default_app):
+        if default_app and _is_installed(default_app):
             app_settings = _get_app_settings(default_app)
             app_domain = app_settings["domain"]
             app_path = app_settings["path"]

--- a/src/dns.py
+++ b/src/dns.py
@@ -529,7 +529,7 @@ def _get_registrar_config_section(domain):
                     parent_domain=parent_domain,
                     parent_domain_link=parent_domain_link,
                 ),
-                "value": "parent_domain",
+                "default": "parent_domain",
             }
         )
         return OrderedDict(registrar_infos)
@@ -542,7 +542,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "success",
                 "ask": m18n.n("domain_dns_registrar_yunohost"),
-                "value": "yunohost",
+                "default": "yunohost",
             }
         )
         return OrderedDict(registrar_infos)
@@ -552,7 +552,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "info",
                 "ask": m18n.n("domain_dns_conf_special_use_tld"),
-                "value": None,
+                "default": None,
             }
         )
 
@@ -564,7 +564,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "warning",
                 "ask": m18n.n("domain_dns_registrar_not_supported"),
-                "value": None,
+                "default": None,
             }
         )
     else:
@@ -573,7 +573,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "info",
                 "ask": m18n.n("domain_dns_registrar_supported", registrar=registrar),
-                "value": registrar,
+                "default": registrar,
             }
         )
 

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -1,0 +1,731 @@
+#
+# Copyright (c) 2023 YunoHost Contributors
+#
+# This file is part of YunoHost (see https://yunohost.org)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import contextlib
+import os
+import re
+from typing import TYPE_CHECKING, Type, Any, Literal, OrderedDict, Sequence, Union
+
+import pydantic
+from packaging.version import Version
+from pydantic import BaseModel, validator
+from pydantic.fields import ModelField
+
+from moulinette import Moulinette, m18n
+from moulinette.interfaces.cli import colorize
+from moulinette.utils.filesystem import mkdir, read_toml, read_yaml, write_to_yaml
+from moulinette.utils.log import getActionLogger
+from yunohost.utils.error import YunohostError, YunohostValidationError
+from yunohost.utils.form import (
+    BaseInputOption,
+    ButtonOption,
+    OptionType,
+    OptionsContainer,
+    Translation,
+    build_form,
+    evaluate_simple_js_expression,
+    fill_form,
+    parse_prefilled_values,
+    prompt_form,
+)
+from yunohost.utils.i18n import _value_for_locale
+
+if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
+    from yunohost.utils.form import YunoForm
+
+
+logger = getActionLogger("yunohost.config")
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╭╮╮╭─╮┌─╮┌─╴╷  ╭─╴                                   │
+# │  ││││ ││ │├─╴│  ╰─╮                                   │
+# │  ╵╵╵╰─╯└─╯╰─╴╰─╴╶─╯                                   │
+# ╰───────────────────────────────────────────────────────╯
+CONFIG_PANEL_VERSION_SUPPORTED = "1.0"
+
+
+class Container(BaseModel):
+    id: str
+    name: Union[str, None] = None
+    services: list[str] = []
+    help: Translation = None
+
+    def translate(self, i18n_key: Union[str, None] = None):
+        """
+        Translate `ask` and `name` attributes of panels and section.
+        This is in place mutation.
+        """
+
+        for key in ("help", "name"):
+            value = getattr(self, key)
+            if value:
+                setattr(self, key, _value_for_locale(value))
+            elif key == "help" and m18n.key_exists(f"{i18n_key}_{self.id}_help"):
+                setattr(self, key, m18n.n(f"{i18n_key}_{self.id}_help"))
+
+
+class Section(Container, OptionsContainer):
+    visible: Union[bool, str] = True
+    # optional: bool = True
+    # options: list[Annotated[AnyOption, Field(discriminator="type")]]
+
+    @property
+    def is_action_section(self):
+        return any([option.type is OptionType.button for option in self.options])
+
+    # Don't forget to pass arguments to super init
+    def __init__(
+        self,
+        id: str,
+        name: Union[str, None] = None,
+        services: list[str] = [],
+        help: Translation = None,
+        visible: Union[bool, str] = True,
+        **kwargs,
+    ) -> None:
+        # Looks like this allow to use Container init while still matching
+        # "options" of OptionsContainer
+        options = self.options_dict_to_list(kwargs, defaults={"optional": True})
+
+        Container.__init__(
+            self,
+            id=id,
+            name=name,
+            services=services,
+            help=help,
+            visible=visible,
+            options=options,
+        )
+
+    def is_visible(self, context: dict[str, Any]):
+        if isinstance(self.visible, bool):
+            return self.visible
+
+        return evaluate_simple_js_expression(self.visible, context=context)
+
+    def translate(self, i18n_key: Union[str, None] = None):
+        """
+        Call to `Container`'s `translate` for self translation
+        + Call to `OptionsContainer`'s `translate_options` for options translation
+        """
+        super().translate(i18n_key)  #
+        self.translate_options(i18n_key)  #
+
+
+class Panel(Container):
+    # actions: dict[str, Translation] = {"apply": {"en": "Apply"}}
+    sections: list[Section]
+
+    class Config:
+        extra = pydantic.Extra.allow
+
+    # Don't forget to pass arguments to super init
+    def __init__(
+        self,
+        id: str,
+        name: Union[str, None] = None,
+        services: list[str] = [],
+        help: Translation = None,
+        **kwargs,
+    ) -> None:
+        sections = [data | {"id": name} for name, data in kwargs.items()]
+        super().__init__(
+            id=id, name=name, services=services, help=help, sections=sections
+        )
+
+    def translate(self, i18n_key: Union[str, None] = None):
+        """
+        Recursivly mutate translatable attributes to their translation
+        """
+        super().translate(i18n_key)
+
+        for section in self.sections:
+            section.translate(i18n_key)
+
+
+class ConfigPanel(BaseModel):
+    version: str = "1.0"
+    i18n: Union[str, None] = None
+    panels: list[Panel]
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = pydantic.Extra.allow
+
+    # Don't forget to pass arguments to super init
+    def __init__(
+        self,
+        version: Version,
+        i18n: Union[str, None] = None,
+        **kwargs,
+    ) -> None:
+        panels = [data | {"id": name} for name, data in kwargs.items()]
+        super().__init__(version=version, i18n=i18n, panels=panels)
+
+    @property
+    def sections(self):
+        """Convinient prop to iter on all sections"""
+        for panel in self.panels:
+            for section in panel.sections:
+                yield section
+
+    @property
+    def options(self):
+        """Convinient prop to iter on all options"""
+        for section in self.sections:
+            for option in section.options:
+                yield option
+
+    @property
+    def services(self) -> list[str]:
+        services = set()
+        for panel in self.panels:
+            services |= set(panel.services)
+            for section in panel.sections:
+                services |= set(section.services)
+
+        services_ = list(services)
+        services_.sort(key="nginx".__eq__)
+        return services_
+
+    def iter_children(
+        self,
+        trigger: list[Literal["panel", "section", "option", "action"]] = ["option"],
+    ):
+        for panel in self.panels:
+            if "panel" in trigger:
+                yield (panel, None, None)
+            for section in panel.sections:
+                if "section" in trigger:
+                    yield (panel, section, None)
+                if "action" in trigger:
+                    for option in section.options:
+                        if isinstance(option, ButtonOption):
+                            yield (panel, section, option)
+                if "option" in trigger:
+                    for option in section.options:
+                        yield (panel, section, option)
+
+    def translate(self):
+        """
+        Recursivly mutate translatable attributes to their translation
+        """
+        for panel in self.panels:
+            panel.translate(self.i18n)
+
+    @validator("version", pre=True, always=True)
+    def parse_as_version(cls, v, field: ModelField):
+        if not isinstance(v, Version):
+            try:
+                v = Version(v)
+            except:
+                raise ValueError(f"Wrong version format: {v}")
+
+        if v < Version(CONFIG_PANEL_VERSION_SUPPORTED):
+            raise ValueError(f"Config panels version '{v}' are no longer supported.")
+
+        return str(v)
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╭─╴╭─╮╭╮╷┌─╴╶┬╴╭─╮   ╶┬╴╭╮╮┌─╮╷                      │
+# │  │  │ ││││├─╴ │ │╶╮    │ │││├─╯│                      │
+# │  ╰─╴╰─╯╵╰╯╵  ╶┴╴╰─╯   ╶┴╴╵╵╵╵  ╰─╴                    │
+# ╰───────────────────────────────────────────────────────╯
+
+
+class Config:
+    entity_type = "config"
+    base_path: str = "/usr/share/yunohost"
+    save_path_tpl: Union[str, None] = None
+    config_path_tpl: str = "config_{entity_type}.toml"
+    save_mode = "full"
+
+    def __init__(
+        self,
+        entity: str,
+        config_path: Union[str, None] = None,
+        save_path: Union[str, None] = None,
+        creation: bool = False,
+    ):
+        self.entity = entity
+
+        self.config_path = config_path or os.path.join(
+            self.base_path,
+            self.config_path_tpl.format(entity=entity, entity_type=self.entity_type),
+        )
+
+        self.save_path = save_path
+        if not save_path and self.save_path_tpl:
+            self.save_path = os.path.join(
+                self.base_path, self.save_path_tpl.format(entity=entity)
+            )
+
+        if (
+            self.save_path
+            and self.save_mode != "diff"
+            and not creation
+            and not os.path.exists(self.save_path)
+        ):
+            raise YunohostValidationError(
+                f"{self.entity_type}_unknown", **{self.entity_type: entity}
+            )
+        if self.save_path and creation and os.path.exists(self.save_path):
+            raise YunohostValidationError(
+                f"{self.entity_type}_exists", **{self.entity_type: entity}
+            )
+
+        # Search for hooks in the config panel
+        self.hooks = {
+            func: getattr(self, func)
+            for func in dir(self)
+            if callable(getattr(self, func))
+            and re.match("^(validate|post_ask)__", func)
+        }
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _try_apply_or_run(error: str, action_id: Union[str, None] = None):
+        try:
+            yield
+        except YunohostError:
+            raise
+        # Script got manually interrupted ...
+        # N.B. : KeyboardInterrupt does not inherit from Exception
+        except (KeyboardInterrupt, EOFError):
+            logger.error(
+                m18n.n(error, action=action_id, error=m18n.n("operation_interrupted"))
+            )
+            raise
+        # Something wrong happened in Yunohost's code (most probably hook_exec)
+        except Exception:
+            import traceback
+
+            logger.error(
+                m18n.n(
+                    error,
+                    action=action_id,
+                    error=m18n.n(
+                        "unexpected_error", error="\n" + traceback.format_exc()
+                    ),
+                )
+            )
+            raise
+        finally:
+            # Delete files uploaded from API
+            # FIXME : this is currently done in the context of config panels,
+            # but could also happen in the context of app install ... (or anywhere else
+            # where we may parse args etc...)
+            # FileQuestion.clean_upload_dirs()
+            # FIXME deal with uploaded file
+            print("FILES TO RM")
+
+    def _get_config_data(
+        self,
+        panel_id: Union[str, None] = None,
+        section_id: Union[str, None] = None,
+        option_id: Union[str, None] = None,
+    ) -> dict[str, Any]:
+        if not os.path.exists(self.config_path):
+            raise YunohostValidationError("config_no_panel")
+            # f"Config panel {self.config_path} doesn't exists"
+
+        return read_toml(self.config_path)
+
+    def _get_settings_data(self, config: "ConfigPanel") -> dict[str, Any]:
+        if not self.save_path or not os.path.exists(self.save_path):
+            raise YunohostValidationError("config_no_settings")
+            # f"Config panel {self.config_path} doesn't exists"
+
+        return read_yaml(self.save_path)
+
+    def _get_partial_config_data(
+        self,
+        panel_id: Union[str, None] = None,
+        section_id: Union[str, None] = None,
+        option_id: Union[str, None] = None,
+    ) -> dict[str, Any]:
+        def filter_keys(
+            data: dict[str, Any],
+            key: str,
+            model: Union[Type[ConfigPanel], Type[Panel], Type[Section]],
+        ) -> dict[str, Any]:
+            # filter in keys defined in model, filter out panels/sections/options that aren't `key`
+            return {k: v for k, v in data.items() if k in model.__fields__ or k == key}
+
+        config_data = self._get_config_data(panel_id, section_id, option_id)
+
+        if panel_id:
+            config_data = filter_keys(config_data, panel_id, ConfigPanel)
+
+            if section_id:
+                config_data[panel_id] = filter_keys(
+                    config_data[panel_id], section_id, Panel
+                )
+
+                if option_id:
+                    config_data[panel_id][section_id] = filter_keys(
+                        config_data[panel_id][section_id], option_id, Section
+                    )
+
+        return config_data
+
+    def _get_partial_settings_data_and_mutate_config(
+        self, config: ConfigPanel
+    ) -> tuple[ConfigPanel, dict[str, Any]]:
+        settings_data = self._get_settings_data(config)
+        values = {}
+
+        for option in config.options:
+            value = data = settings_data.get(
+                option.id, getattr(option, "default", None)
+            )
+
+            if isinstance(data, dict):
+                # Settings data if gathered from bash "ynh_app_config_show"
+                # may be a custom getter that returns a dict with `value` or `current_value`
+                # and other attributes meant to override those of the option.
+
+                if "value" in data:
+                    value = data.pop("value")
+
+                # FIXME do we still need the `current_value`?
+                if "current_value" in data:
+                    value = data.pop("current_value")
+
+                # Mutate other possible option attributes
+                for k, v in data.items():
+                    setattr(option, k, v)
+
+            if isinstance(option, BaseInputOption):  # or option.bind == "null":
+                values[option.id] = value
+
+        return (config, values)
+
+    def _get_config_and_settings(
+        self, panel_id, section_id, option_id, prevalidate: bool = False
+    ) -> tuple[ConfigPanel, "YunoForm"]:
+        config_data = self._get_partial_config_data(panel_id, section_id, option_id)
+        config = ConfigPanel(**config_data)
+        config, settings_data = self._get_partial_settings_data_and_mutate_config(
+            config
+        )
+        config.translate()
+        Settings = build_form(config.options)
+        # FIXME will probably have problems with required stuff if not filled on install
+        # Probably need to not parse & validate data at instantiation
+        # settings = Settings(**settings_data)
+        settings = (
+            Settings(**settings_data)
+            if prevalidate
+            else Settings.construct(**settings_data)
+        )
+
+        return (config, settings)
+
+    def _get_keys(self, key: Union[str, None] = None) -> Sequence[Union[str, None]]:
+        if key and key.count(".") > 2:
+            raise YunohostError(
+                f"The filter key {key} has too many sub-levels, the max is 3.",
+                raw_msg=True,
+            )
+
+        if not key:
+            return (None, None, None)
+        keys = key.split(".")
+        return tuple(keys[i] if len(keys) > i else None for i in range(3))
+
+    def get(
+        self,
+        key: Union[str, None] = None,
+        mode: Literal["classic", "full", "export"] = "classic",
+    ):
+        panel_id, section_id, option_id = self._get_keys(key)
+
+        config, settings = self._get_config_and_settings(
+            panel_id, section_id, option_id
+        )
+
+        if mode == "classic" and option_id:
+            return settings.normalize(option_id)
+
+        result = config.dict() if mode == "full" else OrderedDict()
+
+        if mode == "full":
+            result["version"] = str(result["version"])
+
+        for p, panel in enumerate(config.panels):
+            for s, section in enumerate(panel.sections):
+                for o, option in enumerate(section.options):
+                    if mode == "classic":
+                        key = ".".join((panel.id, section.id, option.id))
+                        result[key] = {"ask": option.ask}
+                        if isinstance(option, BaseInputOption):
+                            result[key]["value"] = settings.normalize(option.id)
+                    elif isinstance(option, BaseInputOption):
+                        value = settings.normalize(option.id)
+                        if mode == "export":
+                            result[option.id] = value
+                        elif mode == "full":
+                            result["panels"][p]["sections"][s]["options"][o][
+                                "value"
+                            ] = value
+
+        return result
+
+    def _save(self, values: dict[str, Any]):
+        logger.info("Saving the new configuration...")
+
+        if not self.save_path:
+            raise YunohostError("Couln't save settings, save path is not defined")
+
+        dir_path = os.path.dirname(os.path.realpath(self.save_path))
+        if not os.path.exists(dir_path):
+            mkdir(dir_path, mode=0o700)
+
+        write_to_yaml(self.save_path, values)
+
+    def _apply(
+        self,
+        settings: "YunoForm",
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+    ):
+        """
+        Save settings in yaml file.
+        If `save_mode` is `"diff"` (which is the default), only values that are
+        different from their default value will be saved.
+        """
+        logger.info("Saving the new configuration...")
+
+        if not self.save_path:
+            raise YunohostError("Couln't save settings, save path is not defined")
+
+        exclude_defaults = self.save_mode == "diff"
+        values = settings.dict(exclude_defaults=exclude_defaults, exclude=exclude)
+
+        dir_path = os.path.dirname(os.path.realpath(self.save_path))
+        if not os.path.exists(dir_path):
+            mkdir(dir_path, mode=0o700)
+
+        write_to_yaml(self.save_path, values)
+
+        return values
+
+    def _reload_services(self, config: ConfigPanel):
+        from yunohost.service import service_reload_or_restart
+
+        if config.services:
+            logger.info("Reloading services...")
+            for service in config.services:
+                if hasattr(self, "entity"):
+                    service = service.replace("__APP__", self.entity)
+                service_reload_or_restart(service)
+
+    def set(
+        self,
+        key: Union[str, None] = None,
+        value: Any = None,
+        args: Union[str, None] = None,
+        args_file=None,
+        operation_logger=None,
+    ):
+        panel_id, section_id, option_id = self._get_keys(key)
+
+        if option_id is None and value is not None:
+            raise YunohostValidationError("config_cant_set_value_on_section")
+
+        settings_args = parse_prefilled_values(args, args_file)
+        if settings_args and value is not None:
+            raise YunohostValidationError(
+                "You should either provide a value, or a serie of args/args_file, but not both at the same time",
+                raw_msg=True,
+            )
+        elif option_id and value is not None:
+            settings_args = {option_id: value}
+
+        # Do not prevalidate current settings else required values without
+        # default will raise a validation error before being able to ask it
+        config, settings = self._get_config_and_settings(
+            panel_id, section_id, option_id, prevalidate=False
+        )
+
+        # Clear fields set when created
+        settings.__fields_set__.clear()
+        # FIXME check len(__fields__) > len(settings_args) to choose if prompt or fill in cli
+        if Moulinette.interface.type == "cli" and os.isatty(1):
+            settings = prompt_config(config, settings, prefilled_answers=settings_args)
+        else:
+            settings = fill_config(config, settings, settings_args)
+
+        # Validate settings to parse everything back to python types?
+        # settings = settings.validate(settings.dict())
+
+        if operation_logger:
+            operation_logger.start()
+
+        # i18n: config_apply_failed
+        with self._try_apply_or_run("config_apply_failed"):
+            self._apply(settings)
+
+        self._reload_services(config)
+
+        logger.success("Config updated as expected")
+        operation_logger.success()
+        return settings.dict()
+
+    def list_actions(self):
+        config = ConfigPanel(**self._get_config_data())
+
+        return {
+            f"{panel.id}.{section.id}.{action.id}": action.ask
+            for panel, section, action in config.iter_children(trigger=["action"])
+        }
+
+    def _run_action(self, action_id: str, settings: "YunoForm"):
+        raise NotImplementedError()
+
+    def run_action(
+        self,
+        key: str,
+        args: Union[str, None] = None,
+        args_file=None,
+        operation_logger=None,
+    ):
+        panel_id, section_id, action_id = self._get_keys(key)
+
+        if not action_id or not all([panel_id, section_id, action_id]):
+            raise YunohostValidationError(
+                "Please provide a full action key like 'panel.section.action'",
+                raw_msg=True,
+            )
+
+        # Get entire section since some data may be required for the action to run
+        config, settings = self._get_config_and_settings(
+            panel_id, section_id, None, prevalidate=False
+        )
+
+        if not any(option.id == action_id for option in config.options):
+            raise YunohostValidationError(
+                f"No action named '{action_id}'", raw_msg=True
+            )
+
+        settings_args = parse_prefilled_values(args, args_file)
+
+        if Moulinette.interface.type == "cli" and os.isatty(1):
+            settings = prompt_config(
+                config, settings, settings_args, action_id=action_id
+            )
+        else:
+            settings = fill_config(config, settings, settings_args, action_id=action_id)
+
+        if operation_logger:
+            operation_logger.start()
+
+        # i18n: config_action_failed
+        with self._try_apply_or_run("config_action_failed", action_id):
+            self._run_action(action_id, settings)
+
+        # FIXME: i18n
+        logger.success(f"Action {action_id} successful")
+        operation_logger.success()
+
+
+def fill_config(
+    config: ConfigPanel,
+    settings: "YunoForm",
+    prefilled_answers: dict[str, Any],
+    action_id: Union[str, None] = None,
+) -> "YunoForm":
+    """
+    API only method to validate form passed as query string.
+    Most checks should be handled by the webadmin but we recheck in case of direct call to API or webadmin missing stuff.
+    """
+    logger.debug("Validating settings...")
+
+    context: dict[str, Any] = {}
+    for section in config.sections:
+        if (action_id is None and section.is_action_section) or not section.is_visible(
+            context
+        ):
+            skipped_options = [
+                option.id
+                for option in section.options
+                if option.id in prefilled_answers
+            ]
+            if skipped_options:
+                logger.warning(
+                    f"Skipping settings: '{skipped_options}' since conditions are not fullfilled."
+                )
+            continue
+
+        settings = fill_form(
+            section.options,
+            settings,
+            prefilled_answers,
+            context=context,
+            action_id=action_id,
+        )
+
+    return settings
+
+
+def prompt_config(
+    config: ConfigPanel,
+    settings: "YunoForm",
+    prefilled_answers: dict[str, Any],
+    action_id: Union[str, None] = None,
+) -> "YunoForm":
+    """
+    CLI only method to interactively prompt the config form
+    """
+    logger.debug("Ask unanswered question and prevalidate data")
+
+    for panel in config.panels:
+        # A section or option may only evaluate its conditions (`visible`
+        # and `enabled`) with its panel's local context that is built
+        # prompt after prompt.
+        # That means that a condition can only reference options of its
+        # own panel and options that are previously defined.
+        context: dict[str, Any] = {}
+        Moulinette.display(
+            colorize(f"\n{'='*40}\n>>>> {panel.name}\n{'='*40}", "purple")
+        )
+
+        for section in panel.sections:
+            if (
+                action_id is None and section.is_action_section
+            ) or not section.is_visible(context):
+                # FIXME useless?
+                Moulinette.display("Skipping section '{panel.id}.{section.id}'…")
+                continue
+
+            if section.name:
+                Moulinette.display(colorize(f"\n# {section.name}", "purple"))
+
+            settings = prompt_form(
+                section.options,
+                settings,
+                prefilled_answers,
+                context=context,
+                action_id=action_id,
+            )
+
+    return settings
+

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1,0 +1,1297 @@
+#
+# Copyright (c) 2023 YunoHost Contributors
+#
+# This file is part of YunoHost (see https://yunohost.org)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+import ast
+import datetime
+import operator as op
+import re
+import urllib
+from enum import Enum
+from pathlib import Path
+from types import new_class
+from typing import Annotated, Any, Literal, Type, TypeVar, Union, get_args, cast
+
+import pydantic
+from pydantic import BaseModel, root_validator, validator
+from pydantic.fields import Field, FieldInfo
+
+from moulinette import Moulinette, m18n
+from moulinette.interfaces.cli import colorize
+from moulinette.utils.filesystem import read_yaml
+from moulinette.utils.log import getActionLogger
+from yunohost.utils.error import YunohostError, YunohostValidationError
+from yunohost.utils.i18n import _value_for_locale
+
+# Use a more generic logger name?
+logger = getActionLogger("yunohost.config")
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╭─╴╷ ╷╭─╴╶┬╴╭─╮╭╮╮   ╶┬╴╷ ╷┌─╮┌─╴╭─╴                 │
+# │  │  │ │╰─╮ │ │ ││││    │ ╰─┤├─╯├─╴╰─╮                 │
+# │  ╰─╴╰─╯╶─╯ ╵ ╰─╯╵╵╵    ╵ ╶─╯╵  ╰─╴╶─╯                 │
+# ╰───────────────────────────────────────────────────────╯
+
+T = TypeVar("T")
+
+
+class ConstrainedComaList(pydantic.ConstrainedList[T]):  # type: ignore
+    """
+    Special type to handle bash style list parsing
+    """
+
+    @classmethod
+    def __get_validators__(cls):
+        # First parse possible bash style list `"item,item"` -> `["item", "item"]`
+        yield cls.parse_bash_style_list
+        # yield pydantic validators (parsing items to given `item_type`, regex validations, etc.)
+        yield from super().__get_validators__()
+
+    @classmethod
+    def parse_bash_style_list(
+        cls, v: Union[list[T], str, None]
+    ) -> Union[list[T], list[str], None]:
+        if v is None or v == "":
+            # FIXME parse `""` as `[]` instead?
+            return None
+
+        if isinstance(v, str):
+            values = [value.strip() for value in v.split(",")]
+            return [value for value in values if value]
+
+        return v
+
+
+def concomalist(
+    item_type: Type[T],
+    *,
+    min_items: Union[int, None] = None,
+    max_items: Union[int, None] = None,
+    unique_items: Union[bool, None] = None,
+) -> Type[list[T]]:
+    """
+    Special factory (copypasta of pydantic.conlist) to create a constrained
+    list class that handle our custom bash style list parsing.
+    """
+    # __args__ is needed to conform to typing generics api
+    namespace = dict(
+        min_items=min_items,
+        max_items=max_items,
+        unique_items=unique_items,
+        item_type=item_type,
+        __args__=(item_type,),
+    )
+    # We use new_class to be able to deal with Generic types
+    return new_class(
+        "ConstrainedComaListValue",
+        (ConstrainedComaList,),
+        {},
+        lambda ns: ns.update(namespace),
+    )
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╭─╮┌─╮╶┬╴╶┬╴╭─╮╭╮╷╭─╴                                │
+# │  │ │├─╯ │  │ │ ││││╰─╮                                │
+# │  ╰─╯╵   ╵ ╶┴╴╰─╯╵╰╯╶─╯                                │
+# ╰───────────────────────────────────────────────────────╯
+
+
+class OptionType(str, Enum):
+    # display
+    display_text = "display_text"
+    markdown = "markdown"
+    alert = "alert"
+    # action
+    button = "button"
+    # text
+    string = "string"
+    text = "text"
+    password = "password"
+    color = "color"
+    # numeric
+    number = "number"
+    range = "range"
+    # boolean
+    boolean = "boolean"
+    # time
+    date = "date"
+    time = "time"
+    # location
+    email = "email"
+    path = "path"
+    url = "url"
+    # choice
+    select = "select"
+    tags = "tags"
+    # file
+    file = "file"
+    # entity
+    app = "app"
+    domain = "domain"
+    user = "user"
+    group = "group"
+
+
+Translation = Union[dict[str, str], str, None]
+Style = Literal["success", "info", "warning", "danger"]
+
+
+class Pattern(BaseModel):
+    regexp: str
+    error: Translation = "error_pattern"
+
+
+def enum_to_cls(enum_value: OptionType):
+    """
+    Return the corresponding: option type enum value -> class definition
+    """
+    # FIXME probably better way to get type class
+    _, types = pydantic.utils.get_discriminator_alias_and_values(
+        AnyOption, discriminator_key="type"
+    )
+    return get_args(AnyOption)[types.index(OptionType[enum_value])]
+
+
+class BaseOption(BaseModel):
+    """
+    BaseOption is the base model for any config panel or manifest install
+    dynamic form 'option'.
+    Any parsing or validation defined on this model or subclasses are to
+    validate and interprete what devs/packagers writes, not what a user could
+    provide for this option.
+
+    The parsing/validation of user inputs are built upon options as another
+    dynamic model created by `build_form`.
+    """
+
+    type: OptionType
+    ask: Translation
+    name: Union[str, None] = None  # FIXME name or id?
+    id: str
+    bind: Union[str, None] = None
+    readonly: bool = False
+    visible: Union[str, bool] = True
+
+    class Config:
+        arbitrary_types_allowed = True
+        use_enum_values = True
+        validate_assignment = True
+
+        @staticmethod
+        def schema_extra(schema: dict[str, Any], model: type["BaseOption"]) -> None:
+            # FIXME Do proper doctstring for Options
+            del schema["description"]
+            schema["additionalProperties"] = False
+
+    def is_visible(self, context: dict[str, Any]):
+        if isinstance(self.visible, bool):
+            return self.visible
+
+        return evaluate_simple_js_expression(self.visible, context=context)
+
+    @root_validator(pre=True)
+    def warn_unsupported_keys(cls, values):
+        extras = set(values.keys()) - set(cls.__fields__.keys())
+        if extras:
+            for extra in extras:
+                logger.warning(
+                    f"Unknown key '{extra}' found in option '{values['id']}'"
+                )
+        return values
+
+    @validator("id")
+    def validate_id(cls, v, values):
+        forbidden_keywords = [
+            "old",
+            "app",
+            "changed",
+            "file_hash",
+            "binds",
+            "types",
+            "formats",
+            "getter",
+            "setter",
+            "short_setting",
+            "type",
+            "bind",
+            "nothing_changed",
+            "changes_validated",
+            "result",
+            "max_progression",
+        ]
+
+        if v in forbidden_keywords:
+            raise YunohostError("config_forbidden_keyword", keyword=values["id"])
+
+        return v
+
+    @validator("readonly")
+    def allowed_as_readonly(cls, v, values):
+        forbidden_readonly_types = [
+            OptionType.password,
+            # FIXME not sure why those are not allowed but maybe I misunderstood what `readonly` originally means.
+            OptionType.file,
+            OptionType.app,
+            OptionType.domain,
+            OptionType.user,
+            OptionType.group,
+        ]
+
+        if v and values["type"] in forbidden_readonly_types:
+            raise YunohostError(
+                "config_forbidden_readonly_type",
+                type=values["type"],
+                id=values["id"],
+            )
+
+        return v
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │ DISPLAY OPTIONS                                       │
+# ╰───────────────────────────────────────────────────────╯
+
+
+class BaseReadonlyOption(BaseOption):
+    _type = str
+    readonly: bool = True
+
+    @validator("readonly")
+    def force(cls, v):
+        if v is False:
+            logger.warning(
+                "Packagers: `readonly` can't be `False` for option of type `{cls.type}`, forcing to `True`"
+            )
+        return True
+
+
+class DisplayTextOption(BaseReadonlyOption):
+    type: Literal[OptionType.display_text]
+
+
+class MarkdownOption(BaseReadonlyOption):
+    type: Literal[OptionType.markdown]
+
+
+class BaseStyledReadonlyOption(BaseReadonlyOption):
+    style: Union[Style, None] = None
+    icon: Union[str, None] = None
+
+
+class AlertOption(BaseStyledReadonlyOption):
+    type: Literal[OptionType.alert]
+    style: Style = "info"
+
+
+class ButtonOption(BaseStyledReadonlyOption):
+    type: Literal[OptionType.button]
+    style: Style = "success"
+    enabled: Union[str, bool] = True
+    # confirm: bool = False  # TODO: to ask confirmation before running an action
+
+    def is_enabled(self, context: dict[str, Any]):
+        if isinstance(self.enabled, bool):
+            return self.enabled
+
+        return evaluate_simple_js_expression(self.enabled, context=context)
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │ INPUT OPTIONS                                         │
+# ╰───────────────────────────────────────────────────────╯
+InputOptions = Literal[
+    OptionType.string,
+    OptionType.text,
+    OptionType.color,
+    OptionType.password,
+    OptionType.number,
+    OptionType.range,
+    OptionType.boolean,
+    OptionType.date,
+    OptionType.time,
+    OptionType.email,
+    OptionType.path,
+    OptionType.url,
+    OptionType.select,
+    OptionType.tags,
+    OptionType.file,
+    OptionType.app,
+    OptionType.domain,
+    OptionType.user,
+    OptionType.group,
+]
+
+
+class BaseInputOption(BaseOption):
+    _anno: Any
+    pattern: Union[Pattern, None] = None
+    limit: Union[int, None] = None  # FIXME move
+    optional: bool = False  # FIXME keep required as default?
+    placeholder: Union[str, None] = None
+    help: Translation = None
+    example: Union[str, None] = None
+    redact: bool = False
+    default: Any
+
+    @property
+    def _dynamic_annotation(self):
+        return self._anno
+
+    def get_field_attrs(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {}
+
+        if self.readonly:
+            attrs["allow_mutation"] = False
+
+        if self.example:
+            attrs["examples"] = [self.example]
+
+        if self.default is not None:
+            attrs["default"] = self.default
+        elif not self.optional:
+            attrs["default"] = ...
+        else:
+            attrs["default"] = None
+
+        return attrs
+
+    def as_dynamic_model_field(
+        self,
+    ) -> tuple[Union[object, Any], FieldInfo]:
+        attrs = self.get_field_attrs()
+        anno = (
+            self._dynamic_annotation
+            if not self.optional
+            else Union[self._dynamic_annotation, None]
+        )
+        field = Field(default=attrs.pop("default", None), **attrs)
+
+        return (anno, field)
+
+    @validator("readonly", pre=True)
+    def can_be_readonly(cls, v, values):
+        forbidden_types = ("password", "app", "domain", "user", "file")
+        if v is True and values["type"] in forbidden_types:
+            raise ValueError(
+                m18n.n(
+                    "config_forbidden_readonly_type",
+                    type=values["type"],
+                    id=values["id"],
+                )
+            )
+        return v
+
+
+# ─ STRINGS ───────────────────────────────────────────────
+
+
+class BaseStringOption(BaseInputOption):
+    _anno = str
+    default: Union[str, None] = ""
+
+    @property
+    def _dynamic_annotation(self):
+        if self.pattern:
+            return pydantic.constr(regex=self.pattern.regexp)
+        return self._anno
+
+    def get_field_attrs(self):
+        attrs = super().get_field_attrs()
+        if self.pattern:
+            attrs["regex_error"] = self.pattern.error  # Extra
+        return attrs
+
+
+class StringOption(BaseStringOption):
+    type: Literal[OptionType.string]
+
+
+class TextOption(BaseStringOption):
+    type: Literal[OptionType.text]
+
+
+class PasswordOption(BaseInputOption):
+    type: Literal[OptionType.password]
+    _anno = pydantic.SecretStr
+    default: None = None
+    redact: bool = True
+    # Unique
+    forbidden_chars: str = "{}"  # FIXME add custom validator
+
+    @root_validator(pre=True)
+    def force(cls, values):
+        values["default"] = None
+        values["redact"] = True
+        return values
+
+
+class ColorOption(BaseInputOption):
+    type: Literal[OptionType.color]
+    _anno = pydantic.color.Color
+    default: Union[pydantic.color.Color, None]
+
+
+# ─ NUMERIC ───────────────────────────────────────────────
+
+
+class BaseNumberOption(BaseInputOption):
+    _anno = Union[int, float]
+    default: Union[int, float, None]
+
+    min: Union[int, None] = None
+    max: Union[int, None] = None
+    step: Union[int, None] = None
+
+    def get_field_attrs(self):
+        attrs = super().get_field_attrs()
+        attrs["ge"] = self.min
+        attrs["le"] = self.max
+        attrs["step"] = self.step  # Extra
+
+        return attrs
+
+
+class NumberOption(BaseNumberOption):
+    type: Literal[OptionType.number]
+
+
+class RangeOption(BaseNumberOption):
+    type: Literal[OptionType.range]
+
+
+# ─ BOOLEAN ───────────────────────────────────────────────
+
+
+class BooleanOption(BaseInputOption):
+    type: Literal[OptionType.boolean]
+    _anno = bool
+    default: Union[bool, None] = False
+    yes: Any = "1"
+    no: Any = "0"
+    _possible_cli_yes: set[str] = {"0", "no", "n", "false", "f", "off"}
+    _possible_cli_no: set[str] = {"0", "no", "n", "false", "f", "off"}
+
+    def get_field_attrs(self):
+        attrs = super().get_field_attrs()
+        attrs["parse"] = {  # Extra
+            "yes": self.yes,
+            "no": self.no,
+            # "possible_yes": self._possible_cli_yes,
+            # "possible_no": self._possible_cli_no,
+        }
+        return attrs
+
+    @validator("yes", pre=True)
+    def yes_is_not_falsy_value(cls, v):
+        if str(v).lower() in cls._possible_cli_no:
+            raise ValueError(f"'yes' value can't be in {cls._possible_cli_no}")
+        return v
+
+    @validator("no", pre=True)
+    def no_is_not_truthy_value(cls, v):
+        if str(v).lower() in cls._possible_cli_yes:
+            raise ValueError(f"'no' value can't be in {cls._possible_cli_yes}")
+        return v
+
+
+# ─ TIME ──────────────────────────────────────────────────
+class DateOption(BaseInputOption):
+    type: Literal[OptionType.date]
+    _anno = datetime.date
+    default: Union[datetime.date, None]
+
+
+class TimeOption(BaseInputOption):
+    type: Literal[OptionType.time]
+    _anno = datetime.time
+    default: Union[datetime.time, None]
+
+
+# ─ LOCATIONS ─────────────────────────────────────────────
+
+
+class EmailOption(BaseInputOption):
+    type: Literal[OptionType.email]
+    _anno = pydantic.EmailStr
+    default: Union[pydantic.EmailStr, None]
+
+
+class PathOption(BaseInputOption):
+    type: Literal[OptionType.path]
+    _anno = Path
+    default: Union[Path, None]
+
+
+class UrlOption(BaseInputOption):
+    type: Literal[OptionType.url]
+    _anno = pydantic.HttpUrl
+    default: Union[pydantic.HttpUrl, None]
+
+
+# ─ CHOICES ───────────────────────────────────────────────
+
+ChoosableOptions = Literal[
+    OptionType.string,
+    OptionType.color,
+    OptionType.number,
+    OptionType.date,
+    OptionType.time,
+    OptionType.email,
+    OptionType.path,
+    OptionType.url,
+    # OptionType.file,
+    # OptionType.app,
+    # OptionType.domain,
+    # OptionType.user,
+    # OptionType.group,
+]
+
+
+class BaseChoicesOption(BaseInputOption):
+    _anno = Any
+    item_type: ChoosableOptions = OptionType.string
+    choices: Union[dict[str, Any], list[Any], None]
+    default: Any = None
+
+    @property
+    def _dynamic_annotation(self):
+        annotation = enum_to_cls(self.item_type)._anno
+        # Repeat pattern stuff since we can't call the bare class `_dynamic_annotation` prop without instantiating it
+        if annotation is str and self.pattern:
+            annotation = pydantic.constr(regex=self.pattern.regexp)
+
+        if self.choices is not None:
+            choices = (
+                self.choices if isinstance(self.choices, list) else self.choices.keys()
+            )
+            annotation = Literal[tuple(choices)]
+
+        return annotation
+
+    @root_validator()
+    def validate_default_in_choices(cls, values):
+        default = values.get("default", None)
+        choices = values.get("choices", None)
+
+        if not default or not choices:
+            return values
+
+        choices = choices.keys() if isinstance(choices, dict) else choices
+
+        if default not in choices:
+            raise ValueError(f"default value '{default}' is not a valid choice.")
+
+        return values
+
+
+class SelectOption(BaseChoicesOption):
+    type: Literal[OptionType.select]
+    choices: Union[dict[str, Any], list[Any]]
+    default: Union[str, None] = None
+
+
+class TagsOption(BaseChoicesOption):
+    type: Literal[OptionType.tags]
+    choices: Union[list[Any], None] = None
+    default: Union[ConstrainedComaList[str], list, None] = None
+    icon: Union[str, None] = None
+
+    @property
+    def _dynamic_annotation(self):
+        return concomalist(super()._dynamic_annotation)
+
+
+# ─ FILE ──────────────────────────────────────────────────
+
+
+class FileOption(BaseInputOption):
+    type: Literal[OptionType.file]
+    # `FilePath` for CLI (file must be a file and must exists)
+    # `str` for API for now since moulinette doesn't handle files
+    _anno = Union[str, pydantic.FilePath]
+    # Unique
+    accept: Union[str, None] = None
+
+
+# ─ ENTITIES ──────────────────────────────────────────────
+
+
+class AppOption(BaseChoicesOption):
+    type: Literal[OptionType.app]
+    _anno = str
+    # Unique
+    filter: Union[str, bool, None] = None
+
+    @root_validator(pre=True)
+    def inject_apps_as_choices(cls, values):
+        return values
+        from yunohost.app import app_list
+
+        apps = app_list(full=True)["apps"]
+
+        if values.get("filter"):
+            apps = [
+                app
+                for app in apps
+                if evaluate_simple_js_expression(values["filter"], context=app)
+            ]
+
+        values["choices"] = {
+            app["id"]: f"{app['label']} ({app.get('domain_path', app['id'])})"
+            for app in apps
+        }
+
+        return values
+
+
+class DomainOption(BaseChoicesOption):
+    type: Literal[OptionType.domain]
+    _anno = str
+    # Unique
+    # filter: Union[str, None] = None
+
+    @root_validator()
+    def inject_domains_as_choices(cls, values):
+        # FIXME remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.domain import domain_list
+
+        domain_list = domain_list()
+        main_domain = domain_list["main"]
+
+        # if values.get("filter"):
+
+        values["choices"] = {
+            domain: domain + " ★" if domain == main_domain else domain
+            for domain in domain_list["domains"]
+        }
+
+        if not values["optional"] and values["default"] is None:
+            values["default"] = main_domain
+
+        return values
+
+
+class UserOption(BaseChoicesOption):
+    type: Literal[OptionType.user]
+    _anno = str
+    # Unique
+    # filter: Union[str, None] = None
+
+    @root_validator()
+    def inject_users_as_choices(cls, values):
+        from yunohost.user import user_list
+
+        # FIXME remove calls to resources in validators (pydantic V2 should adress this)
+        users = user_list(["username", "fullname", "mail", "groups"])["users"].items()
+        # if values.get("filter"):
+
+        values["choices"] = {
+            username: f"{infos['fullname']} ({infos['mail']})"
+            + (" ★" if "admins" in infos["groups"] else "")
+            for username, infos in users
+        }
+
+        if not values["choices"]:
+            # FIXME Is this the right place?
+            raise YunohostValidationError(
+                "app_argument_invalid",
+                name=values["id"],
+                error="You should create a YunoHost user first.",
+            )
+        if not values["optional"] and values["default"] is None:
+            values["default"] = next(
+                username for username, infos in users if "admins" in infos["groups"]
+            )
+
+        return values
+
+
+class GroupOption(BaseChoicesOption):
+    type: Literal[OptionType.group]
+    _anno = str
+    # Unique
+    # filter: Union[str, None] = None
+
+    @root_validator()
+    def inject_groups_as_choices(cls, values):
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.user import user_group_list
+
+        def _human_readable_group(groupname):
+            # i18n: visitors
+            # i18n: all_users
+            # i18n: admins
+            return (
+                m18n.n(groupname)
+                if groupname in ["visitors", "all_users", "admins"]
+                else groupname
+            )
+
+        # TODO could allow filter (without primary groups for example)
+        # if values.get("filter"):
+
+        values["choices"] = {
+            groupname: _human_readable_group(groupname)
+            for groupname in user_group_list(short=True, include_primary_groups=False)[
+                "groups"
+            ]
+        }
+
+        if not values["optional"] and values["default"] is None:
+            values["default"] = "all_users"
+
+        return values
+
+
+AnyOption = Union[
+    # display
+    DisplayTextOption,
+    MarkdownOption,
+    AlertOption,
+    # action
+    ButtonOption,
+    # text
+    StringOption,
+    TextOption,
+    PasswordOption,
+    ColorOption,
+    # number
+    NumberOption,
+    RangeOption,
+    # boolean
+    BooleanOption,
+    # time
+    DateOption,
+    TimeOption,
+    # location
+    EmailOption,
+    PathOption,
+    UrlOption,
+    # choice
+    SelectOption,
+    TagsOption,
+    # file
+    FileOption,
+    # entity
+    AppOption,
+    DomainOption,
+    UserOption,
+    GroupOption,
+]
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ┌─╴╭─╮┌─╮╭╮╮                                         │
+# │  ├─╴│ │├┬╯│││                                         │
+# │  ╵  ╰─╯╵ ╰╵╵╵                                         │
+# ╰───────────────────────────────────────────────────────╯
+
+
+class OptionsContainer(BaseModel):
+    # Pydantic will match option types to their models class based on the "type" attribute
+    options: list[Annotated[AnyOption, Field(discriminator="type")]]
+
+    class Config:
+        extra = pydantic.Extra.allow
+
+    @staticmethod
+    def options_dict_to_list(options: dict[str, Any], defaults: dict[str, Any] = {}):
+        return [
+            data
+            | {
+                "id": name,
+                "type": data.get("type", "string"),
+            }
+            for name, data in options.items()
+        ]
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(options=self.options_dict_to_list(kwargs))
+
+    def translate_options(self, i18n_key: Union[str, None] = None):
+        """
+        Mutate in place translatable attributes of options to their translations
+        """
+        for option in self.options:
+            for key in ("ask", "help"):
+                if not hasattr(option, key):
+                    continue
+
+                value = getattr(option, key)
+                if value:
+                    setattr(option, key, _value_for_locale(value))
+                elif key == "ask" and m18n.key_exists(f"{i18n_key}_{option.id}"):
+                    setattr(option, key, m18n.n(f"{i18n_key}_{option.id}"))
+                elif key == "help" and m18n.key_exists(f"{i18n_key}_{option.id}_help"):
+                    setattr(option, key, m18n.n(f"{i18n_key}_{option.id}_help"))
+                elif key == "ask":
+                    # FIXME raise error?
+                    option.ask = option.id
+
+
+class YunoForm(BaseModel):
+    """
+    Base form on which dynamic forms are built upon Options.
+    """
+
+    def __getitem__(self, name: str):
+        return getattr(self, name)
+
+    def __setitem__(self, name: str, value: Any):
+        setattr(self, name, value)
+
+    def get(self, name: str, default: Any = None) -> Any:
+        try:
+            return getattr(self, name)
+        except:
+            return default
+
+    class Config:
+        validate_assignment = True
+        extra = pydantic.Extra.ignore
+
+    def dict(self, *, as_env: bool = False, normalize: bool = True, **kwargs):
+        data = super().dict(**kwargs)
+        if as_env:
+            return {k: self.bashify(k) for k in data}
+        if normalize:
+            return {k: self.normalize(k) for k in data}
+        return data
+
+    def normalize(self, option_id: str) -> str:
+        """
+        Return a value as Python default types.
+        """
+        v = self[option_id]
+        if isinstance(v, pydantic.SecretStr):
+            return v.get_secret_value()
+        elif isinstance(v, pydantic.color.Color):
+            return v.as_hex()
+        elif isinstance(v, Path):
+            return str(v)
+        else:
+            return v
+
+    def bashify(self, option_id: str) -> str:
+        """
+        Stringify a value for bash environment
+        """
+        v = self[option_id]
+        if isinstance(v, bool):
+            extra = self.__fields__[option_id].field_info.extra
+            return extra["parse"]["yes" if v is True else "no"]
+        elif not v:
+            return ""
+        elif isinstance(v, pydantic.SecretStr):
+            return v.get_secret_value()
+        elif isinstance(v, pydantic.color.Color):
+            return v.as_hex()
+        elif isinstance(v, list):
+            return ",".join(v)
+        else:
+            return str(v)
+
+    def humanize(self, option_id: str) -> str:
+        """
+        Stringify a value to be used in cli prompt
+        """
+        v = self[option_id]
+        if isinstance(v, bool):
+            return "yes" if v is True else "no"
+        elif isinstance(v, pydantic.color.Color):
+            return v.as_named()
+        else:
+            return self.bashify(option_id)
+
+    @validator("*", pre=True)
+    def parse_string(cls, v):
+        """
+        Global validator to clean strings and parse None from CLI
+        """
+        # FIXME maybe do not parse `""` as None
+        if isinstance(v, str):
+            v = v.strip()
+            if v in ("", "null", "none", "_none"):
+                return None
+        return v
+
+
+def parse_prefilled_values(
+    args: Union[str, None] = None,
+    args_file=None,  # FIXME TYPING
+) -> dict[str, Any]:
+    """
+    Retrieve form values from yaml file or query string.
+    """
+    values: dict[str, Any] = {}
+    if args_file:
+        # Import YAML / JSON file
+        values |= read_yaml(args_file)
+    if args:
+        values |= {
+            k: ",".join(v)
+            for k, v in urllib.parse.parse_qs(args, keep_blank_values=True).items()
+        }
+    return values
+
+
+def build_form(
+    options: list[AnyOption], name: str = "DynamicYunoForm"
+) -> Type[YunoForm]:
+    """
+    Returns a dynamic pydantic model class that can act as a form with validation when instanciated.
+    """
+    options_as_fields: Any = {
+        option.id: option.as_dynamic_model_field()
+        for option in options
+        if isinstance(option, BaseInputOption)  # filter out non input options
+    }
+    return pydantic.create_model(
+        name,
+        __base__=YunoForm,
+        **options_as_fields,
+    )
+
+
+def fill_form(
+    options: list[AnyOption],
+    form: "YunoForm",
+    prefilled_answers: dict[str, Any],
+    context: dict[str, Any] = {},
+    action_id: Union[str, None] = None,
+) -> "YunoForm":
+    """
+    API only method to validate a form passed as query string.
+    Most checks should be handled by the webadmin but we recheck in case of
+    direct call to API or webadmin missing some validation.
+    """
+    logger.debug("Validating form...")
+
+    for option in options:
+        if isinstance(option, ButtonOption):
+            if action_id == option.id:
+                if option.is_visible(context) and option.is_enabled(context):
+                    # Action can be ran, quit prompt mode and return current form
+                    return form
+                else:
+                    # TODO provide an meaningfull error within option declaration?
+                    raise YunohostValidationError(
+                        f"Action '{action_id}' couldn't be ran, its conditions are not fullfilled."
+                    )
+
+        prefilled = option.id in prefilled_answers
+        if not option.is_visible(context):
+            if prefilled:
+                logger.warning(
+                    f"Skipping setting: '{option.id}' since conditions are not fullfilled."
+                )
+            continue
+
+        prev_value = form[option.id]
+        try:
+            form[option.id] = (
+                prefilled_answers[option.id] if prefilled else form[option.id]
+            )
+            context[option.id] = form.normalize(option.id)
+            if form[option.id] == prev_value:
+                form.__fields_set__.remove(option.id)
+        except pydantic.ValidationError as e:
+            # TODO could test every form values and return all errors directly instead of the first one
+            errors = "\n".join([error["msg"] for error in e.errors()])
+            raise YunohostValidationError(errors, raw_msg=True)
+
+    return form
+
+
+def prompt_form(
+    options: list[AnyOption],
+    form: "YunoForm",
+    prefilled_answers: dict[str, Any],
+    context: dict[str, Any] = {},
+    action_id: Union[str, None] = None,
+) -> "YunoForm":
+    """
+    CLI only method to interactively prompt and validate a form an option at a time.
+    """
+    for option in options:
+        if isinstance(option, ButtonOption):
+            if option.id != action_id:
+                # Skip other buttons/actions that may be defined in the same action section
+                continue
+            if option.is_visible(context) and option.is_enabled(context):
+                # Action can be ran, quit prompt mode and return current form
+                return form
+            else:
+                # TODO provide an meaningfull error within option toml declaration?
+                raise YunohostValidationError(
+                    f"Action '{action_id}' couldn't be ran, its conditions are not fullfilled."
+                )
+
+        if not option.is_visible(context):
+            if not isinstance(option, BaseReadonlyOption):
+                context[option.id] = form.normalize(option.id)
+            if option.id in prefilled_answers:
+                logger.warning(
+                    f"Skipping setting: '{option.id}' since conditions are not fullfilled."
+                )
+            continue
+
+        # Cast option.ask to str since it should be translated
+        message = cast(str, option.ask)
+
+        if isinstance(option, BaseReadonlyOption):
+            if isinstance(option, AlertOption):
+                colors = {
+                    "success": "green",
+                    "info": "cyan",
+                    "warning": "yellow",
+                    "danger": "red",
+                }
+                title = (
+                    m18n.g(option.style)
+                    if option.style != "danger"
+                    else m18n.n("danger")
+                )
+                message = f"{colorize(title, colors[option.style])} {message}"
+            Moulinette.display(message)
+            continue
+
+        prefill = form.humanize(option.id)
+        if option.readonly:
+            # FIXME a bit annoying to parse the value
+            # Parse the readonly value in case it come from bash then populate the context
+            form[option.id] = prefill
+            context[option.id] = form.normalize(option.id)
+            message = f"{colorize(message, 'purple')} {prefill}"
+            Moulinette.display(message)
+            continue
+
+        choices = []
+        if isinstance(option, BaseChoicesOption) and option.choices:
+            choices = (
+                list(option.choices.keys())
+                if isinstance(option.choices, dict)
+                else option.choices
+            )
+            # Prevent displaying a shitload of choices
+            # (e.g. 100+ available users when choosing an app admin...)
+            choices_to_display = choices[:20]
+            remaining_choices = len(choices[20:])
+
+            if remaining_choices > 0:
+                choices_to_display += [
+                    m18n.n("other_available_options", n=remaining_choices)
+                ]
+
+            message += f" [{' | '.join(choices_to_display)}]"
+
+        prev_value = form[option.id]
+        while True:
+            if option.id in prefilled_answers:
+                # value was given thru query string or file, test it as if it was prompted
+                value = prefilled_answers[option.id]
+            else:
+                value = Moulinette.prompt(
+                    message=message,
+                    is_password=option.redact,
+                    confirm=False,
+                    prefill=prefill,
+                    # default=option.humanize(option.default),
+                    is_multiline=(option.type == "text"),
+                    autocomplete=choices,
+                    help=option.help,
+                )
+
+            try:
+                form[option.id] = value
+                context[option.id] = form.normalize(option.id)
+
+                if form[option.id] == prev_value:
+                    form.__fields_set__.remove(option.id)
+
+                break
+            except pydantic.ValidationError as e:
+                if option.id in prefilled_answers:
+                    Moulinette.display(
+                        "Prefilled answer from args or file is not valid, you can correct it now:",
+                        style="error",
+                    )
+                    # Remove given prefilled_anwsers since its not valid.
+                    # Will prompt for a correction
+                    del prefilled_answers[option.id]
+
+                for error in e.errors():
+                    # FIXME rework errors (use yunohost ones or translate pydantic ones)
+                    Moulinette.display(error["msg"], style="error")
+                # Save erroneus answer and let ppl correct it
+                prefill = value
+
+        # TODO hooks
+        # Question._post_parse_value (redac stuff in operation logger)
+    return form
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ┌─╴╷ ╷╭─┐╷                                           │
+# │  ├─╴│╭╯├─┤│                                           │
+# │  ╰─╴╰╯ ╵ ╵╰─╴                                         │
+# ╰───────────────────────────────────────────────────────╯
+
+# Those js-like evaluate functions are used to eval safely `visible` and
+# `enabled` attributes.
+# The goal is to evaluate in the same way than js simple-evaluate
+# https://github.com/shepherdwind/simple-evaluate
+def evaluate_simple_ast(node, context=None):
+    if context is None:
+        context = {}
+
+    operators = {
+        ast.Not: op.not_,
+        ast.Mult: op.mul,
+        ast.Div: op.truediv,  # number
+        ast.Mod: op.mod,  # number
+        ast.Add: op.add,  # str
+        ast.Sub: op.sub,  # number
+        ast.USub: op.neg,  # Negative number
+        ast.Gt: op.gt,
+        ast.Lt: op.lt,
+        ast.GtE: op.ge,
+        ast.LtE: op.le,
+        ast.Eq: op.eq,
+        ast.NotEq: op.ne,
+    }
+    context["true"] = True
+    context["false"] = False
+    context["null"] = None
+
+    # Variable
+    if isinstance(node, ast.Name):  # Variable
+        return context[node.id]
+
+    # Python <=3.7 String
+    elif isinstance(node, ast.Str):
+        return node.s
+
+    # Python <=3.7 Number
+    elif isinstance(node, ast.Num):
+        return node.n
+
+    # Boolean, None and Python 3.8 for Number, Boolean, String and None
+    elif isinstance(node, (ast.Constant, ast.NameConstant)):
+        return node.value
+
+    # + - * / %
+    elif (
+        isinstance(node, ast.BinOp) and type(node.op) in operators
+    ):  # <left> <operator> <right>
+        left = evaluate_simple_ast(node.left, context)
+        right = evaluate_simple_ast(node.right, context)
+        if type(node.op) == ast.Add:
+            if isinstance(left, str) or isinstance(right, str):  # support 'I am ' + 42
+                left = str(left)
+                right = str(right)
+        elif type(left) != type(right):  # support "111" - "1" -> 110
+            left = float(left)
+            right = float(right)
+
+        return operators[type(node.op)](left, right)
+
+    # Comparison
+    # JS and Python don't give the same result for multi operators
+    # like True == 10 > 2.
+    elif (
+        isinstance(node, ast.Compare) and len(node.comparators) == 1
+    ):  # <left> <ops> <comparators>
+        left = evaluate_simple_ast(node.left, context)
+        right = evaluate_simple_ast(node.comparators[0], context)
+        operator = node.ops[0]
+        if isinstance(left, (int, float)) or isinstance(right, (int, float)):
+            try:
+                left = float(left)
+                right = float(right)
+            except ValueError:
+                return type(operator) == ast.NotEq
+        try:
+            return operators[type(operator)](left, right)
+        except TypeError:  # support "e" > 1 -> False like in JS
+            return False
+
+    # and / or
+    elif isinstance(node, ast.BoolOp):  # <op> <values>
+        for value in node.values:
+            value = evaluate_simple_ast(value, context)
+            if isinstance(node.op, ast.And) and not value:
+                return False
+            elif isinstance(node.op, ast.Or) and value:
+                return True
+        return isinstance(node.op, ast.And)
+
+    # not / USub (it's negation number -\d)
+    elif isinstance(node, ast.UnaryOp):  # <operator> <operand> e.g., -1
+        return operators[type(node.op)](evaluate_simple_ast(node.operand, context))
+
+    # match function call
+    elif isinstance(node, ast.Call) and node.func.__dict__.get("id") == "match":
+        return re.match(
+            evaluate_simple_ast(node.args[1], context), context[node.args[0].id]
+        )
+
+    # Unauthorized opcode
+    else:
+        opcode = str(type(node))
+        raise YunohostError(
+            f"Unauthorize opcode '{opcode}' in visible attribute", raw_msg=True
+        )
+
+
+def js_to_python(expr: str) -> str:
+    in_string = None
+    py_expr = ""
+    i = 0
+    escaped = False
+    for char in expr:
+        if char in r"\"'":
+            # Start a string
+            if not in_string:
+                in_string = char
+
+            # Finish a string
+            elif in_string == char and not escaped:
+                in_string = None
+
+        # If we are not in a string, replace operators
+        elif not in_string:
+            if char == "!" and expr[i + 1] != "=":
+                char = "not "
+            elif char in "|&" and py_expr[-1:] == char:
+                py_expr = py_expr[:-1]
+                char = " and " if char == "&" else " or "
+
+        # Determine if next loop will be in escaped mode
+        escaped = char == "\\" and not escaped
+        py_expr += char
+        i += 1
+    return py_expr
+
+
+def evaluate_simple_js_expression(expr: str, context: dict[str, Any] = {}) -> bool:
+    if not expr.strip():
+        return False
+    node = ast.parse(js_to_python(expr), mode="eval").body
+    return evaluate_simple_ast(node, context)


### PR DESCRIPTION
TLDR:
Use pydantic for config panel and app install form parsing/validation.
PR is not yet ready for review, but i would like to know if it's worth continuing or not ;)
I guess it's a bit too much changes...

While working on the POC migration to FastAPI/typer I started working with [pydantic](https://docs.pydantic.dev/) (the parser/validator behind some features of FastAPI) and found it pretty cool. I thought we could give it a try for handling config panels and other dynamic forms like app install and maybe more.

- It is based on model declaration (which can be dynamicly created)
- It perform most of the basic parsing/validation directly from python type hints
- Allow custom types
- Combine parsing and validation in quite the same fashion 
- Use type coercion rather than strictness and errors (for example, on a model's field typed as a basic python `bool`, it can receive a string like `"yes"` and still manage to auto parse it as `True`) which is useful for our python/bash context.
- Can export models declaration into json schema for IDEs, swagger or custom implementations.
- It has a special class for [settings management](https://docs.pydantic.dev/usage/settings/) that could be used at some point? 

So here's a WIP trying to integrate it to this complex datastructure which features a toml syntax to build custom multi-level and conditional forms that integrate inputs of many types, display/readonly components and has to be displayed as a CLI input sequence and thru API web forms.

The proposed implementation is roughly:
- parse/validate `config.toml` declarations with pydantic models to instantiate a `config: ConfigPanel`
- based on this `config`, build a dynamic pydantic model that will act as `settings: Form` hydrated with current `settings.yml`
- depending on the interface:
    - CLI: use `config` to iterate over what to ask/display and parse/validate user inputs thru `settings` assignements.
    - API: directly try to assign new values to `settings` while still checking conditions from `visible|enabled` props.
- finally, depending on the config panel type:
    - App: export `settings` as an env (only strings) and pass it to bash magic helpers.
    - Setting+Domain: export none-default `settings` as yaml with "real" types, use touched `settings` (only the ones that changed) and update what's needed.

The code is split into two files:
- `form.py`: Custom type to handle bash list, `Option`s models for every implemented display/inputs components, basic form factory, CLI displayer/prompter, API filler, evaluation functions. This can be used directly by `app_install()` for install form.
- `configpanel.py`: which is more or less the config panel implementation built over base stuff in `form.py`. (`ConfigPanel` containing `Panel`s containing `Section`s containing `Option`s) and other specific stuff. (Haven't removed the actual implementation to be able to compare to it easily)

Small new thing i have in mind:
- Types `select` and `tags` can receive an `item_type = "string|color|number|date|time|email|path|url"` default to `string` that will parse/validate every items in the list with the correct type, so you can ask for a list of emails and be sure all are valid emails without reinventing regex to match already defined types. (could be extended to allow `file|app|domain|user|group`)
- Managed to build a first version of a json schema for config panels but i can't paste it here (too long)

### PR STATUS

Not yet ready for review i guess, need to update tests and test it moar + the todo.
This does not yet brings that much new stuff but open the door for more type safe code, i think pydantic could be used in other part of the core code and we could rely on it for most of the validation/parsing we need and use it to define our datastructures. I tried to test it on config panel because i thought it was the most complex but idk.
Also if we definitly plan to move to FastAPI, i guess it will be an easier migration.

### TODO 

- export a json schema for app's config panels and app's manifest.
- iron things out if you think pydantic would be a nice addition to core code:
    - i18n of errors
    - Accept `None` for bool (not set)?
    - Redact stuff on `OperationLogger`
    - file handling which is not really implemented yet (handle API case + temp file for context evaluation)
    - `required` options are not very clear to me in case on config panel, does config panel required options have to be set at install?
        - If not `Config.get()` will yell at settings validation since it may not be defined. 
        - If so, what about required options in conditional section (not visible), action section (required only for action, not as setting)
        - Need to dig a bit to see what could be possible, for now the settings in `Config.set()` are not validated at instantiation to allow the prompt/fill a chance to define a value, but this is not tottaly satisfying since it mess up a bit with "detecting what changed" since originally the form is unparsed/unvalidated.
    - reflect some changes to webadmin

### Possible improvments

- Should pretty easy to separate `""` from `None` and allow multiple values in CLI with a custom type: `"null|nil|none|_none"`)?
- could use part of this code to test apps in package_check?
- Could add some [more types](https://docs.pydantic.dev/usage/types/) that are available in pydantic and some extra properties to current types like `min_length|max_length` of [constr](https://docs.pydantic.dev/usage/types/#arguments-to-constr)
- try to implement an `AppManifest` pydantic model integrating the app install dynamic form.
- API: validate the whole form and return multiple errors if any (not only the first encountered as of today) 
- API: `app_config_get(full=True)` could return a JSON Schema directly instead of our custom toml specs in the web admin (need to update the current web admin config panel/custom forms interpreter to this more generic JSON schema approach)
- Find a way to use directly an adapted `settings` model when CLI prompting/ API filling instead of relying on `config` (repr of config toml stuff) with nested stuff and extra information on each field.
    - This would open the door for defining `SettingConfigPanel` and `DomainConfigPanel` as pydantic models directly and get rid of their `.toml`.

### How to test

```bash
# install pydantic
pip install pydantic
```

Also install [python-email-validator](https://github.com/JoshData/python-email-validator) to use pydantic EmailStr type. This is extra dep so maybe we can use a simpler custom regex validator but this lib handle international stuff (but i'm not sure we do).
```bash
pip install pydantic[email]
```