### PR TITLE
apps: Enhance app_shell()

### DIFF
--- a/helpers/apps
+++ b/helpers/apps
@@ -124,7 +124,7 @@ ynh_remove_apps() {
 # Requires YunoHost version 11.0.* or higher, and that the app relies on packaging v2 or higher.
 # The spawned shell will have environment variables loaded and environment files sourced
 # from the app's service configuration file (defaults to $app.service, overridable by the packager with `service` setting).
-# If the app relies on a specific PHP version, then `php` will be aliased that version.
+# If the app relies on a specific PHP version, then `php` will be aliased that version. The PHP command will also be appended with the `phpflags` settings.
 ynh_spawn_app_shell() {
         # Declare an array to define the options of this helper.
         local legacy_args=a
@@ -176,9 +176,10 @@ ynh_spawn_app_shell() {
         # Force `php` to its intended version
         # We use `eval`+`export` since `alias` is not propagated to subshells, even with `export`
         local phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+        local phpflags=$(ynh_app_setting_get --app=$app --key=phpflags)
         if [ -n "$phpversion" ]
         then
-            eval "php() { php${phpversion} \"\$@\"; }"
+            eval "php() { php${phpversion} ${phpflags} \"\$@\"; }"
             export -f php
         fi
 

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -957,6 +957,8 @@ app:
         ### app_shell()
         shell:
             action_help: Open an interactive shell with the app environment already loaded
+            # Here we set a GET only not to lock the command line. There is no actual API endpoint for app_shell()
+            api: GET /apps/<app>/shell
             arguments:
                 app:
                     help: App ID


### PR DESCRIPTION
- [x] Make sure spawning an app shell does not lock the YunoHost CLI
- [x] Offer to preload the `php` command with flags (from a `phpflags` app setting), useful for Nextcloud for example: its `php${phpversion} --define apc.enable_cli=1 occ...` would be simplified to `php occ ...` if `phpflags="--define apc.enable_cli=1"`)

## PR Status

Finished

## How to test

Lock avoidance tested. PHP flags yolocommitted.
