### PR TITLE
Fix decoding errors not handled when trying to read service logs

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -775,7 +775,7 @@ def _tail(file, n):
             f = gzip.open(file)
             lines = f.read().splitlines()
         else:
-            f = open(file)
+            f = open(file, errors='replace')
             pos = 1
             lines = []
             while len(lines) < to_read and pos > 0:


### PR DESCRIPTION
## The problem

This is to handle decoding errors described in YunoHost/issues#2156

## Solution

Pass `errors='replace'` to argument `open` command to override the default `strict` in `Codes`

The error doesn't seem to happen with gzip-ed logs. 
After gzip-ing a log that would through the decoding error with `open(file).read()` the `.gz` file did not through the error with `gzip.open(file).read()`
So I doesn't seem that `errors='replace'` argument needs to be passed to [`gzip.open(file)`](https://github.com/YunoHost/yunohost/blob/debian/11.1.10/src/service.py#L775)
 
## PR Status

...

## How to test

...
