### PR TITLE
Use the existing db_name setting for database provising

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1338,7 +1338,7 @@ class DatabaseAppResource(AppResource):
     def provision_or_update(self, context: Dict = {}):
         # This is equivalent to ynh_sanitize_dbid
         db_user = self.app.replace("-", "_").replace(".", "_")
-        db_name = self.get_setting("db_name") || db_user
+        db_name = self.get_setting("db_name") or db_user
         self.set_setting("db_name", db_name)
         self.set_setting("db_user", db_user)
 

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1373,7 +1373,7 @@ class DatabaseAppResource(AppResource):
 
     def deprovision(self, context: Dict = {}):
         db_user = self.app.replace("-", "_").replace(".", "_")
-        db_name = self.get_setting("db_name") || db_user
+        db_name = self.get_setting("db_name") or db_user
 
         if self.dbtype == "mysql":
             self._run_script(

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1337,8 +1337,8 @@ class DatabaseAppResource(AppResource):
 
     def provision_or_update(self, context: Dict = {}):
         # This is equivalent to ynh_sanitize_dbid
-        db_name = self.app.replace("-", "_").replace(".", "_")
-        db_user = db_name
+        db_user = self.app.replace("-", "_").replace(".", "_")
+        db_name = self.get_setting("db_name") || db_user
         self.set_setting("db_name", db_name)
         self.set_setting("db_user", db_user)
 
@@ -1372,8 +1372,8 @@ class DatabaseAppResource(AppResource):
                 )
 
     def deprovision(self, context: Dict = {}):
-        db_name = self.app.replace("-", "_").replace(".", "_")
-        db_user = db_name
+        db_user = self.app.replace("-", "_").replace(".", "_")
+        db_name = self.get_setting("db_name") || db_user
 
         if self.dbtype == "mysql":
             self._run_script(


### PR DESCRIPTION
## The problem

Upgrading an app from packaging v1 when db_name was different from `app` can causes issues

see https://github.com/YunoHost-Apps/glitchsoc_ynh/pull/142#issuecomment-1686145422

## Solution

- Use the existing db_name setting during provisioning

## PR Status

Yolocommited

## How to test

...
