### PR TITLE
Do not run CodeQL for tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "dev" ]
+    paths-ignore:
+      - 'src/tests/**'
   schedule:
     - cron: '43 12 * * 3'
 


### PR DESCRIPTION
Silence CodeQL on hardcoded test passwords, but we lose code quality control.