### PR TITLE
trigger hooks when adding or removing user into group

### DIFF
--- a/src/user.py
+++ b/src/user.py
@@ -1137,6 +1137,7 @@ def user_group_update(
 ):
     from yunohost.permission import permission_sync_to_user
     from yunohost.utils.ldap import _get_ldap_interface, _ldap_path_extract
+    from yunohost.hook import hook_callback
 
     existing_users = list(user_list()["users"].keys())
 
@@ -1175,6 +1176,11 @@ def user_group_update(
     ]
     new_group_members = copy.copy(current_group_members)
     new_attr_dict = {}
+
+    # Group permissions
+    current_group_permissions = [
+        _ldap_path_extract(p, "cn") for p in group.get("permission", [])
+    ]
 
     if add:
         users_to_add = [add] if not isinstance(add, list) else add
@@ -1288,6 +1294,36 @@ def user_group_update(
 
     if sync_perm:
         permission_sync_to_user()
+
+    if add and users_to_add:
+        for permission in current_group_permissions:
+            app = permission.split(".")[0]
+            sub_permission = permission.split(".")[1]
+
+            hook_callback(
+                "post_app_addaccess",
+                args=[
+                    app,
+                    ",".join(users_to_add),
+                    sub_permission,
+                    ""
+                ],
+            )
+
+    if remove and users_to_remove:
+        for permission in current_group_permissions:
+            app = permission.split(".")[0]
+            sub_permission = permission.split(".")[1]
+
+            hook_callback(
+                "post_app_removeaccess",
+                args=[
+                    app,
+                    ",".join(users_to_remove),
+                    sub_permission,
+                    ""
+                ],
+            )
 
     if not from_import:
         if groupname != "all_users":


### PR DESCRIPTION
## The problem
The `post_app_addaccess` and `post_app_removeaccess` are not triggered when adding or removing a user to / from a group with the commands `yunohost user group add` and `yunohost user group remove`

## Solution
Add a `hook_callback` call in the appropriate function. 

## PR Status
To be tested

## How to test
- install a app with `post_app_addaccess` and `post_app_removeaccess` hooks
- add a user into a group
- => `post_app_addaccess` hook is called
- remove a user from a group
- => `post_app_removeaccess` hook is called


This PR is related to https://github.com/YunoHost/issues/issues/2213