### PR TITLE
ConfigPanel: switch to pydantic 3/3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: ${python3:Depends}, ${misc:Depends}
  , python3-miniupnpc, python3-dbus, python3-jinja2
  , python3-toml, python3-packaging, python3-publicsuffix2
  , python3-ldap, python3-zeroconf (>= 0.36), python3-lexicon,
- , python-is-python3
+ , python-is-python3, python3-pydantic, python3-email-validator
  , nginx, nginx-extras (>=1.18)
  , apt, apt-transport-https, apt-utils, dirmngr
  , openssh-server, iptables, fail2ban, bind9-dnsutils

--- a/src/app.py
+++ b/src/app.py
@@ -29,7 +29,7 @@ import subprocess
 import tempfile
 import copy
 from collections import OrderedDict
-from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional
+from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional, Union
 from packaging import version
 
 from moulinette import Moulinette, m18n
@@ -75,7 +75,10 @@ from yunohost.app_catalog import (  # noqa
 )
 
 if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
+
     from yunohost.utils.configpanel import ConfigPanelModel, RawSettings
+    from yunohost.utils.form import FormModel
 
 logger = getActionLogger("yunohost.app")
 
@@ -1884,8 +1887,13 @@ class AppConfigPanel(ConfigPanel):
     def _get_raw_settings(self, config: "ConfigPanelModel") -> "RawSettings":
         return self._call_config_script("show")
 
-    def _apply(self):
-        env = {key: str(value) for key, value in self.new_values.items()}
+    def _apply(
+        self,
+        form: "FormModel",
+        previous_settings: dict[str, Any],
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+    ):
+        env = {key: str(value) for key, value in form.dict().items()}
         return_content = self._call_config_script("apply", env=env)
 
         # If the script returned validation error

--- a/src/app.py
+++ b/src/app.py
@@ -132,7 +132,6 @@ def app_info(app, full=False, upgradable=False):
     Get info for a specific app
     """
     from yunohost.permission import user_permission_list
-    from yunohost.domain import domain_config_get
 
     _assert_is_installed(app)
 
@@ -218,9 +217,7 @@ def app_info(app, full=False, upgradable=False):
     ret["is_webapp"] = "domain" in settings and "path" in settings
 
     if ret["is_webapp"]:
-        ret["is_default"] = (
-            domain_config_get(settings["domain"], "feature.app.default_app") == app
-        )
+        ret["is_default"] = settings.get("default_app", "_none")
 
     ret["supports_change_url"] = os.path.exists(
         os.path.join(setting_path, "scripts", "change_url")

--- a/src/app.py
+++ b/src/app.py
@@ -48,10 +48,11 @@ from moulinette.utils.filesystem import (
     chmod,
 )
 
-from yunohost.utils.configpanel import ConfigPanel, ask_questions_and_parse_answers
+from yunohost.utils.configpanel import ConfigPanel
 from yunohost.utils.form import (
     DomainOption,
     WebPathOption,
+    ask_questions_and_parse_answers,
     hydrate_questions_with_choices,
 )
 from yunohost.utils.i18n import _value_for_locale
@@ -1880,10 +1881,6 @@ class AppConfigPanel(ConfigPanel):
     save_path_tpl = os.path.join(APPS_SETTING_PATH, "{entity}/settings.yml")
     config_path_tpl = os.path.join(APPS_SETTING_PATH, "{entity}/config_panel.toml")
 
-    def _run_action(self, action):
-        env = {key: str(value) for key, value in self.new_values.items()}
-        self._call_config_script(action, env=env)
-
     def _get_raw_settings(self, config: "ConfigPanelModel") -> "RawSettings":
         return self._call_config_script("show")
 
@@ -1906,6 +1903,10 @@ class AppConfigPanel(ConfigPanel):
                     name=key,
                     error=message,
                 )
+
+    def _run_action(self, form: "FormModel", action_id: str):
+        env = {key: str(value) for key, value in form.dict().items()}
+        self._call_config_script(action_id, env=env)
 
     def _call_config_script(self, action, env=None):
         from yunohost.hook import hook_exec

--- a/src/app.py
+++ b/src/app.py
@@ -53,7 +53,7 @@ from yunohost.utils.form import (
     DomainOption,
     WebPathOption,
     ask_questions_and_parse_answers,
-    hydrate_questions_with_choices,
+    parse_raw_options,
 )
 from yunohost.utils.i18n import _value_for_locale
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -960,8 +960,7 @@ def app_upgrade(
 def app_manifest(app, with_screenshot=False):
     manifest, extracted_app_folder = _extract_app(app)
 
-    raw_questions = manifest.get("install", {}).values()
-    manifest["install"] = hydrate_questions_with_choices(raw_questions)
+    manifest["install"] = parse_raw_options(manifest.get("install", {}), serialize=True)
 
     # Add a base64 image to be displayed in web-admin
     if with_screenshot and Moulinette.interface.type == "api":

--- a/src/app.py
+++ b/src/app.py
@@ -29,7 +29,7 @@ import subprocess
 import tempfile
 import copy
 from collections import OrderedDict
-from typing import List, Tuple, Dict, Any, Iterator, Optional
+from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional
 from packaging import version
 
 from moulinette import Moulinette, m18n
@@ -73,6 +73,9 @@ from yunohost.app_catalog import (  # noqa
     _load_apps_catalog,
     APPS_CATALOG_LOGOS,
 )
+
+if TYPE_CHECKING:
+    from yunohost.utils.configpanel import ConfigPanelModel, RawSettings
 
 logger = getActionLogger("yunohost.app")
 
@@ -1878,8 +1881,8 @@ class AppConfigPanel(ConfigPanel):
         env = {key: str(value) for key, value in self.new_values.items()}
         self._call_config_script(action, env=env)
 
-    def _get_raw_settings(self):
-        self.values = self._call_config_script("show")
+    def _get_raw_settings(self, config: "ConfigPanelModel") -> "RawSettings":
+        return self._call_config_script("show")
 
     def _apply(self):
         env = {key: str(value) for key, value in self.new_values.items()}

--- a/src/app.py
+++ b/src/app.py
@@ -1889,26 +1889,29 @@ class AppConfigPanel(ConfigPanel):
         form: "FormModel",
         previous_settings: dict[str, Any],
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
-    ):
+    ) -> None:
         env = {key: str(value) for key, value in form.dict().items()}
         return_content = self._call_config_script("apply", env=env)
 
         # If the script returned validation error
         # raise a ValidationError exception using
         # the first key
-        if return_content:
-            for key, message in return_content.get("validation_errors").items():
+        errors = return_content.get("validation_errors")
+        if errors:
+            for key, message in errors.items():
                 raise YunohostValidationError(
                     "app_argument_invalid",
                     name=key,
                     error=message,
                 )
 
-    def _run_action(self, form: "FormModel", action_id: str):
+    def _run_action(self, form: "FormModel", action_id: str) -> None:
         env = {key: str(value) for key, value in form.dict().items()}
         self._call_config_script(action_id, env=env)
 
-    def _call_config_script(self, action, env=None):
+    def _call_config_script(
+        self, action: str, env: Union[dict[str, Any], None] = None
+    ) -> dict[str, Any]:
         from yunohost.hook import hook_exec
 
         if env is None:
@@ -2375,9 +2378,7 @@ def _set_default_ask_questions(questions, script_name="install"):
             for question_with_default in questions_with_default
         ):
             # The key is for example "app_manifest_install_ask_domain"
-            question["ask"] = m18n.n(
-                f"app_manifest_{script_name}_ask_{question['id']}"
-            )
+            question["ask"] = m18n.n(f"app_manifest_{script_name}_ask_{question['id']}")
 
             # Also it in fact doesn't make sense for any of those questions to have an example value nor a default value...
             if question.get("type") in ["domain", "user", "password"]:

--- a/src/dns.py
+++ b/src/dns.py
@@ -529,7 +529,7 @@ def _get_registrar_config_section(domain):
                     parent_domain=parent_domain,
                     parent_domain_link=parent_domain_link,
                 ),
-                "value": "parent_domain",
+                "default": "parent_domain",
             }
         )
         return OrderedDict(registrar_infos)
@@ -542,7 +542,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "success",
                 "ask": m18n.n("domain_dns_registrar_yunohost"),
-                "value": "yunohost",
+                "default": "yunohost",
             }
         )
         return OrderedDict(registrar_infos)
@@ -552,7 +552,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "info",
                 "ask": m18n.n("domain_dns_conf_special_use_tld"),
-                "value": None,
+                "default": None,
             }
         )
 
@@ -564,7 +564,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "warning",
                 "ask": m18n.n("domain_dns_registrar_not_supported"),
-                "value": None,
+                "default": None,
             }
         )
     else:
@@ -573,7 +573,7 @@ def _get_registrar_config_section(domain):
                 "type": "alert",
                 "style": "info",
                 "ask": m18n.n("domain_dns_registrar_supported", registrar=registrar),
-                "value": registrar,
+                "default": registrar,
             }
         )
 

--- a/src/domain.py
+++ b/src/domain.py
@@ -541,22 +541,9 @@ class DomainConfigPanel(ConfigPanel):
     save_path_tpl = f"{DOMAIN_SETTINGS_DIR}/{{entity}}.yml"
     save_mode = "diff"
 
-    def get(self, key="", mode="classic"):
-        result = super().get(key=key, mode=mode)
-
-        if mode == "full":
-            for panel, section, option in self._iterate():
-                # This injects:
-                # i18n: domain_config_cert_renew_help
-                # i18n: domain_config_default_app_help
-                # i18n: domain_config_xmpp_help
-                if m18n.key_exists(self.config["i18n"] + "_" + option["id"] + "_help"):
-                    option["help"] = m18n.n(
-                        self.config["i18n"] + "_" + option["id"] + "_help"
-                    )
-            return self.config
-
-        return result
+    # i18n: domain_config_cert_renew_help
+    # i18n: domain_config_default_app_help
+    # i18n: domain_config_xmpp_help
 
     def _get_raw_config(self) -> "RawConfig":
         # TODO add mechanism to share some settings with other domains on the same zone

--- a/src/domain.py
+++ b/src/domain.py
@@ -18,7 +18,7 @@
 #
 import os
 import time
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 from collections import OrderedDict
 
 from moulinette import m18n, Moulinette
@@ -37,6 +37,9 @@ from yunohost.utils.configpanel import ConfigPanel
 from yunohost.utils.form import BaseOption
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.log import is_unit_operation
+
+if TYPE_CHECKING:
+    from yunohost.utils.configpanel import RawConfig
 
 logger = getActionLogger("yunohost.domain")
 
@@ -555,65 +558,57 @@ class DomainConfigPanel(ConfigPanel):
 
         return result
 
-    def _get_raw_config(self):
-        toml = super()._get_raw_config()
+    def _get_raw_config(self) -> "RawConfig":
+        # TODO add mechanism to share some settings with other domains on the same zone
+        raw_config = super()._get_raw_config()
 
-        toml["feature"]["xmpp"]["xmpp"]["default"] = (
+        any_filter = all(self.filter_key)
+        panel_id, section_id, option_id = self.filter_key
+
+        raw_config["feature"]["xmpp"]["xmpp"]["default"] = (
             1 if self.entity == _get_maindomain() else 0
         )
 
         # Optimize wether or not to load the DNS section,
         # e.g. we don't want to trigger the whole _get_registary_config_section
         # when just getting the current value from the feature section
-        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
-        if not filter_key or filter_key[0] == "dns":
+        if not any_filter or panel_id == "dns":
             from yunohost.dns import _get_registrar_config_section
 
-            toml["dns"]["registrar"] = _get_registrar_config_section(self.entity)
-
-            # FIXME: Ugly hack to save the registar id/value and reinject it in _get_raw_settings ...
-            self.registar_id = toml["dns"]["registrar"]["registrar"]["value"]
-            del toml["dns"]["registrar"]["registrar"]["value"]
+            raw_config["dns"]["registrar"] = _get_registrar_config_section(self.entity)
 
         # Cert stuff
-        if not filter_key or filter_key[0] == "cert":
+        if not any_filter or panel_id == "cert":
             from yunohost.certificate import certificate_status
 
             status = certificate_status([self.entity], full=True)["certificates"][
                 self.entity
             ]
 
-            toml["cert"]["cert"]["cert_summary"]["style"] = status["style"]
+            raw_config["cert"]["cert"]["cert_summary"]["style"] = status["style"]
 
             # i18n: domain_config_cert_summary_expired
             # i18n: domain_config_cert_summary_selfsigned
             # i18n: domain_config_cert_summary_abouttoexpire
             # i18n: domain_config_cert_summary_ok
             # i18n: domain_config_cert_summary_letsencrypt
-            toml["cert"]["cert"]["cert_summary"]["ask"] = m18n.n(
+            raw_config["cert"]["cert"]["cert_summary"]["ask"] = m18n.n(
                 f"domain_config_cert_summary_{status['summary']}"
             )
 
-            # FIXME: Ugly hack to save the cert status and reinject it in _get_raw_settings ...
-            self.cert_status = status
+            for option_id, status_key in [
+                ("cert_validity", "validity"),
+                ("cert_issuer", "CA_type"),
+                ("acme_eligible", "ACME_eligible"),
+                # FIXME not sure why "summary" was injected in settings values
+                # ("summary", "summary")
+            ]:
+                raw_config["cert"]["cert"][option_id]["default"] = status[status_key]
 
-        return toml
+            # Other specific strings used in config panels
+            # i18n: domain_config_cert_renew_help
 
-    def _get_raw_settings(self):
-        # TODO add mechanism to share some settings with other domains on the same zone
-        super()._get_raw_settings()
-
-        # FIXME: Ugly hack to save the registar id/value and reinject it in _get_raw_settings ...
-        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
-        if not filter_key or filter_key[0] == "dns":
-            self.values["registrar"] = self.registar_id
-
-        # FIXME: Ugly hack to save the cert status and reinject it in _get_raw_settings ...
-        if not filter_key or filter_key[0] == "cert":
-            self.values["cert_validity"] = self.cert_status["validity"]
-            self.values["cert_issuer"] = self.cert_status["CA_type"]
-            self.values["acme_eligible"] = self.cert_status["ACME_eligible"]
-            self.values["summary"] = self.cert_status["summary"]
+        return raw_config
 
     def _apply(self):
         if (

--- a/src/domain.py
+++ b/src/domain.py
@@ -605,7 +605,7 @@ class DomainConfigPanel(ConfigPanel):
         form: "FormModel",
         previous_settings: dict[str, Any],
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
-    ):
+    ) -> None:
         next_settings = {
             k: v for k, v in form.dict().items() if previous_settings.get(k) != v
         }

--- a/src/log.py
+++ b/src/log.py
@@ -470,7 +470,7 @@ class OperationLogger:
     This class record logs and metadata like context or start time/end time.
     """
 
-    _instances: List[object] = []
+    _instances: List["OperationLogger"] = []
 
     def __init__(self, operation, related_to=None, **kwargs):
         # TODO add a way to not save password on app installation

--- a/src/settings.py
+++ b/src/settings.py
@@ -18,7 +18,7 @@
 #
 import os
 import subprocess
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
 
 from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -31,7 +31,12 @@ from yunohost.log import is_unit_operation
 from yunohost.utils.legacy import translate_legacy_settings_to_configpanel_settings
 
 if TYPE_CHECKING:
-    from yunohost.utils.configpanel import ConfigPanelModel, RawConfig, RawSettings
+    from yunohost.utils.configpanel import (
+        ConfigPanelGetMode,
+        ConfigPanelModel,
+        RawConfig,
+        RawSettings,
+    )
 
 logger = getActionLogger("yunohost.settings")
 
@@ -129,16 +134,10 @@ class SettingsConfigPanel(ConfigPanel):
     def __init__(self, config_path=None, save_path=None, creation=False):
         super().__init__("settings")
 
-    def get(self, key="", mode="classic"):
+    def get(
+        self, key: Union[str, None] = None, mode: "ConfigPanelGetMode" = "classic"
+    ) -> Any:
         result = super().get(key=key, mode=mode)
-
-        if mode == "full":
-            for panel, section, option in self._iterate():
-                if m18n.key_exists(self.config["i18n"] + "_" + option["id"] + "_help"):
-                    option["help"] = m18n.n(
-                        self.config["i18n"] + "_" + option["id"] + "_help"
-                    )
-            return self.config
 
         # Dirty hack to let settings_get() to work from a python script
         if isinstance(result, str) and result in ["True", "False"]:

--- a/src/settings.py
+++ b/src/settings.py
@@ -31,12 +31,15 @@ from yunohost.log import is_unit_operation
 from yunohost.utils.legacy import translate_legacy_settings_to_configpanel_settings
 
 if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
+
     from yunohost.utils.configpanel import (
         ConfigPanelGetMode,
         ConfigPanelModel,
         RawConfig,
         RawSettings,
     )
+    from yunohost.utils.form import FormModel
 
 logger = getActionLogger("yunohost.settings")
 
@@ -217,19 +220,15 @@ class SettingsConfigPanel(ConfigPanel):
 
         return raw_settings
 
-    def _apply(self):
-        root_password = self.new_values.pop("root_password", None)
-        root_password_confirm = self.new_values.pop("root_password_confirm", None)
-        passwordless_sudo = self.new_values.pop("passwordless_sudo", None)
-
-        self.values = {
-            k: v for k, v in self.values.items() if k not in self.virtual_settings
-        }
-        self.new_values = {
-            k: v for k, v in self.new_values.items() if k not in self.virtual_settings
-        }
-
-        assert all(v not in self.future_values for v in self.virtual_settings)
+    def _apply(
+        self,
+        form: "FormModel",
+        previous_settings: dict[str, Any],
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+    ):
+        root_password = form.get("root_password", None)
+        root_password_confirm = form.get("root_password_confirm", None)
+        passwordless_sudo = form.get("passwordless_sudo", None)
 
         if root_password and root_password.strip():
             if root_password != root_password_confirm:
@@ -248,15 +247,20 @@ class SettingsConfigPanel(ConfigPanel):
                 {"sudoOption": ["!authenticate"] if passwordless_sudo else []},
             )
 
-        super()._apply()
-
-        settings = {
-            k: v for k, v in self.future_values.items() if self.values.get(k) != v
+        # First save settings except virtual + default ones
+        super()._apply(form, previous_settings, exclude=self.virtual_settings)
+        next_settings = {
+            k: v
+            for k, v in form.dict(exclude=self.virtual_settings).items()
+            if previous_settings.get(k) != v
         }
-        for setting_name, value in settings.items():
+
+        for setting_name, value in next_settings.items():
             try:
+                # FIXME not sure to understand why we need the previous value if
+                # updated_settings has already been filtered
                 trigger_post_change_hook(
-                    setting_name, self.values.get(setting_name), value
+                    setting_name, previous_settings.get(setting_name), value
                 )
             except Exception as e:
                 logger.error(f"Post-change hook for setting failed : {e}")

--- a/src/settings.py
+++ b/src/settings.py
@@ -132,7 +132,7 @@ class SettingsConfigPanel(ConfigPanel):
     entity_type = "global"
     save_path_tpl = SETTINGS_PATH
     save_mode = "diff"
-    virtual_settings = ["root_password", "root_password_confirm", "passwordless_sudo"]
+    virtual_settings = {"root_password", "root_password_confirm", "passwordless_sudo"}
 
     def __init__(self, config_path=None, save_path=None, creation=False):
         super().__init__("settings")

--- a/src/settings.py
+++ b/src/settings.py
@@ -136,7 +136,7 @@ class SettingsConfigPanel(ConfigPanel):
     save_mode = "diff"
     virtual_settings = {"root_password", "root_password_confirm", "passwordless_sudo"}
 
-    def __init__(self, config_path=None, save_path=None, creation=False):
+    def __init__(self, config_path=None, save_path=None, creation=False) -> None:
         super().__init__("settings")
 
     def get(
@@ -150,7 +150,11 @@ class SettingsConfigPanel(ConfigPanel):
 
         return result
 
-    def reset(self, key: Union[str, None] = None, operation_logger: Union["OperationLogger", None] = None,):
+    def reset(
+        self,
+        key: Union[str, None] = None,
+        operation_logger: Union["OperationLogger", None] = None,
+    ) -> None:
         self.filter_key = parse_filter_key(key)
 
         # Read config panel toml
@@ -160,8 +164,11 @@ class SettingsConfigPanel(ConfigPanel):
         previous_settings = self.form.dict()
 
         for option in self.config.options:
-            if not option.readonly and (option.optional or option.default not in {None, ""}):
-                self.form[option.id] = option.normalize(option.default, option)
+            if not option.readonly and (
+                option.optional or option.default not in {None, ""}
+            ):
+                # FIXME Mypy complains about option.default not being a valid type for normalize but this should be ok
+                self.form[option.id] = option.normalize(option.default, option)  # type: ignore
 
         # FIXME Not sure if this is need (redact call to operation logger does it on all the instances)
         # BaseOption.operation_logger = operation_logger
@@ -230,7 +237,7 @@ class SettingsConfigPanel(ConfigPanel):
         form: "FormModel",
         previous_settings: dict[str, Any],
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
-    ):
+    ) -> None:
         root_password = form.get("root_password", None)
         root_password_confirm = form.get("root_password_confirm", None)
         passwordless_sudo = form.get("passwordless_sudo", None)

--- a/src/settings.py
+++ b/src/settings.py
@@ -18,6 +18,7 @@
 #
 import os
 import subprocess
+from typing import TYPE_CHECKING
 
 from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -28,6 +29,9 @@ from yunohost.regenconf import regen_conf
 from yunohost.firewall import firewall_reload
 from yunohost.log import is_unit_operation
 from yunohost.utils.legacy import translate_legacy_settings_to_configpanel_settings
+
+if TYPE_CHECKING:
+    from yunohost.utils.configpanel import ConfigPanelModel, RawConfig, RawSettings
 
 logger = getActionLogger("yunohost.settings")
 
@@ -180,8 +184,8 @@ class SettingsConfigPanel(ConfigPanel):
         logger.success(m18n.n("global_settings_reset_success"))
         operation_logger.success()
 
-    def _get_raw_config(self):
-        toml = super()._get_raw_config()
+    def _get_raw_config(self) -> "RawConfig":
+        raw_config = super()._get_raw_config()
 
         # Dynamic choice list for portal themes
         THEMEDIR = "/usr/share/ssowat/portal/assets/themes/"
@@ -189,28 +193,30 @@ class SettingsConfigPanel(ConfigPanel):
             themes = [d for d in os.listdir(THEMEDIR) if os.path.isdir(THEMEDIR + d)]
         except Exception:
             themes = ["unsplash", "vapor", "light", "default", "clouds"]
-        toml["misc"]["portal"]["portal_theme"]["choices"] = themes
+        raw_config["misc"]["portal"]["portal_theme"]["choices"] = themes
 
-        return toml
+        return raw_config
 
-    def _get_raw_settings(self):
-        super()._get_raw_settings()
+    def _get_raw_settings(self, config: "ConfigPanelModel") -> "RawSettings":
+        raw_settings = super()._get_raw_settings(config)
 
         # Specific logic for those settings who are "virtual" settings
         # and only meant to have a custom setter mapped to tools_rootpw
-        self.values["root_password"] = ""
-        self.values["root_password_confirm"] = ""
+        raw_settings["root_password"] = ""
+        raw_settings["root_password_confirm"] = ""
 
         # Specific logic for virtual setting "passwordless_sudo"
         try:
             from yunohost.utils.ldap import _get_ldap_interface
 
             ldap = _get_ldap_interface()
-            self.values["passwordless_sudo"] = "!authenticate" in ldap.search(
+            raw_settings["passwordless_sudo"] = "!authenticate" in ldap.search(
                 "ou=sudo", "cn=admins", ["sudoOption"]
             )[0].get("sudoOption", [])
         except Exception:
-            self.values["passwordless_sudo"] = False
+            raw_settings["passwordless_sudo"] = False
+
+        return raw_settings
 
     def _apply(self):
         root_password = self.new_values.pop("root_password", None)

--- a/src/tests/test_app_config.py
+++ b/src/tests/test_app_config.py
@@ -125,9 +125,9 @@ def test_app_config_get_nonexistentstuff(config_app):
     with pytest.raises(YunohostValidationError):
         app_config_get(config_app, "main.components.nonexistent")
 
-    app_setting(config_app, "boolean", delete=True)
+    app_setting(config_app, "number", delete=True)
     with pytest.raises(YunohostError):
-        app_config_get(config_app, "main.components.boolean")
+        app_config_get(config_app, "main.components.number")
 
 
 def test_app_config_regular_setting(config_app):

--- a/src/tests/test_dns.py
+++ b/src/tests/test_dns.py
@@ -49,19 +49,19 @@ def test_registrar_list_integrity():
 
 
 def test_magic_guess_registrar_weird_domain():
-    assert _get_registrar_config_section("yolo.tld")["registrar"]["value"] is None
+    assert _get_registrar_config_section("yolo.tld")["registrar"]["default"] is None
 
 
 def test_magic_guess_registrar_ovh():
     assert (
-        _get_registrar_config_section("yolo.yunohost.org")["registrar"]["value"]
+        _get_registrar_config_section("yolo.yunohost.org")["registrar"]["default"]
         == "ovh"
     )
 
 
 def test_magic_guess_registrar_yunodyndns():
     assert (
-        _get_registrar_config_section("yolo.nohost.me")["registrar"]["value"]
+        _get_registrar_config_section("yolo.nohost.me")["registrar"]["default"]
         == "yunohost"
     )
 

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -447,7 +447,7 @@ class BaseTest:
         assert isinstance(option, OPTIONS[raw_option["type"]])
         assert option.type == raw_option["type"]
         assert option.id == id_
-        assert option.ask == {"en": id_}
+        assert option.ask == id_
         assert option.readonly is (True if is_special_readonly_option else False)
         assert option.visible is True
         # assert option.bind is None
@@ -493,7 +493,7 @@ class BaseTest:
             )
             option, value = _fill_or_prompt_one_option(raw_option, None)
 
-            expected_message = option.ask["en"]
+            expected_message = option.ask
             choices = []
 
             if isinstance(option, BaseChoicesOption):
@@ -510,7 +510,7 @@ class BaseTest:
                 prefill=prefill,
                 is_multiline=option.type == "text",
                 autocomplete=choices,
-                help=option.help["en"],
+                help=option.help,
             )
 
     def test_scenarios(self, intake, expected_output, raw_option, data):
@@ -558,7 +558,7 @@ class TestDisplayText(BaseTest):
                     options, form = ask_questions_and_parse_answers(
                         {_id: raw_option}, answers
                     )
-                    assert stdout.getvalue() == f"{options[0].ask['en']}\n"
+                    assert stdout.getvalue() == f"{options[0].ask}\n"
 
 
 # ╭───────────────────────────────────────────────────────╮
@@ -609,7 +609,7 @@ class TestAlert(TestDisplayText):
                     options, form = ask_questions_and_parse_answers(
                         {"display_text_id": raw_option}, answers
                     )
-                    ask = options[0].ask["en"]
+                    ask = options[0].ask
                     if style in colors:
                         color = colors[style]
                         title = style.title() + (":" if style != "success" else "!")

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -1803,9 +1803,7 @@ class TestGroup(BaseTest):
             "scenarios": [
                 ("custom_group", "custom_group"),
                 *all_as("", None, output="visitors", raw_option={"default": "visitors"}),
-                *xpass(scenarios=[
-                    ("", "custom_group", {"default": "custom_group"}),
-                ], reason="Should throw 'default must be in (None, 'all_users', 'visitors', 'admins')"),
+                ("", FAIL, {"default": "custom_group"}),  # Not allowed to set a default which is not a default group
                 # readonly
                 ("admins", FAIL, {"readonly": True}),  # readonly is forbidden
             ]
@@ -1822,13 +1820,6 @@ class TestGroup(BaseTest):
                 prefill_data={
                     "raw_option": {"default": "admins"},
                     "prefill": "admins",
-                }
-            )
-            # FIXME This should fail, not allowed to set a default which is not a default group
-            super().test_options_prompted_with_ask_help(
-                prefill_data={
-                    "raw_option": {"default": "custom_group"},
-                    "prefill": "custom_group",
                 }
             )
 

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -595,7 +595,7 @@ class TestAlert(TestDisplayText):
         (None, None, {"ask": "Some text\na new line"}),
         (None, None, {"ask": {"en": "Some text\na new line", "fr": "Un peu de texte\nune nouvelle ligne"}}),
         *[(None, None, {"ask": "question", "style": style}) for style in ("success", "info", "warning", "danger")],
-        (None, FAIL, {"ask": "question", "style": "nimp"}),
+        (None, YunohostError, {"ask": "question", "style": "nimp"}),
     ]
     # fmt: on
 
@@ -737,7 +737,7 @@ class TestPassword(BaseTest):
         *all_fails([], ["one"], {}, raw_option={"optional": True}, error=AttributeError),  # FIXME those fails with AttributeError
         *all_fails("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
         *nones(None, "", output=""),
-        ("s3cr3t!!", FAIL, {"default": "SUPAs3cr3t!!"}),  # default is forbidden
+        ("s3cr3t!!", YunohostError, {"default": "SUPAs3cr3t!!"}),  # default is forbidden
         *xpass(scenarios=[
             ("s3cr3t!!", "s3cr3t!!", {"example": "SUPAs3cr3t!!"}),  # example is forbidden
         ], reason="Should fail; example is forbidden"),
@@ -749,7 +749,7 @@ class TestPassword(BaseTest):
         ("secret", FAIL),
         *[("supersecret" + char, FAIL) for char in FORBIDDEN_PASSWORD_CHARS],  # FIXME maybe add ` \n` to the list?
         # readonly
-        ("s3cr3t!!", FAIL, {"readonly": True}),  # readonly is forbidden
+        ("s3cr3t!!", YunohostError, {"readonly": True}),  # readonly is forbidden
     ]
     # fmt: on
 
@@ -1474,10 +1474,10 @@ class TestTags(BaseTest):
         # basic types (not in a list) should fail
         *all_fails(True, False, -1, 0, 1, 1337, 13.37, {}),
         # Mixed choices should fail
-        ([False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}], FAIL, {"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
-        ("False,True,-1,0,1,1337,13.37,[],['one'],{}", FAIL, {"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
-        *all_fails(*([t] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
-        *all_fails(*([str(t)] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
+        ([False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}], YunohostError, {"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
+        ("False,True,-1,0,1,1337,13.37,[],['one'],{}", YunohostError, {"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
+        *all_fails(*([t] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}, error=YunohostError),
+        *all_fails(*([str(t)] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}, error=YunohostError),
         # readonly
         ("one", "one,two", {"readonly": True, "choices": ["one", "two"], "default": "one,two"}),
     ]
@@ -1527,7 +1527,7 @@ class TestDomain(BaseTest):
                 ("doesnt_exist.pouet", FAIL, {}),
                 ("fake.com", FAIL, {"choices": ["fake.com"]}),
                 # readonly
-                (domains1[0], FAIL, {"readonly": True}),  # readonly is forbidden
+                (domains1[0], YunohostError, {"readonly": True}),  # readonly is forbidden
             ]
         },
         {
@@ -1623,7 +1623,7 @@ class TestApp(BaseTest):
                 (installed_non_webapp["id"], installed_non_webapp["id"]),
                 (installed_non_webapp["id"], FAIL, {"filter": "is_webapp"}),
                 # readonly
-                (installed_non_webapp["id"], FAIL, {"readonly": True}),  # readonly is forbidden
+                (installed_non_webapp["id"], YunohostError, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]
@@ -1740,7 +1740,7 @@ class TestUser(BaseTest):
                     ("", regular_username, {"default": regular_username})
                 ], reason="Should throw 'no default allowed'"),
                 # readonly
-                (admin_username, FAIL, {"readonly": True}),  # readonly is forbidden
+                (admin_username, YunohostError, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]
@@ -1811,9 +1811,9 @@ class TestGroup(BaseTest):
             "scenarios": [
                 ("custom_group", "custom_group"),
                 *all_as("", None, output="visitors", raw_option={"default": "visitors"}),
-                ("", FAIL, {"default": "custom_group"}),  # Not allowed to set a default which is not a default group
+                ("", YunohostError, {"default": "custom_group"}),  # Not allowed to set a default which is not a default group
                 # readonly
-                ("admins", FAIL, {"readonly": True}),  # readonly is forbidden
+                ("admins", YunohostError, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -741,7 +741,7 @@ class TestPassword(BaseTest):
         ("secret", FAIL),
         *[("supersecret" + char, FAIL) for char in FORBIDDEN_PASSWORD_CHARS],  # FIXME maybe add ` \n` to the list?
         # readonly
-        ("s3cr3t!!", FAIL, {"readonly": True, "current_value": "isforbidden"}),  # readonly is forbidden
+        ("s3cr3t!!", FAIL, {"readonly": True}),  # readonly is forbidden
     ]
     # fmt: on
 
@@ -1519,7 +1519,7 @@ class TestDomain(BaseTest):
                 ("doesnt_exist.pouet", FAIL, {}),
                 ("fake.com", FAIL, {"choices": ["fake.com"]}),
                 # readonly
-                (domains1[0], YunohostError, {"readonly": True}),  # readonly is forbidden
+                (domains1[0], FAIL, {"readonly": True}),  # readonly is forbidden
             ]
         },
         {
@@ -1615,7 +1615,7 @@ class TestApp(BaseTest):
                 (installed_non_webapp["id"], installed_non_webapp["id"]),
                 (installed_non_webapp["id"], FAIL, {"filter": "is_webapp"}),
                 # readonly
-                (installed_non_webapp["id"], YunohostError, {"readonly": True}),  # readonly is forbidden
+                (installed_non_webapp["id"], FAIL, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]
@@ -1732,7 +1732,7 @@ class TestUser(BaseTest):
                     ("", regular_username, {"default": regular_username})
                 ], reason="Should throw 'no default allowed'"),
                 # readonly
-                (admin_username, YunohostError, {"readonly": True}),  # readonly is forbidden
+                (admin_username, FAIL, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]
@@ -1807,7 +1807,7 @@ class TestGroup(BaseTest):
                     ("", "custom_group", {"default": "custom_group"}),
                 ], reason="Should throw 'default must be in (None, 'all_users', 'visitors', 'admins')"),
                 # readonly
-                ("admins", "all_users", {"readonly": True}),  # readonly is forbidden (default is "all_users")
+                ("admins", FAIL, {"readonly": True}),  # readonly is forbidden
             ]
         },
     ]

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -20,7 +20,6 @@ from yunohost.utils.form import (
     BaseChoicesOption,
     BaseInputOption,
     BaseReadonlyOption,
-    PasswordOption,
     DomainOption,
     WebPathOption,
     BooleanOption,
@@ -436,6 +435,10 @@ class BaseTest:
     @classmethod
     def _test_basic_attrs(self):
         raw_option = self.get_raw_option(optional=True)
+
+        if raw_option["type"] == "select":
+            raw_option["choices"] = ["one"]
+
         id_ = raw_option["id"]
         option, value = _fill_or_prompt_one_option(raw_option, None)
 
@@ -481,6 +484,7 @@ class BaseTest:
         base_raw_option = prefill_data["raw_option"]
         prefill = prefill_data["prefill"]
 
+        # FIXME could patch prompt with prefill if we switch to "do not apply default if value is None|''"
         with patch_prompt("") as prompt:
             raw_option = self.get_raw_option(
                 raw_option=base_raw_option,
@@ -583,9 +587,7 @@ class TestAlert(TestDisplayText):
         (None, None, {"ask": "Some text\na new line"}),
         (None, None, {"ask": {"en": "Some text\na new line", "fr": "Un peu de texte\nune nouvelle ligne"}}),
         *[(None, None, {"ask": "question", "style": style}) for style in ("success", "info", "warning", "danger")],
-        *xpass(scenarios=[
-            (None, None, {"ask": "question", "style": "nimp"}),
-        ], reason="Should fail, wrong style"),
+        (None, FAIL, {"ask": "question", "style": "nimp"}),
     ]
     # fmt: on
 
@@ -643,11 +645,15 @@ class TestString(BaseTest):
     scenarios = [
         *nones(None, "", output=""),
         # basic typed values
-        *unchanged(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),  # FIXME should output as str?
+        (False, "False"),
+        (True, "True"),
+        (0, "0"),
+        (1, "1"),
+        (-1, "-1"),
+        (1337, "1337"),
+        (13.37, "13.37"),
+        *all_fails([], ["one"], {}),
         *unchanged("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", raw_option={"optional": True}),
-        *xpass(scenarios=[
-            ([], []),
-        ], reason="Should fail"),
         # test strip
         ("value", "value"),
         ("value\n", "value"),
@@ -660,7 +666,7 @@ class TestString(BaseTest):
             (" ##value \n \tvalue\n  ", "##value \n \tvalue"),
         ], reason=r"should fail or without `\n`?"),
         # readonly
-        ("overwrite", "expected value", {"readonly": True, "current_value": "expected value"}),
+        ("overwrite", "expected value", {"readonly": True, "default": "expected value"}),  # FIXME do we want to fail instead?
     ]
     # fmt: on
 
@@ -680,11 +686,15 @@ class TestText(BaseTest):
     scenarios = [
         *nones(None, "", output=""),
         # basic typed values
-        *unchanged(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),  # FIXME should fail or output as str?
+        (False, "False"),
+        (True, "True"),
+        (0, "0"),
+        (1, "1"),
+        (-1, "-1"),
+        (1337, "1337"),
+        (13.37, "13.37"),
+        *all_fails([], ["one"], {}),
         *unchanged("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", raw_option={"optional": True}),
-        *xpass(scenarios=[
-            ([], [])
-        ], reason="Should fail"),
         ("value", "value"),
         ("value\n value", "value\n value"),
         # test no strip
@@ -697,7 +707,7 @@ class TestText(BaseTest):
             (r" ##value \n \tvalue\n  ", r"##value \n \tvalue\n"),
         ], reason="Should not be stripped"),
         # readonly
-        ("overwrite", "expected value", {"readonly": True, "current_value": "expected value"}),
+        ("overwrite", "expected value", {"readonly": True, "default": "expected value"}),
     ]
     # fmt: on
 
@@ -715,7 +725,7 @@ class TestPassword(BaseTest):
     }
     # fmt: off
     scenarios = [
-        *all_fails(False, True, 0, 1, -1, 1337, 13.37, raw_option={"optional": True}, error=TypeError),  # FIXME those fails with TypeError
+        *all_fails(False, True, 0, 1, -1, 1337, 13.37, raw_option={"optional": True}),
         *all_fails([], ["one"], {}, raw_option={"optional": True}, error=AttributeError),  # FIXME those fails with AttributeError
         *all_fails("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
         *nones(None, "", output=""),
@@ -729,9 +739,9 @@ class TestPassword(BaseTest):
         ], reason="Should output exactly the same"),
         ("s3cr3t!!", "s3cr3t!!"),
         ("secret", FAIL),
-        *[("supersecret" + char, FAIL) for char in PasswordOption.forbidden_chars],  # FIXME maybe add ` \n` to the list?
+        *[("supersecret" + char, FAIL) for char in FORBIDDEN_PASSWORD_CHARS],  # FIXME maybe add ` \n` to the list?
         # readonly
-        ("s3cr3t!!", YunohostError, {"readonly": True, "current_value": "isforbidden"}),  # readonly is forbidden
+        ("s3cr3t!!", FAIL, {"readonly": True, "current_value": "isforbidden"}),  # readonly is forbidden
     ]
     # fmt: on
 
@@ -744,35 +754,31 @@ class TestPassword(BaseTest):
 class TestColor(BaseTest):
     raw_option = {"type": "color", "id": "color_id"}
     prefill = {
-        "raw_option": {"default": "#ff0000"},
-        "prefill": "#ff0000",
-        # "intake": "#ff00ff",
+        "raw_option": {"default": "red"},
+        "prefill": "red",
     }
     # fmt: off
     scenarios = [
         *all_fails(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),
-        *all_fails("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
+        *all_fails("none", "_none", "False", "True", "0", "1", "-1", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
         *nones(None, "", output=""),
         # custom valid
-        ("#000000", "#000000"),
+        (" #fe1  ", "#fe1"),
+        ("#000000", "#000"),
         ("#000", "#000"),
-        ("#fe100", "#fe100"),
-        (" #fe100  ", "#fe100"),
-        ("#ABCDEF", "#ABCDEF"),
+        ("#ABCDEF", "#abcdef"),
+        ('1337', "#1337"),  # rgba=(17, 51, 51, 0.47)
+        ("000000", "#000"),
+        ("#feaf", "#fea"),  # `#feaf` is `#fea` with alpha at `f|100%` -> equivalent to `#fea`
+        # named
+        ("red", "#f00"),
+        ("yellow", "#ff0"),
         # custom fail
-        *xpass(scenarios=[
-            ("#feaf", "#feaf"),
-        ], reason="Should fail; not a legal color value"),
-        ("000000", FAIL),
         ("#12", FAIL),
         ("#gggggg", FAIL),
         ("#01010101af", FAIL),
-        *xfail(scenarios=[
-            ("red", "#ff0000"),
-            ("yellow", "#ffff00"),
-        ], reason="Should work with pydantic"),
         # readonly
-        ("#ffff00", "#fe100", {"readonly": True, "current_value": "#fe100"}),
+        ("#ffff00", "#000", {"readonly": True, "default": "#000"}),
     ]
     # fmt: on
 
@@ -796,10 +802,8 @@ class TestNumber(BaseTest):
 
         *nones(None, "", output=None),
         *unchanged(0, 1, -1, 1337),
-        *xpass(scenarios=[(False, False)], reason="should fail or output as `0`"),
-        *xpass(scenarios=[(True, True)], reason="should fail or output as `1`"),
-        *all_as("0", 0, output=0),
-        *all_as("1", 1, output=1),
+        *all_as(False, "0", 0, output=0),  # FIXME should `False` fail instead?
+        *all_as(True, "1", 1, output=1),  # FIXME should `True` fail instead?
         *all_as("1337", 1337, output=1337),
         *xfail(scenarios=[
             ("-1", -1)
@@ -814,7 +818,7 @@ class TestNumber(BaseTest):
         (-10, -10, {"default": 10}),
         (-10, -10, {"default": 10, "optional": True}),
         # readonly
-        (1337, 10000, {"readonly": True, "current_value": 10000}),
+        (1337, 10000, {"readonly": True, "default": "10000"}),
     ]
     # fmt: on
     # FIXME should `step` be some kind of "multiple of"?
@@ -839,14 +843,20 @@ class TestBoolean(BaseTest):
         *all_fails("none", "None"),  # FIXME should output as `0` (default) like other none values when required?
         *all_as(None, "", output=0, raw_option={"optional": True}),  # FIXME should output as `None`?
         *all_as("none", "None", output=None, raw_option={"optional": True}),
-        # FIXME even if default is explicity `None|""`, it ends up with class_default `0`
-        *all_as(None, "", output=0, raw_option={"default": None}),  # FIXME this should fail, default is `None`
-        *all_as(None, "", output=0, raw_option={"optional": True, "default": None}),  # FIXME even if default is explicity None, it ends up with class_default
-        *all_as(None, "", output=0, raw_option={"default": ""}),  # FIXME this should fail, default is `""`
-        *all_as(None, "", output=0, raw_option={"optional": True, "default": ""}),  # FIXME even if default is explicity None, it ends up with class_default
-        # With "none" behavior is ok
-        *all_fails(None, "", raw_option={"default": "none"}),
-        *all_as(None, "", output=None, raw_option={"optional": True, "default": "none"}),
+        {
+            "raw_options": [
+                {"default": None},
+                {"default": ""},
+                {"default": "none"},
+                {"default": "None"}
+            ],
+            "scenarios": [
+                # All none values fails if default is overriden
+                *all_fails(None, "", "none", "None"),
+                # All none values ends up as None if default is overriden
+                *all_as(None, "", "none", "None", output=None, raw_option={"optional": True}),
+            ]
+        },
         # Unhandled types should fail
         *all_fails(1337, "1337", "string", [], "[]", ",", "one,two"),
         *all_fails(1337, "1337", "string", [], "[]", ",", "one,two", {"optional": True}),
@@ -879,7 +889,7 @@ class TestBoolean(BaseTest):
             "scenarios": all_fails("", "y", "n", error=AssertionError),
         },
         # readonly
-        (1, 0, {"readonly": True, "current_value": 0}),
+        (1, 0, {"readonly": True, "default": 0}),
     ]
 
 
@@ -896,8 +906,12 @@ class TestDate(BaseTest):
     }
     # fmt: off
     scenarios = [
-        *all_fails(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),
-        *all_fails("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
+        # Those passes since False|True are parsed as 0|1 then int|float are considered a timestamp in seconds which ends up as default Unix date
+        *all_as(False, True, 0, 1, 1337, 13.37, "0", "1", "1337", "13.37", output="1970-01-01"),
+        # Those are negative one second timestamp ending up as Unix date - 1 sec (so day change)
+        *all_as(-1, "-1", output="1969-12-31"),
+        *all_fails([], ["one"], {}, raw_option={"optional": True}),
+        *all_fails("none", "_none", "False", "True", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
         *nones(None, "", output=""),
         # custom valid
         ("2070-12-31", "2070-12-31"),
@@ -906,18 +920,16 @@ class TestDate(BaseTest):
             ("2025-06-15T13:45:30", "2025-06-15"),
             ("2025-06-15 13:45:30", "2025-06-15")
         ], reason="iso date repr should be valid and extra data striped"),
-        *xfail(scenarios=[
-            (1749938400, "2025-06-15"),
-            (1749938400.0, "2025-06-15"),
-            ("1749938400", "2025-06-15"),
-            ("1749938400.0", "2025-06-15"),
-        ], reason="timestamp could be an accepted value"),
+        (1749938400, "2025-06-14"),
+        (1749938400.0, "2025-06-14"),
+        ("1749938400", "2025-06-14"),
+        ("1749938400.0", "2025-06-14"),
         # custom invalid
         ("29-12-2070", FAIL),
         ("12-01-10", FAIL),
         ("2022-02-29", FAIL),
         # readonly
-        ("2070-12-31", "2024-02-29", {"readonly": True, "current_value": "2024-02-29"}),
+        ("2070-12-31", "2024-02-29", {"readonly": True, "default": "2024-02-29"}),
     ]
     # fmt: on
 
@@ -935,22 +947,26 @@ class TestTime(BaseTest):
     }
     # fmt: off
     scenarios = [
-        *all_fails(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),
-        *all_fails("none", "_none", "False", "True", "0", "1", "-1", "1337", "13.37", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
+        # Those passes since False|True are parsed as 0|1 then int|float are considered a timestamp in seconds but we don't take seconds into account so -> 00:00
+        *all_as(False, True, 0, 1, 13.37, "0", "1", "13.37", output="00:00"),
+        # 1337 seconds == 22 minutes
+        *all_as(1337, "1337", output="00:22"),
+        # Negative timestamp fails
+        *all_fails(-1, "-1", error=OverflowError),  # FIXME should handle that as a validation error
+        # *all_fails(False, True, 0, 1, -1, 1337, 13.37, [], ["one"], {}, raw_option={"optional": True}),
+        *all_fails("none", "_none", "False", "True", "[]", ",", "['one']", "one,two", r"{}", "value", "value\n", raw_option={"optional": True}),
         *nones(None, "", output=""),
         # custom valid
         *unchanged("00:00", "08:00", "12:19", "20:59", "23:59"),
-        ("3:00", "3:00"),  # FIXME should fail or output as `"03:00"`?
-        *xfail(scenarios=[
-            ("22:35:05", "22:35"),
-            ("22:35:03.514", "22:35"),
-        ], reason="time as iso format could be valid"),
+        ("3:00", "03:00"),
+        ("23:1", "23:01"),
+        ("22:35:05", "22:35"),
+        ("22:35:03.514", "22:35"),
         # custom invalid
         ("24:00", FAIL),
-        ("23:1", FAIL),
         ("23:005", FAIL),
         # readonly
-        ("00:00", "08:00", {"readonly": True, "current_value": "08:00"}),
+        ("00:00", "08:00", {"readonly": True, "default": "08:00"}),
     ]
     # fmt: on
 
@@ -973,72 +989,75 @@ class TestEmail(BaseTest):
 
         *nones(None, "", output=""),
         ("\n Abc@example.tld  ", "Abc@example.tld"),
+        *xfail(scenarios=[("admin@ynh.local", "admin@ynh.local")], reason="Should this pass?"),
         # readonly
-        ("Abc@example.tld", "admin@ynh.local", {"readonly": True, "current_value": "admin@ynh.local"}),
+        ("Abc@example.tld", "admin@ynh.org", {"readonly": True, "default": "admin@ynh.org"}),
 
         # Next examples are from https://github.com/JoshData/python-email-validator/blob/main/tests/test_syntax.py
         # valid email values
-        ("Abc@example.tld", "Abc@example.tld"),
-        ("Abc.123@test-example.com", "Abc.123@test-example.com"),
-        ("user+mailbox/department=shipping@example.tld", "user+mailbox/department=shipping@example.tld"),
-        ("伊昭傑@郵件.商務", "伊昭傑@郵件.商務"),
-        ("राम@मोहन.ईन्फो", "राम@मोहन.ईन्फो"),
-        ("юзер@екзампл.ком", "юзер@екзампл.ком"),
-        ("θσερ@εχαμπλε.ψομ", "θσερ@εχαμπλε.ψομ"),
-        ("葉士豪@臺網中心.tw", "葉士豪@臺網中心.tw"),
-        ("jeff@臺網中心.tw", "jeff@臺網中心.tw"),
-        ("葉士豪@臺網中心.台灣", "葉士豪@臺網中心.台灣"),
-        ("jeff葉@臺網中心.tw", "jeff葉@臺網中心.tw"),
-        ("ñoñó@example.tld", "ñoñó@example.tld"),
-        ("甲斐黒川日本@example.tld", "甲斐黒川日本@example.tld"),
-        ("чебурашкаящик-с-апельсинами.рф@example.tld", "чебурашкаящик-с-апельсинами.рф@example.tld"),
-        ("उदाहरण.परीक्ष@domain.with.idn.tld", "उदाहरण.परीक्ष@domain.with.idn.tld"),
-        ("ιωάννης@εεττ.gr", "ιωάννης@εεττ.gr"),
+        *unchanged(
+            "Abc@example.tld",
+            "Abc.123@test-example.com",
+            "user+mailbox/department=shipping@example.tld",
+            "伊昭傑@郵件.商務",
+            "राम@मोहन.ईन्फो",
+            "юзер@екзампл.ком",
+            "θσερ@εχαμπλε.ψομ",
+            "葉士豪@臺網中心.tw",
+            "jeff@臺網中心.tw",
+            "葉士豪@臺網中心.台灣",
+            "jeff葉@臺網中心.tw",
+            "ñoñó@example.tld",
+            "甲斐黒川日本@example.tld",
+            "чебурашкаящик-с-апельсинами.рф@example.tld",
+            "उदाहरण.परीक्ष@domain.with.idn.tld",
+            "ιωάννης@εεττ.gr",
+        ),
         # invalid email (Hiding because our current regex is very permissive)
-        # ("my@localhost", FAIL),
-        # ("my@.leadingdot.com", FAIL),
-        # ("my@．leadingfwdot.com", FAIL),
-        # ("my@twodots..com", FAIL),
-        # ("my@twofwdots．．.com", FAIL),
-        # ("my@trailingdot.com.", FAIL),
-        # ("my@trailingfwdot.com．", FAIL),
-        # ("me@-leadingdash", FAIL),
-        # ("me@－leadingdashfw", FAIL),
-        # ("me@trailingdash-", FAIL),
-        # ("me@trailingdashfw－", FAIL),
-        # ("my@baddash.-.com", FAIL),
-        # ("my@baddash.-a.com", FAIL),
-        # ("my@baddash.b-.com", FAIL),
-        # ("my@baddashfw.－.com", FAIL),
-        # ("my@baddashfw.－a.com", FAIL),
-        # ("my@baddashfw.b－.com", FAIL),
-        # ("my@example.com\n", FAIL),
-        # ("my@example\n.com", FAIL),
-        # ("me@x!", FAIL),
-        # ("me@x ", FAIL),
-        # (".leadingdot@domain.com", FAIL),
-        # ("twodots..here@domain.com", FAIL),
-        # ("trailingdot.@domain.email", FAIL),
-        # ("me@⒈wouldbeinvalid.com", FAIL),
-        ("@example.com", FAIL),
-        # ("\nmy@example.com", FAIL),
-        ("m\ny@example.com", FAIL),
-        ("my\n@example.com", FAIL),
-        # ("11111111112222222222333333333344444444445555555555666666666677777@example.com", FAIL),
-        # ("111111111122222222223333333333444444444455555555556666666666777777@example.com", FAIL),
-        # ("me@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.111111111122222222223333333333444444444455555555556.com", FAIL),
-        # ("me@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555566.com", FAIL),
-        # ("me@中1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555566.com", FAIL),
-        # ("my.long.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.11111111112222222222333333333344444.info", FAIL),
-        # ("my.long.address@λ111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.11111111112222222222333333.info", FAIL),
-        # ("my.long.address@λ111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444.info", FAIL),
-        # ("my.λong.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.111111111122222222223333333333444.info", FAIL),
-        # ("my.λong.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444.info", FAIL),
-        # ("me@bad-tld-1", FAIL),
-        # ("me@bad.tld-2", FAIL),
-        # ("me@xn--0.tld", FAIL),
-        # ("me@yy--0.tld", FAIL),
-        # ("me@yy－－0.tld", FAIL),
+        *all_fails(
+            "my@localhost",
+            "my@.leadingdot.com",
+            "my@．leadingfwdot.com",
+            "my@twodots..com",
+            "my@twofwdots．．.com",
+            "my@trailingdot.com.",
+            "my@trailingfwdot.com．",
+            "me@-leadingdash",
+            "me@－leadingdashfw",
+            "me@trailingdash-",
+            "me@trailingdashfw－",
+            "my@baddash.-.com",
+            "my@baddash.-a.com",
+            "my@baddash.b-.com",
+            "my@baddashfw.－.com",
+            "my@baddashfw.－a.com",
+            "my@baddashfw.b－.com",
+            "my@example\n.com",
+            "me@x!",
+            "me@x ",
+            ".leadingdot@domain.com",
+            "twodots..here@domain.com",
+            "trailingdot.@domain.email",
+            "me@⒈wouldbeinvalid.com",
+            "@example.com",
+            "m\ny@example.com",
+            "my\n@example.com",
+            "11111111112222222222333333333344444444445555555555666666666677777@example.com",
+            "111111111122222222223333333333444444444455555555556666666666777777@example.com",
+            "me@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.111111111122222222223333333333444444444455555555556.com",
+            "me@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555566.com",
+            "me@中1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555566.com",
+            "my.long.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.11111111112222222222333333333344444.info",
+            "my.long.address@λ111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.11111111112222222222333333.info",
+            "my.long.address@λ111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444.info",
+            "my.λong.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.111111111122222222223333333333444.info",
+            "my.λong.address@1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444444444555555555.6666666666777777777788888888889999999999000000000.1111111111222222222233333333334444.info",
+            "me@bad-tld-1",
+            "me@bad.tld-2",
+            "me@xn--0.tld",
+            "me@yy--0.tld",
+            "me@yy－－0.tld",
+        )
     ]
     # fmt: on
 
@@ -1087,7 +1106,7 @@ class TestWebPath(BaseTest):
             ("https://example.com/folder", "/https://example.com/folder")
         ], reason="Should fail or scheme+domain removed"),
         # readonly
-        ("/overwrite", "/value", {"readonly": True, "current_value": "/value"}),
+        ("/overwrite", "/value", {"readonly": True, "default": "/value"}),
         # FIXME should path have forbidden_chars?
     ]
     # fmt: on
@@ -1111,21 +1130,17 @@ class TestUrl(BaseTest):
 
         *nones(None, "", output=""),
         ("http://some.org/folder/file.txt", "http://some.org/folder/file.txt"),
+        ('  https://www.example.com \n', 'https://www.example.com'),
         # readonly
-        ("https://overwrite.org", "https://example.org", {"readonly": True, "current_value": "https://example.org"}),
+        ("https://overwrite.org", "https://example.org", {"readonly": True, "default": "https://example.org"}),
         # rest is taken from https://github.com/pydantic/pydantic/blob/main/tests/test_networks.py
         # valid
         *unchanged(
             # Those are valid but not sure how they will output with pydantic
             'http://example.org',
-            'http://test',
-            'http://localhost',
             'https://example.org/whatever/next/',
             'https://example.org',
-            'http://localhost',
-            'http://localhost/',
-            'http://localhost:8000',
-            'http://localhost:8000/',
+
             'https://foo_bar.example.com/',
             'http://example.co.jp',
             'http://www.example.com/a%C2%B1b',
@@ -1149,29 +1164,31 @@ class TestUrl(BaseTest):
             'http://twitter.com/@handle/',
             'http://11.11.11.11.example.com/action',
             'http://abc.11.11.11.11.example.com/action',
-            'http://example#',
-            'http://example/#',
-            'http://example/#fragment',
-            'http://example/?#',
             'http://example.org/path#',
             'http://example.org/path#fragment',
             'http://example.org/path?query#',
             'http://example.org/path?query#fragment',
+            'https://foo_bar.example.com/',
+            'https://exam_ple.com/',
+            'HTTP://EXAMPLE.ORG',
+            'https://example.org',
+            'https://example.org?a=1&b=2',
+            'https://example.org#a=3;b=3',
+            'https://example.xn--p1ai',
+            'https://example.xn--vermgensberatung-pwb',
+            'https://example.xn--zfr164b',
         ),
-        # Pydantic default parsing add a final `/`
-        ('https://foo_bar.example.com/', 'https://foo_bar.example.com/'),
-        ('https://exam_ple.com/', 'https://exam_ple.com/'),
         *xfail(scenarios=[
-            ('  https://www.example.com \n', 'https://www.example.com/'),
-            ('HTTP://EXAMPLE.ORG', 'http://example.org/'),
-            ('https://example.org', 'https://example.org/'),
-            ('https://example.org?a=1&b=2', 'https://example.org/?a=1&b=2'),
-            ('https://example.org#a=3;b=3', 'https://example.org/#a=3;b=3'),
-            ('https://example.xn--p1ai', 'https://example.xn--p1ai/'),
-            ('https://example.xn--vermgensberatung-pwb', 'https://example.xn--vermgensberatung-pwb/'),
-            ('https://example.xn--zfr164b', 'https://example.xn--zfr164b/'),
-        ], reason="pydantic default behavior would append a final `/`"),
-
+            ('http://test', 'http://test'),
+            ('http://localhost', 'http://localhost'),
+            ('http://localhost/', 'http://localhost/'),
+            ('http://localhost:8000', 'http://localhost:8000'),
+            ('http://localhost:8000/', 'http://localhost:8000/'),
+            ('http://example#', 'http://example#'),
+            ('http://example/#', 'http://example/#'),
+            ('http://example/#fragment', 'http://example/#fragment'),
+            ('http://example/?#', 'http://example/?#'),
+        ], reason="Should this be valid?"),
         # invalid
         *all_fails(
             'ftp://example.com/',
@@ -1182,15 +1199,13 @@ class TestUrl(BaseTest):
             "/",
             "+http://example.com/",
             "ht*tp://example.com/",
+            "http:///",
+            "http://??",
+            "https://example.org more",
+            "http://2001:db8::ff00:42:8329",
+            "http://[192.168.1.1]:8329",
+            "http://example.com:99999",
         ),
-        *xpass(scenarios=[
-            ("http:///", "http:///"),
-            ("http://??", "http://??"),
-            ("https://example.org more", "https://example.org more"),
-            ("http://2001:db8::ff00:42:8329", "http://2001:db8::ff00:42:8329"),
-            ("http://[192.168.1.1]:8329", "http://[192.168.1.1]:8329"),
-            ("http://example.com:99999", "http://example.com:99999"),
-        ], reason="Should fail"),
     ]
     # fmt: on
 
@@ -1361,7 +1376,6 @@ class TestSelect(BaseTest):
             # [-1, 0, 1]
             "raw_options": [
                 {"choices": [-1, 0, 1, 10]},
-                {"choices": {-1: "verbose -one", 0: "verbose zero", 1: "verbose one", 10: "verbose ten"}},
             ],
             "scenarios": [
                 *nones(None, "", output=""),
@@ -1372,6 +1386,18 @@ class TestSelect(BaseTest):
                     ("1", 1),
                     ("10", 10),
                 ], reason="str -> int not handled"),
+                *all_fails("100", 100),
+            ]
+        },
+        {
+            "raw_options": [
+                {"choices": {-1: "verbose -one", 0: "verbose zero", 1: "verbose one", 10: "verbose ten"}},
+                {"choices": {"-1": "verbose -one", "0": "verbose zero", "1": "verbose one", "10": "verbose ten"}},
+            ],
+            "scenarios": [
+                *nones(None, "", output=""),
+                *all_fails(-1, 0, 1, 10),  # Should pass? converted to str?
+                *unchanged("-1", "0", "1", "10"),
                 *all_fails("100", 100),
             ]
         },
@@ -1402,7 +1428,7 @@ class TestSelect(BaseTest):
             ]
         },
         # readonly
-        ("one", "two", {"readonly": True, "choices": ["one", "two"], "current_value": "two"}),
+        ("one", "two", {"readonly": True, "choices": ["one", "two"], "default": "two"}),
     ]
     # fmt: on
 
@@ -1411,7 +1437,7 @@ class TestSelect(BaseTest):
 # │ TAGS                                                  │
 # ╰───────────────────────────────────────────────────────╯
 
-
+#  [], ["one"], {}
 class TestTags(BaseTest):
     raw_option = {"type": "tags", "id": "tags_id"}
     prefill = {
@@ -1420,12 +1446,7 @@ class TestTags(BaseTest):
     }
     # fmt: off
     scenarios = [
-        *nones(None, [], "", output=""),
-        # FIXME `","` could be considered a none value which kinda already is since it fail when required
-        (",", FAIL),
-        *xpass(scenarios=[
-            (",", ",", {"optional": True})
-        ], reason="Should output as `''`? ie: None"),
+        *nones(None, [], "", ",", output=""),
         {
             "raw_options": [
                 {},
@@ -1450,7 +1471,7 @@ class TestTags(BaseTest):
         *all_fails(*([t] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
         *all_fails(*([str(t)] for t in [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]), raw_option={"choices": [False, True, -1, 0, 1, 1337, 13.37, [], ["one"], {}]}),
         # readonly
-        ("one", "one,two", {"readonly": True, "choices": ["one", "two"], "current_value": "one,two"}),
+        ("one", "one,two", {"readonly": True, "choices": ["one", "two"], "default": "one,two"}),
     ]
     # fmt: on
 
@@ -1562,8 +1583,7 @@ class TestApp(BaseTest):
             ],
             "scenarios": [
                 # FIXME there are currently 3 different nones (`None`, `""` and `_none`), choose one?
-                *nones(None, output=None),  # FIXME Should return chosen none?
-                *nones("", output=""),  # FIXME Should return chosen none?
+                *nones(None, "", output=""),  # FIXME Should return chosen none?
                 *xpass(scenarios=[
                     ("_none", "_none"),
                     ("_none", "_none", {"default": "_none"}),
@@ -1586,7 +1606,7 @@ class TestApp(BaseTest):
                 (installed_webapp["id"], installed_webapp["id"], {"filter": "is_webapp"}),
                 (installed_webapp["id"], FAIL, {"filter": "is_webapp == false"}),
                 (installed_webapp["id"], FAIL, {"filter": "id != 'my_webapp'"}),
-                (None, None, {"filter": "id == 'fake_app'", "optional": True}),
+                (None, "", {"filter": "id == 'fake_app'", "optional": True}),
             ]
         },
         {
@@ -1787,7 +1807,7 @@ class TestGroup(BaseTest):
                     ("", "custom_group", {"default": "custom_group"}),
                 ], reason="Should throw 'default must be in (None, 'all_users', 'visitors', 'admins')"),
                 # readonly
-                ("admins", YunohostError, {"readonly": True}),  # readonly is forbidden
+                ("admins", "all_users", {"readonly": True}),  # readonly is forbidden (default is "all_users")
             ]
         },
     ]
@@ -1867,12 +1887,12 @@ def test_options_query_string():
         "string_id": "string",
         "text_id": "text\ntext",
         "password_id": "sUpRSCRT",
-        "color_id": "#ffff00",
+        "color_id": "#ff0",
         "number_id": 10,
         "boolean_id": 1,
         "date_id": "2030-03-06",
         "time_id": "20:55",
-        "email_id": "coucou@ynh.local",
+        "email_id": "coucou@ynh.org",
         "path_id": "/ynh-dev",
         "url_id": "https://yunohost.org",
         "file_id": file_content1,
@@ -1895,7 +1915,7 @@ def test_options_query_string():
             "&boolean_id=y"
             "&date_id=2030-03-06"
             "&time_id=20:55"
-            "&email_id=coucou@ynh.local"
+            "&email_id=coucou@ynh.org"
             "&path_id=ynh-dev/"
             "&url_id=https://yunohost.org"
             f"&file_id={file_repr}"

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -11,11 +11,11 @@ from typing import Any, Literal, Sequence, TypedDict, Union
 
 from _pytest.mark.structures import ParameterSet
 
-
 from moulinette import Moulinette
 from yunohost import app, domain, user
 from yunohost.utils.form import (
     OPTIONS,
+    FORBIDDEN_PASSWORD_CHARS,
     ask_questions_and_parse_answers,
     BaseChoicesOption,
     BaseInputOption,
@@ -378,8 +378,8 @@ def _fill_or_prompt_one_option(raw_option, intake):
     options = {id_: raw_option}
     answers = {id_: intake} if intake is not None else {}
 
-    option = ask_questions_and_parse_answers(options, answers)[0]
-    return (option, option.value if isinstance(option, BaseInputOption) else None)
+    options, form = ask_questions_and_parse_answers(options, answers)
+    return (options[0], form[id_] if isinstance(options[0], BaseInputOption) else None)
 
 
 def _test_value_is_expected_output(value, expected_output):
@@ -551,7 +551,7 @@ class TestDisplayText(BaseTest):
                     ask_questions_and_parse_answers({_id: raw_option}, answers)
             else:
                 with patch.object(sys, "stdout", new_callable=StringIO) as stdout:
-                    options = ask_questions_and_parse_answers(
+                    options, form = ask_questions_and_parse_answers(
                         {_id: raw_option}, answers
                     )
                     assert stdout.getvalue() == f"{options[0].ask['en']}\n"
@@ -604,7 +604,7 @@ class TestAlert(TestDisplayText):
                     )
             else:
                 with patch.object(sys, "stdout", new_callable=StringIO) as stdout:
-                    options = ask_questions_and_parse_answers(
+                    options, form = ask_questions_and_parse_answers(
                         {"display_text_id": raw_option}, answers
                     )
                     ask = options[0].ask["en"]
@@ -1912,9 +1912,7 @@ def test_options_query_string():
             "&fake_id=fake_value"
         )
 
-    def _assert_correct_values(options, raw_options):
-        form = {option.id: option.value for option in options}
-
+    def _assert_correct_values(options, form, raw_options):
         for k, v in results.items():
             if k == "file_id":
                 assert os.path.exists(form["file_id"]) and os.path.isfile(
@@ -1930,24 +1928,24 @@ def test_options_query_string():
 
     with patch_interface("api"), patch_file_api(file_content1) as b64content:
         with patch_query_string(b64content.decode("utf-8")) as query_string:
-            options = ask_questions_and_parse_answers(raw_options, query_string)
-            _assert_correct_values(options, raw_options)
+            options, form = ask_questions_and_parse_answers(raw_options, query_string)
+            _assert_correct_values(options, form, raw_options)
 
     with patch_interface("cli"), patch_file_cli(file_content1) as filepath:
         with patch_query_string(filepath) as query_string:
-            options = ask_questions_and_parse_answers(raw_options, query_string)
-            _assert_correct_values(options, raw_options)
+            options, form = ask_questions_and_parse_answers(raw_options, query_string)
+            _assert_correct_values(options, form, raw_options)
 
 
 def test_question_string_default_type():
     questions = {"some_string": {}}
     answers = {"some_string": "some_value"}
 
-    out = ask_questions_and_parse_answers(questions, answers)[0]
-
-    assert out.id == "some_string"
-    assert out.type == "string"
-    assert out.value == "some_value"
+    options, form = ask_questions_and_parse_answers(questions, answers)
+    option = options[0]
+    assert option.id == "some_string"
+    assert option.type == "string"
+    assert form[option.id] == "some_value"
 
 
 def test_option_default_type_with_choices_is_select():

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -26,6 +26,7 @@ from yunohost.utils.form import (
     FileOption,
     evaluate_simple_js_expression,
 )
+from yunohost.utils import form
 from yunohost.utils.error import YunohostError, YunohostValidationError
 
 
@@ -91,6 +92,12 @@ def patch_no_tty():
 @pytest.fixture
 def patch_with_tty():
     with patch_isatty(True):
+        yield
+
+
+@pytest.fixture
+def patch_cli_retries():
+    with patch.object(form, "MAX_RETRIES", 0):
         yield
 
 
@@ -405,6 +412,7 @@ def _test_intake_may_fail(raw_option, intake, expected_output):
         _test_intake(raw_option, intake, expected_output)
 
 
+@pytest.mark.usefixtures("patch_cli_retries")  # To avoid chain error logging
 class BaseTest:
     raw_option: dict[str, Any] = {}
     prefill: dict[Literal["raw_option", "prefill", "intake"], Any]

--- a/src/tests/test_questions.py
+++ b/src/tests/test_questions.py
@@ -1976,10 +1976,10 @@ def test_option_default_type_with_choices_is_select():
     }
     answers = {"some_choices": "a", "some_legacy": "a"}
 
-    options = ask_questions_and_parse_answers(questions, answers)
+    options, form = ask_questions_and_parse_answers(questions, answers)
     for option in options:
         assert option.type == "select"
-        assert option.value == "a"
+        assert form[option.id] == "a"
 
 
 @pytest.mark.skip  # we should do something with this example

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -363,7 +363,20 @@ class ConfigPanel:
         # Format result in 'classic' or 'export' mode
         self.config.translate()
         logger.debug(f"Formating result in '{mode}' mode")
+
+        if mode == "full":
+            result = self.config.dict(exclude_none=True)
+
+            for panel in result["panels"]:
+                for section in panel["sections"]:
+                    for opt in section["options"]:
+                        instance = self.config.get_option(opt["id"])
+                        if isinstance(instance, BaseInputOption):
+                            opt["value"] = instance.normalize(self.form[opt["id"]], instance)
+            return result
+
         result = OrderedDict()
+
         for panel in self.config.panels:
             for section in panel.sections:
                 if section.is_action_section and mode != "full":
@@ -388,10 +401,7 @@ class ConfigPanel:
                                     "value"
                                 ] = "**************"  # Prevent displaying password in `config get`
 
-        if mode == "full":
-            return self.config.dict(exclude_none=True)
-        else:
-            return result
+        return result
 
     def set(
         self,

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -31,6 +31,7 @@ from moulinette.utils.filesystem import mkdir, read_toml, read_yaml, write_to_ya
 from moulinette.utils.log import getActionLogger
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.form import (
+    AnyOption,
     BaseInputOption,
     BaseOption,
     BaseReadonlyOption,
@@ -190,6 +191,13 @@ class ConfigPanelModel(BaseModel):
             for option in section.options:
                 yield option
 
+    def get_option(self, option_id) -> Union[AnyOption, None]:
+        for option in self.options:
+            if option.id == option_id:
+                return option
+        # FIXME raise error?
+        return None
+
 
     def iter_children(
         self,
@@ -236,6 +244,7 @@ if TYPE_CHECKING:
     FilterKey = Sequence[Union[str, None]]
     RawConfig = OrderedDict[str, Any]
     RawSettings = dict[str, Any]
+    ConfigPanelGetMode = Literal["classic", "full", "export"]
 
 
 def parse_filter_key(key: Union[str, None] = None) -> "FilterKey":
@@ -310,74 +319,59 @@ class ConfigPanel:
             and re.match("^(validate|post_ask)__", func)
         }
 
-    def get(self, key="", mode="classic"):
-        self.filter_key = key or ""
+    def get(
+        self, key: Union[str, None] = None, mode: "ConfigPanelGetMode" = "classic"
+    ) -> Any:
+        self.filter_key = parse_filter_key(key)
+        self.config, self.form = self._get_config_panel(prevalidate=False)
 
-        # Read config panel toml
-        self._get_config_panel()
-
-        if not self.config:
-            raise YunohostValidationError("config_no_panel")
-
-        # Read or get values and hydrate the config
-        self._get_raw_settings()
-        self._hydrate()
+        panel_id, section_id, option_id = self.filter_key
 
         # In 'classic' mode, we display the current value if key refer to an option
-        if self.filter_key.count(".") == 2 and mode == "classic":
-            option = self.filter_key.split(".")[-1]
-            value = self.values.get(option, None)
+        if option_id and mode == "classic":
+            option = self.config.get_option(option_id)
 
-            option_type = None
-            for _, _, option_ in self._iterate():
-                if option_["id"] == option:
-                    option_type = OPTIONS[option_["type"]]
-                    break
+            if option is None:
+                # FIXME i18n
+                raise YunohostValidationError(
+                    f"Couldn't find any option with id {option_id}"
+                )
 
-            return option_type.normalize(value) if option_type else value
+            if isinstance(option, BaseReadonlyOption):
+                return None
+
+            return self.form[option_id]
 
         # Format result in 'classic' or 'export' mode
+        self.config.translate()
         logger.debug(f"Formating result in '{mode}' mode")
-        result = {}
-        for panel, section, option in self._iterate():
-            if section["is_action_section"] and mode != "full":
-                continue
+        result = OrderedDict()
+        for panel in self.config.panels:
+            for section in panel.sections:
+                if section.is_action_section and mode != "full":
+                    continue
 
-            key = f"{panel['id']}.{section['id']}.{option['id']}"
-            if mode == "export":
-                result[option["id"]] = option.get("current_value")
-                continue
+                for option in section.options:
+                    if mode == "export":
+                        if isinstance(option, BaseInputOption):
+                            result[option.id] = self.form[option.id]
+                        continue
 
-            ask = None
-            if "ask" in option:
-                ask = _value_for_locale(option["ask"])
-            elif "i18n" in self.config:
-                ask = m18n.n(self.config["i18n"] + "_" + option["id"])
+                    if mode == "classic":
+                        key = f"{panel.id}.{section.id}.{option.id}"
+                        result[key] = {"ask": option.ask}
 
-            if mode == "full":
-                option["ask"] = ask
-                question_class = OPTIONS[option.get("type", OptionType.string)]
-                # FIXME : maybe other properties should be taken from the question, not just choices ?.
-                if issubclass(question_class, BaseChoicesOption):
-                    option["choices"] = question_class(option).choices
-                if issubclass(question_class, BaseInputOption):
-                    option["default"] = question_class(option).default
-                    option["pattern"] = question_class(option).pattern
-            else:
-                result[key] = {"ask": ask}
-                if "current_value" in option:
-                    question_class = OPTIONS[option.get("type", OptionType.string)]
-                    result[key]["value"] = question_class.humanize(
-                        option["current_value"], option
-                    )
-                    # FIXME: semantics, technically here this is not about a prompt...
-                    if question_class.hide_user_input_in_prompt:
-                        result[key][
-                            "value"
-                        ] = "**************"  # Prevent displaying password in `config get`
+                        if isinstance(option, BaseInputOption):
+                            result[key]["value"] = option.humanize(
+                                self.form[option.id], option
+                            )
+                            if option.type is OptionType.password:
+                                result[key][
+                                    "value"
+                                ] = "**************"  # Prevent displaying password in `config get`
 
         if mode == "full":
-            return self.config
+            return self.config.dict(exclude_none=True)
         else:
             return result
 

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -450,31 +450,6 @@ class ConfigPanel:
                 "config_unknown_filter_key", filter_key=self.filter_key
             )
 
-        # List forbidden keywords from helpers and sections toml (to avoid conflict)
-        forbidden_keywords = [
-            "old",
-            "app",
-            "changed",
-            "file_hash",
-            "binds",
-            "types",
-            "formats",
-            "getter",
-            "setter",
-            "short_setting",
-            "type",
-            "bind",
-            "nothing_changed",
-            "changes_validated",
-            "result",
-            "max_progression",
-        ]
-        forbidden_keywords += format_description["sections"]
-
-        for _, _, option in self._iterate():
-            if option["id"] in forbidden_keywords:
-                raise YunohostError("config_forbidden_keyword", keyword=option["id"])
-
         return self.config
 
     def _get_default_values(self):

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -31,15 +31,16 @@ from moulinette.utils.filesystem import mkdir, read_toml, read_yaml, write_to_ya
 from moulinette.utils.log import getActionLogger
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.form import (
-    OPTIONS,
     BaseInputOption,
     BaseOption,
     BaseReadonlyOption,
     FileOption,
+    FormModel,
     OptionsModel,
     OptionType,
     Translation,
     ask_questions_and_parse_answers,
+    build_form,
     evaluate_simple_js_expression,
 )
 from yunohost.utils.i18n import _value_for_locale
@@ -93,7 +94,7 @@ class SectionModel(ContainerModel, OptionsModel):
         visible: Union[bool, str] = True,
         **kwargs,
     ) -> None:
-        options = self.options_dict_to_list(kwargs, defaults={"optional": True})
+        options = self.options_dict_to_list(kwargs, optional=True)
 
         ContainerModel.__init__(
             self,
@@ -231,12 +232,33 @@ class ConfigPanelModel(BaseModel):
 # │  ╰─╴╰─╯╵╰╯╵  ╶┴╴╰─╯   ╶┴╴╵╵╵╵  ╰─╴                    │
 # ╰───────────────────────────────────────────────────────╯
 
+if TYPE_CHECKING:
+    FilterKey = Sequence[Union[str, None]]
+    RawConfig = OrderedDict[str, Any]
+    RawSettings = dict[str, Any]
+
+
+def parse_filter_key(key: Union[str, None] = None) -> "FilterKey":
+    if key and key.count(".") > 2:
+        raise YunohostError(
+            f"The filter key {key} has too many sub-levels, the max is 3.",
+            raw_msg=True,
+        )
+
+    if not key:
+        return (None, None, None)
+    keys = key.split(".")
+    return tuple(keys[i] if len(keys) > i else None for i in range(3))
+
 
 class ConfigPanel:
     entity_type = "config"
     save_path_tpl: Union[str, None] = None
     config_path_tpl = "/usr/share/yunohost/config_{entity_type}.toml"
     save_mode = "full"
+    filter_key: "FilterKey" = (None, None, None)
+    config: Union[ConfigPanelModel, None] = None
+    form: Union[FormModel, None] = None
 
     @classmethod
     def list(cls):
@@ -265,9 +287,6 @@ class ConfigPanel:
         self.save_path = save_path
         if not save_path and self.save_path_tpl:
             self.save_path = self.save_path_tpl.format(entity=entity)
-        self.config = {}
-        self.values = {}
-        self.new_values = {}
 
         if (
             self.save_path
@@ -497,214 +516,103 @@ class ConfigPanel:
         logger.success(f"Action {action_id} successful")
         operation_logger.success()
 
-    def _get_raw_config(self):
+    def _get_raw_config(self) -> "RawConfig":
+        if not os.path.exists(self.config_path):
+            raise YunohostValidationError("config_no_panel")
+
         return read_toml(self.config_path)
 
-    def _get_config_panel(self):
-        # Split filter_key
-        filter_key = self.filter_key.split(".") if self.filter_key != "" else []
-        if len(filter_key) > 3:
-            raise YunohostError(
-                f"The filter key {filter_key} has too many sub-levels, the max is 3.",
-                raw_msg=True,
+    def _get_raw_settings(self, config: ConfigPanelModel) -> "RawSettings":
+        if not self.save_path or not os.path.exists(self.save_path):
+            raise YunohostValidationError("config_no_settings")
+
+        return read_yaml(self.save_path)
+
+    def _get_partial_raw_config(self) -> "RawConfig":
+        def filter_keys(
+            data: "RawConfig",
+            key: str,
+            model: Union[Type[ConfigPanelModel], Type[PanelModel], Type[SectionModel]],
+        ) -> "RawConfig":
+            # filter in keys defined in model, filter out panels/sections/options that aren't `key`
+            return OrderedDict(
+                {k: v for k, v in data.items() if k in model.__fields__ or k == key}
             )
 
-        if not os.path.exists(self.config_path):
-            logger.debug(f"Config panel {self.config_path} doesn't exists")
-            return None
+        raw_config = self._get_raw_config()
 
-        toml_config_panel = self._get_raw_config()
+        panel_id, section_id, option_id = self.filter_key
+        if panel_id:
+            raw_config = filter_keys(raw_config, panel_id, ConfigPanelModel)
 
-        # Check TOML config panel is in a supported version
-        if float(toml_config_panel["version"]) < CONFIG_PANEL_VERSION_SUPPORTED:
-            logger.error(
-                f"Config panels version {toml_config_panel['version']} are not supported"
-            )
-            return None
+            if section_id:
+                raw_config[panel_id] = filter_keys(
+                    raw_config[panel_id], section_id, PanelModel
+                )
 
-        # Transform toml format into internal format
-        format_description = {
-            "root": {
-                "properties": ["version", "i18n"],
-                "defaults": {"version": 1.0},
-            },
-            "panels": {
-                "properties": ["name", "services", "actions", "help"],
-                "defaults": {
-                    "services": [],
-                    "actions": {"apply": {"en": "Apply"}},
-                },
-            },
-            "sections": {
-                "properties": ["name", "services", "optional", "help", "visible"],
-                "defaults": {
-                    "name": "",
-                    "services": [],
-                    "optional": True,
-                    "is_action_section": False,
-                },
-            },
-            "options": {
-                "properties": [
-                    "ask",
-                    "type",
-                    "bind",
-                    "help",
-                    "example",
-                    "default",
-                    "style",
-                    "icon",
-                    "placeholder",
-                    "visible",
-                    "optional",
-                    "choices",
-                    "yes",
-                    "no",
-                    "pattern",
-                    "limit",
-                    "min",
-                    "max",
-                    "step",
-                    "accept",
-                    "redact",
-                    "filter",
-                    "readonly",
-                    "enabled",
-                    # "confirm", # TODO: to ask confirmation before running an action
-                ],
-                "defaults": {},
-            },
-        }
-
-        def _build_internal_config_panel(raw_infos, level):
-            """Convert TOML in internal format ('full' mode used by webadmin)
-            Here are some properties of 1.0 config panel in toml:
-            - node properties and node children are mixed,
-            - text are in english only
-            - some properties have default values
-            This function detects all children nodes and put them in a list
-            """
-
-            defaults = format_description[level]["defaults"]
-            properties = format_description[level]["properties"]
-
-            # Start building the ouput (merging the raw infos + defaults)
-            out = {key: raw_infos.get(key, value) for key, value in defaults.items()}
-
-            # Now fill the sublevels (+ apply filter_key)
-            i = list(format_description).index(level)
-            sublevel = list(format_description)[i + 1] if level != "options" else None
-            search_key = filter_key[i] if len(filter_key) > i else False
-
-            for key, value in raw_infos.items():
-                # Key/value are a child node
-                if (
-                    isinstance(value, OrderedDict)
-                    and key not in properties
-                    and sublevel
-                ):
-                    # We exclude all nodes not referenced by the filter_key
-                    if search_key and key != search_key:
-                        continue
-                    subnode = _build_internal_config_panel(value, sublevel)
-                    subnode["id"] = key
-                    if level == "root":
-                        subnode.setdefault("name", {"en": key.capitalize()})
-                    elif level == "sections":
-                        subnode["name"] = key  # legacy
-                        subnode.setdefault("optional", raw_infos.get("optional", True))
-                        # If this section contains at least one button, it becomes an "action" section
-                        if subnode.get("type") == OptionType.button:
-                            out["is_action_section"] = True
-                    out.setdefault(sublevel, []).append(subnode)
-                # Key/value are a property
-                else:
-                    if key not in properties:
-                        logger.warning(f"Unknown key '{key}' found in config panel")
-                    # Todo search all i18n keys
-                    out[key] = (
-                        value
-                        if key not in ["ask", "help", "name"] or isinstance(value, dict)
-                        else {"en": value}
+                if option_id:
+                    raw_config[panel_id][section_id] = filter_keys(
+                        raw_config[panel_id][section_id], option_id, SectionModel
                     )
-            return out
 
-        self.config = _build_internal_config_panel(toml_config_panel, "root")
+        return raw_config
+
+    def _get_partial_raw_settings_and_mutate_config(
+        self, config: ConfigPanelModel
+    ) -> tuple[ConfigPanelModel, "RawSettings"]:
+        raw_settings = self._get_raw_settings(config)
+        values = {}
+
+        for _, section, option in config.iter_children():
+            value = data = raw_settings.get(option.id, getattr(option, "default", None))
+
+            if isinstance(data, dict):
+                # Settings data if gathered from bash "ynh_app_config_show"
+                # may be a custom getter that returns a dict with `value` or `current_value`
+                # and other attributes meant to override those of the option.
+
+                if "value" in data:
+                    value = data.pop("value")
+
+                # Allow to use value instead of current_value in app config script.
+                # e.g. apps may write `echo 'value: "foobar"'` in the config file (which is more intuitive that `echo 'current_value: "foobar"'`
+                # For example hotspot used it...
+                # See https://github.com/YunoHost/yunohost/pull/1546
+                # FIXME do we still need the `current_value`?
+                if "current_value" in data:
+                    value = data.pop("current_value")
+
+                # Mutate other possible option attributes
+                for k, v in data.items():
+                    setattr(option, k, v)
+
+            if isinstance(option, BaseInputOption):  # or option.bind == "null":
+                values[option.id] = value
+
+        return (config, values)
+
+    def _get_config_panel(
+        self, prevalidate: bool = False
+    ) -> tuple[ConfigPanelModel, FormModel]:
+        raw_config = self._get_partial_raw_config()
+        config = ConfigPanelModel(**raw_config)
+        config, raw_settings = self._get_partial_raw_settings_and_mutate_config(config)
+        config.translate()
+        Settings = build_form(config.options)
+        settings = (
+            Settings(**raw_settings)
+            if prevalidate
+            else Settings.construct(**raw_settings)
+        )
 
         try:
-            self.config["panels"][0]["sections"][0]["options"][0]
+            config.panels[0].sections[0].options[0]
         except (KeyError, IndexError):
             raise YunohostValidationError(
                 "config_unknown_filter_key", filter_key=self.filter_key
             )
 
-        return self.config
-
-    def _get_default_values(self):
-        return {
-            option["id"]: option["default"]
-            for _, _, option in self._iterate()
-            if "default" in option
-        }
-
-    def _get_raw_settings(self):
-        """
-        Retrieve entries in YAML file
-        And set default values if needed
-        """
-
-        # Inject defaults if needed (using the magic .update() ;))
-        self.values = self._get_default_values()
-
-        # Retrieve entries in the YAML
-        if os.path.exists(self.save_path) and os.path.isfile(self.save_path):
-            self.values.update(read_yaml(self.save_path) or {})
-
-    def _hydrate(self):
-        # Hydrating config panel with current value
-        for _, section, option in self._iterate():
-            if option["id"] not in self.values:
-                allowed_empty_types = {
-                    OptionType.alert,
-                    OptionType.display_text,
-                    OptionType.markdown,
-                    OptionType.file,
-                    OptionType.button,
-                }
-
-                if section["is_action_section"] and option.get("default") is not None:
-                    self.values[option["id"]] = option["default"]
-                elif (
-                    option["type"] in allowed_empty_types
-                    or option.get("bind") == "null"
-                ):
-                    continue
-                else:
-                    raise YunohostError(
-                        f"Config panel question '{option['id']}' should be initialized with a value during install or upgrade.",
-                        raw_msg=True,
-                    )
-            value = self.values[option["id"]]
-
-            # Allow to use value instead of current_value in app config script.
-            # e.g. apps may write `echo 'value: "foobar"'` in the config file (which is more intuitive that `echo 'current_value: "foobar"'`
-            # For example hotspot used it...
-            # See https://github.com/YunoHost/yunohost/pull/1546
-            if (
-                isinstance(value, dict)
-                and "value" in value
-                and "current_value" not in value
-            ):
-                value["current_value"] = value["value"]
-
-            # In general, the value is just a simple value.
-            # Sometimes it could be a dict used to overwrite the option itself
-            value = value if isinstance(value, dict) else {"current_value": value}
-            option.update(value)
-
-            self.values[option["id"]] = value.get("current_value")
-
-        return self.values
+        return (config, settings)
 
     def _ask(self, action=None):
         logger.debug("Ask unanswered question and prevalidate data")
@@ -776,19 +684,6 @@ class ConfigPanel:
                 }
             )
 
-    @property
-    def future_values(self):
-        return {**self.values, **self.new_values}
-
-    def __getattr__(self, name):
-        if "new_values" in self.__dict__ and name in self.new_values:
-            return self.new_values[name]
-
-        if "values" in self.__dict__ and name in self.values:
-            return self.values[name]
-
-        return self.__dict__[name]
-
     def _parse_pre_answered(self, args, value, args_file):
         args = urllib.parse.parse_qs(args or "", keep_blank_values=True)
         self.args = {key: ",".join(value_) for key, value_ in args.items()}
@@ -831,14 +726,3 @@ class ConfigPanel:
             if hasattr(self, "entity"):
                 service = service.replace("__APP__", self.entity)
             service_reload_or_restart(service)
-
-    def _iterate(self, trigger=["option"]):
-        for panel in self.config.get("panels", []):
-            if "panel" in trigger:
-                yield (panel, None, panel)
-            for section in panel.get("sections", []):
-                if "section" in trigger:
-                    yield (panel, section, section)
-                if "option" in trigger:
-                    for option in section.get("options", []):
-                        yield (panel, section, option)

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -20,7 +20,7 @@ import glob
 import os
 import re
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, Union, cast
 
 from pydantic import BaseModel, Extra, validator
 
@@ -100,7 +100,9 @@ class SectionModel(ContainerModel, OptionsModel):
         **kwargs,
     ) -> None:
         options = self.options_dict_to_list(kwargs, optional=optional)
-        is_action_section = any([option["type"] == OptionType.button for option in options])
+        is_action_section = any(
+            [option["type"] == OptionType.button for option in options]
+        )
         ContainerModel.__init__(
             self,
             id=id,
@@ -370,7 +372,9 @@ class ConfigPanel:
                     for opt in section["options"]:
                         instance = self.config.get_option(opt["id"])
                         if isinstance(instance, BaseInputOption):
-                            opt["value"] = instance.normalize(self.form[opt["id"]], instance)
+                            opt["value"] = instance.normalize(
+                                self.form[opt["id"]], instance
+                            )
             return result
 
         result = OrderedDict()
@@ -381,6 +385,9 @@ class ConfigPanel:
                     continue
 
                 for option in section.options:
+                    # FIXME not sure why option resolves as possibly `None`
+                    option = cast(AnyOption, option)
+
                     if mode == "export":
                         if isinstance(option, BaseInputOption):
                             result[option.id] = self.form[option.id]

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
     from yunohost.utils.form import FormModel, Hooks
+    from yunohost.log import OperationLogger
 
 logger = getActionLogger("yunohost.configpanel")
 
@@ -390,15 +391,15 @@ class ConfigPanel:
             return result
 
     def set(
-        self, key=None, value=None, args=None, args_file=None, operation_logger=None
+        self,
+        key: Union[str, None] = None,
+        value: Any = None,
+        args: Union[str, None] = None,
+        args_file: Union[str, None] = None,
+        operation_logger: Union["OperationLogger", None] = None,
     ):
-        self.filter_key = key or ""
-
-        # Read config panel toml
-        self._get_config_panel()
-
-        if not self.config:
-            raise YunohostValidationError("config_no_panel")
+        self.filter_key = parse_filter_key(key)
+        panel_id, section_id, option_id = self.filter_key
 
         if (args is not None or args_file is not None) and value is not None:
             raise YunohostValidationError(
@@ -406,27 +407,35 @@ class ConfigPanel:
                 raw_msg=True,
             )
 
-        if self.filter_key.count(".") != 2 and value is not None:
+        if not option_id and value is not None:
             raise YunohostValidationError("config_cant_set_value_on_section")
 
         # Import and parse pre-answered options
         logger.debug("Import and parse pre-answered options")
         if option_id and value is not None:
-            self.args = {option_id: value}
+            prefilled_answers = {option_id: value}
         else:
-            self.args = parse_prefilled_values(args, value, args_file)
+            prefilled_answers = parse_prefilled_values(args, args_file)
 
-        # Read or get values and hydrate the config
-        self._get_raw_settings()
-        self._hydrate()
-        BaseOption.operation_logger = operation_logger
-        self._ask()
+        self.config, self.form = self._get_config_panel()
+        # FIXME find a better way to exclude previous settings
+        previous_settings = self.form.dict()
+
+        # FIXME Not sure if this is need (redact call to operation logger does it on all the instances)
+        # BaseOption.operation_logger = operation_logger
+
+        self.form = self._ask(
+            self.config,
+            self.form,
+            prefilled_answers=prefilled_answers,
+            hooks=self.hooks,
+        )
 
         if operation_logger:
             operation_logger.start()
 
         try:
-            self._apply()
+            self._apply(self.form, previous_settings)
         except YunohostError:
             raise
         # Script got manually interrupted ...
@@ -452,7 +461,9 @@ class ConfigPanel:
         self._reload_services()
 
         logger.success("Config updated as expected")
-        operation_logger.success()
+
+        if operation_logger:
+            operation_logger.success()
 
     def list_actions(self):
         actions = {}
@@ -625,7 +636,7 @@ class ConfigPanel:
 
         return (config, settings)
 
-    def ask(
+    def _ask(
         self,
         config: ConfigPanelModel,
         settings: "FormModel",

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -47,6 +47,7 @@ from yunohost.utils.i18n import _value_for_locale
 
 if TYPE_CHECKING:
     from pydantic.fields import ModelField
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
     from yunohost.utils.form import FormModel, Hooks
 
@@ -681,21 +682,30 @@ class ConfigPanel:
 
         return settings
 
-    def _apply(self):
+    def _apply(
+        self,
+        form: "FormModel",
+        previous_settings: dict[str, Any],
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+    ) -> dict[str, Any]:
+        """
+        Save settings in yaml file.
+        If `save_mode` is `"diff"` (which is the default), only values that are
+        different from their default value will be saved.
+        """
         logger.info("Saving the new configuration...")
+
         dir_path = os.path.dirname(os.path.realpath(self.save_path))
         if not os.path.exists(dir_path):
             mkdir(dir_path, mode=0o700)
 
-        values_to_save = self.future_values
-        if self.save_mode == "diff":
-            defaults = self._get_default_values()
-            values_to_save = {
-                k: v for k, v in values_to_save.items() if defaults.get(k) != v
-            }
+        exclude_defaults = self.save_mode == "diff"
+        settings = form.dict(exclude_defaults=exclude_defaults, exclude=exclude)  # type: ignore
 
         # Save the settings to the .yaml file
-        write_to_yaml(self.save_path, values_to_save)
+        write_to_yaml(self.save_path, settings)
+
+        return settings
 
     def _reload_services(self):
         from yunohost.service import service_reload_or_restart

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -355,7 +355,7 @@ class ConfigPanel:
             if isinstance(option, BaseReadonlyOption):
                 return None
 
-            return self.form[option_id]
+            return option.normalize(self.form[option_id], option)
 
         # Format result in 'classic' or 'export' mode
         self.config.translate()

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -86,6 +86,7 @@ class ContainerModel(BaseModel):
 class SectionModel(ContainerModel, OptionsModel):
     visible: Union[bool, str] = True
     optional: bool = True
+    is_action_section: bool = False
 
     # Don't forget to pass arguments to super init
     def __init__(
@@ -99,7 +100,7 @@ class SectionModel(ContainerModel, OptionsModel):
         **kwargs,
     ) -> None:
         options = self.options_dict_to_list(kwargs, optional=optional)
-
+        is_action_section = any([option["type"] == OptionType.button for option in options])
         ContainerModel.__init__(
             self,
             id=id,
@@ -108,11 +109,8 @@ class SectionModel(ContainerModel, OptionsModel):
             help=help,
             visible=visible,
             options=options,
+            is_action_section=is_action_section,
         )
-
-    @property
-    def is_action_section(self) -> bool:
-        return any([option.type is OptionType.button for option in self.options])
 
     def is_visible(self, context: dict[str, Any]) -> bool:
         if isinstance(self.visible, bool):

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -43,6 +43,7 @@ from yunohost.utils.form import (
     ask_questions_and_parse_answers,
     build_form,
     evaluate_simple_js_expression,
+    parse_prefilled_values,
 )
 from yunohost.utils.i18n import _value_for_locale
 
@@ -397,7 +398,10 @@ class ConfigPanel:
 
         # Import and parse pre-answered options
         logger.debug("Import and parse pre-answered options")
-        self._parse_pre_answered(args, value, args_file)
+        if option_id and value is not None:
+            self.args = {option_id: value}
+        else:
+            self.args = parse_prefilled_values(args, value, args_file)
 
         # Read or get values and hydrate the config
         self._get_raw_settings()
@@ -468,7 +472,7 @@ class ConfigPanel:
 
         # Import and parse pre-answered options
         logger.debug("Import and parse pre-answered options")
-        self._parse_pre_answered(args, None, args_file)
+        self.args = parse_prefilled_values(args, args_file)
 
         # Read or get values and hydrate the config
         self._get_raw_settings()
@@ -677,17 +681,6 @@ class ConfigPanel:
                     if question.value is not None
                 }
             )
-
-    def _parse_pre_answered(self, args, value, args_file):
-        args = urllib.parse.parse_qs(args or "", keep_blank_values=True)
-        self.args = {key: ",".join(value_) for key, value_ in args.items()}
-
-        if args_file:
-            # Import YAML / JSON file but keep --args values
-            self.args = {**read_yaml(args_file), **self.args}
-
-        if value is not None:
-            self.args = {self.filter_key.split(".")[-1]: value}
 
     def _apply(self):
         logger.info("Saving the new configuration...")

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -601,6 +601,17 @@ class ConfigPanel:
         for _, section, option in config.iter_children():
             value = data = raw_settings.get(option.id, getattr(option, "default", None))
 
+            if isinstance(option, BaseInputOption) and option.id not in raw_settings:
+                if option.default is not None:
+                    value = option.default
+                elif option.type is OptionType.file or option.bind == "null":
+                    continue
+                else:
+                    raise YunohostError(
+                        f"Config panel question '{option.id}' should be initialized with a value during install or upgrade.",
+                        raw_msg=True,
+                    )
+
             if isinstance(data, dict):
                 # Settings data if gathered from bash "ynh_app_config_show"
                 # may be a custom getter that returns a dict with `value` or `current_value`

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -470,12 +470,12 @@ class ConfigPanel:
 
         # FIXME : meh, loading the entire config panel is again going to cause
         # stupid issues for domain (e.g loading registrar stuff when willing to just list available actions ...)
-        self.filter_key = ""
-        self._get_config_panel()
-        for panel, section, option in self._iterate():
-            if option["type"] == OptionType.button:
-                key = f"{panel['id']}.{section['id']}.{option['id']}"
-                actions[key] = _value_for_locale(option["ask"])
+        self.config, self.form = self._get_config_panel()
+
+        for panel, section, option in self.config.iter_children():
+            if option.type == OptionType.button:
+                key = f"{panel.id}.{section.id}.{option.id}"
+                actions[key] = _value_for_locale(option.ask)
 
         return actions
 

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -95,9 +95,10 @@ class SectionModel(ContainerModel, OptionsModel):
         services: list[str] = [],
         help: Union[Translation, None] = None,
         visible: Union[bool, str] = True,
+        optional: bool = True,
         **kwargs,
     ) -> None:
-        options = self.options_dict_to_list(kwargs, optional=True)
+        options = self.options_dict_to_list(kwargs, optional=optional)
 
         ContainerModel.__init__(
             self,

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1305,7 +1305,10 @@ class OptionsModel(BaseModel):
         for id_, data in options.items():
             option = data | {
                 "id": data.get("id", id_),
-                "type": data.get("type", OptionType.select if "choices" in data else OptionType.string),
+                "type": data.get(
+                    "type",
+                    OptionType.select if "choices" in data else OptionType.string,
+                ),
                 "optional": data.get("optional", optional),
             }
 
@@ -1407,22 +1410,6 @@ def build_form(
             **options_as_fields,
         ),
     )
-
-
-def hydrate_option_type(raw_option: dict[str, Any]) -> dict[str, Any]:
-    type_ = raw_option.get(
-        "type", OptionType.select if "choices" in raw_option else OptionType.string
-    )
-    # LEGACY (`choices` in option `string` used to be valid)
-    if "choices" in raw_option and type_ == OptionType.string:
-        logger.warning(
-            f"Packagers: option {raw_option['id']} has 'choices' but has type 'string', use 'select' instead to remove this warning."
-        )
-        type_ = OptionType.select
-
-    raw_option["type"] = type_
-
-    return raw_option
 
 
 # ╭───────────────────────────────────────────────────────╮

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1532,7 +1532,11 @@ def prompt_or_validate_form(
             except (ValidationError, YunohostValidationError) as e:
                 # If in interactive cli, re-ask the current question
                 if i < MAX_RETRIES and interactive:
-                    logger.error(str(e))
+                    logger.error(
+                        "\n".join([err["msg"] for err in e.errors()])
+                        if isinstance(e, ValidationError)
+                        else str(e)
+                    )
                     value = None
                     continue
 
@@ -1622,8 +1626,7 @@ def parse_raw_options(
         model = OptionsModel(**raw_options)
     except ValidationError as e:
         error = "\n".join([err["msg"] for err in e.errors()])
-        # FIXME use YunohostError instead since it is not really a user mistake?
-        raise YunohostValidationError(error, raw_msg=True)
+        raise YunohostError(error, raw_msg=True)
 
     model.translate_options()
 

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1281,12 +1281,14 @@ class OptionsModel(BaseModel):
     options: list[Annotated[AnyOption, Field(discriminator="type")]]
 
     @staticmethod
-    def options_dict_to_list(options: dict[str, Any], defaults: dict[str, Any] = {}):
+    def options_dict_to_list(options: dict[str, Any], optional: bool = False):
         return [
             option
             | {
                 "id": id_,
                 "type": option.get("type", "string"),
+                # ConfigPanel options needs to be set as optional by default
+                "optional": option.get("optional", optional)
             }
             for id_, option in options.items()
         ]

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1459,6 +1459,9 @@ def parse_prefilled_values(
     return values
 
 
+MAX_RETRIES = 4
+
+
 def prompt_or_validate_form(
     options: list[AnyOption],
     form: FormModel,
@@ -1538,7 +1541,7 @@ def prompt_or_validate_form(
                 context[option.id] = form[option.id]
             except (ValidationError, YunohostValidationError) as e:
                 # If in interactive cli, re-ask the current question
-                if i < 4 and interactive:
+                if i < MAX_RETRIES and interactive:
                     logger.error(str(e))
                     value = None
                     continue

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -265,7 +265,26 @@ FORBIDDEN_READONLY_TYPES = {
     OptionType.user,
     OptionType.group,
 }
-
+FORBIDDEN_KEYWORDS = {
+    "old",
+    "app",
+    "changed",
+    "file_hash",
+    "binds",
+    "types",
+    "formats",
+    "getter",
+    "setter",
+    "short_setting",
+    "type",
+    "bind",
+    "nothing_changed",
+    "changes_validated",
+    "result",
+    "max_progression",
+    "properties",
+    "defaults",
+}
 
 Context = dict[str, Any]
 Translation = Union[dict[str, str], str]
@@ -297,6 +316,12 @@ class BaseOption(BaseModel):
             # FIXME Do proper doctstring for Options
             del schema["description"]
             schema["additionalProperties"] = False
+
+    @validator("id", pre=True)
+    def check_id_is_not_forbidden(cls, value: str) -> str:
+        if value in FORBIDDEN_KEYWORDS:
+            raise ValueError(m18n.n("config_forbidden_keyword", keyword=value))
+        return value
 
     # FIXME Legacy, is `name` still needed?
     @validator("name", pre=True, always=True)

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1488,7 +1488,7 @@ def prompt_or_validate_form(
                 # - we doesn't want to give a specific value
                 # - we want to keep the previous value
                 # - we want the default value
-                context[option.id] = form[option.id] = None
+                context[option.id] = None
 
             continue
 

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -285,6 +285,7 @@ class BaseOption(BaseModel):
     readonly: bool = False
     visible: Union[JSExpression, bool] = True
     bind: Union[str, None] = None
+    name: Union[str, None] = None  # LEGACY (replaced by `id`)
 
     class Config:
         arbitrary_types_allowed = True
@@ -297,6 +298,12 @@ class BaseOption(BaseModel):
             del schema["description"]
             schema["additionalProperties"] = False
 
+    # FIXME Legacy, is `name` still needed?
+    @validator("name", pre=True, always=True)
+    def apply_legacy_name(cls, value: Union[str, None], values: Values) -> str:
+        if value is None:
+            return values["id"]
+        return value
 
     @validator("readonly", pre=True)
     def can_be_readonly(cls, value: bool, values: Values) -> bool:

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1304,7 +1304,7 @@ class OptionsModel(BaseModel):
             option
             | {
                 "id": option.get("id", id_),
-                "type": option.get("type", "string"),
+                "type": option.get("type", "select" if "choices" in option else "string"),
                 "optional": option.get("optional", optional),
             }
             for id_, option in options.items()

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -938,18 +938,6 @@ class FileOption(BaseInputOption):
 # ─ CHOICES ───────────────────────────────────────────────
 
 
-ChoosableOptions = Literal[
-    OptionType.string,
-    OptionType.color,
-    OptionType.number,
-    OptionType.date,
-    OptionType.time,
-    OptionType.email,
-    OptionType.path,
-    OptionType.url,
-]
-
-
 class BaseChoicesOption(BaseInputOption):
     # FIXME probably forbid choices to be None?
     filter: Union[JSExpression, None] = None  # filter before choices

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -43,7 +43,6 @@ from pydantic import (
     Extra,
     ValidationError,
     create_model,
-    root_validator,
     validator,
 )
 from pydantic.color import Color
@@ -324,7 +323,7 @@ class BaseOption(BaseModel):
         return value
 
     # FIXME Legacy, is `name` still needed?
-    @validator("name", pre=True, always=True)
+    @validator("name")
     def apply_legacy_name(cls, value: Union[str, None], values: Values) -> str:
         if value is None:
             return values["id"]
@@ -1096,21 +1095,30 @@ class DomainOption(BaseChoicesOption):
     type: Literal[OptionType.domain] = OptionType.domain
     choices: Union[dict[str, str], None]
 
-    @root_validator()
-    def inject_domains_choices_and_default(cls, values: Values) -> Values:
+    @validator("choices", pre=True, always=True)
+    def inject_domains_choices(
+        cls, value: Union[dict[str, str], None], values: Values
+    ) -> dict[str, str]:
         # TODO remove calls to resources in validators (pydantic V2 should adress this)
         from yunohost.domain import domain_list
 
         data = domain_list()
-        values["choices"] = {
+        return {
             domain: domain + " ★" if domain == data["main"] else domain
             for domain in data["domains"]
         }
 
-        if values["default"] is None:
-            values["default"] = data["main"]
+    @validator("default")
+    def inject_default(
+        cls, value: Union[str, None], values: Values
+    ) -> Union[str, None]:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.domain import _get_maindomain
 
-        return values
+        if value is None:
+            return _get_maindomain()
+
+        return value
 
     @staticmethod
     def normalize(value, option={}):
@@ -1130,8 +1138,11 @@ class AppOption(BaseChoicesOption):
     choices: Union[dict[str, str], None]
     filter: Union[str, None] = None
 
-    @root_validator()
-    def inject_apps_choices(cls, values: Values) -> Values:
+    @validator("choices", pre=True, always=True)
+    def inject_apps_choices(
+        cls, value: Union[dict[str, str], None], values: Values
+    ) -> dict[str, str]:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
         from yunohost.app import app_list
 
         apps = app_list(full=True)["apps"]
@@ -1142,57 +1153,73 @@ class AppOption(BaseChoicesOption):
                 for app in apps
                 if evaluate_simple_js_expression(values["filter"], context=app)
             ]
-        values["choices"] = {"_none": "---"}
-        values["choices"].update(
+
+        value = {"_none": "---"}
+        value.update(
             {
                 app["id"]: f"{app['label']} ({app.get('domain_path', app['id'])})"
                 for app in apps
             }
         )
 
-        return values
+        return value
 
 
 class UserOption(BaseChoicesOption):
     type: Literal[OptionType.user] = OptionType.user
     choices: Union[dict[str, str], None]
 
-    @root_validator()
-    def inject_users_choices_and_default(cls, values: dict[str, Any]) -> dict[str, Any]:
-        from yunohost.domain import _get_maindomain
-        from yunohost.user import user_info, user_list
+    @validator("choices", pre=True, always=True)
+    def inject_users_choices(
+        cls, value: Union[dict[str, str], None], values: Values
+    ) -> dict[str, str]:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.user import user_list
 
-        values["choices"] = {
+        value = {
             username: f"{infos['fullname']} ({infos['mail']})"
             for username, infos in user_list()["users"].items()
         }
 
         # FIXME keep this to test if any user, do not raise error if no admin?
-        if not values["choices"]:
+        if not value:
             raise YunohostValidationError(
                 "app_argument_invalid",
                 name=values["id"],
                 error="You should create a YunoHost user first.",
             )
 
-        if values["default"] is None:
+        return value
+
+    @validator("default")
+    def inject_default(
+        cls, value: Union[str, None], values: Values
+    ) -> Union[str, None]:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.domain import _get_maindomain
+        from yunohost.user import user_info
+
+        if value is None:
             # FIXME: this code is obsolete with the new admins group
             # Should be replaced by something like "any first user we find in the admin group"
             root_mail = "root@%s" % _get_maindomain()
             for user in values["choices"].keys():
                 if root_mail in user_info(user).get("mail-aliases", []):
-                    values["default"] = user
-                    break
+                    return user
 
-        return values
+        return value
 
 
 class GroupOption(BaseChoicesOption):
     type: Literal[OptionType.group] = OptionType.group
     choices: Union[dict[str, str], None]
+    default: Union[Literal["visitors", "all_users", "admins"], None] = "all_users"
 
-    @root_validator()
-    def inject_groups_choices_and_default(cls, values: Values) -> Values:
+    @validator("choices", pre=True, always=True)
+    def inject_groups_choices(
+        cls, value: Union[dict[str, str], None], values: Values
+    ) -> dict[str, str]:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
         from yunohost.user import user_group_list
 
         groups = user_group_list(short=True, include_primary_groups=False)["groups"]
@@ -1207,14 +1234,7 @@ class GroupOption(BaseChoicesOption):
                 else groupname
             )
 
-        values["choices"] = {
-            groupname: _human_readable_group(groupname) for groupname in groups
-        }
-
-        if values["default"] is None:
-            values["default"] = "all_users"
-
-        return values
+        return {groupname: _human_readable_group(groupname) for groupname in groups}
 
 
 OPTIONS = {
@@ -1288,7 +1308,7 @@ class OptionsModel(BaseModel):
                 "id": id_,
                 "type": option.get("type", "string"),
                 # ConfigPanel options needs to be set as optional by default
-                "optional": option.get("optional", optional)
+                "optional": option.get("optional", optional),
             }
             for id_, option in options.items()
         ]

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1300,15 +1300,25 @@ class OptionsModel(BaseModel):
     def options_dict_to_list(
         options: dict[str, Any], optional: bool = False
     ) -> list[dict[str, Any]]:
-        return [
-            option
-            | {
-                "id": option.get("id", id_),
-                "type": option.get("type", "select" if "choices" in option else "string"),
-                "optional": option.get("optional", optional),
+        options_list = []
+
+        for id_, data in options.items():
+            option = data | {
+                "id": data.get("id", id_),
+                "type": data.get("type", OptionType.select if "choices" in data else OptionType.string),
+                "optional": data.get("optional", optional),
             }
-            for id_, option in options.items()
-        ]
+
+            # LEGACY (`choices` in option `string` used to be valid)
+            if "choices" in option and option["type"] == OptionType.string:
+                logger.warning(
+                    f"Packagers: option {id_} has 'choices' but has type 'string', use 'select' instead to remove this warning."
+                )
+                option["type"] = OptionType.select
+
+            options_list.append(option)
+
+        return options_list
 
     def __init__(self, **kwargs) -> None:
         super().__init__(options=self.options_dict_to_list(kwargs))

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -396,6 +396,7 @@ class AlertOption(BaseReadonlyOption):
 
 class ButtonOption(BaseReadonlyOption):
     type: Literal[OptionType.button] = OptionType.button
+    bind: Literal["null"] = "null"
     help: Union[Translation, None] = None
     style: State = State.success
     icon: Union[str, None] = None
@@ -839,10 +840,8 @@ class EmailOption(BaseInputOption):
     _annotation = EmailStr
 
 
-class WebPathOption(BaseInputOption):
+class WebPathOption(BaseStringOption):
     type: Literal[OptionType.path] = OptionType.path
-    default: Union[str, None]
-    _annotation = str
 
     @staticmethod
     def normalize(value, option={}) -> str:
@@ -876,7 +875,6 @@ class WebPathOption(BaseInputOption):
 
 class URLOption(BaseStringOption):
     type: Literal[OptionType.url] = OptionType.url
-    default: Union[str, None]
     _annotation = HttpUrl
 
 

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -300,8 +300,7 @@ class BaseOption(BaseModel):
 
     @validator("readonly", pre=True)
     def can_be_readonly(cls, value: bool, values: Values) -> bool:
-        forbidden_types = ("password", "app", "domain", "user", "file")
-        if value is True and values["type"] in forbidden_types:
+        if value is True and values["type"] in FORBIDDEN_READONLY_TYPES:
             raise ValueError(
                 m18n.n(
                     "config_forbidden_readonly_type",

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -17,6 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 import ast
+import datetime
 import operator as op
 import os
 import re
@@ -24,7 +25,16 @@ import shutil
 import tempfile
 import urllib.parse
 from enum import Enum
-from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Union
+from typing import Any, Callable, Dict, List, Literal, Mapping, Union
+
+from pydantic import (
+    BaseModel,
+    root_validator,
+    validator,
+)
+from pydantic.color import Color
+from pydantic.networks import EmailStr, HttpUrl
+from pydantic.types import FilePath
 
 from moulinette import Moulinette, m18n
 from moulinette.interfaces.cli import colorize
@@ -36,7 +46,6 @@ from yunohost.utils.i18n import _value_for_locale
 
 logger = getActionLogger("yunohost.form")
 
-Context = dict[str, Any]
 
 # ╭───────────────────────────────────────────────────────╮
 # │  ┌─╴╷ ╷╭─┐╷                                           │
@@ -240,27 +249,58 @@ FORBIDDEN_READONLY_TYPES = {
 }
 
 
-class BaseOption:
-    def __init__(
-        self,
-        question: Dict[str, Any],
-    ):
-        self.id = question["id"]
-        self.type = question.get("type", OptionType.string)
-        self.visible = question.get("visible", True)
+Context = dict[str, Any]
+Translation = Union[dict[str, str], str]
+JSExpression = str
+Values = dict[str, Any]
 
-        self.readonly = question.get("readonly", False)
-        if self.readonly and self.type in FORBIDDEN_READONLY_TYPES:
-            # FIXME i18n
-            raise YunohostError(
-                "config_forbidden_readonly_type",
-                type=self.type,
-                id=self.id,
+
+class Pattern(BaseModel):
+    regexp: str
+    error: Translation = "error_pattern"  # FIXME add generic i18n key
+
+
+class BaseOption(BaseModel):
+    type: OptionType
+    id: str
+    ask: Union[Translation, None]
+    readonly: bool = False
+    visible: Union[JSExpression, bool] = True
+    bind: Union[str, None] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        use_enum_values = True
+        validate_assignment = True
+
+        @staticmethod
+        def schema_extra(schema: dict[str, Any], model: Type["BaseOption"]) -> None:
+            # FIXME Do proper doctstring for Options
+            del schema["description"]
+            schema["additionalProperties"] = False
+
+    @validator("ask", always=True)
+    def parse_or_set_default_ask(
+        cls, value: Union[Translation, None], values: Values
+    ) -> Translation:
+        if value is None:
+            return {"en": values["id"]}
+        if isinstance(value, str):
+            return {"en": value}
+        return value
+
+    @validator("readonly", pre=True)
+    def can_be_readonly(cls, value: bool, values: Values) -> bool:
+        forbidden_types = ("password", "app", "domain", "user", "file")
+        if value is True and values["type"] in forbidden_types:
+            raise ValueError(
+                m18n.n(
+                    "config_forbidden_readonly_type",
+                    type=values["type"],
+                    id=values["id"],
+                )
             )
-
-        self.ask = question.get("ask", self.id)
-        if not isinstance(self.ask, dict):
-            self.ask = {"en": self.ask}
+        return value
 
     def is_visible(self, context: Context) -> bool:
         if isinstance(self.visible, bool):
@@ -268,7 +308,7 @@ class BaseOption:
 
         return evaluate_simple_js_expression(self.visible, context=context)
 
-    def _get_prompt_message(self) -> str:
+    def _get_prompt_message(self, value: None) -> str:
         return _value_for_locale(self.ask)
 
 
@@ -278,9 +318,7 @@ class BaseOption:
 
 
 class BaseReadonlyOption(BaseOption):
-    def __init__(self, question):
-        super().__init__(question)
-        self.readonly = True
+    readonly: Literal[True] = True
 
 
 class DisplayTextOption(BaseReadonlyOption):
@@ -291,38 +329,35 @@ class MarkdownOption(BaseReadonlyOption):
     type: Literal[OptionType.markdown] = OptionType.markdown
 
 
+class State(str, Enum):
+    success = "success"
+    info = "info"
+    warning = "warning"
+    danger = "danger"
+
+
 class AlertOption(BaseReadonlyOption):
     type: Literal[OptionType.alert] = OptionType.alert
+    style: State = State.info
+    icon: Union[str, None] = None
 
-    def __init__(self, question):
-        super().__init__(question)
-        self.style = question.get("style", "info")
-
-    def _get_prompt_message(self) -> str:
-        text = _value_for_locale(self.ask)
-
-        if self.style in ["success", "info", "warning", "danger"]:
-            color = {
-                "success": "green",
-                "info": "cyan",
-                "warning": "yellow",
-                "danger": "red",
-            }
-            prompt = m18n.g(self.style) if self.style != "danger" else m18n.n("danger")
-            return colorize(prompt, color[self.style]) + f" {text}"
-        else:
-            return text
+    def _get_prompt_message(self, value: None) -> str:
+        colors = {
+            State.success: "green",
+            State.info: "cyan",
+            State.warning: "yellow",
+            State.danger: "red",
+        }
+        message = m18n.g(self.style) if self.style != State.danger else m18n.n("danger")
+        return f"{colorize(message, colors[self.style])} {_value_for_locale(self.ask)}"
 
 
 class ButtonOption(BaseReadonlyOption):
     type: Literal[OptionType.button] = OptionType.button
-    enabled = True
-
-    def __init__(self, question):
-        super().__init__(question)
-        self.help = question.get("help")
-        self.style = question.get("style", "success")
-        self.enabled = question.get("enabled", True)
+    help: Union[Translation, None] = None
+    style: State = State.success
+    icon: Union[str, None] = None
+    enabled: Union[JSExpression, bool] = True
 
     def is_enabled(self, context: Context) -> bool:
         if isinstance(self.enabled, bool):
@@ -337,26 +372,27 @@ class ButtonOption(BaseReadonlyOption):
 
 
 class BaseInputOption(BaseOption):
-    hide_user_input_in_prompt = False
-    pattern: Optional[Dict] = None
+    help: Union[Translation, None] = None
+    example: Union[str, None] = None
+    placeholder: Union[str, None] = None
+    redact: bool = False
+    optional: bool = False  # FIXME keep required as default?
+    default: Any = None
 
-    def __init__(self, question: Dict[str, Any]):
-        super().__init__(question)
-        self.default = question.get("default", None)
-        self.optional = question.get("optional", False)
-        self.pattern = question.get("pattern", self.pattern)
-        self.help = question.get("help")
-        self.redact = question.get("redact", False)
+    @validator("default", pre=True)
+    def check_empty_default(value: Any) -> Any:
+        if value == "":
+            return None
+        return value
+
+    # FIXME remove
+    def old__init__(self, question: Dict[str, Any]):
         # .current_value is the currently stored value
         self.current_value = question.get("current_value")
         # .value is the "proposed" value which we got from the user
         self.value = question.get("value")
         # Use to return several values in case answer is in mutipart
         self.values: Dict[str, Any] = {}
-
-        # Empty value is parsed as empty string
-        if self.default == "":
-            self.default = None
 
     @staticmethod
     def humanize(value, option={}):
@@ -368,12 +404,12 @@ class BaseInputOption(BaseOption):
             value = value.strip()
         return value
 
-    def _get_prompt_message(self) -> str:
-        message = super()._get_prompt_message()
+    def _get_prompt_message(self, value: Any) -> str:
+        message = super()._get_prompt_message(value)
 
         if self.readonly:
             message = colorize(message, "purple")
-            return f"{message} {self.humanize(self.current_value)}"
+            return f"{message} {self.humanize(value, self)}"
 
         return message
 
@@ -418,7 +454,8 @@ class BaseInputOption(BaseOption):
 
 
 class BaseStringOption(BaseInputOption):
-    default_value = ""
+    default: Union[str, None]
+    pattern: Union[Pattern, None] = None
 
 
 class StringOption(BaseStringOption):
@@ -429,27 +466,23 @@ class TextOption(BaseStringOption):
     type: Literal[OptionType.text] = OptionType.text
 
 
+FORBIDDEN_PASSWORD_CHARS = r"{}"
+
+
 class PasswordOption(BaseInputOption):
     type: Literal[OptionType.password] = OptionType.password
-    hide_user_input_in_prompt = True
-    default_value = ""
-    forbidden_chars = "{}"
-
-    def __init__(self, question):
-        super().__init__(question)
-        self.redact = True
-        if self.default is not None:
-            raise YunohostValidationError(
-                "app_argument_password_no_default", name=self.id
-            )
+    example: Literal[None] = None
+    default: Literal[None] = None
+    redact: Literal[True] = True
+    _forbidden_chars: str = FORBIDDEN_PASSWORD_CHARS
 
     def _value_pre_validator(self):
         super()._value_pre_validator()
 
         if self.value not in [None, ""]:
-            if any(char in self.value for char in self.forbidden_chars):
+            if any(char in self.value for char in self._forbidden_chars):
                 raise YunohostValidationError(
-                    "pattern_password_app", forbidden_chars=self.forbidden_chars
+                    "pattern_password_app", forbidden_chars=self._forbidden_chars
                 )
 
             # If it's an optional argument the value should be empty or strong enough
@@ -458,26 +491,25 @@ class PasswordOption(BaseInputOption):
             assert_password_is_strong_enough("user", self.value)
 
 
-class ColorOption(BaseStringOption):
+class ColorOption(BaseInputOption):
     type: Literal[OptionType.color] = OptionType.color
-    pattern = {
-        "regexp": r"^#[ABCDEFabcdef\d]{3,6}$",
-        "error": "config_validate_color",  # i18n: config_validate_color
-    }
+    default: Union[str, None]
+    # pattern = {
+    #     "regexp": r"^#[ABCDEFabcdef\d]{3,6}$",
+    #     "error": "config_validate_color",  # i18n: config_validate_color
+    # }
 
 
 # ─ NUMERIC ───────────────────────────────────────────────
 
 
 class NumberOption(BaseInputOption):
+    # `number` and `range` are exactly the same, but `range` does render as a slider in web-admin
     type: Literal[OptionType.number, OptionType.range] = OptionType.number
-    default_value = None
-
-    def __init__(self, question):
-        super().__init__(question)
-        self.min = question.get("min", None)
-        self.max = question.get("max", None)
-        self.step = question.get("step", None)
+    default: Union[int, None]
+    min: Union[int, None] = None
+    max: Union[int, None] = None
+    step: Union[int, None] = None
 
     @staticmethod
     def normalize(value, option={}):
@@ -493,7 +525,7 @@ class NumberOption(BaseInputOption):
         if value in [None, ""]:
             return None
 
-        option = option.__dict__ if isinstance(option, BaseOption) else option
+        option = option.dict() if isinstance(option, BaseOption) else option
         raise YunohostValidationError(
             "app_argument_invalid",
             name=option.get("id"),
@@ -525,20 +557,15 @@ class NumberOption(BaseInputOption):
 
 class BooleanOption(BaseInputOption):
     type: Literal[OptionType.boolean] = OptionType.boolean
-    default_value = 0
-    yes_answers = ["1", "yes", "y", "true", "t", "on"]
-    no_answers = ["0", "no", "n", "false", "f", "off"]
-
-    def __init__(self, question):
-        super().__init__(question)
-        self.yes = question.get("yes", 1)
-        self.no = question.get("no", 0)
-        if self.default is None:
-            self.default = self.no
+    yes: Any = 1
+    no: Any = 0
+    default: Union[bool, int, str, None] = 0
+    _yes_answers: set[str] = {"1", "yes", "y", "true", "t", "on"}
+    _no_answers: set[str] = {"0", "no", "n", "false", "f", "off"}
 
     @staticmethod
     def humanize(value, option={}):
-        option = option.__dict__ if isinstance(option, BaseOption) else option
+        option = option.dict() if isinstance(option, BaseOption) else option
 
         yes = option.get("yes", 1)
         no = option.get("no", 0)
@@ -561,7 +588,7 @@ class BooleanOption(BaseInputOption):
 
     @staticmethod
     def normalize(value, option={}):
-        option = option.__dict__ if isinstance(option, BaseOption) else option
+        option = option.dict() if isinstance(option, BaseOption) else option
 
         if isinstance(value, str):
             value = value.strip()
@@ -569,8 +596,8 @@ class BooleanOption(BaseInputOption):
         technical_yes = option.get("yes", 1)
         technical_no = option.get("no", 0)
 
-        no_answers = BooleanOption.no_answers
-        yes_answers = BooleanOption.yes_answers
+        no_answers = BooleanOption._no_answers
+        yes_answers = BooleanOption._yes_answers
 
         assert (
             str(technical_yes).lower() not in no_answers
@@ -579,8 +606,8 @@ class BooleanOption(BaseInputOption):
             str(technical_no).lower() not in yes_answers
         ), f"'no' value can't be in {yes_answers}"
 
-        no_answers += [str(technical_no).lower()]
-        yes_answers += [str(technical_yes).lower()]
+        no_answers.add(str(technical_no).lower())
+        yes_answers.add(str(technical_yes).lower())
 
         strvalue = str(value).lower()
 
@@ -602,8 +629,8 @@ class BooleanOption(BaseInputOption):
     def get(self, key, default=None):
         return getattr(self, key, default)
 
-    def _get_prompt_message(self):
-        message = super()._get_prompt_message()
+    def _get_prompt_message(self, value: Union[bool, None]) -> str:
+        message = super()._get_prompt_message(value)
 
         if not self.readonly:
             message += " [yes | no]"
@@ -614,12 +641,13 @@ class BooleanOption(BaseInputOption):
 # ─ TIME ──────────────────────────────────────────────────
 
 
-class DateOption(BaseStringOption):
+class DateOption(BaseInputOption):
     type: Literal[OptionType.date] = OptionType.date
-    pattern = {
-        "regexp": r"^\d{4}-\d\d-\d\d$",
-        "error": "config_validate_date",  # i18n: config_validate_date
-    }
+    default: Union[str, None]
+    # pattern = {
+    #     "regexp": r"^\d{4}-\d\d-\d\d$",
+    #     "error": "config_validate_date",  # i18n: config_validate_date
+    # }
 
     def _value_pre_validator(self):
         from datetime import datetime
@@ -633,32 +661,34 @@ class DateOption(BaseStringOption):
                 raise YunohostValidationError("config_validate_date")
 
 
-class TimeOption(BaseStringOption):
+class TimeOption(BaseInputOption):
     type: Literal[OptionType.time] = OptionType.time
-    pattern = {
-        "regexp": r"^(?:\d|[01]\d|2[0-3]):[0-5]\d$",
-        "error": "config_validate_time",  # i18n: config_validate_time
-    }
+    default: Union[str, int, None]
+    # pattern = {
+    #     "regexp": r"^(?:\d|[01]\d|2[0-3]):[0-5]\d$",
+    #     "error": "config_validate_time",  # i18n: config_validate_time
+    # }
 
 
 # ─ LOCATIONS ─────────────────────────────────────────────
 
 
-class EmailOption(BaseStringOption):
+class EmailOption(BaseInputOption):
     type: Literal[OptionType.email] = OptionType.email
-    pattern = {
-        "regexp": r"^.+@.+",
-        "error": "config_validate_email",  # i18n: config_validate_email
-    }
+    default: Union[EmailStr, None]
+    # pattern = {
+    #     "regexp": r"^.+@.+",
+    #     "error": "config_validate_email",  # i18n: config_validate_email
+    # }
 
 
 class WebPathOption(BaseInputOption):
     type: Literal[OptionType.path] = OptionType.path
-    default_value = ""
+    default: Union[str, None]
 
     @staticmethod
     def normalize(value, option={}):
-        option = option.__dict__ if isinstance(option, BaseOption) else option
+        option = option.dict() if isinstance(option, BaseOption) else option
 
         if not isinstance(value, str):
             raise YunohostValidationError(
@@ -685,10 +715,11 @@ class WebPathOption(BaseInputOption):
 
 class URLOption(BaseStringOption):
     type: Literal[OptionType.url] = OptionType.url
-    pattern = {
-        "regexp": r"^https?://.*$",
-        "error": "config_validate_url",  # i18n: config_validate_url
-    }
+    default: Union[str, None]
+    # pattern = {
+    #     "regexp": r"^https?://.*$",
+    #     "error": "config_validate_url",  # i18n: config_validate_url
+    # }
 
 
 # ─ FILE ──────────────────────────────────────────────────
@@ -696,16 +727,16 @@ class URLOption(BaseStringOption):
 
 class FileOption(BaseInputOption):
     type: Literal[OptionType.file] = OptionType.file
-    upload_dirs: List[str] = []
-
-    def __init__(self, question):
-        super().__init__(question)
-        self.accept = question.get("accept", "")
+    # `FilePath` for CLI (path must exists and must be a file)
+    # `bytes` for API (a base64 encoded file actually)
+    accept: Union[str, None] = ""  # currently only used by the web-admin
+    default: Union[str, None]
+    _upload_dirs: set[str] = set()
 
     @classmethod
     def clean_upload_dirs(cls):
         # Delete files uploaded from API
-        for upload_dir in cls.upload_dirs:
+        for upload_dir in cls._upload_dirs:
             if os.path.exists(upload_dir):
                 shutil.rmtree(upload_dir)
 
@@ -738,7 +769,7 @@ class FileOption(BaseInputOption):
         upload_dir = tempfile.mkdtemp(prefix="ynh_filequestion_")
         _, file_path = tempfile.mkstemp(dir=upload_dir)
 
-        FileOption.upload_dirs += [upload_dir]
+        FileOption._upload_dirs.add(upload_dir)
 
         logger.debug(f"Saving file {self.id} for file question into {file_path}")
 
@@ -760,26 +791,30 @@ class FileOption(BaseInputOption):
 # ─ CHOICES ───────────────────────────────────────────────
 
 
-class BaseChoicesOption(BaseInputOption):
-    def __init__(
-        self,
-        question: Dict[str, Any],
-    ):
-        super().__init__(question)
-        # Don't restrict choices if there's none specified
-        self.choices = question.get("choices", None)
+ChoosableOptions = Literal[
+    OptionType.string,
+    OptionType.color,
+    OptionType.number,
+    OptionType.date,
+    OptionType.time,
+    OptionType.email,
+    OptionType.path,
+    OptionType.url,
+]
 
-    def _get_prompt_message(self) -> str:
-        message = super()._get_prompt_message()
+
+class BaseChoicesOption(BaseInputOption):
+    # FIXME probably forbid choices to be None?
+    choices: Union[dict[str, Any], list[Any], None]
+
+    def _get_prompt_message(self, value: Any) -> str:
+        message = super()._get_prompt_message(value)
 
         if self.readonly:
-            message = message
-            choice = self.current_value
+            if isinstance(self.choices, dict) and value is not None:
+                value = self.choices[value]
 
-            if isinstance(self.choices, dict) and choice is not None:
-                choice = self.choices[choice]
-
-            return f"{colorize(message, 'purple')} {choice}"
+            return f"{colorize(message, 'purple')} {value}"
 
         if self.choices:
             # Prevent displaying a shitload of choices
@@ -789,17 +824,15 @@ class BaseChoicesOption(BaseInputOption):
                 if isinstance(self.choices, dict)
                 else self.choices
             )
-            choices_to_display = choices[:20]
+            splitted_choices = choices[:20]
             remaining_choices = len(choices[20:])
 
             if remaining_choices > 0:
-                choices_to_display += [
+                splitted_choices += [
                     m18n.n("other_available_options", n=remaining_choices)
                 ]
 
-            choices_to_display = " | ".join(
-                str(choice) for choice in choices_to_display
-            )
+            choices_to_display = " | ".join(str(choice) for choice in splitted_choices)
 
             return f"{message} [{choices_to_display}]"
 
@@ -821,12 +854,15 @@ class BaseChoicesOption(BaseInputOption):
 
 class SelectOption(BaseChoicesOption):
     type: Literal[OptionType.select] = OptionType.select
-    default_value = ""
+    choices: Union[dict[str, Any], list[Any]]
+    default: Union[str, None]
 
 
 class TagsOption(BaseChoicesOption):
     type: Literal[OptionType.tags] = OptionType.tags
-    default_value = ""
+    choices: Union[list[str], None] = None
+    pattern: Union[Pattern, None] = None
+    default: Union[str, list[str], None]
 
     @staticmethod
     def humanize(value, option={}):
@@ -879,19 +915,23 @@ class TagsOption(BaseChoicesOption):
 
 class DomainOption(BaseChoicesOption):
     type: Literal[OptionType.domain] = OptionType.domain
+    choices: Union[dict[str, str], None]
 
-    def __init__(self, question):
-        from yunohost.domain import domain_list, _get_maindomain
+    @root_validator()
+    def inject_domains_choices_and_default(cls, values: Values) -> Values:
+        # TODO remove calls to resources in validators (pydantic V2 should adress this)
+        from yunohost.domain import domain_list
 
-        super().__init__(question)
-
-        if self.default is None:
-            self.default = _get_maindomain()
-
-        self.choices = {
-            domain: domain + " ★" if domain == self.default else domain
-            for domain in domain_list()["domains"]
+        data = domain_list()
+        values["choices"] = {
+            domain: domain + " ★" if domain == data["main"] else domain
+            for domain in data["domains"]
         }
+
+        if values["default"] is None:
+            values["default"] = data["main"]
+
+        return values
 
     @staticmethod
     def normalize(value, option={}):
@@ -908,83 +948,94 @@ class DomainOption(BaseChoicesOption):
 
 class AppOption(BaseChoicesOption):
     type: Literal[OptionType.app] = OptionType.app
+    choices: Union[dict[str, str], None]
+    filter: Union[str, None] = None
 
-    def __init__(self, question):
+    @root_validator()
+    def inject_apps_choices(cls, values: Values) -> Values:
         from yunohost.app import app_list
-
-        super().__init__(question)
-        self.filter = question.get("filter", None)
 
         apps = app_list(full=True)["apps"]
 
-        if self.filter:
+        if values.get("filter", None):
             apps = [
                 app
                 for app in apps
-                if evaluate_simple_js_expression(self.filter, context=app)
+                if evaluate_simple_js_expression(values["filter"], context=app)
             ]
+        values["choices"] = {"_none": "---"}
+        values["choices"].update(
+            {
+                app["id"]: f"{app['label']} ({app.get('domain_path', app['id'])})"
+                for app in apps
+            }
+        )
 
-        def _app_display(app):
-            domain_path_or_id = f" ({app.get('domain_path', app['id'])})"
-            return app["label"] + domain_path_or_id
-
-        self.choices = {"_none": "---"}
-        self.choices.update({app["id"]: _app_display(app) for app in apps})
+        return values
 
 
 class UserOption(BaseChoicesOption):
     type: Literal[OptionType.user] = OptionType.user
+    choices: Union[dict[str, str], None]
 
-    def __init__(self, question):
-        from yunohost.user import user_list, user_info
+    @root_validator()
+    def inject_users_choices_and_default(cls, values: dict[str, Any]) -> dict[str, Any]:
         from yunohost.domain import _get_maindomain
+        from yunohost.user import user_info, user_list
 
-        super().__init__(question)
-
-        self.choices = {
+        values["choices"] = {
             username: f"{infos['fullname']} ({infos['mail']})"
             for username, infos in user_list()["users"].items()
         }
 
-        if not self.choices:
+        # FIXME keep this to test if any user, do not raise error if no admin?
+        if not values["choices"]:
             raise YunohostValidationError(
                 "app_argument_invalid",
-                name=self.id,
+                name=values["id"],
                 error="You should create a YunoHost user first.",
             )
 
-        if self.default is None:
+        if values["default"] is None:
             # FIXME: this code is obsolete with the new admins group
             # Should be replaced by something like "any first user we find in the admin group"
             root_mail = "root@%s" % _get_maindomain()
-            for user in self.choices.keys():
+            for user in values["choices"].keys():
                 if root_mail in user_info(user).get("mail-aliases", []):
-                    self.default = user
+                    values["default"] = user
                     break
+
+        return values
 
 
 class GroupOption(BaseChoicesOption):
     type: Literal[OptionType.group] = OptionType.group
+    choices: Union[dict[str, str], None]
 
-    def __init__(self, question):
+    @root_validator()
+    def inject_groups_choices_and_default(cls, values: Values) -> Values:
         from yunohost.user import user_group_list
 
-        super().__init__(question)
+        groups = user_group_list(short=True, include_primary_groups=False)["groups"]
 
-        self.choices = list(
-            user_group_list(short=True, include_primary_groups=False)["groups"]
-        )
-
-        def _human_readable_group(g):
+        def _human_readable_group(groupname):
             # i18n: visitors
             # i18n: all_users
             # i18n: admins
-            return m18n.n(g) if g in ["visitors", "all_users", "admins"] else g
+            return (
+                m18n.n(groupname)
+                if groupname in ["visitors", "all_users", "admins"]
+                else groupname
+            )
 
-        self.choices = {g: _human_readable_group(g) for g in self.choices}
+        values["choices"] = {
+            groupname: _human_readable_group(groupname) for groupname in groups
+        }
 
-        if self.default is None:
-            self.default = "all_users"
+        if values["default"] is None:
+            values["default"] = "all_users"
+
+        return values
 
 
 OPTIONS = {
@@ -993,7 +1044,7 @@ OPTIONS = {
     OptionType.alert: AlertOption,
     OptionType.button: ButtonOption,
     OptionType.string: StringOption,
-    OptionType.text: StringOption,
+    OptionType.text: TextOption,
     OptionType.password: PasswordOption,
     OptionType.color: ColorOption,
     OptionType.number: NumberOption,

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -52,7 +52,7 @@ from pydantic.types import constr
 
 from moulinette import Moulinette, m18n
 from moulinette.interfaces.cli import colorize
-from moulinette.utils.filesystem import read_file, write_to_file
+from moulinette.utils.filesystem import read_file, read_yaml, write_to_file
 from moulinette.utils.log import getActionLogger
 from yunohost.log import OperationLogger
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -1426,6 +1426,31 @@ def hydrate_option_type(raw_option: dict[str, Any]) -> dict[str, Any]:
 Hooks = dict[str, Callable[[BaseInputOption], Any]]
 
 
+def parse_prefilled_values(
+    args: Union[str, None] = None,
+    args_file: Union[str, None] = None,
+    method: Literal["parse_qs", "parse_qsl"] = "parse_qs",
+) -> dict[str, Any]:
+    """
+    Retrieve form values from yaml file or query string.
+    """
+    values: Values = {}
+    if args_file:
+        # Import YAML / JSON file
+        values |= read_yaml(args_file)
+    if args:
+        # FIXME See `ask_questions_and_parse_answers`
+        parsed = getattr(urllib.parse, method)(args, keep_blank_values=True)
+        if isinstance(parsed, dict):  # parse_qs
+            # FIXME could do the following to get a list directly?
+            # k: None if not len(v) else (v if len(v) > 1 else v[0])
+            values |= {k: ",".join(v) for k, v in parsed.items()}
+        else:
+            values |= dict(parsed)
+
+    return values
+
+
 def prompt_or_validate_form(
     options: list[AnyOption],
     form: FormModel,
@@ -1556,9 +1581,7 @@ def ask_questions_and_parse_answers(
         # whereas parse.qs return list of values (which is useful for tags, etc)
         # For now, let's not migrate this piece of code to parse_qs
         # Because Aleks believes some bits of the app CI rely on overriding values (e.g. foo=foo&...&foo=bar)
-        answers = dict(
-            urllib.parse.parse_qsl(prefilled_answers or "", keep_blank_values=True)
-        )
+        answers = parse_prefilled_values(prefilled_answers, method="parse_qsl")
     elif isinstance(prefilled_answers, Mapping):
         answers = {**prefilled_answers}
     else:

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -26,6 +26,8 @@ import tempfile
 import urllib.parse
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
+    cast,
     Annotated,
     Any,
     Callable,
@@ -34,7 +36,6 @@ from typing import (
     Mapping,
     Type,
     Union,
-    cast,
 )
 
 from pydantic import (
@@ -48,6 +49,7 @@ from pydantic import (
 from pydantic.color import Color
 from pydantic.fields import Field
 from pydantic.networks import EmailStr, HttpUrl
+from pydantic.types import constr
 
 from moulinette import Moulinette, m18n
 from moulinette.interfaces.cli import colorize
@@ -56,6 +58,9 @@ from moulinette.utils.log import getActionLogger
 from yunohost.log import OperationLogger
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.utils.i18n import _value_for_locale
+
+if TYPE_CHECKING:
+    from pydantic.fields import FieldInfo
 
 logger = getActionLogger("yunohost.form")
 
@@ -391,6 +396,7 @@ class BaseInputOption(BaseOption):
     redact: bool = False
     optional: bool = False  # FIXME keep required as default?
     default: Any = None
+    _annotation = Any
 
     @validator("default", pre=True)
     def check_empty_default(value: Any) -> Any:
@@ -407,6 +413,57 @@ class BaseInputOption(BaseOption):
         if isinstance(value, str):
             value = value.strip()
         return value
+
+    @property
+    def _dynamic_annotation(self) -> Any:
+        """
+        Returns the expected type of an Option's value.
+        This may be dynamic based on constraints.
+        """
+        return self._annotation
+
+    def _get_field_attrs(self) -> dict[str, Any]:
+        """
+        Returns attributes to build a `pydantic.Field`.
+        This may contains non `Field` attrs that will end up in `Field.extra`.
+        Those extra can be used as constraints in custom validators and ends up
+        in the JSON Schema.
+        """
+        # TODO
+        # - help
+        # - placeholder
+        attrs: dict[str, Any] = {
+            "redact": self.redact,  # extra
+            "none_as_empty_str": self._none_as_empty_str,
+        }
+
+        if self.readonly:
+            attrs["allow_mutation"] = False
+
+        if self.example:
+            attrs["examples"] = [self.example]
+
+        if self.default is not None:
+            attrs["default"] = self.default
+        else:
+            attrs["default"] = ... if not self.optional else None
+
+        return attrs
+
+    def _as_dynamic_model_field(self) -> tuple[Any, "FieldInfo"]:
+        """
+        Return a tuple of a type and a Field instance to be injected in a
+        custom form declaration.
+        """
+        attrs = self._get_field_attrs()
+        anno = (
+            self._dynamic_annotation
+            if not self.optional
+            else Union[self._dynamic_annotation, None]
+        )
+        field = Field(default=attrs.pop("default", None), **attrs)
+
+        return (anno, field)
 
     def _get_prompt_message(self, value: Any) -> str:
         message = super()._get_prompt_message(value)
@@ -460,6 +517,22 @@ class BaseInputOption(BaseOption):
 class BaseStringOption(BaseInputOption):
     default: Union[str, None]
     pattern: Union[Pattern, None] = None
+    _annotation = str
+
+    @property
+    def _dynamic_annotation(self) -> Type[str]:
+        if self.pattern:
+            return constr(regex=self.pattern.regexp)
+
+        return self._annotation
+
+    def _get_field_attrs(self) -> dict[str, Any]:
+        attrs = super()._get_field_attrs()
+
+        if self.pattern:
+            attrs["regex_error"] = self.pattern.error  # extra
+
+        return attrs
 
 
 class StringOption(BaseStringOption):
@@ -478,7 +551,15 @@ class PasswordOption(BaseInputOption):
     example: Literal[None] = None
     default: Literal[None] = None
     redact: Literal[True] = True
+    _annotation = str
     _forbidden_chars: str = FORBIDDEN_PASSWORD_CHARS
+
+    def _get_field_attrs(self) -> dict[str, Any]:
+        attrs = super()._get_field_attrs()
+
+        attrs["forbidden_chars"] = self._forbidden_chars  # extra
+
+        return attrs
 
     def _value_pre_validator(self):
         super()._value_pre_validator()
@@ -498,10 +579,7 @@ class PasswordOption(BaseInputOption):
 class ColorOption(BaseInputOption):
     type: Literal[OptionType.color] = OptionType.color
     default: Union[str, None]
-    # pattern = {
-    #     "regexp": r"^#[ABCDEFabcdef\d]{3,6}$",
-    #     "error": "config_validate_color",  # i18n: config_validate_color
-    # }
+    _annotation = Color
 
 
 # ─ NUMERIC ───────────────────────────────────────────────
@@ -514,6 +592,7 @@ class NumberOption(BaseInputOption):
     min: Union[int, None] = None
     max: Union[int, None] = None
     step: Union[int, None] = None
+    _annotation = int
 
     @staticmethod
     def normalize(value, option={}):
@@ -535,6 +614,14 @@ class NumberOption(BaseInputOption):
             name=option.get("id"),
             error=m18n.n("invalid_number"),
         )
+
+    def _get_field_attrs(self) -> dict[str, Any]:
+        attrs = super()._get_field_attrs()
+        attrs["ge"] = self.min
+        attrs["le"] = self.max
+        attrs["step"] = self.step  # extra
+
+        return attrs
 
     def _value_pre_validator(self):
         super()._value_pre_validator()
@@ -564,6 +651,7 @@ class BooleanOption(BaseInputOption):
     yes: Any = 1
     no: Any = 0
     default: Union[bool, int, str, None] = 0
+    _annotation = Union[bool, int, str]
     _yes_answers: set[str] = {"1", "yes", "y", "true", "t", "on"}
     _no_answers: set[str] = {"0", "no", "n", "false", "f", "off"}
 
@@ -633,6 +721,14 @@ class BooleanOption(BaseInputOption):
     def get(self, key, default=None):
         return getattr(self, key, default)
 
+    def _get_field_attrs(self) -> dict[str, Any]:
+        attrs = super()._get_field_attrs()
+        attrs["parse"] = {  # extra
+            True: self.yes,
+            False: self.no,
+        }
+        return attrs
+
     def _get_prompt_message(self, value: Union[bool, None]) -> str:
         message = super()._get_prompt_message(value)
 
@@ -648,10 +744,7 @@ class BooleanOption(BaseInputOption):
 class DateOption(BaseInputOption):
     type: Literal[OptionType.date] = OptionType.date
     default: Union[str, None]
-    # pattern = {
-    #     "regexp": r"^\d{4}-\d\d-\d\d$",
-    #     "error": "config_validate_date",  # i18n: config_validate_date
-    # }
+    _annotation = datetime.date
 
     def _value_pre_validator(self):
         super()._value_pre_validator()
@@ -666,10 +759,7 @@ class DateOption(BaseInputOption):
 class TimeOption(BaseInputOption):
     type: Literal[OptionType.time] = OptionType.time
     default: Union[str, int, None]
-    # pattern = {
-    #     "regexp": r"^(?:\d|[01]\d|2[0-3]):[0-5]\d$",
-    #     "error": "config_validate_time",  # i18n: config_validate_time
-    # }
+    _annotation = datetime.time
 
 
 # ─ LOCATIONS ─────────────────────────────────────────────
@@ -678,15 +768,13 @@ class TimeOption(BaseInputOption):
 class EmailOption(BaseInputOption):
     type: Literal[OptionType.email] = OptionType.email
     default: Union[EmailStr, None]
-    # pattern = {
-    #     "regexp": r"^.+@.+",
-    #     "error": "config_validate_email",  # i18n: config_validate_email
-    # }
+    _annotation = EmailStr
 
 
 class WebPathOption(BaseInputOption):
     type: Literal[OptionType.path] = OptionType.path
     default: Union[str, None]
+    _annotation = str
 
     @staticmethod
     def normalize(value, option={}):
@@ -718,10 +806,7 @@ class WebPathOption(BaseInputOption):
 class URLOption(BaseStringOption):
     type: Literal[OptionType.url] = OptionType.url
     default: Union[str, None]
-    # pattern = {
-    #     "regexp": r"^https?://.*$",
-    #     "error": "config_validate_url",  # i18n: config_validate_url
-    # }
+    _annotation = HttpUrl
 
 
 # ─ FILE ──────────────────────────────────────────────────
@@ -733,6 +818,7 @@ class FileOption(BaseInputOption):
     # `bytes` for API (a base64 encoded file actually)
     accept: Union[str, None] = ""  # currently only used by the web-admin
     default: Union[str, None]
+    _annotation = str  # TODO could be Path at some point
     _upload_dirs: set[str] = set()
 
     @classmethod
@@ -809,6 +895,17 @@ class BaseChoicesOption(BaseInputOption):
     # FIXME probably forbid choices to be None?
     choices: Union[dict[str, Any], list[Any], None]
 
+    @property
+    def _dynamic_annotation(self) -> Union[object, Type[str]]:
+        if self.choices is not None:
+            choices = (
+                self.choices if isinstance(self.choices, list) else self.choices.keys()
+            )
+            # FIXME in case of dict, try to parse keys with `item_type` (at least number)
+            return Literal[tuple(choices)]
+
+        return self._annotation
+
     def _get_prompt_message(self, value: Any) -> str:
         message = super()._get_prompt_message(value)
 
@@ -858,6 +955,7 @@ class SelectOption(BaseChoicesOption):
     type: Literal[OptionType.select] = OptionType.select
     choices: Union[dict[str, Any], list[Any]]
     default: Union[str, None]
+    _annotation = str
 
 
 class TagsOption(BaseChoicesOption):
@@ -865,6 +963,7 @@ class TagsOption(BaseChoicesOption):
     choices: Union[list[str], None] = None
     pattern: Union[Pattern, None] = None
     default: Union[str, list[str], None]
+    _annotation = str
 
     @staticmethod
     def humanize(value, option={}):
@@ -879,6 +978,26 @@ class TagsOption(BaseChoicesOption):
         if isinstance(value, str):
             value = value.strip()
         return value
+
+    @property
+    def _dynamic_annotation(self):
+        # TODO use Literal when serialization is seperated from validation
+        # if self.choices is not None:
+        #     return Literal[tuple(self.choices)]
+
+        # Repeat pattern stuff since we can't call the bare class `_dynamic_annotation` prop without instantiating it
+        if self.pattern:
+            return constr(regex=self.pattern.regexp)
+
+        return self._annotation
+
+    def _get_field_attrs(self) -> dict[str, Any]:
+        attrs = super()._get_field_attrs()
+
+        if self.choices:
+            attrs["choices"] = self.choices  # extra
+
+        return attrs
 
     def _value_pre_validator(self):
         values = self.value

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1303,9 +1303,8 @@ class OptionsModel(BaseModel):
         return [
             option
             | {
-                "id": id_,
+                "id": option.get("id", id_),
                 "type": option.get("type", "string"),
-                # ConfigPanel options needs to be set as optional by default
                 "optional": option.get("optional", optional),
             }
             for id_, option in options.items()


### PR DESCRIPTION
Handle ConfigPanel and Options parsing/validation with pydantic.
This merely does the same thing as before with different structure. Things can be improved/made clearer but i'm trying to keep a readable diff so maybe we can iterate later.


<details><summary>Previous PR message</summary>
PR: https://github.com/YunoHost/yunohost/pull/1603

While working on the POC migration to FastAPI/typer I started working with [pydantic](https://docs.pydantic.dev/) (the parser/validator behind some features of FastAPI) and found it pretty cool. I thought we could give it a try for handling config panels and other dynamic forms like app install and maybe more.

- It is based on model declaration (which can be dynamicly created)
- It perform most of the basic parsing/validation directly from python type hints
- Allow custom types
- Combine parsing and validation in quite the same fashion 
- Use type coercion rather than strictness and errors (for example, on a model's field typed as a basic python `bool`, it can receive a string like `"yes"` and still manage to auto parse it as `True`) which is useful for our python/bash context.
- Can export models declaration into json schema for IDEs, swagger or custom implementations.
- It has a special class for [settings management](https://docs.pydantic.dev/usage/settings/) that could be used at some point? 


The proposed implementation is roughly:
- parse/validate `config.toml` declarations with pydantic models to instantiate a `config: ConfigPanel`
- based on this `config`, build a dynamic pydantic model that will act as `settings: Form` hydrated with current `settings.yml`
- depending on the interface:
    - CLI: use `config` to iterate over what to ask/display and parse/validate user inputs thru `settings` assignements.
    - API: directly try to assign new values to `settings` while still checking conditions from `visible|enabled` props.

The code is split into two files:
- `form.py`: Custom type to handle bash list, `Option`s models for every implemented display/inputs components, basic form factory, CLI displayer/prompter, API filler, evaluation functions. This can be used directly by `app_install()` for install form.
- `configpanel.py`: which is more or less the config panel implementation built over base stuff in `form.py`. (`ConfigPanel` containing `Panel`s containing `Section`s containing `Option`s) and other specific stuff. (Haven't removed the actual implementation to be able to compare to it easily)

</details>

- add `python3-pydantic` + `python3-email-validator` debian dependencies
- Option no longer have a `value` prop, Option values are now in a separate pydantic model `FormModel` that is dynamicly created from Options. So there's now an Option list and a form.
- `alert`, `button` and other readonly options can no longer have a value attached to it
- force reset of context to empty dict for each panels
- `boolean` can now have a `None` default (was a hard `0` default)
- added some `translate` method to automaticly try to translate some keys like `ask`, `help`, `name`, etc. For Option and ConfigPanel. 
- replace `ConfigPanel._parse_pre_answered()` with a more generic `parse_prefilled_values()` function.
- Check https://github.com/YunoHost/yunohost/pull/1653 for the doc

There's still some FIXME's in the code that can be managed now or later.

TODO (but in another PR i guess):
- Errors from pydantic are currently in english only, could iterate on that and add translations
- update type `user` `default` value to the new `admin` group stuff
- add `item_type` to `type = "tags"` to parse/validate inner list element to specified type
- generate config panels json schema
- add something in `package_check` to validate the `config_panel.toml`?
- Maybe have a more python type first parsing and have a `serialize()` class method that would parse python types to what bash helpers expects. This would make system config panel (domains + settings) less confusing by not having boolean like `1|0` and list like `item1,item2`?
    - `yunohost app config get --full` could also return directly python types => json and remove the need for parsing on the web-admin side.
- add tests for context stuff (with `visible`, `enabled`), `pattern`, `redact`, `hooks`


### PR STATUS

Ok with basic stuff, tested with apps_test only for now, will recheck.

### How to test

```bash
# install pydantic
pip install pydantic
```

Also install [python-email-validator](https://github.com/JoshData/python-email-validator) to use pydantic EmailStr type. This is extra dep so maybe we can use a simpler custom regex validator but this lib handle international stuff (but i'm not sure we do).

```bash
pip install pydantic[email]
```

```bash
yunohost app install *
yunohost app config <get|set> *
yunohost app action <list|run> *

yunohost settings <get|set> *
yunohost domain config <get|set> *
```
