### PR TITLE
Offer a shell into an app environment

### DIFF
--- a/helpers/apps
+++ b/helpers/apps
@@ -164,6 +164,14 @@ ynh_spawn_app_shell() {
         [ -n "$env_var" ] && export $env_var;
         export HOME=$install_dir;
 
+        # Force `php` to its intended version
+        local phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+        if [ -n "$phpversion" ]
+        then
+            eval "php() { php${phpversion} \"\$@\"; }"
+            export -f php
+        fi
+
         # Source the EnvironmentFiles from the app's service
         local env_files=(`systemctl show $app.service -p "EnvironmentFiles" --value`)
         if [ ${#env_files[*]} -gt 0 ]

--- a/helpers/apps
+++ b/helpers/apps
@@ -112,16 +112,19 @@ ynh_remove_apps() {
 	fi
 }
 
-# Load an app environment in the current Bash shell
+# Spawn a Bash shell with the app environment loaded
 #
-# usage: ynh_install_apps --app="app"
+# usage: ynh_spawn_app_shell --app="app"
 #     | arg: -a, --app=     - the app ID
 #
 # examples:
 #   ynh_spawn_app_shell --app="APP" <<< 'echo "$USER"'
 #   ynh_spawn_app_shell --app="APP" < /tmp/some_script.bash
 #
-# Requires YunoHost version 11.0.* or higher.
+# Requires YunoHost version 11.0.* or higher, and that the app relies on packaging v2 or higher.
+# The spawned shell will have environment variables loaded and environment files sourced
+# from the app's service configuration file (defaults to $app.service, overridable by the packager with `service` setting).
+# If the app relies on a specific PHP version, then `php` will be aliased that version.
 ynh_spawn_app_shell() {
         # Declare an array to define the options of this helper.
         local legacy_args=a

--- a/helpers/apps
+++ b/helpers/apps
@@ -167,7 +167,7 @@ ynh_spawn_app_shell() {
         [ -z "$service" ] && service=$app;
 
         # Load the Environment variables from the app's service
-        local env_var=`systemctl show $service.service -p "Environment" --value`
+        local env_var=$(systemctl show $service.service -p "Environment" --value)
         [ -n "$env_var" ] && export $env_var;
         export HOME=$install_dir;
 
@@ -180,7 +180,7 @@ ynh_spawn_app_shell() {
         fi
 
         # Source the EnvironmentFiles from the app's service
-        local env_files=(`systemctl show $service.service -p "EnvironmentFiles" --value`)
+        local env_files=($(systemctl show $service.service -p "EnvironmentFiles" --value))
         if [ ${#env_files[*]} -gt 0 ]
         then
             # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.

--- a/helpers/apps
+++ b/helpers/apps
@@ -178,5 +178,12 @@ ynh_spawn_app_shell() {
         fi
 
         # Open the app shell
+        local env_dir = $(systemctl show $app.service -p "WorkingDirectory" --value)
+        if [[ $env_dir = "" ]];
+        then
+            env_dir = $install_dir
+        fi
+
+        cd $env_dir
         su -s /bin/bash $app
 }

--- a/helpers/apps
+++ b/helpers/apps
@@ -166,12 +166,15 @@ ynh_spawn_app_shell() {
         local service=$(ynh_app_setting_get --app=$app --key=service)
         [ -z "$service" ] && service=$app;
 
+        # Export HOME variable
+        export HOME=$install_dir;
+
         # Load the Environment variables from the app's service
         local env_var=$(systemctl show $service.service -p "Environment" --value)
         [ -n "$env_var" ] && export $env_var;
-        export HOME=$install_dir;
 
         # Force `php` to its intended version
+        # We use `eval`+`export` since `alias` is not propagated to subshells, even with `export`
         local phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
         if [ -n "$phpversion" ]
         then

--- a/helpers/apps
+++ b/helpers/apps
@@ -152,7 +152,7 @@ ynh_spawn_app_shell() {
         fi
 
         # Make sure the app has an install_dir setting
-        local install_dir="$(yunohost app setting $app install_dir)"
+        local install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
         if [ -z "$install_dir" ]
         then
             ynh_print_err --message="$app has no install_dir setting (does it use packaging format >=2?)"
@@ -185,13 +185,11 @@ ynh_spawn_app_shell() {
             set +a
         fi
 
-        # Open the app shell
+        # cd into the WorkingDirectory set in the service, or default to the install_dir
         local env_dir = $(systemctl show $app.service -p "WorkingDirectory" --value)
-        if [[ $env_dir = "" ]];
-        then
-            env_dir = $install_dir
-        fi
-
+        [ -z $env_dir ] && env_dir=$install_dir;
         cd $env_dir
+
+        # Spawn the app shell
         su -s /bin/bash $app
 }

--- a/helpers/apps
+++ b/helpers/apps
@@ -159,8 +159,12 @@ ynh_spawn_app_shell() {
             exit 1
         fi
 
+        # Load the app's service name, or default to $app
+        local service=$(ynh_app_setting_get --app=$app --key=service)
+        [ -z "$service" ] && service=$app;
+
         # Load the Environment variables from the app's service
-        local env_var=`systemctl show $app.service -p "Environment" --value`
+        local env_var=`systemctl show $service.service -p "Environment" --value`
         [ -n "$env_var" ] && export $env_var;
         export HOME=$install_dir;
 
@@ -173,7 +177,7 @@ ynh_spawn_app_shell() {
         fi
 
         # Source the EnvironmentFiles from the app's service
-        local env_files=(`systemctl show $app.service -p "EnvironmentFiles" --value`)
+        local env_files=(`systemctl show $service.service -p "EnvironmentFiles" --value`)
         if [ ${#env_files[*]} -gt 0 ]
         then
             # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.
@@ -186,7 +190,7 @@ ynh_spawn_app_shell() {
         fi
 
         # cd into the WorkingDirectory set in the service, or default to the install_dir
-        local env_dir = $(systemctl show $app.service -p "WorkingDirectory" --value)
+        local env_dir = $(systemctl show $service.service -p "WorkingDirectory" --value)
         [ -z $env_dir ] && env_dir=$install_dir;
         cd $env_dir
 

--- a/helpers/apps
+++ b/helpers/apps
@@ -127,7 +127,7 @@ ynh_load_app_environment() {
         ynh_handle_getopts_args "$@"
 
         # Force Bash to be used to run this helper
-        if [ $0 != "bash" ]
+        if [[ ! $0 =~ \/?bash$ ]]
         then
             ynh_print_err --message="Please use Bash as shell"
             exit 1

--- a/helpers/apps
+++ b/helpers/apps
@@ -190,7 +190,7 @@ ynh_spawn_app_shell() {
         fi
 
         # cd into the WorkingDirectory set in the service, or default to the install_dir
-        local env_dir = $(systemctl show $service.service -p "WorkingDirectory" --value)
+        local env_dir=$(systemctl show $service.service -p "WorkingDirectory" --value)
         [ -z $env_dir ] && env_dir=$install_dir;
         cd $env_dir
 

--- a/helpers/apps
+++ b/helpers/apps
@@ -117,6 +117,10 @@ ynh_remove_apps() {
 # usage: ynh_install_apps --app="app"
 #     | arg: -a, --app=     - the app ID
 #
+# examples:
+#   ynh_load_app_environment --app="APP" <<< 'echo "$USER"'
+#   ynh_load_app_environment --app="APP" < /tmp/some_script.bash
+# 
 # Requires YunoHost version 11.0.* or higher.
 ynh_load_app_environment() {
         # Declare an array to define the options of this helper.

--- a/helpers/apps
+++ b/helpers/apps
@@ -111,3 +111,61 @@ ynh_remove_apps() {
 		done
 	fi
 }
+
+# Load an app environment in the current Bash shell
+#
+# usage: ynh_install_apps --app="app"
+#     | arg: -a, --app=     - the app ID
+#
+# Requires YunoHost version 11.0.* or higher.
+ynh_load_app_environment() {
+        # Declare an array to define the options of this helper.
+        local legacy_args=a
+        local -A args_array=([a]=app=)
+        local app
+        # Manage arguments with getopts
+        ynh_handle_getopts_args "$@"
+
+        # Retrieve the list of installed apps
+        local installed_apps_list=($(yunohost app list --output-as json --quiet | jq -r .apps[].id))
+
+        # Force Bash to be used to run this helper
+        if [ $0 != "bash" ]
+        then
+            ynh_print_err --message="Please use Bash as shell"
+            exit 1
+        fi
+
+        # Make sure the app is installed
+        if [[ " ${installed_apps_list[*]} " != *" ${app} "* ]]
+        then
+            ynh_print_err --message="$app is not in the apps list"
+            exit 1
+        fi
+
+        # Make sure the app has an install_dir setting
+        install_dir="$(yunohost app setting $app install_dir)"
+        if [ -z "$install_dir" ]
+        then
+            ynh_print_err --message="$app has no install_dir setting (does it use packaging format >=2?)"
+            exit 1
+        fi
+
+        # Load the Environment variables from the app's service
+        env_var=`systemctl show $app.service -p "Environment" --value`
+        [ -n "$env_var" ] && export $env_var;
+        export HOME=$install_dir;
+
+        # Source the EnvironmentFiles from the app's service
+        env_files=(`systemctl show $app.service -p "EnvironmentFiles" --value`)
+        if [ ${#env_files[*]} -gt 0 ]
+        then
+            for file in ${env_files[*]}
+            do
+                [[ $file = /* ]] && source $file
+            done
+        fi
+
+        # Open the app shell
+        su -s /bin/bash $app
+}

--- a/helpers/apps
+++ b/helpers/apps
@@ -126,9 +126,6 @@ ynh_load_app_environment() {
         # Manage arguments with getopts
         ynh_handle_getopts_args "$@"
 
-        # Retrieve the list of installed apps
-        local installed_apps_list=($(yunohost app list --output-as json --quiet | jq -r .apps[].id))
-
         # Force Bash to be used to run this helper
         if [ $0 != "bash" ]
         then
@@ -137,14 +134,21 @@ ynh_load_app_environment() {
         fi
 
         # Make sure the app is installed
+        local installed_apps_list=($(yunohost app list --output-as json --quiet | jq -r .apps[].id))
         if [[ " ${installed_apps_list[*]} " != *" ${app} "* ]]
         then
             ynh_print_err --message="$app is not in the apps list"
             exit 1
         fi
 
+        # Make sure the app is installed
+        if ! id -u "$app" &>/dev/null; then
+            ynh_print_err --message="There is no \"$app\" system user"
+            exit 1
+        fi
+
         # Make sure the app has an install_dir setting
-        install_dir="$(yunohost app setting $app install_dir)"
+        local install_dir="$(yunohost app setting $app install_dir)"
         if [ -z "$install_dir" ]
         then
             ynh_print_err --message="$app has no install_dir setting (does it use packaging format >=2?)"
@@ -152,18 +156,21 @@ ynh_load_app_environment() {
         fi
 
         # Load the Environment variables from the app's service
-        env_var=`systemctl show $app.service -p "Environment" --value`
+        local env_var=`systemctl show $app.service -p "Environment" --value`
         [ -n "$env_var" ] && export $env_var;
         export HOME=$install_dir;
 
         # Source the EnvironmentFiles from the app's service
-        env_files=(`systemctl show $app.service -p "EnvironmentFiles" --value`)
+        local env_files=(`systemctl show $app.service -p "EnvironmentFiles" --value`)
         if [ ${#env_files[*]} -gt 0 ]
         then
+            # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.
+            set -a
             for file in ${env_files[*]}
             do
                 [[ $file = /* ]] && source $file
             done
+            set +a
         fi
 
         # Open the app shell

--- a/helpers/apps
+++ b/helpers/apps
@@ -118,11 +118,11 @@ ynh_remove_apps() {
 #     | arg: -a, --app=     - the app ID
 #
 # examples:
-#   ynh_load_app_environment --app="APP" <<< 'echo "$USER"'
-#   ynh_load_app_environment --app="APP" < /tmp/some_script.bash
-# 
+#   ynh_spawn_app_shell --app="APP" <<< 'echo "$USER"'
+#   ynh_spawn_app_shell --app="APP" < /tmp/some_script.bash
+#
 # Requires YunoHost version 11.0.* or higher.
-ynh_load_app_environment() {
+ynh_spawn_app_shell() {
         # Declare an array to define the options of this helper.
         local legacy_args=a
         local -A args_array=([a]=app=)

--- a/helpers/apps
+++ b/helpers/apps
@@ -148,7 +148,7 @@ ynh_spawn_app_shell() {
             exit 1
         fi
 
-        # Make sure the app is installed
+        # Make sure the app has its own user
         if ! id -u "$app" &>/dev/null; then
             ynh_print_err --message="There is no \"$app\" system user"
             exit 1

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -954,6 +954,12 @@ app:
                     help: Delete the key
                     action: store_true
 
+        ### app_shell()
+        shell:
+            action_help: Open an interactive shell with the app environment already loaded
+            arguments:
+                app:
+                    help: App ID
 
         ### app_register_url()
         register-url:

--- a/src/app.py
+++ b/src/app.py
@@ -1653,7 +1653,6 @@ def app_shell(app):
         app -- App ID
 
     """
-    app_settings = _get_app_settings(app) or {}
 
    #TODO Find out how to open an interactive Bash shell from Python
    #TODO run `ynh_load_app_environment --app=$app` helper in there

--- a/src/app.py
+++ b/src/app.py
@@ -1653,7 +1653,7 @@ def app_shell(app):
         app -- App ID
 
     """
-    subprocess.run(['/bin/bash', '-c', 'source /usr/share/yunohost/helpers && ynh_load_app_environment '+app])
+    subprocess.run(['/bin/bash', '-c', 'source /usr/share/yunohost/helpers && ynh_spawn_app_shell '+app])
 
 def app_register_url(app, domain, path):
     """

--- a/src/app.py
+++ b/src/app.py
@@ -1653,9 +1653,7 @@ def app_shell(app):
         app -- App ID
 
     """
-
-   #TODO Find out how to open an interactive Bash shell from Python
-   #TODO run `ynh_load_app_environment --app=$app` helper in there
+    subprocess.run(['/bin/bash', '-c', 'source /usr/share/yunohost/helpers && ynh_load_app_environment '+app])
 
 def app_register_url(app, domain, path):
     """

--- a/src/app.py
+++ b/src/app.py
@@ -1655,15 +1655,8 @@ def app_shell(app):
     """
     app_settings = _get_app_settings(app) or {}
 
-   #TODO init a env_dict
-   #TODO load the app's environment, parsed from:
-   #TODO   - its settings (phpversion, ...)
-   #TODO   - its service configuration (PATH, NodeJS production mode...)
-   #TODO     this one could be performed in Bash, directly after initiating the subprocess:
-   #TODO     - "Environment" clause: `systemctl show $app.service -p "Environment" --value`
-   #TODO     - Source "EnvironmentFile" clauses
-   #TODO
-   #TODO find out how to open an interactive Bash shell from Python
+   #TODO Find out how to open an interactive Bash shell from Python
+   #TODO run `ynh_load_app_environment --app=$app` helper in there
 
 def app_register_url(app, domain, path):
     """

--- a/src/app.py
+++ b/src/app.py
@@ -1645,6 +1645,26 @@ def app_setting(app, key, value=None, delete=False):
     _set_app_settings(app, app_settings)
 
 
+def app_shell(app):
+    """
+    Open an interactive shell with the app environment already loaded
+
+    Keyword argument:
+        app -- App ID
+
+    """
+    app_settings = _get_app_settings(app) or {}
+
+   #TODO init a env_dict
+   #TODO load the app's environment, parsed from:
+   #TODO   - its settings (phpversion, ...)
+   #TODO   - its service configuration (PATH, NodeJS production mode...)
+   #TODO     this one could be performed in Bash, directly after initiating the subprocess:
+   #TODO     - "Environment" clause: `systemctl show $app.service -p "Environment" --value`
+   #TODO     - Source "EnvironmentFile" clauses
+   #TODO
+   #TODO find out how to open an interactive Bash shell from Python
+
 def app_register_url(app, domain, path):
     """
     Book/register a web path for a given app


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/2041 

TODO:
- [x] check that sourced `EnvironmentFiles` are actually propagated to the subshell
- [x] check that `$app` user actually exists
- [x] do we need to fail if no `$install_dir` is set (non-webapp)
- [x] how to handle e.g. Synapse, whose service is not `synapse.service` but `matrix-synapse.service`?
- [x] `alias` `php` command to `php$phpversion`

## PR Status

To be extensively tested.

## How to test

...
