### PR TITLE
Serialize the JWT token to a cookie string instead of failing

### DIFF
--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -132,7 +132,7 @@ class Authenticator(BaseAuthenticator):
 
         response.set_cookie(
             "yunohost.portal",
-            jwt.encode(new_infos, session_secret, algorithm="HS256"),
+            jwt.encode(new_infos, session_secret, algorithm="HS256").decode(),
             secure=True,
             httponly=True,
             path="/",


### PR DESCRIPTION
As per the instructions here: https://github.com/YunoHost/issues/issues/2028#issuecomment-1676380458