### PR TITLE
Simplify handling of ssh_password_authentication 

### DIFF
--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -57,11 +57,7 @@ UsePAM yes
 
 # PLEASE: if you wish to force everybody to authenticate using ssh keys, run this command:
 # yunohost settings set security.ssh.ssh_password_authentication -v no
-{% if password_authentication == "False" %}
-PasswordAuthentication no
-{% else %}
-#PasswordAuthentication yes
-{% endif %}
+PasswordAuthentication {{ password_authentication }}
 
 # Post-login stuff
 Banner /etc/issue.net
@@ -103,7 +99,7 @@ Match Group sftp.app,!ssh.app
     AllowStreamLocalForwarding no
     PermitTunnel no
     PermitUserRC no
-    PasswordAuthentication yes
+    PasswordAuthentication {{ password_authentication }}
 
 # root login is allowed on local networks
 # It's meant to be a backup solution in case LDAP is down and

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -42,6 +42,8 @@ name = "Security"
         [security.ssh.ssh_password_authentication]
         type = "boolean"
         default = true
+        yes = "yes"
+        no = "no"
 
     [security.nginx]
     name = "NGINX (web server)"


### PR DESCRIPTION
The current template use if/else/endif which introduce spurious empty lines. As the setting value is "yes" or "no", as expected by the configuration file, the value is directly use.

All uses of passwordauthentication are addressed. This adds the one used for the sftp group.

Finally, the global configuration sets the yes and no values to "yes" and "no" respectively.

## The problem

sftp group doesn't use the ssh password setting.
Imperative style introduce useless complexity with it's control-flow.

## Solution

- Propagate the setting
- Use config_global default values

## PR Status

...

## How to test

...
