### PR TITLE
[FIX] Mailbox used space wrong

### DIFF
--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -89,15 +89,15 @@ def binary_to_human(n: int) -> str:
     """
     Convert bytes or bits into human readable format with binary prefix
     """
-    symbols = ("K", "M", "G", "T", "P", "E", "Z", "Y")
+    symbols = ("M", "G", "T", "P", "E", "Z", "Y")
     prefix = {}
     for i, s in enumerate(symbols):
         prefix[s] = 1 << (i + 1) * 10
     for s in reversed(symbols):
         if n >= prefix[s]:
             value = float(n) / prefix[s]
-            return "%.1f%s" % (value, s)
-    return "%s" % n
+            return "%d%s" % (value, s)
+    return "%sK" % n
 
 
 def ram_available():


### PR DESCRIPTION
## The problem

When viewing the Mailbox used space for users at https://domain.tld/yunohost/admin/#/users/, the displayed storage usage is 1000x lower than the actual usage. For example, the usage is shown in K instead of M, and nothing instead of K

## Solution

Update the binary_to_human function to start the list of symbols with "K" (kilo) instead of noting and adjust the returned value accordingly. This will ensure that the displayed storage usage is accurate.

## PR Status

Ready for review and merge.

## How to test
1. Update the binary_to_human function.
2. Restart yunohost-api, you may also need to delete pycache.
3. Visit https://domain.tld/yunohost/admin/#/users/ and check the Mailbox used space for each user.
4. Verify that the displayed storage usage is now accurate and correctly shows the values in K, M, G, etc., as appropriate.
