### PR TITLE
Handle both cookies in the same way (please let me logout)

### DIFF
--- a/src/authenticators/ldap_admin.py
+++ b/src/authenticators/ldap_admin.py
@@ -138,6 +138,7 @@ class Authenticator(BaseAuthenticator):
             secure=True,
             secret=session_secret,
             httponly=True,
+            path="/"
             # samesite="strict", # Bottle 0.12 doesn't support samesite, to be added in next versions
         )
 
@@ -172,5 +173,4 @@ class Authenticator(BaseAuthenticator):
     def delete_session_cookie(self):
         from bottle import response
 
-        response.set_cookie("yunohost.admin", "", max_age=-1)
-        response.delete_cookie("yunohost.admin")
+        response.delete_cookie("yunohost.admin", path="/")

--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -172,5 +172,4 @@ class Authenticator(BaseAuthenticator):
 
         from bottle import response
 
-        response.set_cookie("yunohost.portal", "")
-        response.delete_cookie("yunohost.portal")
+        response.delete_cookie("yunohost.portal", path="/")


### PR DESCRIPTION
## The problem

I could not log out from the new SSO. It would display the login form but the cookie was still there hiding in the shadows.

## Solution

The cookie was created with path '/' so removing it only works if the same path is provided.

## PR Status

I unified all paths to '/' which seems to work. Maybe we should just not specify it.