### PR TITLE
Magically keeping all custom-config panel settings during the conf upgrade via ynh_add_config without having to define all of them as yunohost settings

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -496,6 +496,11 @@ ynh_add_config() {
         ynh_die --message="The provided template $template doesn't exist"
     fi
 
+    # Backup variables handled by the config panel
+    local configpanel_backup_path
+    configpanel_backup_path="$(mktemp)"
+    yunohost app config get $app --export > "$configpanel_backup_path"
+
     ynh_backup_if_checksum_is_different --file="$destination"
 
     # Make sure to set the permissions before we copy the file
@@ -513,6 +518,12 @@ ynh_add_config() {
     ynh_replace_vars --file="$destination"
 
     ynh_store_file_checksum --file="$destination"
+
+    # Restore variables handled by the config panel
+    yunohost app config set $app -f "$configpanel_backup_path"
+    ynh_secure_remove --file="$configpanel_backup_path"
+    ynh_store_file_checksum --file="$destination"
+
 }
 
 # Replace variables in a file


### PR DESCRIPTION
## The problem

- YunoHost/issues#1973

## Solution

In `ynh_add_config`:
- Backup config_panel values with `yunohost app config get $app --export`
- *usual ynh_add_config stuff...*
- Restore the config_panel values with `yunohost app config set $app -f $file`
- Recompute and store the file hash

## PR Status

Yolocommited, working with a single .env file
Need to be tested with a config_panel with multiples files

## How to test

```
sudo yunohost app install https://github.com/Tagadda/helloworld_ynh/tree/enh/ynh_add_config/keep_config_panel_settings_during_upgrade
sudo yunohost config set helloworld max_poll_option_chars -v 666
sudo yunohost app upgrade helloworld -u https://github.com/Tagadda/helloworld_ynh/tree/enh/ynh_add_config/keep_config_panel_settings_during_upgrade
sudo yunohost config get helloworld max_poll_option_chars
```