### PR TITLE
trying to fix _port_is_used

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -916,8 +916,8 @@ class PortsResource(AppResource):
             % port
         )
         # This second command is mean to cover (most) case where an app is using a port yet ain't currently using it for some reason (typically service ain't up)
-        cmd2 = f"grep --quiet \"port: '{port}'\" /etc/yunohost/apps/*/settings.yml"
-        return os.system(cmd1) == 0 and os.system(cmd2) == 0
+        cmd2 = f"grep --quiet --extended-regexp \"port: '?{port}'?\" /etc/yunohost/apps/*/settings.yml"
+        return os.system(cmd1) == 0 or os.system(cmd2) == 0
 
     def provision_or_update(self, context: Dict = {}):
         from yunohost.firewall import firewall_allow, firewall_disallow


### PR DESCRIPTION
## The problem

In `_port_is_used`:
- cmd1 return 0 if the port is found
- there is no simple quote around the port number in `settings.yml`

If cmd1 OR (and not AND)cmd2 is true, then the port is used


## Solution

...

## PR Status

Yolotested while packaging an app

## How to test

...
