### PR TITLE
[fix] Remove deprecated domain_dns_conf

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -537,17 +537,6 @@ domain:
                     full: --force
                     help: Do not ask confirmation to remove apps
                     action: store_true
-
-
-        ### domain_dns_conf()
-        dns-conf:
-            deprecated: true
-            action_help: Generate sample DNS configuration for a domain
-            arguments:
-                domain:
-                    help: Target domain
-                    extra:
-                        pattern: *pattern_domain
         
         ### domain_maindomain()
         main-domain:

--- a/src/domain.py
+++ b/src/domain.py
@@ -718,10 +718,6 @@ def domain_cert_renew(domain_list, force=False, no_checks=False, email=False):
     return certificate_renew(domain_list, force, no_checks, email)
 
 
-def domain_dns_conf(domain):
-    return domain_dns_suggest(domain)
-
-
 def domain_dns_suggest(domain):
     from yunohost.dns import domain_dns_suggest
 


### PR DESCRIPTION
## The problem

This issue https://github.com/YunoHost/issues/issues/2090 exists since 22 nov 2022, I think we could delete the deprecation and close the issue.

## Solution

Delete actionmap and the corresponding function

## PR Status

Done

## How to test

Clone then, use with ynh-dev.
