### PR TITLE
Update fail2ban jail conf

### DIFF
--- a/conf/fail2ban/jail.conf
+++ b/conf/fail2ban/jail.conf
@@ -105,7 +105,7 @@ bantime  = 10m
 findtime  = 10m
 
 # "maxretry" is the number of failures before a host get banned.
-maxretry = 5
+maxretry = 10
 
 # "maxmatches" is the number of matches stored in ticket (resolvable via tag <matches> in actions).
 maxmatches = %(maxretry)s

--- a/conf/fail2ban/jail.conf
+++ b/conf/fail2ban/jail.conf
@@ -18,7 +18,7 @@
 # See man 5 jail.conf for details.
 #
 # [DEFAULT]
-# bantime = 3600
+# bantime = 1h
 #
 # [sshd]
 # enabled = true
@@ -44,10 +44,52 @@ before = paths-debian.conf
 # MISCELLANEOUS OPTIONS
 #
 
-# "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
-# ban a host which matches an address in this list. Several addresses can be
-# defined using space (and/or comma) separator.
-ignoreip = 127.0.0.1/8
+# "bantime.increment" allows to use database for searching of previously banned ip's to increase a 
+# default ban time using special formula, default it is banTime * 1, 2, 4, 8, 16, 32...
+#bantime.increment = true
+
+# "bantime.rndtime" is the max number of seconds using for mixing with random time 
+# to prevent "clever" botnets calculate exact time IP can be unbanned again:
+#bantime.rndtime = 
+
+# "bantime.maxtime" is the max number of seconds using the ban time can reach (doesn't grow further)
+#bantime.maxtime = 
+
+# "bantime.factor" is a coefficient to calculate exponent growing of the formula or common multiplier,
+# default value of factor is 1 and with default value of formula, the ban time 
+# grows by 1, 2, 4, 8, 16 ...
+#bantime.factor = 1
+
+# "bantime.formula" used by default to calculate next value of ban time, default value below,
+# the same ban time growing will be reached by multipliers 1, 2, 4, 8, 16, 32...
+#bantime.formula = ban.Time * (1<<(ban.Count if ban.Count<20 else 20)) * banFactor
+#
+# more aggressive example of formula has the same values only for factor "2.0 / 2.885385" :
+#bantime.formula = ban.Time * math.exp(float(ban.Count+1)*banFactor)/math.exp(1*banFactor)
+
+# "bantime.multipliers" used to calculate next value of ban time instead of formula, corresponding
+# previously ban count and given "bantime.factor" (for multipliers default is 1);
+# following example grows ban time by 1, 2, 4, 8, 16 ... and if last ban count greater as multipliers count, 
+# always used last multiplier (64 in example), for factor '1' and original ban time 600 - 10.6 hours
+#bantime.multipliers = 1 2 4 8 16 32 64
+# following example can be used for small initial ban time (bantime=60) - it grows more aggressive at begin,
+# for bantime=60 the multipliers are minutes and equal: 1 min, 5 min, 30 min, 1 hour, 5 hour, 12 hour, 1 day, 2 day
+#bantime.multipliers = 1 5 30 60 300 720 1440 2880
+
+# "bantime.overalljails" (if true) specifies the search of IP in the database will be executed 
+# cross over all jails, if false (default), only current jail of the ban IP will be searched
+#bantime.overalljails = false
+
+# --------------------
+
+# "ignoreself" specifies whether the local resp. own IP addresses should be ignored
+# (default is true). Fail2ban will not ban a host which matches such addresses.
+#ignoreself = true
+
+# "ignoreip" can be a list of IP addresses, CIDR masks or DNS hosts. Fail2ban
+# will not ban a host which matches an address in this list. Several addresses
+# can be defined using space (and/or comma) separator.
+#ignoreip = 127.0.0.1/8 ::1
 
 # External command that will take an tagged arguments to ignore, e.g. <ip>,
 # and return true if the IP is to be ignored. False otherwise.
@@ -56,14 +98,17 @@ ignoreip = 127.0.0.1/8
 ignorecommand =
 
 # "bantime" is the number of seconds that a host is banned.
-bantime  = 600
+bantime  = 10m
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-findtime  = 600
+findtime  = 10m
 
 # "maxretry" is the number of failures before a host get banned.
-maxretry = 10
+maxretry = 5
+
+# "maxmatches" is the number of matches stored in ticket (resolvable via tag <matches> in actions).
+maxmatches = %(maxretry)s
 
 # "backend" specifies the backend used to get files modification.
 # Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
@@ -113,10 +158,13 @@ logencoding = auto
 enabled = false
 
 
+# "mode" defines the mode of the filter (see corresponding filter implementation for more info).
+mode = normal
+
 # "filter" defines the filter to use by the jail.
 #  By default jails have names matching their filter name
 #
-filter = %(__name__)s
+filter = %(__name__)s[mode=%(mode)s]
 
 
 #
@@ -130,7 +178,7 @@ filter = %(__name__)s
 destemail = root@localhost
 
 # Sender email address used solely for some actions
-sender = root@localhost
+sender = root@<fq-hostname>
 
 # E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
 # mailing. Change mta configuration parameter to mail if you want to
@@ -140,8 +188,8 @@ mta = sendmail
 # Default protocol
 protocol = tcp
 
-# Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+# Specify chain where jumps would need to be added in ban-actions expecting parameter chain
+chain = <known/chain>
 
 # Ports to be banned
 # Usually should be overridden in a particular jail
@@ -161,51 +209,53 @@ banaction = iptables-multiport
 banaction_allports = iptables-allports
 
 # The simplest action to take: ban only
-action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+action_ = %(banaction)s[port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report to the destemail.
-action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-            %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+action_mw = %(action_)s
+            %(mta)s-whois[sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report and relevant log lines
 # to the destemail.
-action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+action_mwl = %(action_)s
+             %(mta)s-whois-lines[sender="%(sender)s", dest="%(destemail)s", logpath="%(logpath)s", chain="%(chain)s"]
 
 # See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
 #
 # ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
 # to the destemail.
-action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+action_xarf = %(action_)s
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath="%(logpath)s", port="%(port)s"]
+
+# ban & send a notification to one or more of the 50+ services supported by Apprise.
+# See https://github.com/caronc/apprise/wiki for details on what is supported.
+#
+# You may optionally over-ride the default configuration line (containing the Apprise URLs)
+# by using 'apprise[config="/alternate/path/to/apprise.cfg"]' otherwise
+# /etc/fail2ban/apprise.conf is sourced for your supported notification configuration.
+# action = %(action_)s
+#          apprise
 
 # ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
 # to the destemail.
 action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
-                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+                %(mta)s-whois-lines[sender="%(sender)s", dest="%(destemail)s", logpath="%(logpath)s", chain="%(chain)s"]
 
 # Report block via blocklist.de fail2ban reporting service API
 # 
-# See the IMPORTANT note in action.d/blocklist_de.conf for when to
-# use this action. Create a file jail.d/blocklist_de.local containing
-# [Init]
-# blocklist_de_apikey = {api key from registration]
+# See the IMPORTANT note in action.d/blocklist_de.conf for when to use this action.
+# Specify expected parameters in file action.d/blocklist_de.local or if the interpolation
+# `action_blocklist_de` used for the action, set value of `blocklist_de_apikey`
+# in your `jail.local` globally (section [DEFAULT]) or per specific jail section (resp. in 
+# corresponding jail.d/my-jail.local file).
 #
-action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
+action_blocklist_de  = blocklist_de[email="%(sender)s", service="%(__name__)s", apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
 
-# Report ban via badips.com, and use as blacklist
+# Report ban via abuseipdb.com.
 #
-# See BadIPsAction docstring in config/action.d/badips.py for
-# documentation for this action.
+# See action.d/abuseipdb.conf for usage example and details.
 #
-# NOTE: This action relies on banaction being present on start and therefore
-# should be last action defined for a jail.
-#
-action_badips = badips.py[category="%(__name__)s", banaction="%(banaction)s", agent="%(fail2ban_agent)s"]
-#
-# Report ban via badips.com (uses action.d/badips.conf for reporting only)
-#
-action_badips_report = badips[category="%(__name__)s", agent="%(fail2ban_agent)s"]
+action_abuseipdb = abuseipdb
 
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
@@ -223,15 +273,10 @@ action = %(action_)s
 
 [sshd]
 
-port    = ssh
-logpath = %(sshd_log)s
-backend = %(sshd_backend)s
-
-
-[sshd-ddos]
-# This jail corresponds to the standard configuration in Fail2ban.
-# The mail-whois action send a notification e-mail with a whois request
-# in the body.
+# To use more aggressive sshd modes set filter parameter "mode" in jail.local:
+# normal (default), ddos, extra or aggressive (combines all).
+# See "tests/files/logs/sshd" or "filter.d/sshd.conf" for usage example and details.
+#mode   = normal
 port    = ssh
 logpath = %(sshd_log)s
 backend = %(sshd_backend)s
@@ -265,7 +310,7 @@ logpath  = %(apache_error_log)s
 # for email addresses. The mail outputs are buffered.
 port     = http,https
 logpath  = %(apache_access_log)s
-bantime  = 172800
+bantime  = 48h
 maxretry = 1
 
 
@@ -301,7 +346,7 @@ maxretry = 2
 port     = http,https
 logpath  = %(apache_access_log)s
 maxretry = 1
-ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
+ignorecommand = %(fail2ban_confpath)s/filter.d/ignorecommands/apache-fakegooglebot <ip>
 
 
 [apache-modsecurity]
@@ -321,12 +366,15 @@ maxretry = 1
 [openhab-auth]
 
 filter = openhab
-action = iptables-allports[name=NoAuthFailures]
+banaction = %(banaction_allports)s
 logpath = /opt/openhab/logs/request.log
 
 
+# To use more aggressive http-auth modes set filter parameter "mode" in jail.local:
+# normal (default), aggressive (combines all), auth or fallback
+# See "tests/files/logs/nginx-http-auth" or "filter.d/nginx-http-auth.conf" for usage example and details.
 [nginx-http-auth]
-
+# mode = normal
 port    = http,https
 logpath = %(nginx_error_log)s
 
@@ -342,8 +390,10 @@ logpath = %(nginx_error_log)s
 
 port     = http,https
 logpath  = %(nginx_error_log)s
-maxretry = 2
 
+[nginx-bad-request]
+port    = http,https
+logpath = %(nginx_access_log)s
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year
@@ -377,6 +427,8 @@ logpath = %(lighttpd_error_log)s
 
 port     = http,https
 logpath  = %(roundcube_errors_log)s
+# Use following line in your jail.local if roundcube logs to journal.
+#backend = %(syslog_backend)s
 
 
 [openwebmail]
@@ -426,11 +478,13 @@ backend  = %(syslog_backend)s
 
 port     = http,https
 logpath  = /var/log/tomcat*/catalina.out
+#logpath  = /var/log/guacamole.log
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 port = 2812
 logpath  = /var/log/monit
+           /var/log/monit.log
 
 
 [webmin-auth]
@@ -513,27 +567,29 @@ logpath  = %(vsftpd_log)s
 # ASSP SMTP Proxy Jail
 [assp]
 
-port     = smtp,submission
+port     = smtp,465,submission
 logpath  = /root/path/to/assp/logs/maillog.txt
 
 
 [courier-smtp]
 
-port     = smtp,submission
+port     = smtp,465,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [postfix]
-
-port     = smtp,submission
-logpath  = %(postfix_log)s
-backend  = %(postfix_backend)s
+# To use another modes set filter parameter "mode" in jail.local:
+mode    = more
+port    = smtp,465,submission
+logpath = %(postfix_log)s
+backend = %(postfix_backend)s
 
 
 [postfix-rbl]
 
-port     = smtp,submission
+filter   = postfix[mode=rbl]
+port     = smtp,465,submission
 logpath  = %(postfix_log)s
 backend  = %(postfix_backend)s
 maxretry = 1
@@ -541,14 +597,17 @@ maxretry = 1
 
 [sendmail-auth]
 
-port    = submission,smtp
+port    = submission,465,smtp
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
 
 [sendmail-reject]
-
-port     = smtp,submission
+# To use more aggressive modes set filter parameter "mode" in jail.local:
+# normal (default), extra or aggressive
+# See "tests/files/logs/sendmail-reject" or "filter.d/sendmail-reject.conf" for usage example and details.
+#mode    = normal
+port     = smtp,465,submission
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
@@ -556,7 +615,7 @@ backend  = %(syslog_backend)s
 [qmail-rbl]
 
 filter  = qmail
-port    = smtp,submission
+port    = smtp,465,submission
 logpath = /service/qmail/log/main/current
 
 
@@ -564,14 +623,14 @@ logpath = /service/qmail/log/main/current
 # but can be set by syslog_facility in the dovecot configuration.
 [dovecot]
 
-port    = pop3,pop3s,imap,imaps,submission,sieve
+port    = pop3,pop3s,imap,imaps,submission,465,sieve
 logpath = %(dovecot_log)s
 backend = %(dovecot_backend)s
 
 
 [sieve]
 
-port   = smtp,submission
+port   = smtp,465,submission
 logpath = %(dovecot_log)s
 backend = %(dovecot_backend)s
 
@@ -583,20 +642,21 @@ logpath = %(solidpop3d_log)s
 
 
 [exim]
-
-port   = smtp,submission
+# see filter.d/exim.conf for further modes supported from filter:
+#mode = normal
+port   = smtp,465,submission
 logpath = %(exim_main_log)s
 
 
 [exim-spam]
 
-port   = smtp,submission
+port   = smtp,465,submission
 logpath = %(exim_main_log)s
 
 
 [kerio]
 
-port    = imap,smtp,imaps
+port    = imap,smtp,imaps,465
 logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
@@ -607,14 +667,15 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 
 [courier-auth]
 
-port     = smtp,submission,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
 
 [postfix-sasl]
 
-port     = smtp,submission,imap,imaps,pop3,pop3s
+filter   = postfix[mode=auth]
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -631,7 +692,7 @@ backend = %(syslog_backend)s
 
 [squirrelmail]
 
-port = smtp,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
+port = smtp,465,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
@@ -684,8 +745,8 @@ logpath  = /var/log/named/security.log
 [nsd]
 
 port     = 53
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath = /var/log/nsd.log
 
 
@@ -696,9 +757,8 @@ logpath = /var/log/nsd.log
 [asterisk]
 
 port     = 5060,5061
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/asterisk/messages
 maxretry = 10
 
@@ -706,16 +766,22 @@ maxretry = 10
 [freeswitch]
 
 port     = 5060,5061
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/freeswitch.log
 maxretry = 10
 
 
+# enable adminlog; it will log to a file inside znc's directory by default.
+[znc-adminlog]
+
+port     = 6667
+logpath  = /var/lib/znc/moddata/adminlog/znc.log
+
+
 # To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
 # equivalent section:
-# log-warning = 2
+# log-warnings = 2
 #
 # for syslog (daemon facility)
 # [mysqld_safe]
@@ -729,6 +795,14 @@ maxretry = 10
 port     = 3306
 logpath  = %(mysql_log)s
 backend  = %(mysql_backend)s
+
+
+[mssql-auth]
+# Default configuration for Microsoft SQL Server for Linux
+# See the 'mssql-conf' manpage how to change logpath or port
+logpath = /var/opt/mssql/log/errorlog
+port = 1433
+filter = mssql-auth
 
 
 # Log wrong MongoDB auth (for details see filter 'filter.d/mongodb-auth.conf')
@@ -749,8 +823,8 @@ logpath  = /var/log/mongodb/mongodb.log
 
 logpath  = /var/log/fail2ban.log
 banaction = %(banaction_allports)s
-bantime  = 604800  ; 1 week
-findtime = 86400   ; 1 day
+bantime  = 1w
+findtime = 1d
 
 
 # Generic filter for PAM. Has to be used with action which bans all
@@ -786,11 +860,31 @@ logpath = /var/log/ejabberd/ejabberd.log
 [counter-strike]
 
 logpath = /opt/cstrike/logs/L[0-9]*.log
-# Firewall: http://www.cstrike-planet.com/faq/6
 tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
-action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp"]
+
+[softethervpn]
+port     = 500,4500
+protocol = udp
+logpath  = /usr/local/vpnserver/security_log/*/sec.log
+
+[gitlab]
+port    = http,https
+logpath = /var/log/gitlab/gitlab-rails/application.log
+
+[grafana]
+port    = http,https
+logpath = /var/log/grafana/grafana.log
+
+[bitwarden]
+port    = http,https
+logpath = /home/*/bwdata/logs/identity/Identity/log.txt
+
+[centreon]
+port    = http,https
+logpath = /var/log/centreon/login.log
 
 # consider low maxretry and a long bantime
 # nobody except your own Nagios server should ever probe nrpe
@@ -824,7 +918,9 @@ filter       = apache-pass[knocking_url="%(knocking_url)s"]
 logpath      = %(apache_access_log)s
 blocktype    = RETURN
 returntype   = DROP
-bantime      = 3600
+action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s,
+                        actionstart_on_demand=false, actionrepair_on_unban=true]
+bantime      = 1h
 maxretry     = 1
 findtime     = 1
 
@@ -832,8 +928,8 @@ findtime     = 1
 [murmur]
 # AKA mumble-server
 port     = 64738
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol=udp, chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/mumble-server/mumble-server.log
 
 
@@ -851,5 +947,34 @@ logpath  = /var/log/haproxy.log
 
 [slapd]
 port    = ldap,ldaps
-filter  = slapd
 logpath = /var/log/slapd.log
+
+[domino-smtp]
+port    = smtp,ssmtp
+logpath = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log
+
+[phpmyadmin-syslog]
+port    = http,https
+logpath = %(syslog_authpriv)s
+backend = %(syslog_backend)s
+
+
+[zoneminder]
+# Zoneminder HTTP/HTTPS web interface auth
+# Logs auth failures to apache2 error log
+port    = http,https
+logpath = %(apache_error_log)s
+
+[traefik-auth]
+# to use 'traefik-auth' filter you have to configure your Traefik instance,
+# see `filter.d/traefik-auth.conf` for details and service example.
+port    = http,https
+logpath = /var/log/traefik/access.log
+
+[scanlogd]
+logpath = %(syslog_local0)s
+banaction = %(banaction_allports)s
+
+[monitorix]
+port	= 8080
+logpath = /var/log/monitorix-httpd

--- a/conf/fail2ban/jail.conf
+++ b/conf/fail2ban/jail.conf
@@ -178,7 +178,7 @@ filter = %(__name__)s[mode=%(mode)s]
 destemail = root@localhost
 
 # Sender email address used solely for some actions
-sender = root@<fq-hostname>
+sender = root@localhost
 
 # E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
 # mailing. Change mta configuration parameter to mail if you want to
@@ -189,7 +189,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in ban-actions expecting parameter chain
-chain = <known/chain>
+chain = INPUT
 
 # Ports to be banned
 # Usually should be overridden in a particular jail


### PR DESCRIPTION
## The problem

`jail.conf` is an old version

## Solution

Update it to the [version used on bookworm](https://sources.debian.org/src/fail2ban/1.0.2-2/config/jail.conf/)

## PR Status

Yolocommitted, not tested

## How to test

...
