### PR TITLE
User registration backend

### DIFF
--- a/hooks/conf_regen/01-yunohost
+++ b/hooks/conf_regen/01-yunohost
@@ -52,6 +52,9 @@ do_init_regen() {
     # Empty service conf
     touch /etc/yunohost/services.yml
 
+    # Make sure the subscriptions file exists
+    touch /etc/yunohost/subscriptions.yml
+
     mkdir -p /var/cache/yunohost/repo
     chown root:root /var/cache/yunohost
     chmod 700 /var/cache/yunohost

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -474,6 +474,171 @@ user:
                         key:
                             help: The key to be removed
 
+        subscription:
+            subcategory_help: Manage subscriptions
+            actions:
+
+                ### user_subscription_list()
+                list:
+                    action_help: Show pending subscriptions
+                    api: GET /users/subscriptions
+
+                ### user_subscription_accept()
+                accept:
+                    action_help: Accept a subscriptions
+                    api: POST /users/subscriptions/<login>/accept
+                    arguments:
+                        login:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_subscription_deny()
+                deny:
+                    action_help: Deny a subscriptions
+                    api: DELETE /users/subscriptions/<login>
+                    arguments:
+                        login:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_subscription_invite_list()
+                invite:
+                    action_help: List the current ephemereal invitation code(s)
+                    api: GET /users/subscriptions/invite
+
+                ### user_subscription_invite_create()
+                invite:
+                    action_help: Create an ephemereal invitation code
+                    api: POST /users/subscriptions/invite/create
+                    arguments:
+                        --send-to:
+                            help: Email recipient of the invitation link
+                            extra:
+                                pattern: *pattern_email
+                        -q:
+                            full: --mailbox-quota
+                            help: Mailbox size quota
+                            default: "0"
+                            metavar: "{SIZE|0}"
+                            extra:
+                            pattern: &pattern_mailbox_quota
+                                - !!str ^(\d+[bkMGT])|0$
+                        -g:
+                            full: --groups
+                            help: Group(s) to which the user will be added
+                            nargs: "*"
+                            metavar: GROUPNAME
+                            extra:
+                                pattern: *pattern_groupname
+                        -n:
+                            help: Number of registrations the invitation link will allow
+                            type: int
+                            default: "1"
+
+                ### user_subscription_invite_delete()
+                invite:
+                    action_help: Delete an ephemereal invitation code
+                    api: DELETE /users/subscriptions/invite/<code>
+                    arguments:
+                        code:
+                            help: Invitation code to be deleted
+
+                ### user_subscription_captcha()
+                captcha:
+                    action_help: CAPTCHA validation for registration
+                    authentication:
+                    # We need to be able to register without being authenticated
+                        api: null
+                    api:
+                      - GET /users/subscriptions/captcha
+
+                ### user_subscription_register()
+                register:
+                    action_help: Register a new user
+                    authentication:
+                    # We need to be able to register without being authenticated
+                        api: null
+                    api:
+                      - POST /users/subscriptions
+                    arguments:
+                        username:
+                            help: The unique username to create
+                            extra:
+                                pattern: &pattern_username
+                                    - !!str ^[a-z0-9_]+$
+                                    - "pattern_username"
+                        -F:
+                            full: --fullname
+                            help: The full name of the user. For example 'Camille Dupont'
+                            extra:
+                                ask: ask_fullname
+                                required: False
+                                pattern: &pattern_fullname
+                                    - !!str ^([^\W_]{1,30}[ ,.'-]{0,3})+$
+                                    - "pattern_fullname"
+                        -p:
+                            full: --password
+                            help: User password
+                            extra:
+                                password: ask_password
+                                required: True
+                                pattern: &pattern_password
+                                    - !!str ^.{3,}$
+                                    - "pattern_password"
+                                comment: good_practices_about_user_password
+#TODO: let the admin or the user decide that?
+#                        -d:
+#                            full: --domain
+#                            help: Domain for the email address and xmpp account
+#                            extra:
+#                                pattern: &pattern_domain
+#                                    - !!str ^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})$
+#                                    - "pattern_domain"
+#TODO: this should not be let up to the user
+#                        -q:
+#                            full: --mailbox-quota
+#                            help: Mailbox size quota
+#                            default: "0"
+#                            metavar: "{SIZE|0}"
+#                            extra:
+#                                pattern: &pattern_mailbox_quota
+#                                    - !!str ^(\d+[bkMGT])|0$
+#                                    - "pattern_mailbox_quota"
+#TODO: let's keep it simple and let it default?
+#                        -s:
+#                            full: --loginShell
+#                            help: The login shell used
+#                            default: "/bin/bash"
+                        -c:
+                            full: --code
+                            help: Invitation code
+
+                ### user_subscription_resend()
+                resend:
+                    action_help: Resend a subscription email
+                    api: POST /users/subscriptions/<login>/resend
+                    arguments:
+                        login:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+
+                ### user_subscription_validate()
+                validate:
+                    action_help: Validate a subscription
+                    api:
+                      - POST /users/subscriptions/<login>/accept
+                      - POST /users/subscriptions/<login>/validate/<code>
+                    arguments:
+                        login:
+                            help: Username of the user
+                            extra:
+                                pattern: *pattern_username
+                        code:
+                            help: Validation code
+
 #############################
 #          Domain           #
 #############################

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -523,8 +523,7 @@ user:
                             default: "0"
                             metavar: "{SIZE|0}"
                             extra:
-                            pattern: &pattern_mailbox_quota
-                                - !!str ^(\d+[bkMGT])|0$
+                            pattern: *pattern_mailbox_quota
                         -g:
                             full: --groups
                             help: Group(s) to which the user will be added
@@ -566,36 +565,28 @@ user:
                         username:
                             help: The unique username to create
                             extra:
-                                pattern: &pattern_username
-                                    - !!str ^[a-z0-9_]+$
-                                    - "pattern_username"
+                                pattern: *pattern_username
                         -F:
                             full: --fullname
                             help: The full name of the user. For example 'Camille Dupont'
                             extra:
                                 ask: ask_fullname
                                 required: False
-                                pattern: &pattern_fullname
-                                    - !!str ^([^\W_]{1,30}[ ,.'-]{0,3})+$
-                                    - "pattern_fullname"
+                                pattern: *pattern_fullname
                         -p:
                             full: --password
                             help: User password
                             extra:
                                 password: ask_password
                                 required: True
-                                pattern: &pattern_password
-                                    - !!str ^.{3,}$
-                                    - "pattern_password"
+                                pattern: *pattern_password
                                 comment: good_practices_about_user_password
 #TODO: let the admin or the user decide that?
 #                        -d:
 #                            full: --domain
 #                            help: Domain for the email address and xmpp account
 #                            extra:
-#                                pattern: &pattern_domain
-#                                    - !!str ^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})$
-#                                    - "pattern_domain"
+#                                pattern: *pattern_domain
 #TODO: this should not be let up to the user
 #                        -q:
 #                            full: --mailbox-quota
@@ -603,9 +594,7 @@ user:
 #                            default: "0"
 #                            metavar: "{SIZE|0}"
 #                            extra:
-#                                pattern: &pattern_mailbox_quota
-#                                    - !!str ^(\d+[bkMGT])|0$
-#                                    - "pattern_mailbox_quota"
+#                                pattern: *pattern_mailbox_quota
 #TODO: let's keep it simple and let it default?
 #                        -s:
 #                            full: --loginShell

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -63,6 +63,20 @@ name = "Security"
         choices.modern = "Modern (TLS 1.3 only)"
         default = "intermediate"
 
+    [security.registration]
+    name = "User registration"
+        [security.registration.mode]
+        type = "select"
+        choices.disabled = "Disabled"
+        choices.invitation_link_only = "Invitation link only"
+        choices.admin_validation = "Public, with admin validation"
+        choices.public = "Public"
+        default = "disabled"
+
+        [security.registration.email_validation]
+        type = "boolean"
+        default = "true"
+
     [security.webadmin]
     name = "Webadmin"
         [security.webadmin.webadmin_allowlist_enabled]

--- a/src/user.py
+++ b/src/user.py
@@ -25,10 +25,15 @@ import random
 import string
 import subprocess
 import copy
+import yaml
 
 from moulinette import Moulinette, m18n
 from moulinette.utils.log import getActionLogger
 from moulinette.utils.process import check_output
+from moulinette.utils.filesystem import (
+    read_yaml,
+    write_to_yaml,
+)
 
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from yunohost.service import service_status
@@ -1440,6 +1445,66 @@ def user_ssh_remove_key(username, key):
 
 #
 # End SSH subcategory
+#
+
+#
+# Subcription subcategory
+#
+
+REGISTRATIONS = "/etc/yunohost/registrations.yml"
+
+def user_subscription_list():
+    """
+    List pending subscriptions
+    """
+
+    return read_yaml(REGISTRATIONS).get("subscriptions", None)
+
+#TODO: user_subscription_accept(username)
+
+def user_subscription_deny(username):
+    """
+    Deny a pending subscription
+    """
+
+    registrations = read_yaml(REGISTRATIONS)
+    for r in registrations["subscriptions"]:
+        if r["username"] == username:
+            registrations.remove(r)
+    write_to_yaml(registrations)
+    return True
+
+def user_subscription_invite_list():
+    """
+    List current invitations
+    """
+
+    return read_yaml(REGISTRATIONS).get("invitations", None)
+
+#TODO: user_subscription_invite_create(email, groups, quota, nb_account)
+
+def user_subscription_invite_delete(code):
+    """
+    Delete an invitation
+    """
+
+    registrations = read_yaml(REGISTRATIONS)
+    for r in registrations["invitations"]:
+        if r["code"] == code:
+            registrations.remove(r)
+    write_to_yaml(registrations)
+    return True
+
+#TODO: user_subscription_captcha(code)
+
+#TODO: user_subscription_register(username, code, firstname, lastname, password)
+
+#TODO: user_subscription_resend(code)
+
+#TODO: user_subscription_validate(username)
+
+#
+# End subcription subcategory
 #
 
 


### PR DESCRIPTION
*Disclaimer: only technical discussions are allowed in the comments. 🛠️*

Addresses some parts of https://github.com/YunoHost/issues/issues/1677.
Will depend on other PRs in SSOwat and the webadmin.

- [x] configuration panel for registration modes (discarding user-to-user mode suggested by users for the time being)
- [x] actionsmap
    - deviation from the initial plan: add endpoints to list, create, delete invitation codes (to manage the suggested `nb_account` number of accounts that can be create by an invitation code)
    - deviation from the initial plan: split CAPTCHA (GET) and register (POST) endpoints
    - [ ] decide if we let users decide their domain for main email address and xmpp account
    - [ ] decide if we let users decide their login shell (IMHO it's poweruser level, let's default it)
- Python functions:
    - [ ] user_subscription_list()
    - [ ] user_subscription_accept()
    - [ ] user_subscription_deny()
    - [ ] user_subscription_invite_list()
    - [ ] user_subscription_invite_create()
    - [ ] user_subscription_invite_delete()
    - [ ] user_subscription_captcha() (help needed, I have no idea how to implement that)
    - [ ] user_subscription_register()
    - [ ] user_subscription_resend()
    - [ ] user_subscription_validate()
- [ ] cron to clean old validation/invitation codes
- [ ] log for Fail2Ban to prevent brute-force attempts on the invitation codes

## PR Status

Much drafty.

## How to test

Don't.
