### PR TITLE
[Fixes 2158] Create parent dirs when provisioning install_dir

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -623,7 +623,7 @@ class InstalldirAppResource(AppResource):
                 )
                 shutil.move(current_install_dir, self.dir)
             else:
-                mkdir(self.dir)
+                mkdir(self.dir, parents=True)
 
         owner, owner_perm = self.owner.split(":")
         group, group_perm = self.group.split(":")


### PR DESCRIPTION
## The problem

Installing an app to /opt/yunohost/__APP__ fails if it is the first app to be installed in /opt/yunohost.

## Solution

Add the parents=True flag to mkdir.

## PR Status

...

## How to test

Install [app v2 branch of p4p4j0hn/trilium_ynh](https://github.com/p4p4j0hn/trilium_ynh/tree/packaging_v2) with current dev branch and see the failure. Then try with this PR and it will work.
