### PR TITLE
[fix] Pop3 is not enable in config file

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -8,7 +8,7 @@ mail_home = /var/mail/%n
 mail_location = maildir:/var/mail/%n
 mail_uid = 500
 
-protocols = imap sieve {% if pop3_enabled == "True" %}pop3{% endif %}
+protocols = imap sieve {% if pop3_enabled == "1" %}pop3{% endif %}
 
 mail_plugins = $mail_plugins quota notify push_notification
 


### PR DESCRIPTION
## The problem

Dovecot config file is not change when activating pop3

Comparaison with"True" intead of "1"

## Solution

Replace "True" by "1"

## PR Status

...

## How to test

...
