### PR TITLE
[DEL] remove args parameter from actionsmap

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1032,9 +1032,6 @@ app:
                         help: App name
                     action:
                         help: action id
-                    -a:
-                        full: --args
-                        help: Serialized arguments for app script (i.e. "domain=domain.tld&path=/path")
 
       config:
           subcategory_help: Applications configuration panel


### PR DESCRIPTION
## The problem

when adding a button to a config panel like in https://github.com/moshchot/libreerp_ynh/blob/update_oca_and_gitaggregate/config_panel.toml#L10, I can run my action perfectly fine from the terminal with

```
yunohost app action run libreerp custom_code.components.gitaggregate
```

But calling this via the admin interface, I receive `argument @args: expected one argument` without this change, with the request posting an empty args parameter:

![image](https://user-images.githubusercontent.com/2563186/226970242-7686884f-da9e-48f4-aca2-af1a1b942d61.png)


## Solution

As passing parameters to actions doesn't really work currently anyways, I figure we can remove this parameter entirely from the map.

## PR Status

Dubious. Probably the correct solution would be not to post the args parameter at all from the admin interface?

## How to test

Create a button in `config_panel.toml` similar to the one linked above, observe you can call the action from the CLI as well as via the admin interface.