### PR TITLE
Fix current_version parsing for notifications

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3130,8 +3130,8 @@ def _notification_is_dismissed(name, settings):
 
 
 def _filter_and_hydrate_notifications(notifications, current_version=None, data={}):
-    current_version=str(current_version)
     def is_version_more_recent_than_current_version(name):
+        current_version = str(current_version)
         # Boring code to handle the fact that "0.1 < 9999~ynh1" is False
 
         if "~" in name:

--- a/src/app.py
+++ b/src/app.py
@@ -3130,6 +3130,7 @@ def _notification_is_dismissed(name, settings):
 
 
 def _filter_and_hydrate_notifications(notifications, current_version=None, data={}):
+    current_version=str(current_version)
     def is_version_more_recent_than_current_version(name):
         # Boring code to handle the fact that "0.1 < 9999~ynh1" is False
 


### PR DESCRIPTION
## The problem

```
$ touch doc/PRE_UPGRADE.d/5.44.0\~ynh1.md
$ yunohost app upgrade ghost -f . -F

Info: Now upgrading ghost...
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 111, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 507, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 584, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 676, in app_upgrade
    notifications = _filter_and_hydrate_notifications(
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3141, in _filter_and_hydrate_notifications
    return {
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3147, in <dictcomp>
    or is_version_more_recent_than_current_version(name)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3137, in is_version_more_recent_than_current_version
    return version.parse(name) > version.parse(current_version)
  File "/usr/lib/python3/dist-packages/packaging/version.py", line 57, in parse
    return Version(version)
  File "/usr/lib/python3/dist-packages/packaging/version.py", line 296, in __init__
    match = self._regex.search(version)
TypeError: expected string or bytes-like object

$ mv doc/PRE_UPGRADE.d/5.44.0\~ynh1.md doc/PRE_UPGRADE.d/5.44.0.md

$ yunohost app upgrade ghost -f . -F

Info: Now upgrading ghost...
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 111, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 507, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 584, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 676, in app_upgrade
    notifications = _filter_and_hydrate_notifications(
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3141, in _filter_and_hydrate_notifications
    return {
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3147, in <dictcomp>
    or is_version_more_recent_than_current_version(name)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 3139, in is_version_more_recent_than_current_version
    return version.parse(name) > version.parse(current_version.split("~")[0])
AttributeError: 'LegacyVersion' object has no attribute 'split'
```