### PR TITLE
POC to add a route to fetch what's the current running action, cf plans to improve the webadmin UX

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1911,6 +1911,11 @@ log:
                 path:
                     help: Log file to share
 
+        ### log_current-operation()
+        current-operation:
+            action_help: Return YunoHost current operation (if any)
+            api: GET /logs/current_operation
+
 
 #############################
 #          Diagnosis        #


### PR DESCRIPTION
## The problem

cf https://github.com/YunoHost/issues/issues/2055

We should have a mechanism to know what's the current operation running on the server when the lock is active

## Solution

Add a `yunohost log current-operation` (and similar API route)

## PR Status

Tested during an app install, working-ish ...

## How to test

Trigger an app install and run `yunohost log current-operation` in parallel ... Should return `operation_description: 'app_install'` while you answer the questions, and then a proper human-readable description during the actual app install
