### PR TITLE
[fix] typo in app_upgrade argument help

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -980,7 +980,7 @@ app:
                     action: store_true
                 -c:
                     full: --continue-on-failure
-                    help: Continue to upgrade apps event if one or more upgrade failed
+                    help: Continue to upgrade apps even if one or more upgrade failed
                     action: store_true
 
         ### app_change_url()


### PR DESCRIPTION
## The problem
Small typo in --continue-on-failure arg help in yunohost app_upgrade:
Continue to upgrade apps event if one or more upgrade failed instead of
Continue to upgrade apps even if one or more upgrade failed

## Solution
Fix typo in share/actionsmap.yml

## PR Status

...

## How to test
Run sudo yunohost app -h and check typo is fixed
...
