### PR TITLE
[fix] dovecot-pop3d is never installed

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -347,7 +347,7 @@ def reconfigure_dovecot(setting_name, old_value, new_value):
     environment = os.environ.copy()
     environment.update({"DEBIAN_FRONTEND": "noninteractive"})
 
-    if new_value == "True":
+    if new_value == True:
         command = [
             "apt-get",
             "-y",


### PR DESCRIPTION
## The problem

Running `yunohost settings set email.pop3.pop3_enabled -v 1` doesn't install dovecot-pop3d even if it was equal to 0 before.
Same with webadmin

## Solution

This fix is simple the value is equal to True and not "True"

## PR Status

Tested on a prod instance

## How to test

```
yunohost settings set email.pop3.pop3_enabled -v 0
yunohost settings set email.pop3.pop3_enabled -v 1
```
