### PR TITLE
Allow system users to send mails from IPv6 localhost.

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3261,7 +3261,7 @@ def regen_mail_app_user_config_for_dovecot_and_postfix(only=None):
         if dovecot:
             hashed_password = _hash_user_password(settings["mail_pwd"])
             dovecot_passwd.append(
-                f"{app}:{hashed_password}::::::allow_nets=127.0.0.1/24"
+                f"{app}:{hashed_password}::::::allow_nets=::1,127.0.0.1/24,local"
             )
         if postfix:
             mail_user = settings.get("mail_user", app)


### PR DESCRIPTION
## The problem

As observed in FitTrackee system user was not able to send mail. I narrowed it down to the following stanza(s)

manifest.toml:

```toml
[resources]
    [resources.system_user]
    allow_email = true
```

sample.py:

```python
import smtplib
import ssl

sender_email = "system_user@domain.tld"
username = "system_user"
password = "password"
host = "domain.tld"
port = 25
recipient = "some_user@some.domain.tld"

message = "From: %s\r\nTo: %s\r\n\r\nTest message" % (sender_email, recipient)

print(message)

connection_params = {}
context = ssl.create_default_context()

with smtplib.SMTP(
  host, port, **connection_params
) as smtp:
  smtp.set_debuglevel(2)
  smtp.ehlo()
  smtp.starttls(context=context)
  smtp.ehlo()
  smtp.login(username, password)
  smtp.sendmail(sender_email, recipient, message)
  smtp.quit()
```

`journalctl` would indicate `SMTP AUTH` error for connection coming from `localhost[::1]`.

## Solution

As per documentation on [`allow_nets` dovecot password file property](https://doc.dovecot.org/configuration_manual/authentication/allow_nets/) one should add IPv6's `localhost` aka `::1` as well as `local` to allowed domains to allow connections in IPv6 environment as well as auth in no-IP scenarios (whatever these are).

## PR Status

This is the piece of code that powers `yunohost tools regen-conf`, right?

Resulting change tested, hopefully it generates dovecot configuration as expected.

## How to test

Relevant Python stanza provided, test with any provisioned system user with e-mail capabilities.