### PR TITLE
[tests] Rework questions/options tests

### DIFF
--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -13,7 +13,7 @@ from _pytest.mark.structures import ParameterSet
 
 
 from moulinette import Moulinette
-from yunohost import domain, user
+from yunohost import app, domain, user
 from yunohost.utils.config import (
     ARGUMENTS_TYPE_PARSERS,
     ask_questions_and_parse_answers,

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -519,6 +519,45 @@ class BaseTest:
 
 
 # ╭───────────────────────────────────────────────────────╮
+# │ DISPLAY_TEXT                                          │
+# ╰───────────────────────────────────────────────────────╯
+
+
+class TestDisplayText(BaseTest):
+    raw_option = {"type": "display_text", "id": "display_text_id"}
+    prefill = {
+        "raw_option": {},
+        "prefill": " custom default",
+    }
+    # fmt: off
+    scenarios = [
+        (None, None, {"ask": "Some text\na new line"}),
+        (None, None, {"ask": {"en": "Some text\na new line", "fr": "Un peu de texte\nune nouvelle ligne"}}),
+    ]
+    # fmt: on
+
+    def test_options_prompted_with_ask_help(self, prefill_data=None):
+        pytest.skip(reason="no prompt for display types")
+
+    def test_scenarios(self, intake, expected_output, raw_option, data):
+        _id = raw_option.pop("id")
+        answers = {_id: intake} if intake is not None else {}
+        options = None
+        with patch_interface("cli"):
+            if inspect.isclass(expected_output) and issubclass(
+                expected_output, Exception
+            ):
+                with pytest.raises(expected_output):
+                    ask_questions_and_parse_answers({_id: raw_option}, answers)
+            else:
+                with patch.object(sys, "stdout", new_callable=StringIO) as stdout:
+                    options = ask_questions_and_parse_answers(
+                        {_id: raw_option}, answers
+                    )
+                    assert stdout.getvalue() == f"{options[0].ask['en']}\n"
+
+
+# ╭───────────────────────────────────────────────────────╮
 # │ STRING                                                │
 # ╰───────────────────────────────────────────────────────╯
 
@@ -1212,17 +1251,6 @@ def test_question_number_input_test_ask_with_help():
         ask_questions_and_parse_answers(questions, answers)
         assert ask_text in prompt.call_args[1]["message"]
         assert help_value in prompt.call_args[1]["message"]
-
-
-def test_question_display_text():
-    questions = {"some_app": {"type": "display_text", "ask": "foobar"}}
-    answers = {}
-
-    with patch.object(sys, "stdout", new_callable=StringIO) as stdout, patch.object(
-        os, "isatty", return_value=True
-    ):
-        ask_questions_and_parse_answers(questions, answers)
-        assert "foobar" in stdout.getvalue()
 
 
 def test_question_file_from_cli():

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1506,7 +1506,7 @@ class FileQuestion(Question):
         super()._prevalidate()
 
         # Validation should have already failed if required
-        if self.value in (None, ""):
+        if self.value in [None, ""]:
             return self.value
 
         if Moulinette.interface.type != "api":


### PR DESCRIPTION
Rework the questions/options tests and add multiple missing option types tests scenarios.

There's some tests that currently passes but probably shouldn't, some that do not but probably should.
You can search for `xfail`, `xpass`, and some `FIXME`s to have a quick look at those.
Plan is to fix the unexpected results on the pydantic migration if you agree with my comments.
There's a bunch of problems with nones () where things are not very clear what final None value we want.

Also added some quick fixes in `utils/config.py` to ease tests. @zamentur do you see any potential problems with those modifications? There might be magic stuff in bash helpers that I'm not aware of.

## PR Status

ok?

## How to test

```bash
pytest src/tests/test_questions.py
```
