### PR TITLE
[enh] app id in settings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2012,6 +2012,9 @@ def _get_app_settings(app):
         ):
             settings["path"] = "/" + settings["path"].strip("/")
             _set_app_settings(app, settings)
+            
+        # Make the app id available as $app too
+        settings["app"] = app
 
         if app == settings["id"]:
             return settings


### PR DESCRIPTION
## The problem

`__APP__` is not being replaced by the app ID in the notifications.

## Solution

Add `$app` as a setting.

## PR Status

...

## How to test

...
