### PR TITLE
Set out-of-catalog, broken, bad quality apps diagnosis as warnings

### DIFF
--- a/src/diagnosers/80-apps.py
+++ b/src/diagnosers/80-apps.py
@@ -62,12 +62,12 @@ class MyDiagnoser(Diagnoser):
         # Check quality level in catalog
 
         if not app.get("from_catalog") or app["from_catalog"].get("state") != "working":
-            yield ("error", "diagnosis_apps_not_in_app_catalog")
+            yield ("warning", "diagnosis_apps_not_in_app_catalog")
         elif (
             not isinstance(app["from_catalog"].get("level"), int)
             or app["from_catalog"]["level"] == 0
         ):
-            yield ("error", "diagnosis_apps_broken")
+            yield ("warning", "diagnosis_apps_broken")
         elif app["from_catalog"]["level"] <= 4:
             yield ("warning", "diagnosis_apps_bad_quality")
 


### PR DESCRIPTION
- Broken and bad quality apps are usually temporary and do not affect current instances. It is useless to worry our users too much.
- Out-of-catalog apps are usually manually installed by users, so they well know what they are doing.

Let's thus replace `error` by `warning` for their related diagnosis results.

## PR Status

Done

## How to test

...
