### PR TITLE
[enh] exclude .well-known subpaths from conflict checks

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2869,7 +2869,7 @@ def _get_conflicting_apps(domain, path, ignore_app=None):
         for p, a in apps_map[domain].items():
             if a["id"] == ignore_app:
                 continue
-            if path == p or path == "/" or p == "/":
+            if path == p or ( not path.startswith("/.well-known/") and path == "/" ) or ( not path.startswith("/.well-known/") and p == "/" ):
                 conflicts.append((p, a["id"], a["label"]))
 
     return conflicts

--- a/src/app.py
+++ b/src/app.py
@@ -2869,7 +2869,7 @@ def _get_conflicting_apps(domain, path, ignore_app=None):
         for p, a in apps_map[domain].items():
             if a["id"] == ignore_app:
                 continue
-            if path == p or ( not path.startswith("/.well-known/") and path == "/" ) or ( not path.startswith("/.well-known/") and p == "/" ):
+            if path == p or ( not path.startswith("/.well-known/") and ( path == "/" or p == "/" ) ):
                 conflicts.append((p, a["id"], a["label"]))
 
     return conflicts


### PR DESCRIPTION
Attempts to solve:
Fixes https://github.com/YunoHost/issues/issues/684
Fixes https://github.com/YunoHost/issues/issues/2016

It basically adds an exception for app conflicts if an app is installed at the root of a domain and another app tries to add a `./well-known/foo` subpath, but keeps returning a conflict if any two apps try to register the same `./well-known/foo` subpath.

## PR Status

Finished? Untested.

## How to test

...
