### PR TITLE
[enh] bind heritage in config panel

### DIFF
--- a/helpers/config
+++ b/helpers/config
@@ -172,7 +172,7 @@ for panel_name, panel in loaded_toml.items():
             if bind == "settings" and param.get('type', 'string') == 'file':
                 bind = 'null'
 
-            print(';'.join([
+            print('|'.join([
                 name,
                 param.get('type', 'string'),
                 bind
@@ -181,7 +181,7 @@ EOL
     )
     for line in $lines; do
         # Split line into short_setting, type and bind
-        IFS=';' read short_setting type bind <<<"$line"
+        IFS='|' read short_setting type bind <<<"$line"
         binds[${short_setting}]="$bind"
         types[${short_setting}]="$type"
         file_hash[${short_setting}]=""

--- a/helpers/config
+++ b/helpers/config
@@ -153,13 +153,16 @@ for panel_name, panel in loaded_toml.items():
                 if bind_section:
                     bind = bind_section
                 else:
-                    bind = 'settings' if param.get('type', 'string') != 'file' else 'null'
+                    bind = 'settings'
             elif bind[-1] == ":" and bind_section and ":" in bind_section:
                 regex, bind_file = bind_section.split(":")
                 if ">" in bind:
                     bind = bind + bind_file
                 else:
                     bind = regex + bind + bind_file
+            if bind == "settings" and param.get('type', 'string') == 'file':
+                bind = 'null'
+
             print(';'.join([
                 name,
                 param.get('type', 'string'),

--- a/helpers/config
+++ b/helpers/config
@@ -108,11 +108,11 @@ _ynh_app_config_apply_one() {
         else
             local bind_after=""
             local bind_key_="$(echo "$bind" | cut -d: -f1)"
-            bind_key_=${bind_key_:-$short_setting}
             if [[ "$bind_key_" == *">"* ]]; then
                 bind_after="$(echo "${bind_key_}" | cut -d'>' -f1)"
                 bind_key_="$(echo "${bind_key_}" | cut -d'>' -f2)"
             fi
+            bind_key_=${bind_key_:-$short_setting}
             local bind_file="$(echo "$bind" | cut -d: -f2 | sed s@__INSTALL_DIR__@$install_dir@ | sed s@__FINALPATH__@$final_path@ | sed s/__APP__/$app/)"
 
             ynh_backup_if_checksum_is_different --file="$bind_file"
@@ -139,15 +139,31 @@ loaded_toml = toml.loads(file_content, _dict=OrderedDict)
 
 for panel_name, panel in loaded_toml.items():
     if not isinstance(panel, dict): continue
+    bind_panel = panel.get('bind')
     for section_name, section in panel.items():
         if not isinstance(section, dict): continue
+        bind_section = section.get('bind', bind_panel)
         for name, param in section.items():
             if not isinstance(param, dict):
                 continue
+
+            bind = param.get('bind')
+
+            if not bind:
+                if bind_section:
+                    bind = bind_section
+                else:
+                    bind = 'settings' if param.get('type', 'string') != 'file' else 'null'
+            elif bind[-1] == ":" and bind_section and ":" in bind_section:
+                regex, bind_file = bind_section.split(":")
+                if ">" in bind:
+                    bind = bind + bind_file
+                else:
+                    bind = regex + bind + bind_file
             print(';'.join([
                 name,
                 param.get('type', 'string'),
-                param.get('bind', 'settings' if param.get('type', 'string') != 'file' else 'null')
+                bind
                 ]))
 EOL
     )

--- a/helpers/config
+++ b/helpers/config
@@ -142,7 +142,16 @@ for panel_name, panel in loaded_toml.items():
     bind_panel = panel.get('bind')
     for section_name, section in panel.items():
         if not isinstance(section, dict): continue
-        bind_section = section.get('bind', bind_panel)
+        bind_section = section.get('bind')
+        if not bind_section:
+            bind_section = bind_panel
+        elif bind_section[-1] == ":" and bind_panel and ":" in bind_panel:
+            regex, bind_panel_file = bind_panel.split(":")
+            if ">" in bind_section:
+                bind_section = bind_section + bind_panel_file
+            else:
+                bind_section = regex + bind_section + bind_panel_file
+            
         for name, param in section.items():
             if not isinstance(param, dict):
                 continue

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -345,14 +345,14 @@ class ConfigPanel:
                 "defaults": {"version": 1.0},
             },
             "panels": {
-                "properties": ["name", "services", "actions", "help"],
+                "properties": ["name", "services", "actions", "help", "bind"],
                 "defaults": {
                     "services": [],
                     "actions": {"apply": {"en": "Apply"}},
                 },
             },
             "sections": {
-                "properties": ["name", "services", "optional", "help", "visible"],
+                "properties": ["name", "services", "optional", "help", "visible", "bind"],
                 "defaults": {
                     "name": "",
                     "services": [],


### PR DESCRIPTION
## The problem

When we create config panel, sometimes all a section or a panel is bound to a same config file. Always copy the bind property with the config file path is so much verbose !

## Solution

Implements a sort of heritage between panel section and params, example:
```toml
[main]
name = ""
bind = ":__INSTALL_DIR__/public/organization.properties"
  
  [main.section_1]
  name = "General"
    [main.section_1.foo]
    bind = "toto:" # -> "toto:__INSTALL_DIR__/public/organization.properties"
    [main.section_1.bar]
    # Pas de bind à ce niveau -> ":__INSTALL_DIR__/public/organization.properties"
    [main.section_1.aaa]
    bind = "settings" # -> "settings"
    [main.section_1.zzz]
    bind = "null" # -> "null"
    [main.section_1.plop]
    bind = "plop()" # -> "plop()"

  [main.section_2]
  name = "Advanced"
  bind = "advanced>:" # -> "advanced>:__INSTALL_DIR__/public/organization.properties"
    [main.section_2.foo_2]
    bind = "foo:" # -> "advanced>foo:__INSTALL_DIR__/public/organization.properties"
    [main.section_2.bar_2]
    bind = "somewhere>bar:" # -> "somewhere>bar:__INSTALL_DIR__/public/organization.properties"
```


## PR Status

Tested manually (without unit tests)

## How to test
On my side i have tested it with chatonsinfos_ynh package
