### PR TITLE
Gandi's `api_protocol` field should be a `select` type

### DIFF
--- a/share/registrar_list.toml
+++ b/share/registrar_list.toml
@@ -227,7 +227,7 @@
     redact = true
     
     [gandi.api_protocol]
-    type = "string"
+    type = "select"
     choices.rpc = "RPC"
     choices.rest = "REST"
     default = "rest"


### PR DESCRIPTION
## The problem

In the domain's config panel:
```
Packagers: option api_protocol has 'choices' but has type 'string', use 'select' instead to remove this warning.
```
