### PR TITLE
regenconf: Add a new ssh security setting to hide the banner

### DIFF
--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -64,7 +64,13 @@ PasswordAuthentication no
 {% endif %}
 
 # Post-login stuff
+# PLEASE: if you wish to hide the system name and version when attempting to connect to your server, run this command:
+# yunohost settings set security.ssh.ssh_banner -v no
+{% if banner == "False" %}
+#Banner none
+{% else %}
 Banner /etc/issue.net
+{% endif %}
 PrintMotd no
 PrintLastLog yes
 ClientAliveInterval 60

--- a/hooks/conf_regen/03-ssh
+++ b/hooks/conf_regen/03-ssh
@@ -18,6 +18,7 @@ do_pre_regen() {
     export compatibility="$(yunohost settings get 'security.ssh.ssh_compatibility')"
     export port="$(yunohost settings get 'security.ssh.ssh_port')"
     export password_authentication="$(yunohost settings get 'security.ssh.ssh_password_authentication' | int_to_bool)"
+    export banner="$(yunohost settings get 'security.ssh.ssh_banner')"
     export ssh_keys
     export ipv6_enabled
     ynh_render_template "sshd_config" "${pending_dir}/etc/ssh/sshd_config"

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -43,6 +43,10 @@ name = "Security"
         type = "boolean"
         default = true
 
+        [security.ssh.ssh_banner]
+        type = "boolean"
+        default = true
+
     [security.nginx]
     name = "NGINX (web server)"
         [security.nginx.nginx_redirect_to_https]


### PR DESCRIPTION
## The problem

I’m not very confident about advertizing the whole world what system is running on my server. Maybe it may look as a pedantic or useless feature, but if others are like me, this MR will avoid us to always be warned about configuration not managed by yunohost.

## Solution

Add a new `security.ssh.ssh_banner` as a boolean to comment or not the display of `/etc/issue.net`. By default it’s still yes to keep the current behavior.

## PR Status

...

## How to test

After installation and regenconf (and thus by default) the `sshd_config` file must still contain `Banner /etc/issue.net`

    $ grep Banner /etc/ssh/sshd_config
    Banner /etc/issue.net

Then enter `yunohost settings set security.ssh.ssh_banner -v no`. You must now have

    $ grep Banner /etc/ssh/sshd_config
    #Banner none

Finally ensure the "yes" value with `yunohost settings set security.ssh.ssh_banner -v yes`. You must have again

    $ grep Banner /etc/ssh/sshd_config
    Banner /etc/issue.net

I’ve added a comment as for the other ssh settings in the file to ease migration path for others like me willing to hide this banner.