### PR TITLE
helpers: tweak behavior of checksum helper in CI context to help debug why file appear as 'manually modified'

### DIFF
--- a/helpers/backup
+++ b/helpers/backup
@@ -327,6 +327,12 @@ ynh_store_file_checksum() {
 
     ynh_app_setting_set --app=$app --key=$checksum_setting_name --value=$(md5sum "$file" | cut --delimiter=' ' --fields=1)
 
+    if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+        # Using a base64 is in fact more reversible than "replace / and space by _" ... So we can in fact obtain the original file path in an easy reliable way ...
+        local file_path_base64=$(echo "$file" | base64)
+        cat $file > /var/cache/yunohost/appconfbackup/original_${file_path_base64}
+    fi
+
     # If backup_file_checksum isn't empty, ynh_backup_if_checksum_is_different has made a backup
     if [ -n "${backup_file_checksum-}" ]; then
         # Print the diff between the previous file and the new one.
@@ -361,11 +367,20 @@ ynh_backup_if_checksum_is_different() {
     backup_file_checksum=""
     if [ -n "$checksum_value" ]; then                                                     # Proceed only if a value was stored into the app settings
         if [ -e $file ] && ! echo "$checksum_value $file" | md5sum --check --status; then # If the checksum is now different
+
             backup_file_checksum="/var/cache/yunohost/appconfbackup/$file.backup.$(date '+%Y%m%d.%H%M%S')"
             mkdir --parents "$(dirname "$backup_file_checksum")"
             cp --archive "$file" "$backup_file_checksum" # Backup the current file
             ynh_print_warn "File $file has been manually modified since the installation or last upgrade. So it has been duplicated in $backup_file_checksum"
             echo "$backup_file_checksum" # Return the name of the backup file
+            if [ ${PACKAGE_CHECK_EXEC:-0} -eq 1 ]; then
+                local file_path_base64=$(echo "$file" | base64)
+                if test -e /var/cache/yunohost/appconfbackup/original_${file_path_base64}
+                then
+                    ynh_print_warn "Diff with the original file:"
+                    diff --report-identical-files --unified --color=always /var/cache/yunohost/appconfbackup/original_${file_path_base64} $file >&2 || true
+                fi
+            fi
         fi
     fi
 }


### PR DESCRIPTION
## The problem

cf many situations where file appear as "manually modified" on the CI despite no "manual" modification

## Solution

Tweak behavior of helpers to save the original file and display the diff to help debug what's happening

## PR Status

Yolocommited

## How to test

...
