### PR TITLE
keep fail2ban rules on firewall reload

### DIFF
--- a/hooks/post_iptable_rules/52-fail2ban
+++ b/hooks/post_iptable_rules/52-fail2ban
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -e
-
-systemctl restart fail2ban

--- a/hooks/post_iptable_rules/52-fail2ban
+++ b/hooks/post_iptable_rules/52-fail2ban
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+systemctl restart fail2ban

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -331,7 +331,7 @@ def firewall_reload(skip_upnp=False):
         # Refresh port forwarding with UPnP
         firewall_upnp(no_refresh=False)
 
-    _run_service_command("reload", "fail2ban")
+    _run_service_command("restart", "fail2ban")
 
     if errors:
         logger.warning(m18n.n("firewall_rules_cmd_failed"))


### PR DESCRIPTION

## The problem

Reloading firewall flushes all iptables rules to create new ones, dropping fail2ban rules in the same time.


## Solution

Restarting fail2ban restores its iptables rules.

## PR Status

Proposal.
I'm new to yunohost, I don't know if/how it should be fixed.

## How to test

With fail2ban activated, check the firewall status

```
# iptables -nL
Chain INPUT (policy DROP)
target     prot opt source               destination
f2b-recidive  tcp  --  anywhere             anywhere
f2b-sshd   tcp  --  anywhere             anywhere             multiport dports ssh
[...]
```

Reload yunohost firewall

```
# yunohost firewall reload
```

The fail2ban rules are gone
```
# iptables -nL
Chain INPUT (policy DROP)
target     prot opt source               destination
[...]
```
