### PR TITLE
Allow inline scripts for yunohost-portal (nginx CSP)

### DIFF
--- a/conf/nginx/plain/yunohost_sso.conf.inc
+++ b/conf/nginx/plain/yunohost_sso.conf.inc
@@ -13,5 +13,5 @@ location /yunohost/sso/ {
         more_set_headers "Cache-Control: no-store, no-cache, must-revalidate";
     }
 
-    more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'none'; img-src 'self' data:;";
+    more_set_headers "Content-Security-Policy: upgrade-insecure-requests; default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; img-src 'self' data:;";
 }


### PR DESCRIPTION
The new yunohost-portal package uses inline scripts in its current form so it should be allowed in the CSP for this route.

See also https://github.com/YunoHost/issues/issues/2028#issuecomment-1676380458