### PR TITLE
Update "worker" Content-Security-Policy header when in experimental security mode

### DIFF
--- a/conf/nginx/security.conf.inc
+++ b/conf/nginx/security.conf.inc
@@ -26,7 +26,7 @@ ssl_dhparam /usr/share/yunohost/ffdhe2048.pem;
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security
 # https://observatory.mozilla.org/
 {% if experimental == "True" %}
-more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'";
+more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'; worker-src 'self' blob:;";
 {% else %}
 more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
 {% endif %}


### PR DESCRIPTION
## The problem

Chromium [fails](https://github.com/YunoHost-Apps/jitsi_ynh/issues/113) to load a jitsi video conference, refusing to create a worker because it violates the Content Security Policy directive: "script-src https: data: 'unsafe-inline' 'unsafe-eval'".

## Solution

Add a custom CSP for worker.

## PR Status

Proposal

## How to test

1. Enable experimental security settings in tools / yunohost settings
2. Install jitsi_ynh app
3. Test the app with chromium