### PR TITLE
Allow installation from gitea

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -84,7 +84,7 @@ re_app_instance_name = re.compile(
 )
 
 APP_REPO_URL = re.compile(
-    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./~]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?(tree|src/branch)/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
+    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./~]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?(tree|src/(branch|tag|commit))/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
 )
 
 APP_FILES_TO_COPY = [

--- a/src/app.py
+++ b/src/app.py
@@ -84,7 +84,7 @@ re_app_instance_name = re.compile(
 )
 
 APP_REPO_URL = re.compile(
-    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./~]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?tree/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
+    r"^https://[a-zA-Z0-9-_.]+/[a-zA-Z0-9-_./~]+/[a-zA-Z0-9-_.]+_ynh(/?(-/)?(tree|src/branch)/[a-zA-Z0-9-_.]+)?(\.git)?/?$"
 )
 
 APP_FILES_TO_COPY = [

--- a/src/tests/test_appurl.py
+++ b/src/tests/test_appurl.py
@@ -69,8 +69,19 @@ def test_repo_url_definition():
     assert _is_app_repo_url("git@github.com:YunoHost-Apps/foobar_ynh.git")
     assert _is_app_repo_url("https://git.super.host/~max/foobar_ynh")
 
+    ### Gitea
+    assert _is_app_repo_url("https://gitea.instance.tld/user/repo_ynh")
+    assert _is_app_repo_url("https://gitea.instance.tld/user/repo_ynh/src/branch/branch_name")
+    assert _is_app_repo_url("https://gitea.instance.tld/user/repo_ynh/src/tag/tag_name")
+    assert _is_app_repo_url("https://gitea.instance.tld/user/repo_ynh/src/commit/abcd1234")
+    
+    ### Invalid patterns
+
+    # no schema
     assert not _is_app_repo_url("github.com/YunoHost-Apps/foobar_ynh")
+    # http
     assert not _is_app_repo_url("http://github.com/YunoHost-Apps/foobar_ynh")
+    # does not end in `_ynh`
     assert not _is_app_repo_url("https://github.com/YunoHost-Apps/foobar_wat")
     assert not _is_app_repo_url("https://github.com/YunoHost-Apps/foobar_ynh_wat")
     assert not _is_app_repo_url("https://github.com/YunoHost-Apps/foobar/tree/testing")


### PR DESCRIPTION
[Gitea](https://about.gitea.com/) has branch URL in form `https://domain.tld/gitea/path/<owner>/<repo>_ynh/src/branch/<branch_name>`.

## The problem
It's impossible to install branch from non-default branch if repo is hosted in Gitea.
...

## Solution
Adjust `APP_REPO_URL` to allow Gitea-specific syntax.
...

## PR Status
Ready I guess :)

...

## How to test
Try installing apps from repo mirrored to Gitea. Should work with default branch, arbitrary branch, tag and commit hash.
...
