### PR TITLE
Support variables in permissions declaration

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -569,7 +569,7 @@ class PermissionsResource(AppResource):
                        variable, self.get_setting(variable.lower().replace("__",""))
                     )
             for i in range(0, len(infos.get("additional_urls", []))):
-                for variable in re.findall(r"(__[A-Z0-9_]+__)", infos.get("additional_urls", [])[i])):
+                for variable in re.findall(r"(__[A-Z0-9_]+__)", infos.get("additional_urls", [])[i]):
                     infos["additional_urls"][i] = infos["additional_urls"][i].replace(
                        variable, self.get_setting(variable.lower().replace("__",""))
                     )


### PR DESCRIPTION
## The problem

`server_client_infos.url = "__SERVER_NAME__/.well-known/matrix "` in Dendrite's `manifest.toml` ends up in the CI with

```
6614 ERROR Provisioning, deprovisioning, or updating resources for dendrite failed: Domain '__SERVER_NAME__' unknown
```

## Solution

Replace variables declarations with their values.

## PR Status

Untested.

## How to test

Demo:

```
#!/usr/bin/python3
import re

infos={"url": "__SERVER_NAME__/.well-known/matrix", "additional_urls": ["__SERVER_NAME__/.well-known/matrix", "a__TEST__z__TEST2__"]}

if infos.get("url"):
    for variable in re.findall(r"(__[A-Z0-9_]+__)", infos.get("url", "")):
        infos["url"] = infos["url"].replace(
            variable, "${"+variable.lower().replace("__","")+"}"
        )
for i in range(0, len(infos.get("additional_urls", []))):
    for variable in re.findall(r"(__[A-Z0-9_]+__)", infos.get("additional_urls", [])[i]):
        infos["additional_urls"][i] = infos["additional_urls"][i].replace(
            variable, "${"+variable.lower().replace("__","")+"}"
        )

print(infos)
```

Prints `{'url': '${server_name}/.well-known/matrix', 'additional_urls': ['${server_name}/.well-known/matrix', 'a${test}z${test2}']}`
