### PR TITLE
ConfigPanel: Before pydantic (renames) 1/3

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -50,8 +50,8 @@ from moulinette.utils.filesystem import (
 
 from yunohost.utils.configpanel import ConfigPanel, ask_questions_and_parse_answers
 from yunohost.utils.form import (
-    DomainQuestion,
-    PathQuestion,
+    DomainOption,
+    WebPathOption,
     hydrate_questions_with_choices,
 )
 from yunohost.utils.i18n import _value_for_locale
@@ -430,10 +430,10 @@ def app_change_url(operation_logger, app, domain, path):
 
     # Normalize path and domain format
 
-    domain = DomainQuestion.normalize(domain)
-    old_domain = DomainQuestion.normalize(old_domain)
-    path = PathQuestion.normalize(path)
-    old_path = PathQuestion.normalize(old_path)
+    domain = DomainOption.normalize(domain)
+    old_domain = DomainOption.normalize(old_domain)
+    path = WebPathOption.normalize(path)
+    old_path = WebPathOption.normalize(old_path)
 
     if (domain, path) == (old_domain, old_path):
         raise YunohostValidationError(
@@ -1660,8 +1660,8 @@ def app_register_url(app, domain, path):
         permission_sync_to_user,
     )
 
-    domain = DomainQuestion.normalize(domain)
-    path = PathQuestion.normalize(path)
+    domain = DomainOption.normalize(domain)
+    path = WebPathOption.normalize(path)
 
     # We cannot change the url of an app already installed simply by changing
     # the settings...
@@ -2853,8 +2853,8 @@ def _get_conflicting_apps(domain, path, ignore_app=None):
 
     from yunohost.domain import _assert_domain_exists
 
-    domain = DomainQuestion.normalize(domain)
-    path = PathQuestion.normalize(path)
+    domain = DomainOption.normalize(domain)
+    path = WebPathOption.normalize(path)
 
     # Abort if domain is unknown
     _assert_domain_exists(domain)

--- a/src/app.py
+++ b/src/app.py
@@ -1882,7 +1882,7 @@ class AppConfigPanel(ConfigPanel):
         env = {key: str(value) for key, value in self.new_values.items()}
         self._call_config_script(action, env=env)
 
-    def _load_current_values(self):
+    def _get_raw_settings(self):
         self.values = self._call_config_script("show")
 
     def _apply(self):

--- a/src/app.py
+++ b/src/app.py
@@ -1878,12 +1878,12 @@ class AppConfigPanel(ConfigPanel):
     save_path_tpl = os.path.join(APPS_SETTING_PATH, "{entity}/settings.yml")
     config_path_tpl = os.path.join(APPS_SETTING_PATH, "{entity}/config_panel.toml")
 
-    def _load_current_values(self):
-        self.values = self._call_config_script("show")
-
     def _run_action(self, action):
         env = {key: str(value) for key, value in self.new_values.items()}
         self._call_config_script(action, env=env)
+
+    def _load_current_values(self):
+        self.values = self._call_config_script("show")
 
     def _apply(self):
         env = {key: str(value) for key, value in self.new_values.items()}

--- a/src/domain.py
+++ b/src/domain.py
@@ -555,8 +555,8 @@ class DomainConfigPanel(ConfigPanel):
 
         return result
 
-    def _get_toml(self):
-        toml = super()._get_toml()
+    def _get_raw_config(self):
+        toml = super()._get_raw_config()
 
         toml["feature"]["xmpp"]["xmpp"]["default"] = (
             1 if self.entity == _get_maindomain() else 0
@@ -571,7 +571,7 @@ class DomainConfigPanel(ConfigPanel):
 
             toml["dns"]["registrar"] = _get_registrar_config_section(self.entity)
 
-            # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
+            # FIXME: Ugly hack to save the registar id/value and reinject it in _get_raw_settings ...
             self.registar_id = toml["dns"]["registrar"]["registrar"]["value"]
             del toml["dns"]["registrar"]["registrar"]["value"]
 
@@ -594,21 +594,21 @@ class DomainConfigPanel(ConfigPanel):
                 f"domain_config_cert_summary_{status['summary']}"
             )
 
-            # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
+            # FIXME: Ugly hack to save the cert status and reinject it in _get_raw_settings ...
             self.cert_status = status
 
         return toml
 
-    def _load_current_values(self):
+    def _get_raw_settings(self):
         # TODO add mechanism to share some settings with other domains on the same zone
-        super()._load_current_values()
+        super()._get_raw_settings()
 
-        # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
+        # FIXME: Ugly hack to save the registar id/value and reinject it in _get_raw_settings ...
         filter_key = self.filter_key.split(".") if self.filter_key != "" else []
         if not filter_key or filter_key[0] == "dns":
             self.values["registrar"] = self.registar_id
 
-        # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
+        # FIXME: Ugly hack to save the cert status and reinject it in _get_raw_settings ...
         if not filter_key or filter_key[0] == "cert":
             self.values["cert_validity"] = self.cert_status["validity"]
             self.values["cert_issuer"] = self.cert_status["CA_type"]

--- a/src/domain.py
+++ b/src/domain.py
@@ -538,6 +538,83 @@ class DomainConfigPanel(ConfigPanel):
     save_path_tpl = f"{DOMAIN_SETTINGS_DIR}/{{entity}}.yml"
     save_mode = "diff"
 
+    def get(self, key="", mode="classic"):
+        result = super().get(key=key, mode=mode)
+
+        if mode == "full":
+            for panel, section, option in self._iterate():
+                # This injects:
+                # i18n: domain_config_cert_renew_help
+                # i18n: domain_config_default_app_help
+                # i18n: domain_config_xmpp_help
+                if m18n.key_exists(self.config["i18n"] + "_" + option["id"] + "_help"):
+                    option["help"] = m18n.n(
+                        self.config["i18n"] + "_" + option["id"] + "_help"
+                    )
+            return self.config
+
+        return result
+
+    def _get_toml(self):
+        toml = super()._get_toml()
+
+        toml["feature"]["xmpp"]["xmpp"]["default"] = (
+            1 if self.entity == _get_maindomain() else 0
+        )
+
+        # Optimize wether or not to load the DNS section,
+        # e.g. we don't want to trigger the whole _get_registary_config_section
+        # when just getting the current value from the feature section
+        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
+        if not filter_key or filter_key[0] == "dns":
+            from yunohost.dns import _get_registrar_config_section
+
+            toml["dns"]["registrar"] = _get_registrar_config_section(self.entity)
+
+            # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
+            self.registar_id = toml["dns"]["registrar"]["registrar"]["value"]
+            del toml["dns"]["registrar"]["registrar"]["value"]
+
+        # Cert stuff
+        if not filter_key or filter_key[0] == "cert":
+            from yunohost.certificate import certificate_status
+
+            status = certificate_status([self.entity], full=True)["certificates"][
+                self.entity
+            ]
+
+            toml["cert"]["cert"]["cert_summary"]["style"] = status["style"]
+
+            # i18n: domain_config_cert_summary_expired
+            # i18n: domain_config_cert_summary_selfsigned
+            # i18n: domain_config_cert_summary_abouttoexpire
+            # i18n: domain_config_cert_summary_ok
+            # i18n: domain_config_cert_summary_letsencrypt
+            toml["cert"]["cert"]["cert_summary"]["ask"] = m18n.n(
+                f"domain_config_cert_summary_{status['summary']}"
+            )
+
+            # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
+            self.cert_status = status
+
+        return toml
+
+    def _load_current_values(self):
+        # TODO add mechanism to share some settings with other domains on the same zone
+        super()._load_current_values()
+
+        # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
+        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
+        if not filter_key or filter_key[0] == "dns":
+            self.values["registrar"] = self.registar_id
+
+        # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
+        if not filter_key or filter_key[0] == "cert":
+            self.values["cert_validity"] = self.cert_status["validity"]
+            self.values["cert_issuer"] = self.cert_status["CA_type"]
+            self.values["acme_eligible"] = self.cert_status["ACME_eligible"]
+            self.values["summary"] = self.cert_status["summary"]
+
     def _apply(self):
         if (
             "default_app" in self.future_values
@@ -585,83 +662,6 @@ class DomainConfigPanel(ConfigPanel):
 
         if stuff_to_regen_conf:
             regen_conf(names=stuff_to_regen_conf)
-
-    def _get_toml(self):
-        toml = super()._get_toml()
-
-        toml["feature"]["xmpp"]["xmpp"]["default"] = (
-            1 if self.entity == _get_maindomain() else 0
-        )
-
-        # Optimize wether or not to load the DNS section,
-        # e.g. we don't want to trigger the whole _get_registary_config_section
-        # when just getting the current value from the feature section
-        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
-        if not filter_key or filter_key[0] == "dns":
-            from yunohost.dns import _get_registrar_config_section
-
-            toml["dns"]["registrar"] = _get_registrar_config_section(self.entity)
-
-            # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
-            self.registar_id = toml["dns"]["registrar"]["registrar"]["value"]
-            del toml["dns"]["registrar"]["registrar"]["value"]
-
-        # Cert stuff
-        if not filter_key or filter_key[0] == "cert":
-            from yunohost.certificate import certificate_status
-
-            status = certificate_status([self.entity], full=True)["certificates"][
-                self.entity
-            ]
-
-            toml["cert"]["cert"]["cert_summary"]["style"] = status["style"]
-
-            # i18n: domain_config_cert_summary_expired
-            # i18n: domain_config_cert_summary_selfsigned
-            # i18n: domain_config_cert_summary_abouttoexpire
-            # i18n: domain_config_cert_summary_ok
-            # i18n: domain_config_cert_summary_letsencrypt
-            toml["cert"]["cert"]["cert_summary"]["ask"] = m18n.n(
-                f"domain_config_cert_summary_{status['summary']}"
-            )
-
-            # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
-            self.cert_status = status
-
-        return toml
-
-    def get(self, key="", mode="classic"):
-        result = super().get(key=key, mode=mode)
-
-        if mode == "full":
-            for panel, section, option in self._iterate():
-                # This injects:
-                # i18n: domain_config_cert_renew_help
-                # i18n: domain_config_default_app_help
-                # i18n: domain_config_xmpp_help
-                if m18n.key_exists(self.config["i18n"] + "_" + option["id"] + "_help"):
-                    option["help"] = m18n.n(
-                        self.config["i18n"] + "_" + option["id"] + "_help"
-                    )
-            return self.config
-
-        return result
-
-    def _load_current_values(self):
-        # TODO add mechanism to share some settings with other domains on the same zone
-        super()._load_current_values()
-
-        # FIXME: Ugly hack to save the registar id/value and reinject it in _load_current_values ...
-        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
-        if not filter_key or filter_key[0] == "dns":
-            self.values["registrar"] = self.registar_id
-
-        # FIXME: Ugly hack to save the cert status and reinject it in _load_current_values ...
-        if not filter_key or filter_key[0] == "cert":
-            self.values["cert_validity"] = self.cert_status["validity"]
-            self.values["cert_issuer"] = self.cert_status["CA_type"]
-            self.values["acme_eligible"] = self.cert_status["ACME_eligible"]
-            self.values["summary"] = self.cert_status["summary"]
 
 
 def domain_action_run(domain, action, args=None):

--- a/src/domain.py
+++ b/src/domain.py
@@ -34,7 +34,7 @@ from yunohost.app import (
 )
 from yunohost.regenconf import regen_conf, _force_clear_hashes, _process_regen_conf
 from yunohost.utils.configpanel import ConfigPanel
-from yunohost.utils.form import Question
+from yunohost.utils.form import BaseOption
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.log import is_unit_operation
 
@@ -528,7 +528,7 @@ def domain_config_set(
     """
     Apply a new domain configuration
     """
-    Question.operation_logger = operation_logger
+    BaseOption.operation_logger = operation_logger
     config = DomainConfigPanel(domain)
     return config.set(key, value, args, args_file, operation_logger=operation_logger)
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -180,8 +180,8 @@ class SettingsConfigPanel(ConfigPanel):
         logger.success(m18n.n("global_settings_reset_success"))
         operation_logger.success()
 
-    def _get_toml(self):
-        toml = super()._get_toml()
+    def _get_raw_config(self):
+        toml = super()._get_raw_config()
 
         # Dynamic choice list for portal themes
         THEMEDIR = "/usr/share/ssowat/portal/assets/themes/"
@@ -193,8 +193,8 @@ class SettingsConfigPanel(ConfigPanel):
 
         return toml
 
-    def _load_current_values(self):
-        super()._load_current_values()
+    def _get_raw_settings(self):
+        super()._get_raw_settings()
 
         # Specific logic for those settings who are "virtual" settings
         # and only meant to have a custom setter mapped to tools_rootpw

--- a/src/settings.py
+++ b/src/settings.py
@@ -22,7 +22,7 @@ import subprocess
 from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.configpanel import ConfigPanel
-from yunohost.utils.form import Question
+from yunohost.utils.form import BaseOption
 from moulinette.utils.log import getActionLogger
 from yunohost.regenconf import regen_conf
 from yunohost.firewall import firewall_reload
@@ -82,7 +82,7 @@ def settings_set(operation_logger, key=None, value=None, args=None, args_file=No
         value -- New value
 
     """
-    Question.operation_logger = operation_logger
+    BaseOption.operation_logger = operation_logger
     settings = SettingsConfigPanel()
     key = translate_legacy_settings_to_configpanel_settings(key)
     return settings.set(key, value, args, args_file, operation_logger=operation_logger)
@@ -231,7 +231,7 @@ class SettingsConfigPanel(ConfigPanel):
         # Replace all values with default values
         self.values = self._get_default_values()
 
-        Question.operation_logger = operation_logger
+        BaseOption.operation_logger = operation_logger
 
         if operation_logger:
             operation_logger.start()

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -15,7 +15,7 @@ from _pytest.mark.structures import ParameterSet
 from moulinette import Moulinette
 from yunohost import app, domain, user
 from yunohost.utils.form import (
-    ARGUMENTS_TYPE_PARSERS,
+    OPTIONS,
     ask_questions_and_parse_answers,
     DisplayTextOption,
     PasswordOption,
@@ -440,7 +440,7 @@ class BaseTest:
 
         is_special_readonly_option = isinstance(option, DisplayTextOption)
 
-        assert isinstance(option, ARGUMENTS_TYPE_PARSERS[raw_option["type"]])
+        assert isinstance(option, OPTIONS[raw_option["type"]])
         assert option.type == raw_option["type"]
         assert option.name == id_
         assert option.ask == {"en": id_}

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -17,12 +17,12 @@ from yunohost import app, domain, user
 from yunohost.utils.form import (
     ARGUMENTS_TYPE_PARSERS,
     ask_questions_and_parse_answers,
-    DisplayTextQuestion,
-    PasswordQuestion,
-    DomainQuestion,
-    PathQuestion,
-    BooleanQuestion,
-    FileQuestion,
+    DisplayTextOption,
+    PasswordOption,
+    DomainOption,
+    WebPathOption,
+    BooleanOption,
+    FileOption,
     evaluate_simple_js_expression,
 )
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -438,7 +438,7 @@ class BaseTest:
         id_ = raw_option["id"]
         option, value = _fill_or_prompt_one_option(raw_option, None)
 
-        is_special_readonly_option = isinstance(option, DisplayTextQuestion)
+        is_special_readonly_option = isinstance(option, DisplayTextOption)
 
         assert isinstance(option, ARGUMENTS_TYPE_PARSERS[raw_option["type"]])
         assert option.type == raw_option["type"]
@@ -734,7 +734,7 @@ class TestPassword(BaseTest):
         ], reason="Should output exactly the same"),
         ("s3cr3t!!", "s3cr3t!!"),
         ("secret", FAIL),
-        *[("supersecret" + char, FAIL) for char in PasswordQuestion.forbidden_chars],  # FIXME maybe add ` \n` to the list?
+        *[("supersecret" + char, FAIL) for char in PasswordOption.forbidden_chars],  # FIXME maybe add ` \n` to the list?
         # readonly
         *xpass(scenarios=[
             ("s3cr3t!!", "s3cr3t!!", {"readonly": True}),
@@ -1225,9 +1225,9 @@ class TestUrl(BaseTest):
 
 @pytest.fixture
 def file_clean():
-    FileQuestion.clean_upload_dirs()
+    FileOption.clean_upload_dirs()
     yield
-    FileQuestion.clean_upload_dirs()
+    FileOption.clean_upload_dirs()
 
 
 @contextmanager
@@ -1263,7 +1263,7 @@ def _test_file_intake_may_fail(raw_option, intake, expected_output):
     with open(value) as f:
         assert f.read() == expected_output
 
-    FileQuestion.clean_upload_dirs()
+    FileOption.clean_upload_dirs()
 
     assert not os.path.exists(value)
 
@@ -2138,88 +2138,88 @@ def test_question_number_input_test_ask_with_example():
 
 
 def test_normalize_boolean_nominal():
-    assert BooleanQuestion.normalize("yes") == 1
-    assert BooleanQuestion.normalize("Yes") == 1
-    assert BooleanQuestion.normalize(" yes  ") == 1
-    assert BooleanQuestion.normalize("y") == 1
-    assert BooleanQuestion.normalize("true") == 1
-    assert BooleanQuestion.normalize("True") == 1
-    assert BooleanQuestion.normalize("on") == 1
-    assert BooleanQuestion.normalize("1") == 1
-    assert BooleanQuestion.normalize(1) == 1
+    assert BooleanOption.normalize("yes") == 1
+    assert BooleanOption.normalize("Yes") == 1
+    assert BooleanOption.normalize(" yes  ") == 1
+    assert BooleanOption.normalize("y") == 1
+    assert BooleanOption.normalize("true") == 1
+    assert BooleanOption.normalize("True") == 1
+    assert BooleanOption.normalize("on") == 1
+    assert BooleanOption.normalize("1") == 1
+    assert BooleanOption.normalize(1) == 1
 
-    assert BooleanQuestion.normalize("no") == 0
-    assert BooleanQuestion.normalize("No") == 0
-    assert BooleanQuestion.normalize(" no  ") == 0
-    assert BooleanQuestion.normalize("n") == 0
-    assert BooleanQuestion.normalize("false") == 0
-    assert BooleanQuestion.normalize("False") == 0
-    assert BooleanQuestion.normalize("off") == 0
-    assert BooleanQuestion.normalize("0") == 0
-    assert BooleanQuestion.normalize(0) == 0
+    assert BooleanOption.normalize("no") == 0
+    assert BooleanOption.normalize("No") == 0
+    assert BooleanOption.normalize(" no  ") == 0
+    assert BooleanOption.normalize("n") == 0
+    assert BooleanOption.normalize("false") == 0
+    assert BooleanOption.normalize("False") == 0
+    assert BooleanOption.normalize("off") == 0
+    assert BooleanOption.normalize("0") == 0
+    assert BooleanOption.normalize(0) == 0
 
-    assert BooleanQuestion.normalize("") is None
-    assert BooleanQuestion.normalize("   ") is None
-    assert BooleanQuestion.normalize(" none   ") is None
-    assert BooleanQuestion.normalize("None") is None
-    assert BooleanQuestion.normalize("noNe") is None
-    assert BooleanQuestion.normalize(None) is None
+    assert BooleanOption.normalize("") is None
+    assert BooleanOption.normalize("   ") is None
+    assert BooleanOption.normalize(" none   ") is None
+    assert BooleanOption.normalize("None") is None
+    assert BooleanOption.normalize("noNe") is None
+    assert BooleanOption.normalize(None) is None
 
 
 def test_normalize_boolean_humanize():
-    assert BooleanQuestion.humanize("yes") == "yes"
-    assert BooleanQuestion.humanize("true") == "yes"
-    assert BooleanQuestion.humanize("on") == "yes"
+    assert BooleanOption.humanize("yes") == "yes"
+    assert BooleanOption.humanize("true") == "yes"
+    assert BooleanOption.humanize("on") == "yes"
 
-    assert BooleanQuestion.humanize("no") == "no"
-    assert BooleanQuestion.humanize("false") == "no"
-    assert BooleanQuestion.humanize("off") == "no"
+    assert BooleanOption.humanize("no") == "no"
+    assert BooleanOption.humanize("false") == "no"
+    assert BooleanOption.humanize("off") == "no"
 
 
 def test_normalize_boolean_invalid():
     with pytest.raises(YunohostValidationError):
-        BooleanQuestion.normalize("yesno")
+        BooleanOption.normalize("yesno")
     with pytest.raises(YunohostValidationError):
-        BooleanQuestion.normalize("foobar")
+        BooleanOption.normalize("foobar")
     with pytest.raises(YunohostValidationError):
-        BooleanQuestion.normalize("enabled")
+        BooleanOption.normalize("enabled")
 
 
 def test_normalize_boolean_special_yesno():
     customyesno = {"yes": "enabled", "no": "disabled"}
 
-    assert BooleanQuestion.normalize("yes", customyesno) == "enabled"
-    assert BooleanQuestion.normalize("true", customyesno) == "enabled"
-    assert BooleanQuestion.normalize("enabled", customyesno) == "enabled"
-    assert BooleanQuestion.humanize("yes", customyesno) == "yes"
-    assert BooleanQuestion.humanize("true", customyesno) == "yes"
-    assert BooleanQuestion.humanize("enabled", customyesno) == "yes"
+    assert BooleanOption.normalize("yes", customyesno) == "enabled"
+    assert BooleanOption.normalize("true", customyesno) == "enabled"
+    assert BooleanOption.normalize("enabled", customyesno) == "enabled"
+    assert BooleanOption.humanize("yes", customyesno) == "yes"
+    assert BooleanOption.humanize("true", customyesno) == "yes"
+    assert BooleanOption.humanize("enabled", customyesno) == "yes"
 
-    assert BooleanQuestion.normalize("no", customyesno) == "disabled"
-    assert BooleanQuestion.normalize("false", customyesno) == "disabled"
-    assert BooleanQuestion.normalize("disabled", customyesno) == "disabled"
-    assert BooleanQuestion.humanize("no", customyesno) == "no"
-    assert BooleanQuestion.humanize("false", customyesno) == "no"
-    assert BooleanQuestion.humanize("disabled", customyesno) == "no"
+    assert BooleanOption.normalize("no", customyesno) == "disabled"
+    assert BooleanOption.normalize("false", customyesno) == "disabled"
+    assert BooleanOption.normalize("disabled", customyesno) == "disabled"
+    assert BooleanOption.humanize("no", customyesno) == "no"
+    assert BooleanOption.humanize("false", customyesno) == "no"
+    assert BooleanOption.humanize("disabled", customyesno) == "no"
 
 
 def test_normalize_domain():
-    assert DomainQuestion.normalize("https://yolo.swag/") == "yolo.swag"
-    assert DomainQuestion.normalize("http://yolo.swag") == "yolo.swag"
-    assert DomainQuestion.normalize("yolo.swag/") == "yolo.swag"
+    assert DomainOption.normalize("https://yolo.swag/") == "yolo.swag"
+    assert DomainOption.normalize("http://yolo.swag") == "yolo.swag"
+    assert DomainOption.normalize("yolo.swag/") == "yolo.swag"
 
 
 def test_normalize_path():
-    assert PathQuestion.normalize("") == "/"
-    assert PathQuestion.normalize("") == "/"
-    assert PathQuestion.normalize("macnuggets") == "/macnuggets"
-    assert PathQuestion.normalize("/macnuggets") == "/macnuggets"
-    assert PathQuestion.normalize("   /macnuggets      ") == "/macnuggets"
-    assert PathQuestion.normalize("/macnuggets") == "/macnuggets"
-    assert PathQuestion.normalize("mac/nuggets") == "/mac/nuggets"
-    assert PathQuestion.normalize("/macnuggets/") == "/macnuggets"
-    assert PathQuestion.normalize("macnuggets/") == "/macnuggets"
-    assert PathQuestion.normalize("////macnuggets///") == "/macnuggets"
+    assert WebPathOption.normalize("") == "/"
+    assert WebPathOption.normalize("") == "/"
+    assert WebPathOption.normalize("macnuggets") == "/macnuggets"
+    assert WebPathOption.normalize("/macnuggets") == "/macnuggets"
+    assert WebPathOption.normalize("   /macnuggets      ") == "/macnuggets"
+    assert WebPathOption.normalize("/macnuggets") == "/macnuggets"
+    assert WebPathOption.normalize("mac/nuggets") == "/mac/nuggets"
+    assert WebPathOption.normalize("/macnuggets/") == "/macnuggets"
+    assert WebPathOption.normalize("macnuggets/") == "/macnuggets"
+    assert WebPathOption.normalize("////macnuggets///") == "/macnuggets"
 
 
 def test_simple_evaluate():

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -36,7 +36,7 @@ from moulinette.utils.filesystem import (
 from yunohost.utils.i18n import _value_for_locale
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.form import (
-    ARGUMENTS_TYPE_PARSERS,
+    OPTIONS,
     FileOption,
     BaseOption,
     ask_questions_and_parse_answers,
@@ -127,7 +127,7 @@ class ConfigPanel:
             option_type = None
             for _, _, option_ in self._iterate():
                 if option_["id"] == option:
-                    option_type = ARGUMENTS_TYPE_PARSERS[option_["type"]]
+                    option_type = OPTIONS[option_["type"]]
                     break
 
             return option_type.normalize(value) if option_type else value
@@ -152,7 +152,7 @@ class ConfigPanel:
 
             if mode == "full":
                 option["ask"] = ask
-                question_class = ARGUMENTS_TYPE_PARSERS[option.get("type", "string")]
+                question_class = OPTIONS[option.get("type", "string")]
                 # FIXME : maybe other properties should be taken from the question, not just choices ?.
                 option["choices"] = question_class(option).choices
                 option["default"] = question_class(option).default
@@ -160,9 +160,7 @@ class ConfigPanel:
             else:
                 result[key] = {"ask": ask}
                 if "current_value" in option:
-                    question_class = ARGUMENTS_TYPE_PARSERS[
-                        option.get("type", "string")
-                    ]
+                    question_class = OPTIONS[option.get("type", "string")]
                     result[key]["value"] = question_class.humanize(
                         option["current_value"], option
                     )

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -37,8 +37,8 @@ from yunohost.utils.i18n import _value_for_locale
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.form import (
     ARGUMENTS_TYPE_PARSERS,
-    FileQuestion,
-    Question,
+    FileOption,
+    BaseOption,
     ask_questions_and_parse_answers,
     evaluate_simple_js_expression,
 )
@@ -213,7 +213,7 @@ class ConfigPanel:
         # Read or get values and hydrate the config
         self._load_current_values()
         self._hydrate()
-        Question.operation_logger = operation_logger
+        BaseOption.operation_logger = operation_logger
         self._ask(action=action_id)
 
         # FIXME: here, we could want to check constrains on
@@ -244,7 +244,7 @@ class ConfigPanel:
             # FIXME : this is currently done in the context of config panels,
             # but could also happen in the context of app install ... (or anywhere else
             # where we may parse args etc...)
-            FileQuestion.clean_upload_dirs()
+            FileOption.clean_upload_dirs()
 
         # FIXME: i18n
         logger.success(f"Action {action_id} successful")
@@ -277,7 +277,7 @@ class ConfigPanel:
         # Read or get values and hydrate the config
         self._load_current_values()
         self._hydrate()
-        Question.operation_logger = operation_logger
+        BaseOption.operation_logger = operation_logger
         self._ask()
 
         if operation_logger:
@@ -305,7 +305,7 @@ class ConfigPanel:
             # FIXME : this is currently done in the context of config panels,
             # but could also happen in the context of app install ... (or anywhere else
             # where we may parse args etc...)
-            FileQuestion.clean_upload_dirs()
+            FileOption.clean_upload_dirs()
 
         self._reload_services()
 

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -23,25 +23,19 @@ import urllib.parse
 from collections import OrderedDict
 from typing import Union
 
-from moulinette.interfaces.cli import colorize
 from moulinette import Moulinette, m18n
+from moulinette.interfaces.cli import colorize
+from moulinette.utils.filesystem import mkdir, read_toml, read_yaml, write_to_yaml
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import (
-    read_toml,
-    read_yaml,
-    write_to_yaml,
-    mkdir,
-)
-
-from yunohost.utils.i18n import _value_for_locale
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.form import (
     OPTIONS,
-    FileOption,
     BaseOption,
+    FileOption,
     ask_questions_and_parse_answers,
     evaluate_simple_js_expression,
 )
+from yunohost.utils.i18n import _value_for_locale
 
 logger = getActionLogger("yunohost.configpanel")
 CONFIG_PANEL_VERSION_SUPPORTED = 1.0

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -116,7 +116,7 @@ class ConfigPanel:
             raise YunohostValidationError("config_no_panel")
 
         # Read or get values and hydrate the config
-        self._load_current_values()
+        self._get_raw_settings()
         self._hydrate()
 
         # In 'classic' mode, we display the current value if key refer to an option
@@ -200,7 +200,7 @@ class ConfigPanel:
         self._parse_pre_answered(args, value, args_file)
 
         # Read or get values and hydrate the config
-        self._load_current_values()
+        self._get_raw_settings()
         self._hydrate()
         BaseOption.operation_logger = operation_logger
         self._ask()
@@ -271,7 +271,7 @@ class ConfigPanel:
         self._parse_pre_answered(args, None, args_file)
 
         # Read or get values and hydrate the config
-        self._load_current_values()
+        self._get_raw_settings()
         self._hydrate()
         BaseOption.operation_logger = operation_logger
         self._ask(action=action_id)
@@ -310,7 +310,7 @@ class ConfigPanel:
         logger.success(f"Action {action_id} successful")
         operation_logger.success()
 
-    def _get_toml(self):
+    def _get_raw_config(self):
         return read_toml(self.config_path)
 
     def _get_config_panel(self):
@@ -326,7 +326,7 @@ class ConfigPanel:
             logger.debug(f"Config panel {self.config_path} doesn't exists")
             return None
 
-        toml_config_panel = self._get_toml()
+        toml_config_panel = self._get_raw_config()
 
         # Check TOML config panel is in a supported version
         if float(toml_config_panel["version"]) < CONFIG_PANEL_VERSION_SUPPORTED:
@@ -495,7 +495,7 @@ class ConfigPanel:
             if "default" in option
         }
 
-    def _load_current_values(self):
+    def _get_raw_settings(self):
         """
         Retrieve entries in YAML file
         And set default values if needed

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -40,6 +40,13 @@ from yunohost.log import OperationLogger
 logger = getActionLogger("yunohost.form")
 
 
+# ╭───────────────────────────────────────────────────────╮
+# │  ┌─╴╷ ╷╭─┐╷                                           │
+# │  ├─╴│╭╯├─┤│                                           │
+# │  ╰─╴╰╯ ╵ ╵╰─╴                                         │
+# ╰───────────────────────────────────────────────────────╯
+
+
 # Those js-like evaluate functions are used to eval safely visible attributes
 # The goal is to evaluate in the same way than js simple-evaluate
 # https://github.com/shepherdwind/simple-evaluate
@@ -181,6 +188,13 @@ def evaluate_simple_js_expression(expr, context={}):
         return False
     node = ast.parse(js_to_python(expr), mode="eval").body
     return evaluate_simple_ast(node, context)
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╭─╮┌─╮╶┬╴╶┬╴╭─╮╭╮╷╭─╴                                │
+# │  │ │├─╯ │  │ │ ││││╰─╮                                │
+# │  ╰─╯╵   ╵ ╶┴╴╰─╯╵╰╯╶─╯                                │
+# ╰───────────────────────────────────────────────────────╯
 
 
 class BaseOption:
@@ -377,6 +391,11 @@ class BaseOption:
         return self.value
 
 
+# ╭───────────────────────────────────────────────────────╮
+# │ DISPLAY OPTIONS                                       │
+# ╰───────────────────────────────────────────────────────╯
+
+
 class DisplayTextOption(BaseOption):
     argument_type = "display_text"
 
@@ -416,6 +435,14 @@ class ButtonOption(BaseOption):
     ):
         super().__init__(question, context, hooks)
         self.enabled = question.get("enabled", None)
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │ INPUT OPTIONS                                         │
+# ╰───────────────────────────────────────────────────────╯
+
+
+# ─ STRINGS ───────────────────────────────────────────────
 
 
 class StringOption(BaseOption):
@@ -459,6 +486,9 @@ class ColorOption(StringOption):
         "regexp": r"^#[ABCDEFabcdef\d]{3,6}$",
         "error": "config_validate_color",  # i18n: config_validate_color
     }
+
+
+# ─ NUMERIC ───────────────────────────────────────────────
 
 
 class NumberOption(BaseOption):
@@ -512,6 +542,9 @@ class NumberOption(BaseOption):
                 name=self.name,
                 error=m18n.n("invalid_number_max", max=self.max),
             )
+
+
+# ─ BOOLEAN ───────────────────────────────────────────────
 
 
 class BooleanOption(BaseOption):
@@ -604,6 +637,9 @@ class BooleanOption(BaseOption):
         return text_for_user_input_in_cli
 
 
+# ─ TIME ──────────────────────────────────────────────────
+
+
 class DateOption(StringOption):
     pattern = {
         "regexp": r"^\d{4}-\d\d-\d\d$",
@@ -627,6 +663,9 @@ class TimeOption(StringOption):
         "regexp": r"^(?:\d|[01]\d|2[0-3]):[0-5]\d$",
         "error": "config_validate_time",  # i18n: config_validate_time
     }
+
+
+# ─ LOCATIONS ─────────────────────────────────────────────
 
 
 class EmailOption(StringOption):
@@ -672,6 +711,9 @@ class URLOption(StringOption):
         "regexp": r"^https?://.*$",
         "error": "config_validate_url",  # i18n: config_validate_url
     }
+
+
+# ─ FILE ──────────────────────────────────────────────────
 
 
 class FileOption(BaseOption):
@@ -737,6 +779,9 @@ class FileOption(BaseOption):
         self.value = file_path
 
         return self.value
+
+
+# ─ CHOICES ───────────────────────────────────────────────
 
 
 class TagsOption(BaseOption):
@@ -931,6 +976,13 @@ OPTIONS = {
     "user": UserOption,
     "group": GroupOption,
 }
+
+
+# ╭───────────────────────────────────────────────────────╮
+# │  ╷ ╷╶┬╴╶┬╴╷  ╭─╴                                      │
+# │  │ │ │  │ │  ╰─╮                                      │
+# │  ╰─╯ ╵ ╶┴╴╰─╴╶─╯                                      │
+# ╰───────────────────────────────────────────────────────╯
 
 
 def ask_questions_and_parse_answers(

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -906,7 +906,7 @@ class ButtonOption(BaseOption):
         self.enabled = question.get("enabled", None)
 
 
-ARGUMENTS_TYPE_PARSERS = {
+OPTIONS = {
     "string": StringOption,
     "text": StringOption,
     "select": StringOption,
@@ -969,7 +969,7 @@ def ask_questions_and_parse_answers(
 
     for name, raw_question in raw_questions.items():
         raw_question["name"] = name
-        question_class = ARGUMENTS_TYPE_PARSERS[raw_question.get("type", "string")]
+        question_class = OPTIONS[raw_question.get("type", "string")]
         raw_question["value"] = answers.get(name)
         question = question_class(raw_question, context=context, hooks=hooks)
         if question.type == "button":
@@ -996,7 +996,7 @@ def hydrate_questions_with_choices(raw_questions: List) -> List:
     out = []
 
     for raw_question in raw_questions:
-        question = ARGUMENTS_TYPE_PARSERS[raw_question.get("type", "string")](
+        question = OPTIONS[raw_question.get("type", "string")](
             raw_question
         )
         if question.choices:

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -279,7 +279,7 @@ class BaseOption:
             try:
                 # Normalize and validate
                 self.value = self.normalize(self.value, self)
-                self._prevalidate()
+                self._value_pre_validator()
             except YunohostValidationError as e:
                 # If in interactive cli, re-ask the current question
                 if i < 4 and Moulinette.interface.type == "cli" and os.isatty(1):
@@ -292,7 +292,7 @@ class BaseOption:
 
             break
 
-        self.value = self.values[self.name] = self._post_parse_value()
+        self.value = self.values[self.name] = self._value_post_validator()
 
         # Search for post actions in hooks
         post_hook = f"post_ask__{self.name}"
@@ -301,7 +301,7 @@ class BaseOption:
 
         return self.values
 
-    def _prevalidate(self):
+    def _value_pre_validator(self):
         if self.value in [None, ""] and not self.optional:
             raise YunohostValidationError("app_argument_required", name=self.name)
 
@@ -353,7 +353,7 @@ class BaseOption:
 
         return text_for_user_input_in_cli
 
-    def _post_parse_value(self):
+    def _value_post_validator(self):
         if not self.redact:
             return self.value
 
@@ -439,8 +439,8 @@ class PasswordOption(BaseOption):
                 "app_argument_password_no_default", name=self.name
             )
 
-    def _prevalidate(self):
-        super()._prevalidate()
+    def _value_pre_validator(self):
+        super()._value_pre_validator()
 
         if self.value not in [None, ""]:
             if any(char in self.value for char in self.forbidden_chars):
@@ -494,8 +494,8 @@ class NumberOption(BaseOption):
             error=m18n.n("invalid_number"),
         )
 
-    def _prevalidate(self):
-        super()._prevalidate()
+    def _value_pre_validator(self):
+        super()._value_pre_validator()
         if self.value in [None, ""]:
             return
 
@@ -610,10 +610,10 @@ class DateOption(StringOption):
         "error": "config_validate_date",  # i18n: config_validate_date
     }
 
-    def _prevalidate(self):
+    def _value_pre_validator(self):
         from datetime import datetime
 
-        super()._prevalidate()
+        super()._value_pre_validator()
 
         if self.value not in [None, ""]:
             try:
@@ -691,11 +691,11 @@ class FileOption(BaseOption):
         super().__init__(question, context, hooks)
         self.accept = question.get("accept", "")
 
-    def _prevalidate(self):
+    def _value_pre_validator(self):
         if self.value is None:
             self.value = self.current_value
 
-        super()._prevalidate()
+        super()._value_pre_validator()
 
         # Validation should have already failed if required
         if self.value in [None, ""]:
@@ -711,7 +711,7 @@ class FileOption(BaseOption):
                     error=m18n.n("file_does_not_exist", path=str(self.value)),
                 )
 
-    def _post_parse_value(self):
+    def _value_post_validator(self):
         from base64 import b64decode
 
         if not self.value:
@@ -757,7 +757,7 @@ class TagsOption(BaseOption):
             value = value.strip()
         return value
 
-    def _prevalidate(self):
+    def _value_pre_validator(self):
         values = self.value
         if isinstance(values, str):
             values = values.split(",")
@@ -780,13 +780,13 @@ class TagsOption(BaseOption):
 
         for value in values:
             self.value = value
-            super()._prevalidate()
+            super()._value_pre_validator()
         self.value = values
 
-    def _post_parse_value(self):
+    def _value_post_validator(self):
         if isinstance(self.value, list):
             self.value = ",".join(self.value)
-        return super()._post_parse_value()
+        return super()._value_post_validator()
 
 
 class DomainOption(BaseOption):

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -16,26 +16,22 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import os
-import re
-import urllib.parse
-import tempfile
-import shutil
 import ast
 import operator as op
-from typing import Optional, Dict, List, Union, Any, Mapping, Callable
+import os
+import re
+import shutil
+import tempfile
+import urllib.parse
+from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
-from moulinette.interfaces.cli import colorize
 from moulinette import Moulinette, m18n
+from moulinette.interfaces.cli import colorize
+from moulinette.utils.filesystem import read_file, write_to_file
 from moulinette.utils.log import getActionLogger
-from moulinette.utils.filesystem import (
-    read_file,
-    write_to_file,
-)
-
-from yunohost.utils.i18n import _value_for_locale
-from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.log import OperationLogger
+from yunohost.utils.error import YunohostError, YunohostValidationError
+from yunohost.utils.i18n import _value_for_locale
 
 logger = getActionLogger("yunohost.form")
 


### PR DESCRIPTION
PR  1/3 for the pydantic migration of config panel.
This is a separated PR to hopefully ease reviewing

This PR contains only function rename and code moves

form:
- rename `*Question`s to `*Option`s
- reorder `*Option`s
- rename `ARGUMENT_TYPE_PARSERS` to `OPTIONS`
- rename `Option._prevalidate()` to `Option._value_pre_validate()`
- rename `Option._post_parse_value()` to `Option._value_post_validate()`

configpanel:
- reorder methods
- rename `ConfigPanel._get_toml()` to `ConfigPanel._get_raw_config()`
- rename `ConfigPanel._load_current_values()` to `ConfigPanel._get_raw_settings()`
