### PR TITLE
diagnosis: Support multiple TXT entries for TLD

### DIFF
--- a/src/diagnosers/12-dnsrecords.py
+++ b/src/diagnosers/12-dnsrecords.py
@@ -182,6 +182,10 @@ class MyDiagnoser(Diagnoser):
         if success != "ok":
             return None
         else:
+            if type_ == "TXT" and isinstance(answers,list):
+                for part in answers:
+                    if part.startswith('"v=spf1'):
+                        return part
             return answers[0] if len(answers) == 1 else answers
 
     def current_record_match_expected(self, r):


### PR DESCRIPTION
The dig of TXT for @ can returns multiple entries. In that case, the DNS diagnosis fails.

The modification preserves the handling of DMARC and the likes which use a single entry and a specfic domain name.

For single entry list, the behavior is preserved.

If mutliple TXT entries are defined for @, only the v=spf1 one is returned.

## The problem

The diagnosic fails when multiple TXT entries are defined for @

## Solution

Filter the v=spf1 one

## PR Status

...

## How to test

...
