### PR TITLE
Add a zsh completion file (automatically generated)

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -6,4 +6,5 @@ conf/* /usr/share/yunohost/conf/
 locales/* /usr/share/yunohost/locales/
 doc/yunohost.8.gz /usr/share/man/man8/
 doc/bash_completion.d/* /etc/bash_completion.d/
+doc/zsh_completion.d/* /usr/share/zsh/vendor-completions/
 src/* /usr/lib/python3/dist-packages/yunohost/

--- a/debian/rules
+++ b/debian/rules
@@ -8,4 +8,8 @@ override_dh_auto_build:
 	# Generate bash completion file
 	mkdir -p doc/bash_completion.d
 	python3 doc/generate_bash_completion.py -o doc/bash_completion.d/yunohost
+	# Generate zsh completion file
+	mkdir -p doc/zsh_completion.d
+	python3 doc/generate_zsh_completion.py -o doc/zsh_completion.d/_yunohost
+	# Generate man pages
 	python3 doc/generate_manpages.py --gzip --output doc/yunohost.8.gz

--- a/doc/generate_zsh_completion.py
+++ b/doc/generate_zsh_completion.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024 YunoHost Contributors
+#
+# This file is part of YunoHost (see https://yunohost.org)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""Automated generation of a zsh_completion file for yunohost.
+
+Using the actionsmap yaml file and a jinja template.
+
+INSTALL:
+  This script creates a zsh completion file for yunohost.
+  To install, copy (and rename) the created file to:
+    - (Debian) `/usr/share/zsh/vendor-completions/_yunohost`
+    - (Fedora) `/usr/share/zsh/site-functions/_yunohost`
+    - (other distribution) `/usr/local/share/zsh/site-functions/_yunohost`
+
+DOCS:
+- https://github.com/zsh-users/zsh/blob/master/Etc/completion-style-guide
+- http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Completion-System
+  or `man zshcompsys`
+- http://zsh.sourceforge.net/Guide/zshguide06.html
+
+MISC:
+- http://zsh.sourceforge.net/Doc/Release/Parameters.html#Array-Parameters
+
+MISSING:
+- use the extra:required:True pattern (similar to `nargs`?)
+- In `yunohost.yml`, consider merging:
+  - metavar
+  - pattern
+  - autocomplete
+- Make use of `type`, maybe using `_guard`
+- Use `pattern`, maybe with `_guard`. This seems hard though, as ZSH has
+its own globbing language...
+Link about this globbing system:
+http://zsh.sourceforge.net/Doc/Release/Expansion.html#Filename-Generation
+
+Notes:
+- Command for debugging zsh: `unfunction _yunohost; autoload -U _yunohost`
+
+- Optimization:
+  - caching mecanism: invalidate the cache afer some commands? Hard, the
+  cache is local to user
+  - implement a zstyle switch, to change the cache validity period?
+
+AUTHORS:
+ - buzuck (Fol)
+ - kayou
+ - getzze
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from jinja2 import Template
+
+if TYPE_CHECKING:
+    from typing import NotRequired, TypedDict
+
+    class Function(TypedDict):
+        """Details of a helper function."""
+
+        name: str
+        shell_call: NotRequired[str]
+        aggregated: NotRequired[str]
+
+    class Case(TypedDict):
+        """Details of dynamic argument completion function."""
+
+        name: str
+        shell_call: str
+
+    class Action(TypedDict):
+        """Command line action."""
+
+        name: str
+        help: str
+        arguments: list[str]
+        cases: list[Case]
+
+    class Category(TypedDict):
+        """Command line category.
+
+        Categories have different level:
+         - level 1: main category, e.g. `yunohost user`
+         - level 2: sub-category, e.g. `yunohost user group`
+
+        Only categories of level 1 have a `subs` key.
+
+        Reminder:
+            yunohost     user        group       list    --full --short
+               ^          ^            ^          ^
+            (script) | category | subcategory | action | parameters
+
+        """
+
+        name: str
+        help: str
+        level: int
+        actions: list[Action]
+        subs: NotRequired[dict[str, str]]
+
+
+YUNOHOST_SRCDIR = Path(__file__).resolve().parent.parent
+
+
+def get_actions_zsh(
+    ynh_map: dict[str, dict[str, Any]],
+) -> tuple[list[Category], list[Function]]:
+    """Parse categories, subcategories and actions from an actionsmap yml file.
+
+    Parameters
+    ----------
+    ynh_map: dict[str, dict[str, Any]]
+        A dict loaded from an actionsmap yml file.
+
+    Returns
+    -------
+    tuple[list[Category], list[Function]]
+        A tuple of categories dict and helper functions dict.
+
+    """
+    categories: list[Category] = []
+    functions: list[Function] = []
+
+    for category, cat_info in ynh_map.items():
+        if category.startswith("_") or cat_info.get("hide_in_help", False):
+            continue
+
+        cats, funcs = parse_category(category, cat_info)
+
+        categories.extend(cats)
+        functions.extend(funcs)
+
+    # Remove duplicates in functions
+    functions = [
+        cast("Function", dict(t)) for t in {tuple(d.items()) for d in functions}
+    ]
+
+    return categories, functions
+
+
+def parse_category(
+    name: str,
+    info: dict[str, Any],
+) -> tuple[list[Category], list[Function]]:
+    """Parse a Category  (level 1) for its actions and subcategories.
+
+    Reminder:
+        yunohost   monitor    info    --cpu --ram
+           ^          ^         ^          ^
+        (script) | category | action | parameters
+
+    A Category may contain subcategories (of level 2), so a list of categories
+    (of level 1 and 2) is returned.
+    A category may need to define help functions that are needed to build
+    the list of options. The list of help functions is returned.
+
+    Parameters
+    ----------
+    name: str
+        the category name
+    info: dict[str, Any]
+        the information dict about the category
+
+    Returns
+    -------
+    tuple[list[Category], list[Function]]
+        A tuple of the list of category and subcategories dicts
+        and the list of category and subcategories helper functions.
+
+    """
+    cat: Category = {
+        "name": name,
+        "level": 1,
+        "help": _escape(info.get("category_help", "")),
+        "actions": [],
+        "subs": {},
+    }
+    # Add the category first, the subcategories will be appended later
+    categories: list[Category] = [cat]
+    functions: list[Function] = []
+
+    # Parse actions (before subcategories)
+    actions = []
+    for action, action_info in info.get("actions", {}).items():
+        if action_info.get("hide_in_help", False):
+            continue
+
+        act, funcs = parse_actions(action, action_info)
+        actions.append(act)
+        functions.extend(funcs)
+    cat["actions"] = actions
+
+    # Parse subcategories
+    subs = {}
+    for subcategory, subcategory_info in info.get("subcategories", {}).items():
+        if subcategory.startswith("_") or subcategory_info.get("hide_in_help", False):
+            continue
+
+        help, subcategory_dict, funcs = parse_subcategory(  # noqa: A001
+            name,
+            subcategory,
+            subcategory_info,
+        )
+        subs[subcategory] = help
+        functions.extend(funcs)
+        # Append subcategory below the category
+        categories.append(subcategory_dict)
+    # Add the list of subcategories to the category
+    cat["subs"] = subs
+
+    return categories, functions
+
+
+def parse_subcategory(
+    category: str,
+    name: str,
+    info: dict[str, Any],
+) -> tuple[str, Category, list[Function]]:
+    """Parse a sub-category (level 2) for its actions.
+
+    Reminder:
+        yunohost     user        group       list    --full --short
+           ^          ^            ^          ^
+        (script) | category | subcategory | action | parameters
+
+    A subcategory is treated as a Category (of level 2), with an 'actions' key,
+    but no 'subs' key.
+    The help text of the subcategory is needed to construct the 'subs' dict
+    of the parent category.
+    Like a level-1 category, subcategories may need to define help functions.
+    The list of help functions is returned.
+
+    Parameters
+    ----------
+    category: str
+        the name of the parent category
+    name: str
+        the subcategory name
+    info: dict[str, Any]
+        the information dict about the subcategory
+
+    Returns
+    -------
+    tuple[str, Category, list[Function]]
+        A tuple of the subcategory help text, the subcategory dict
+        and the list of subcategory helper functions.
+
+    """
+    full_name = f"{category}_{name}"
+    help = _escape(info.get("subcategory_help", ""))  # noqa: A001
+
+    subcat: Category = {"name": full_name, "level": 2, "help": help, "actions": []}
+    functions: list[Function] = []
+
+    # Parse actions (before subcategories)
+    actions = []
+    for action, action_info in info.get("actions", {}).items():
+        if action_info.get("hide_in_help", False):
+            continue
+
+        act, funcs = parse_actions(action, action_info)
+        actions.append(act)
+        functions.extend(funcs)
+    subcat["actions"] = actions
+
+    return help, subcat, functions
+
+
+def parse_actions(
+    name: str,
+    info: dict[str, Any],
+) -> tuple[Action, list[Function]]:
+    """Parse an Action for it's help text and arguments.
+
+    Returns
+    -------
+    tuple[Action, list[Function]]
+        A tuple of the action dict and the list of action helper functions.
+
+    """
+    functions: list[Function] = []
+
+    # This is a counter, in case of position dependent paremeters (the ones not
+    # beginning with a `-`)
+    position = 0
+
+    arguments: list[str] = []
+    cases: list[Case] = []
+
+    for _argument_name, argument_info in info.get("arguments", {}).items():
+        #
+        # Forcing to str, as the yaml parser inteprets numbers as integers
+        # (eg.: `firewall allow... -4`)
+        argument_name = str(_argument_name)
+        case: Case | None = None
+        funcs: list[Function] = []
+
+        #
+        # This is an optional parameter, beginning with a `-`
+        if argument_name.startswith("-"):
+            full_argument, case, funcs = parse_argument_optional(
+                argument_name,
+                argument_info,
+            )
+        #
+        # A parameter not beginning with `-` is considered mandatory.
+        else:
+            position += 1
+            full_argument, case, funcs = parse_argument_mandatory(
+                argument_name,
+                argument_info,
+                position,
+            )
+
+        # If action is None, do not display the parameter
+        if not full_argument:
+            continue
+
+        # If case is not None, add a case below the arguments list
+        if case:
+            cases.append(case)
+
+        # Add helper functions
+        functions.extend(funcs)
+
+        # Append argument
+        arguments.append(full_argument)
+
+    help = _escape(info.get("action_help", ""))  # noqa: A001
+    action_dict: Action = {
+        "name": name,
+        "help": help,
+        "arguments": arguments,
+        "cases": cases,
+    }
+    return action_dict, functions
+
+
+def parse_argument_mandatory(
+    name: str,
+    info: dict[str, Any],
+    position: int = 0,
+) -> tuple[str, Case | None, list[Function]]:
+    """Parse a mandatory argument."""
+    #
+    # Initializing the argument dict to make sure all fields are defined
+    # - id: identifier (`-n` or `--name`). If none (e.g. `ynh app install
+    # APP_NAME`), this field is the arguments position or cardinality (from
+    # `nargs`)
+    # - excludes: usually the argument itself. Only used for optional args
+    # - desc: the argument description
+    # - completion: the completion function name
+    #
+    arg = {"excludes": "", "spec": "", "desc": "", "mess": "", "action": "", "func": ""}
+
+    #
+    # Generation of the completion hints
+    #
+    arg["action"], case, functions = parse_argument_action(name, info)
+
+    # Hidden argument
+    if arg["action"] is None:
+        return ("", None, [])
+
+    # This parameter may be used more than once, else we use the position counter
+    if info.get("nargs", "") in ["+", "*"]:
+        if info["nargs"] == "+":
+            arg["spec"] = f"'{{{position!s},*}}'"
+        else:  # argument_details["nargs"] == "*":
+            arg["spec"] = "*"
+    else:
+        arg["spec"] = str(position)
+    arg["mess"] = info.get("help", name)
+
+    #
+    # If defined, add the default value as a hint
+    if "default" in info:
+        arg["mess"] += f" (default: {info['default']})"
+    # Escape special character in the description
+    arg["mess"] = _escape(arg["mess"])
+
+    # ----
+    # NOTE: a double colon marks for an optional argument:
+    #     ::Username to update:__ynh_user_list
+    # ----
+    placeholder = "'{}{}{}:{}:{}'"
+
+    # Escape special character in the description
+    arg["desc"] = _escape(arg["desc"])
+    argument = placeholder.format(
+        arg["excludes"],
+        arg["spec"],
+        arg["desc"],
+        arg["mess"],
+        arg["action"],
+    )
+    return (argument, case, functions)
+
+
+def parse_argument_optional(
+    name: str,
+    info: dict[str, Any],
+) -> tuple[str, Case | None, list[Function]]:
+    """Parse an optional argument."""
+    #
+    # Initializing the argument dict to make sure all fields are defined
+    # - id: identifier (`-n` or `--name`). If none (e.g. `ynh app install
+    # APP_NAME`), this field is the arguments position or cardinality (from
+    # `nargs`)
+    # - excludes: usually the argument itself. Only used for optional args
+    # - desc: the argument description
+    # - completion: the completion function name
+    #
+    arg = {"excludes": "", "spec": "", "desc": "", "mess": "", "action": "", "func": ""}
+
+    #
+    # Generation of the completion hints
+    #
+    arg["action"], case, functions = parse_argument_action(name, info)
+
+    # Hidden argument
+    if arg["action"] is None:
+        return ("", None, [])
+
+    # `full` is the extended form of the argument (e.g.: -n is short for --number)
+    if "full" in info:
+        full_name = info["full"]
+        arg["mess"] = str(full_name).lstrip("-")
+        arg["spec"] = f"'{{{name},{full_name}}}'"
+        arg["excludes"] = f"({name} {full_name})"
+    else:
+        arg["mess"] = str(name).lstrip("-")
+        arg["spec"] = name
+    # Escape special character in the description
+    arg["mess"] = _escape(arg["mess"])
+
+    # The description of the parameter
+    # Getting the `help` field if any, else simply by using it's name
+    help = info.get("help", arg["mess"])  # noqa: A001
+    arg["desc"] = f"[{help}]"
+
+    has_action = True
+    # Add a pattern field to match multiple arguments
+    if info.get("nargs", "") in ["+", "*"]:
+        if arg["excludes"]:
+            # suppose that `arg["excludes"] = (-f --foo)`
+            arg["excludes"] = "(* " + arg["excludes"][1:]
+        else:
+            arg["excludes"] = "(*)"
+        arg["mess"] = "*:" + arg["mess"]
+        has_action = True
+
+    # Options without arguments should skip the message and action fields
+    elif info.get("action", "").startswith("store_"):
+        has_action = False
+
+    # Place holder for the parameters
+    placeholder = "'{}{}{}:{}:{}'" if has_action else "'{}{}{}'"
+    # Escape special character in the description
+    arg["desc"] = _escape(arg["desc"])
+    argument = placeholder.format(
+        arg["excludes"],
+        arg["spec"],
+        arg["desc"],
+        arg["mess"],
+        arg["action"],
+    )
+    return (argument, case, functions)
+
+
+def parse_argument_action(  # noqa: C901, PLR0911, PLR0912
+    name: str,
+    info: dict[str, Any],
+) -> tuple[str, Case | None, list[Function]]:
+    """Parse an argument action."""
+    functions: list[Function] = []
+    #
+    # Finds the completion function for the given argument, if defined.
+    #
+    # `functions` hold the elements needed to generate it.  The
+    # actual creation of this function will be done by build_completion_functions(),
+    # called near the end of this script.
+    # `choices` and `autocomplete` should not be present at the same time
+    # (`choices` takes precedence)
+
+    #
+    # A list of choices is defined
+    if "choices" in info:
+        all_choices = " ".join(info["choices"])
+        action = f"({all_choices})"
+        return (action, None, functions)
+
+    #
+    # Look for an autocompletion function, but it is not defined
+    if "extra" not in info or "autocomplete" not in info["extra"]:
+        return ("", None, functions)
+
+    #
+    # An autocompletion function is defined
+    autocomplete = info["extra"]["autocomplete"]
+
+    #
+    # Check if the argument should be hidden (API only)
+    if autocomplete.get("hide_in_help", False):
+        return ("", None, functions)
+
+    #
+    # This is a combinaision of YunoHost and jq commands
+    #
+    if "ynh_selector" in autocomplete and "jq_selector" in autocomplete:
+        #
+        # Function dependent on previous arguments
+        #
+        if "depends" in autocomplete and autocomplete["depends"] == "previous":
+            # Create cases that depend on the previous argument.
+            #
+            # First, build the shell command that returns the completions
+            call = (
+                f"sudo yunohost {autocomplete['ynh_selector']} "
+                f'"${{previous}}" --output-as json '
+                f"| jq -cr '{autocomplete['jq_selector']}' | xargs"
+            )
+            # If a cache is needed, wrap the call in the caching function
+            if autocomplete.get("use_cache", False):
+                call = '__get_ynh_cache YNH_{}_"${{previous}}" "{}"'.format(
+                    _norm_name(autocomplete["ynh_selector"]),
+                    # Remove the double-quote in "{previous}"
+                    # because the whole cmd will be encased in quotes.
+                    call.replace('"', ""),
+                )
+
+            function_name = f"->{name}"
+            case: Case = {"name": name, "shell_call": call}
+            return (function_name, case, functions)
+
+        # Create this function's name
+        function_name = _remove_special_chars(
+            "__ynh_" + _norm_name(autocomplete["ynh_selector"]),
+        )
+        #
+        # Add a helper function
+        #
+        # First, build the shell command that returns the completions
+        call = "sudo yunohost {} --output-as json | jq -cr '{}'".format(
+            autocomplete["ynh_selector"],
+            autocomplete["jq_selector"],
+        )
+        # If a cache is needed, wrap the call in the caching function
+        if autocomplete.get("use_cache", False):
+            call = "__get_ynh_cache 'YNH_{}' \"{}\"".format(
+                _norm_name(autocomplete["ynh_selector"]),
+                call,
+            )
+        # Lastly, save the content
+        func: Function = {"name": function_name, "shell_call": call}
+        functions.append(func)
+        return (function_name, None, functions)
+
+    #
+    # The autocompletion is done by a grep
+    #
+    if "shell_call" in autocomplete:
+        # Create this function's name
+        function_name = _remove_special_chars(
+            "__ynh_" + _norm_name(autocomplete["shell_call"]),
+        )
+        #
+        # Add a helper function
+        #
+        # First, build the shell command that returns the completions
+        call = autocomplete["shell_call"]
+
+        # If a cache is needed, wrap the call in the caching function
+        # Note: not tested with grep, only with YunoHost's commands
+        if autocomplete.get("use_cache", False):
+            call = "__get_ynh_cache 'YNH_{}' \"{}\"".format(
+                _remove_special_chars(autocomplete["shell_call"]),
+                call,
+            )
+        # Lastly, save the content
+        func = {"name": function_name, "shell_call": call}
+        functions.append(func)
+        return (function_name, None, functions)
+
+    #
+    # This is a combinaision of two other completion functions
+    #
+    if "aggregate" in autocomplete:
+        # Create this function's name
+        function_name = "__ynh"
+        for subcall in autocomplete["aggregate"]:
+            if "ynh_selector" in subcall:
+                function_name += "_" + _norm_name(subcall["ynh_selector"])
+
+        #
+        # Add a helper function
+        aggregation = ""
+        for subcall in autocomplete["aggregate"]:
+            if "name" in subcall and "ynh_selector" in subcall:
+                aggregation += "\n'{}:{}:{}' \\".format(
+                    subcall["name"],
+                    subcall["name"],
+                    _norm_name("__ynh_" + subcall["ynh_selector"]),
+                )
+        # Lastly, save the content
+        func = {"name": function_name, "aggregated": aggregation}
+        functions.append(func)
+        return (function_name, None, functions)
+
+    #
+    # The autocompletion is done by a ZSH function
+    #
+    if "zsh_completion" in autocomplete:
+        return (autocomplete["zsh_completion"], None, functions)
+
+    #
+    # No autocompletion schema was defined
+    #
+    return ("", None, functions)
+
+
+def render_zsh(categories: list[Category], functions: list[Function]) -> str:
+    """Render the jinja template with the parsed categories and helper functions."""
+    template_file = YUNOHOST_SRCDIR / "doc" / "zsh_completion.j2"
+    template = Template(
+        template_file.read_text(),
+        keep_trailing_newline=True,
+        comment_start_string="auieauieauie",
+    )
+
+    return template.render(
+        categories=categories,
+        functions=functions,
+    )
+
+
+#
+# Utility functions, mainly string manipulation
+#
+
+
+def _norm_name(string: str) -> str:
+    """Normalize a string to make it look like a function name.
+
+    Apply the transformations:
+      - lowercase
+      - spaces replaced by underscores
+      - no dashs
+
+    :param str string: the string to norm.
+    :return str: The normed string
+    """
+    return (
+        string.lower()
+        .replace(" ", "_")
+        .replace("-", "")
+        .replace("/", "_")
+        .replace(".", "_")
+    )
+
+
+def _escape(string: str) -> str:
+    r"""Escape any special character.
+
+    Escape the characters:
+      - single quotes (') are put in a separate double quoted string ('"'"')
+      - colons (:) and other characters are preceded by a backslash (\:)
+
+    :param str string: The string to escape
+    :return str: The escaped string
+    """
+    return string.replace("'", "'\"'\"'").replace(":", r"\:")
+
+
+def _remove_special_chars(string: str) -> str:
+    """Remove any character with a special meaning in ZSH.
+
+    Example of characters to remove:
+        `$`, `{`, `(`, `[`, ...
+
+    :param str string: The string to clean
+    :return str: The cleaned string
+    """
+    # NOTE: this list may not be comprehensive and should be extended if needed
+    return re.sub(r'[- =\^+:\?\'"$(){}\[\]/\\\\]', "", string).replace(".", "")
+
+
+#
+# Get action map
+#
+
+
+def get_action_map() -> dict[str, Any]:
+    """Load the actionmap from a YAML file."""
+    actionsmap = YUNOHOST_SRCDIR / "share" / "actionsmap.yml"
+    return cast("dict[str, Any]", yaml.safe_load(actionsmap.open()))
+
+
+def main() -> None:
+    """Generate the completion file for Zsh."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", "-o", type=Path, required=True)
+
+    args = parser.parse_args()
+
+    yunohost_map = get_action_map()
+
+    categories, functions = get_actions_zsh(yunohost_map)
+    result = render_zsh(categories, functions)
+
+    args.output.write_text(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/zsh_completion.j2
+++ b/doc/zsh_completion.j2
@@ -1,0 +1,219 @@
+#compdef yunohost
+#
+# -----------------------------------------------------------------------------
+# Description
+# -----------
+#  Completion script for yunohost, automatically generated from the action map
+#  decribed by `yunohost.yml`
+# -----------------------------------------------------------------------------
+
+local state line curcontext
+
+# For debug purposes only
+__log() {
+    echo $@ >> '/tmp/zsh-completion.log'
+}
+
+# First argument: The name of the completion list
+# 2nd argument:   The command to get it
+# (( $+functions[__get_ynh_cache] )) ||
+function __get_ynh_cache() {
+    # Checking a global cache policy is defined,
+    # and linkage to ynh-cache-policy
+    local update_policy completion_items
+    zstyle -s ":completion:${curcontext}:" cache-policy update_policy
+    if [[ -z "$update_policy" ]]; then
+        zstyle ":completion:${curcontext}:" cache-policy __yunohost_cache_policy
+    fi
+    # If the cache is invalid (too old), regenerate it
+    if _cache_invalid $1 || ! _retrieve_cache $1; then
+        completion_items=(`eval $2`)
+        _store_cache $1 completion_items
+    else
+        _retrieve_cache $1
+    fi
+    echo $completion_items
+}
+
+# (( $+functions[__yunohost_cache_policy] )) ||
+__yunohost_cache_policy(){
+    local cache_file="$1"
+    # Rebuild if the yunohost executable is newer than cache
+    [[ "${commands[yunohost]}" -nt "${cache_file}" ]] && return
+
+    # Rebuild if cache is more than a week old
+    local -a oldp
+    # oldp=( "$1"(mM+1) ) # month
+    # oldp=( "$1"(Nm+7) ) # 1 week
+    oldp=( "$1"(Nmd+1) ) # 1 day
+    (( $#oldp )) && return
+    return 1
+}
+
+#
+# Routing function, used to go through $words and find the correct subfunction
+# (Suggestions welcome to improve that design... =/ )
+# (( $+functions[__jump] )) ||
+function __jump() {
+    local cmd
+
+    # Remember the subcommand name
+    if (( ${#@} == 0 )); then
+        local cmd=${words[2]}
+    else
+        cmd=$1 # < no more used?
+    fi
+
+    # Set the context for the subcommand
+    ynhcommand="${ynhcommand}_${cmd}"
+    # Narrow the range of words we are looking at to exclude `yunohost`
+    (( CURRENT-- ))
+    shift words
+    # Run the completion for the subcommand
+    if ! _call_function ret ${ynhcommand#:*:}; then
+        _default && ret=0
+    fi
+    return ret
+}
+
+#-----------------------------------------
+#   Command
+#-----------------------------------------
+#
+# Principal entry point with general options and list of commands
+# (( $+functions[_yunohost] )) ||
+function _yunohost() {
+    local curcontext="${curcontext}" state line ret=1
+    local mode
+    # `ynhcommand` is where `__jump` builds the name of the completion function
+    ynhcommand='_yunohost'
+
+    typeset -ag common_options; common_options=(
+        '(-h --help)'{-h,--help}'[Show this help message and exit]:help:'
+        '--version[Display YunoHost packages versions]:version:'
+        '--output-as[Output result in another format]:output-as:(json plain none)'
+        '--debug[Log and print debug messages]'
+        '--quiet[Don'"'"'t produce any output]'
+        '--timeout[Number of seconds before this command will timeout because it can'"'"'t acquire the lock (meaning that another command is currently running), by default there is no timeout and the command will wait until it can get the lock]:timeout:'
+    )
+
+    if (( CURRENT > 2 )); then
+        __jump
+    else
+        local -a yunohost_categories; yunohost_categories=(
+            {%- for catinfo in categories %}
+            {%- if catinfo.help and catinfo.level == 1 %}
+            '{{ catinfo.name }}:{{ catinfo.help }}'
+            {%- endif %}
+            {%- endfor %}
+        )
+        _describe -V -t yunohost-commands 'yunohost category' yunohost_categories "$@"
+    fi
+
+    _arguments -s -C $common_options
+    # unset common_option
+}
+
+#-----------------------------------------
+#   Subcommands
+#-----------------------------------------
+
+{%- for catinfo in categories %}
+{%- if catinfo.actions or catinfo.subs %}
+#-----------------------------------------
+#               {{ catinfo.name }}
+#-----------------------------------------
+
+# (( $+functions[_yunohost_{{ catinfo.name }}] )) ||
+function _yunohost_{{ catinfo.name }}() {
+    if (( CURRENT > 2 )); then
+        __jump
+    else
+        {%- if catinfo.actions %}
+        local -a yunohost_{{ catinfo.name }}; yunohost_{{ catinfo.name }}=(
+            {%- for actioninfo in catinfo.actions %}
+            {%- if actioninfo.help %}
+            '{{ actioninfo.name }}:{{ actioninfo.help }}'
+            {%- endif %}
+            {%- endfor %}
+        )
+        _describe -V -t yunohost-{{ catinfo.name }} 'yunohost {{ catinfo.name }} category' yunohost_{{ catinfo.name }} "$@"
+
+        {%- endif %}
+        {% if catinfo.subs %}
+        local -a yunohost_{{ catinfo.name }}_subcategories; yunohost_{{ catinfo.name }}_subcategories=(
+            {%- for subcat_name, subcat_desc in catinfo.subs.items() %}
+            {%- if subcat_desc %}
+            '{{ subcat_name }}:{{ subcat_desc }}'
+            {%- endif %}
+            {%- endfor %}
+        )
+        _describe -V -t yunohost-{{ catinfo.name }}-subcategories 'yunohost {{ catinfo.name }} subcategories' yunohost_{{ catinfo.name }}_subcategories "$@"
+        {%- endif %}
+    fi
+}
+
+{% if catinfo.actions %}
+{% for actioninfo in catinfo.actions %}
+# (( $+functions[_yunohost_{{ catinfo.name }}_{{ actioninfo.name }}] )) ||
+{%- if actioninfo.arguments %}
+function _yunohost_{{ catinfo.name }}_{{ actioninfo.name }}() {
+    {%- if actioninfo.cases %}
+    local context state state_descr line
+    typeset -A opt_args
+    {% endif %}
+    _arguments -s -C \
+        {%- for argumentinfo in actioninfo.arguments %}
+        {{ argumentinfo }} {% if loop.revindex != 1 %}\{% endif %}
+        {%- endfor %}
+    {%- if actioninfo.cases %}
+
+    if (($CURRENT > 2)); then
+        case "$state" in
+            {%- for case in actioninfo.cases %}
+            {{ case.name }})
+                local previous="$words[${CURRENT} - 1]"
+                local cmd_ret=$({{ case.shell_call }})
+                if (( ${#cmd_ret} != 0 )); then
+                    local -a cmd_list=("${(s/ /)cmd_ret}")
+                    _values '{{ case.name }}' $cmd_list
+                fi
+                ;;
+            {%- endfor %}
+        esac
+    fi
+    return $?
+    {%- endif %}
+}
+
+{%- else %}
+function _yunohost_{{ catinfo.name }}_{{ actioninfo.name }}() { }
+
+{%- endif %}
+{% endfor %}
+{% endif %}
+{%- endif %}
+{%- endfor %}
+
+#-----------------------------------------
+#   Completion functions
+#-----------------------------------------
+
+{% for funcinfo in functions %}
+{%- if funcinfo.aggregated %}
+
+# (( $+functions[{{ funcinfo.name }}] )) ||
+function {{ funcinfo.name }}() {
+    _alternative \
+        {{ funcinfo.aggregated }}
+}
+{%- elif funcinfo.shell_call %}
+
+# (( $+functions[{{ funcinfo.name }}] )) ||
+function {{ funcinfo.name }}() {
+    compadd "$@" -- ${(@)$({{ funcinfo.shell_call }})}
+}
+{%- endif %}
+{% endfor %}
+
+_yunohost "$@"

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -53,6 +53,16 @@ user:
                --fields:
                     help: fields to fetch (username, fullname, mail, mail-alias, mail-forward, mailbox-quota, groups, shell, home-path)
                     nargs: "+"
+                    choices:
+                        - username
+                        - fullname
+                        - mail
+                        - mail-alias
+                        - mail-forward
+                        - mailbox-quota
+                        - groups
+                        - shell
+                        - home-path
 
         ### user_create()
         create:
@@ -91,6 +101,10 @@ user:
                         pattern: &pattern_domain
                             - !!str ^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})$
                             - "pattern_domain"
+                        autocomplete: &domains_list
+                            ynh_selector: domain list
+                            jq_selector: '.domains[]'
+                            use_cache: false
                 -q:
                     full: --mailbox-quota
                     help: Mailbox size quota
@@ -115,6 +129,10 @@ user:
                     help: Username to delete
                     extra:
                         pattern: *pattern_username
+                        autocomplete: &users_list
+                            ynh_selector: user list --fields username
+                            jq_selector: '.users[].username'
+                            use_cache: false
                 --purge:
                     help: Purge user's home and mail directories
                     action: store_true
@@ -129,6 +147,8 @@ user:
             arguments:
                 username:
                     help: Username to update
+                    extra:
+                        autocomplete: *users_list
                 -F:
                     full: --fullname
                     help: The full name of the user. For example 'Camille Dupont'
@@ -189,6 +209,8 @@ user:
             arguments:
                 username:
                     help: Username or email to get information
+                    extra:
+                        autocomplete: *users_list
 
         ### user_export()
         export:
@@ -203,6 +225,9 @@ user:
                 csvfile:
                     help: "CSV file with columns username, firstname, lastname, password, mail, mailbox-quota, mail-alias, mail-forward, groups (separated by coma)"
                     type: open
+                    extra:
+                        autocomplete:
+                            zsh_completion: _files
                 -u:
                     full: --update
                     help: Update all existing users contained in the CSV file (by default existing users are ignored)
@@ -252,6 +277,10 @@ user:
                             help: Name of the group to be deleted
                             extra:
                                 pattern: *pattern_groupname
+                                autocomplete: &user_groups_list
+                                    ynh_selector: user group list -s
+                                    jq_selector: '.groups[]'
+                                    use_cache: false
 
                 ### user_group_info()
                 info:
@@ -261,7 +290,8 @@ user:
                         groupname:
                             help: Name of the group to fetch info about
                             extra:
-                                pattern: *pattern_username
+                                pattern: *pattern_groupname
+                                autocomplete: *user_groups_list
 
                 ### user_group_add()
                 add:
@@ -272,12 +302,14 @@ user:
                             help: Name of the group to add user(s) to
                             extra:
                                 pattern: *pattern_groupname
+                                autocomplete: *user_groups_list
                         usernames:
                             help: User(s) to add in the group
                             nargs: "*"
                             metavar: USERNAME
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *users_list
 
                 ### user_group_remove()
                 remove:
@@ -288,12 +320,14 @@ user:
                             help: Name of the group to remove user(s) from
                             extra:
                                 pattern: *pattern_groupname
+                                autocomplete: *user_groups_list
                         usernames:
                             help: User(s) to remove from the group
                             nargs: "*"
                             metavar: USERNAME
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *users_list
 
                 ### user_group_add_mailalias()
                 add-mailalias:
@@ -304,6 +338,7 @@ user:
                             help: Name of the group to add user(s) to
                             extra:
                                 pattern: *pattern_groupname
+                                autocomplete: *user_groups_list
                         aliases:
                           help: Mail aliases to add
                           nargs: "+"
@@ -323,6 +358,7 @@ user:
                             help: Name of the group to add user(s) to
                             extra:
                                 pattern: *pattern_groupname
+                                autocomplete: *user_groups_list
                         aliases:
                           help: Mail aliases to remove
                           nargs: "+"
@@ -343,6 +379,11 @@ user:
                         apps:
                             help: Apps to list permission for (all by default)
                             nargs: "*"
+                            extra:
+                                autocomplete: &apps_list
+                                    ynh_selector: app list
+                                    jq_selector: '.apps[].id'
+                                    use_cache: false
                         -f:
                             full: --full
                             help: Display all info known about each permission, including the full user list of each group it is granted to.
@@ -355,6 +396,11 @@ user:
                     arguments:
                         permission:
                             help: Name of the permission to fetch info about (use "yunohost user permission list" and "yunohost user permission -f" to see all the current permissions)
+                            extra:
+                                autocomplete: &permissions_list
+                                    ynh_selector: user permission list
+                                    jq_selector: '.permissions | keys[]'
+                                    use_cache: false
 
                 ### user_permission_update()
                 update:
@@ -363,6 +409,8 @@ user:
                     arguments:
                         permission:
                             help: Permission to manage (e.g. mail or nextcloud or wordpress.editors) (use "yunohost user permission list" and "yunohost user permission -f" to see all the current permissions)
+                            extra:
+                                autocomplete: *permissions_list
                         -l:
                             full: --label
                             help: Custom label for this app / permission
@@ -387,8 +435,8 @@ user:
                             full: --hide_from_public
                             help: Mark the tile as to be hidden from the 'public app list' (if enabled). Useful for apps such as Nextcloud that need to be exposed to be publicly exposed for desktop/mobile client to be able to connect to, but not meant to be listed for visitors.
                             choices:
-                                - 'True'
-                                - 'False'
+                                - "True"
+                                - "False"
 
                 ## user_permission_add()
                 add:
@@ -397,12 +445,18 @@ user:
                     arguments:
                         permission:
                             help: Permission to manage (e.g. mail or nextcloud or wordpress.editors) (use "yunohost user permission list" and "yunohost user permission -f" to see all the current permissions)
+                            extra:
+                                autocomplete: *permissions_list
                         names:
                             help: Group or usernames to grant this permission to
                             nargs: "*"
                             metavar: GROUP_OR_USER
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: &user_and_groups_list
+                                    ynh_selector: user group list
+                                    jq_selector: '[(.groups | keys), ([.groups[] | select(.members).members[]] | unique)] | add[]'
+                                    use_cache: false
 
                 ## user_permission_remove()
                 remove:
@@ -411,16 +465,19 @@ user:
                     arguments:
                         permission:
                             help: Permission to manage (e.g. mail or nextcloud or wordpress.editors) (use "yunohost user permission list" and "yunohost user permission -f" to see all the current permissions)
+                            extra:
+                                autocomplete: *permissions_list
                         names:
                             help: Group or usernames to revoke this permission to
                             nargs: "*"
                             metavar: GROUP_OR_USER
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *user_and_groups_list
 
                 ## user_permission_ldapsync()
                 ldapsync:
-                    action_help: Resynchronize permissions to LDAP from app settings. This is a purely technical command, only meant to be ran if you manually modified permission settings in app, which is absolutely not recommended. 
+                    action_help: Resynchronize permissions to LDAP from app settings. This is a purely technical command, only meant to be ran if you manually modified permission settings in app, which is absolutely not recommended.
 
         ssh:
             subcategory_help: Manage ssh access
@@ -435,6 +492,7 @@ user:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *users_list
 
                 ### user_ssh_keys_add()
                 add-key:
@@ -445,6 +503,7 @@ user:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *users_list
                         key:
                             help: The key to be added
                         -c:
@@ -460,6 +519,7 @@ user:
                             help: Username of the user
                             extra:
                                 pattern: *pattern_username
+                                autocomplete: *users_list
                         key:
                             help: The key to be removed
 
@@ -494,6 +554,7 @@ domain:
                     help: Domain to check
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
 
         ### domain_add()
         add:
@@ -527,6 +588,7 @@ domain:
                     help: Domain to delete
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
                 -r:
                     full: --remove-apps
                     help: Remove apps installed on the domain
@@ -558,6 +620,7 @@ domain:
                     help: Change the current main domain
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
 
         ### domain_url_available()
         url-available:
@@ -569,6 +632,7 @@ domain:
                     help: The domain for the web path (e.g. your.domain.tld)
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
                 path:
                     help: The path to check (e.g. /coffee)
 
@@ -581,6 +645,8 @@ domain:
             arguments:
               domain:
                   help: Domain name
+                  extra:
+                      autocomplete: *domains_list
               action:
                   help: action id
               -a:
@@ -599,6 +665,7 @@ domain:
                             help: Domain to subscribe to the DynDNS service
                             extra:
                                 pattern: *pattern_domain
+                                autocomplete: *domains_list
                         -p:
                             full: --recovery-password
                             nargs: "?"
@@ -615,6 +682,7 @@ domain:
                             help: Domain to unsubscribe from the DynDNS service
                             extra:
                                 pattern: *pattern_domain
+                                autocomplete: *domains_list
                                 required: True
                         -p:
                             full: --recovery-password
@@ -632,6 +700,7 @@ domain:
                             help: Domain to set recovery password for
                             extra:
                                 pattern: *pattern_domain
+                                autocomplete: *domains_list
                                 required: True
                         -p:
                             full: --recovery-password
@@ -652,6 +721,8 @@ domain:
                     arguments:
                       domain:
                           help: Domain name
+                          extra:
+                              autocomplete: *domains_list
                       key:
                           help: A specific panel, section or a question identifier
                           nargs: '?'
@@ -671,6 +742,8 @@ domain:
                     arguments:
                       domain:
                           help: Domain name
+                          extra:
+                              autocomplete: *domains_list
                       key:
                           help: The question or form key
                           nargs: '?'
@@ -695,6 +768,7 @@ domain:
                             help: Target domain
                             extra:
                                 pattern: *pattern_domain
+                                autocomplete: *domains_list
 
                 ### domain_dns_push()
                 push:
@@ -705,6 +779,7 @@ domain:
                             help: Domain name to push DNS conf for
                             extra:
                                 pattern: *pattern_domain
+                                autocomplete: *domains_list
                         -d:
                             full: --dry-run
                             help: Only display what's to be pushed
@@ -729,6 +804,8 @@ domain:
                         domain_list:
                             help: Domains to check
                             nargs: "*"
+                            extra:
+                                autocomplete: *domains_list
                         --full:
                             help: Show more details
                             action: store_true
@@ -741,6 +818,8 @@ domain:
                         domain_list:
                             help: Domains for which to install the certificates
                             nargs: "*"
+                            extra:
+                                autocomplete: *domains_list
                         --force:
                             help: Install even if current certificate is not self-signed
                             action: store_true
@@ -759,6 +838,8 @@ domain:
                         domain_list:
                             help: Domains for which to renew the certificates
                             nargs: "*"
+                            extra:
+                                autocomplete: *domains_list
                         --force:
                             help: Ignore the validity threshold (15 days)
                             action: store_true
@@ -807,10 +888,18 @@ app:
             arguments:
                 app:
                     help: Name, local path or git URL of the app to fetch the manifest of
+                    extra:
+                        autocomplete: &apps_catalog_list
+                            ynh_selector: app catalog
+                            jq_selector: '.apps | keys[]'
+                            use_cache: True
                 -s:
                     full: --with-screenshot
                     help: Also return a base64 screenshot if any (API only)
                     action: store_true
+                    extra:
+                        autocomplete:
+                            hide_in_help: True
 
         ### app_list()
         list:
@@ -829,6 +918,8 @@ app:
             arguments:
                 app:
                     help: Specific app ID
+                    extra:
+                        autocomplete: *apps_list
                 -f:
                     full: --full
                     help: Display all details, including the app manifest and various other infos
@@ -845,6 +936,8 @@ app:
                 -a:
                     full: --app
                     help: Specific app to map
+                    extra:
+                        autocomplete: *apps_list
                 -r:
                     full: --raw
                     help: Return complete dict
@@ -854,6 +947,7 @@ app:
                     help: Allowed app map for a user
                     extra:
                         pattern: *pattern_username
+                        autocomplete: *users_list
 
         ### app_install()
         install:
@@ -862,6 +956,8 @@ app:
             arguments:
                 app:
                     help: Name, local path or git URL of the app to install
+                    extra:
+                        autocomplete: *apps_catalog_list
                 -l:
                     full: --label
                     help: Custom name for the app
@@ -888,6 +984,8 @@ app:
             arguments:
                 app:
                     help: App to remove
+                    extra:
+                        autocomplete: *apps_list
                 -p:
                     full: --purge
                     help: Also remove all application data
@@ -901,6 +999,8 @@ app:
                 app:
                     help: App(s) to upgrade (default all)
                     nargs: "*"
+                    extra:
+                        autocomplete: *apps_list
                 -u:
                     full: --url
                     help: Git url to fetch for upgrade
@@ -931,6 +1031,8 @@ app:
             arguments:
                 app:
                     help: Target app instance name
+                    extra:
+                        autocomplete: *apps_list
                 -d:
                     full: --domain
                     help: New app domain on which the application will be moved
@@ -938,6 +1040,7 @@ app:
                         ask: ask_new_domain
                         pattern: *pattern_domain
                         required: True
+                        autocomplete: *domains_list
                 -p:
                     full: --path
                     help: New path at which the application will be moved
@@ -952,6 +1055,8 @@ app:
             arguments:
                 app:
                     help: App ID
+                    extra:
+                        autocomplete: *apps_list
                 key:
                     help: Key to get/set
                 -v:
@@ -970,6 +1075,8 @@ app:
             arguments:
                 app:
                     help: App ID
+                    extra:
+                        autocomplete: *apps_list
 
         ### app_register_url()
         register-url:
@@ -978,8 +1085,12 @@ app:
             arguments:
                 app:
                     help: App which will use the web path
+                    extra:
+                        autocomplete: *apps_list
                 domain:
                     help: The domain on which the app should be registered (e.g. your.domain.tld)
+                    extra:
+                        autocomplete: *domains_list
                 path:
                     help: The path to be registered (e.g. /coffee)
 
@@ -992,9 +1103,13 @@ app:
             arguments:
                 app:
                     help: App name to put on domain root
+                    extra:
+                        autocomplete: *apps_list
                 -d:
                     full: --domain
                     help: Specific domain to put app on (the app domain by default)
+                    extra:
+                        autocomplete: *domains_list
                 -u:
                     full: --undo
                     help: Undo redirection
@@ -1008,8 +1123,13 @@ app:
             arguments:
                 app:
                     help: App ID to dismiss notification for
+                    extra:
+                        autocomplete: *apps_list
                 name:
                     help: Notification name, either post_install or post_upgrade
+                    choices:
+                     - post_install
+                     - post_upgrade
 
         ### app_ssowatconf()
         ssowatconf:
@@ -1022,6 +1142,8 @@ app:
             arguments:
                 app:
                     help: App ID
+                    extra:
+                        autocomplete: *apps_list
                 new_label:
                     help: New app label
 
@@ -1038,6 +1160,8 @@ app:
                   arguments:
                     app:
                         help: App name
+                        extra:
+                            autocomplete: *apps_list
 
               ### app_action_run()
               run:
@@ -1046,6 +1170,8 @@ app:
                   arguments:
                     app:
                         help: App name
+                        extra:
+                            autocomplete: *apps_list
                     action:
                         help: action id
                     -a:
@@ -1065,6 +1191,8 @@ app:
                   arguments:
                     app:
                         help: App name
+                        extra:
+                            autocomplete: *apps_list
                     key:
                         help: A specific panel, section or a question identifier
                         nargs: '?'
@@ -1087,6 +1215,8 @@ app:
                   arguments:
                     app:
                         help: App name
+                        extra:
+                            autocomplete: *apps_list
                     key:
                         help: The question or panel key
                         nargs: '?'
@@ -1138,6 +1268,8 @@ backup:
                 --apps:
                     help: List of application names to backup (or all if none given)
                     nargs: "*"
+                    extra:
+                        autocomplete: *apps_list
                 --dry-run:
                     help: "'Simulate' the backup and return the size details per item to backup"
                     action: store_true
@@ -1149,12 +1281,19 @@ backup:
             arguments:
                 name:
                     help: Name or path of the backup archive
+                    extra:
+                        autocomplete: &backups_list
+                            ynh_selector: backup list
+                            jq_selector: '.archives[]'
+                            use_cache: false
                 --system:
                     help: List of system parts to restore (or all if none is given)
                     nargs: "*"
                 --apps:
                     help: List of application names to restore (or all if none is given)
                     nargs: "*"
+                    extra:
+                        autocomplete: *apps_list
                 --force:
                     help: Force restauration on an already installed system
                     action: store_true
@@ -1180,6 +1319,8 @@ backup:
             arguments:
                 name:
                     help: Name or path of the backup archive
+                    extra:
+                        autocomplete: *backups_list
                 -d:
                     full: --with-details
                     help: Show additional backup information
@@ -1207,6 +1348,7 @@ backup:
                     help: Name of the archive to delete
                     extra:
                         pattern: *pattern_backup_archive_name
+                        autocomplete: *backups_list
 
 #############################
 #         Settings          #
@@ -1232,6 +1374,11 @@ settings:
             arguments:
                 key:
                     help: Settings key
+                    extra:
+                        autocomplete: &settings_list
+                            ynh_selector: settings list
+                            jq_selector: '. | keys[]'
+                            use_cache: false
                 -f:
                     full: --full
                     help: Display all details (meant to be used by the API)
@@ -1249,6 +1396,8 @@ settings:
                 key:
                     help: The question or form key
                     nargs: '?'
+                    extra:
+                        autocomplete: *settings_list
                 -v:
                     full: --value
                     help: new value
@@ -1268,6 +1417,8 @@ settings:
             arguments:
                 key:
                     help: Settings key
+                    extra:
+                        autocomplete: *settings_list
 
 #############################
 #         Service           #
@@ -1289,6 +1440,9 @@ service:
                     full: --log
                     help: Absolute path to log file to display
                     nargs: "+"
+                    extra:
+                        autocomplete:
+                            zsh_completion: _files
                 --test_status:
                     help: Specify a custom bash command to check the status of the service. Note that it only makes sense to specify this if the corresponding systemd service does not return the proper information already.
                 --test_conf:
@@ -1309,6 +1463,11 @@ service:
             arguments:
                 name:
                     help: Service name to remove
+                    extra:
+                        autocomplete: &services_list
+                            ynh_selector: service status
+                            jq_selector: '. | keys[]'
+                            use_cache: false
 
         ### service_start()
         start:
@@ -1319,6 +1478,8 @@ service:
                     help: Service name to start
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_stop()
         stop:
@@ -1329,6 +1490,8 @@ service:
                     help: Service name to stop
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_reload()
         reload:
@@ -1338,6 +1501,8 @@ service:
                     help: Service name to reload
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_restart()
         restart:
@@ -1348,6 +1513,8 @@ service:
                     help: Service name to restart
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_reload_or_restart()
         reload_or_restart:
@@ -1357,6 +1524,8 @@ service:
                     help: Service name to reload or restart
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_enable()
         enable:
@@ -1367,6 +1536,8 @@ service:
                     help: Service name to enable
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_disable()
         disable:
@@ -1377,6 +1548,8 @@ service:
                     help: Service name to disable
                     nargs: "+"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_status()
         status:
@@ -1389,6 +1562,8 @@ service:
                     help: Service name to show
                     nargs: "*"
                     metavar: NAME
+                    extra:
+                        autocomplete: *services_list
 
         ### service_log()
         log:
@@ -1397,6 +1572,8 @@ service:
             arguments:
                 name:
                     help: Service name to log
+                    extra:
+                        autocomplete: *services_list
                 -n:
                     full: --number
                     help: Number of lines to display
@@ -1628,6 +1805,7 @@ dyndns:
                     help: Full domain to subscribe with ( deprecated, use 'yunohost domain dyndns subscribe' instead )
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
                 -p:
                     full: --recovery-password
                     nargs: "?"
@@ -1645,6 +1823,7 @@ dyndns:
                     help: Full domain to update
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
                 -f:
                     full: --force
                     help: Force the update (for debugging only)
@@ -1683,6 +1862,7 @@ tools:
                     help: Change the current main domain
                     extra:
                         pattern: *pattern_domain
+                        autocomplete: *domains_list
 
         ### tools_postinstall()
         postinstall:
@@ -1699,6 +1879,7 @@ tools:
                         ask: ask_main_domain
                         pattern: *pattern_domain
                         required: True
+                        autocomplete: *domains_list
                 -u:
                     full: --username
                     help: Username for the first (admin) user. For example 'camille'
@@ -1706,6 +1887,7 @@ tools:
                         ask: ask_admin_username
                         pattern: *pattern_username
                         required: True
+                        autocomplete: *users_list
                 -F:
                     full: --fullname
                     help: The full name for the first (admin) user. For example 'Camille Dupont'
@@ -1871,6 +2053,11 @@ tools:
                     targets:
                         help: Migrations to run (all pendings by default)
                         nargs: "*"
+                        extra:
+                            autocomplete: &migrations_list
+                                ynh_selector: tools migrations list
+                                jq_selector: '.migrations[].id'
+                                use_cache: false
                     --skip:
                         help: Skip specified migrations (to be used only if you know what you are doing)
                         action: store_true
@@ -1901,8 +2088,13 @@ hook:
             arguments:
                 app:
                     help: App to link with
+                    extra:
+                        autocomplete: *apps_list
                 file:
                     help: Script to add
+                    extra:
+                        autocomplete:
+                            zsh_completion: _files
 
         ### hook_remove()
         remove:
@@ -1910,16 +2102,43 @@ hook:
             arguments:
                 app:
                     help: Scripts related to app will be removed
+                    extra:
+                        autocomplete: *apps_list
 
         ### hook_info()
         info:
-            hide_in_help: True
+            hide_in_help: false
             action_help: Get information about a given hook
             arguments:
                 action:
                     help: Action name
+                    choices: &hook_action_choices
+                        - post_user_create
+                        - post_user_delete
+                        - post_user_update
+                        - post_app_addaccess
+                        - post_app_removeaccess
+                        - post_domain_add
+                        - post_domain_remove
+                        - post_cert_update
+                        - custom_dns_rules
+                        - post_app_change_url
+                        - post_app_upgrade
+                        - post_app_install
+                        - post_app_remove
+                        - backup
+                        - restore
+                        - backup_method
+                        - post_iptable_rules
+                        - conf_regen
                 name:
                     help: Hook name
+                    extra:
+                        autocomplete: &hooks_list_case
+                            ynh_selector: hook list
+                            jq_selector: '.hooks[]'
+                            depends: previous
+                            use_cache: true
 
         ### hook_list()
         list:
@@ -1928,6 +2147,7 @@ hook:
             arguments:
                 action:
                     help: Action name
+                    choices: *hook_action_choices
                 -l:
                     full: --list-by
                     help: Property to list hook by
@@ -1948,6 +2168,7 @@ hook:
             arguments:
                 action:
                     help: Action name
+                    choices: *hook_action_choices
                 -n:
                     full: --hooks
                     help: List of hooks names to execute
@@ -1967,6 +2188,10 @@ hook:
             arguments:
                 path:
                     help: Path of the script to execute
+                    extra:
+                        autocomplete:
+                            zsh_completion: _files
+
                 -a:
                     full: --args
                     help: Ordered list of arguments to pass to the script
@@ -2012,7 +2237,12 @@ log:
                 - display
             arguments:
                 path:
-                    help: Log file which to display the content. 'last' or 'last-X' selects the last but X log file
+                    help: Log file which to display the content
+                    extra:
+                        autocomplete: &logs_list
+                            ynh_selector: log list
+                            jq_selector: '.operation[].name'
+                            use_cache: false
                 -n:
                     full: --number
                     help: Number of lines to display
@@ -2037,6 +2267,8 @@ log:
             arguments:
                 path:
                     help: Log file to share
+                    extra:
+                        autocomplete: *logs_list
 
 #############################
 #          Diagnosis        #
@@ -2056,6 +2288,11 @@ diagnosis:
                 categories:
                     help: Diagnosis categories to display (all by default)
                     nargs: "*"
+                    extra:
+                        autocomplete: &diagnosis_list
+                            ynh_selector: diagnosis list
+                            jq_selector: '.categories[]'
+                            use_cache: false
                 --full:
                     help: Display additional information
                     action: store_true
@@ -2075,6 +2312,8 @@ diagnosis:
             arguments:
                 category:
                     help: Diagnosis category to fetch results from
+                    extra:
+                        autocomplete: *diagnosis_list
                 item:
                     help: "List of criteria describing the test. Must correspond exactly to the 'meta' infos in 'yunohost diagnosis show'"
                     metavar: CRITERIA
@@ -2087,6 +2326,8 @@ diagnosis:
                 categories:
                     help: Diagnosis categories to run (all by default)
                     nargs: "*"
+                    extra:
+                        autocomplete: *diagnosis_list
                 --force:
                     help: Ignore the cached report even if it is still 'fresh'
                     action: store_true


### PR DESCRIPTION
## The problem

There is no auto-completion suggestions for ZSH.

## Solution

Follow up on PR #1034.

Add auto-completion to ZSH, by generating that completion file from `share/actionsmap.yml`

As `yunohost` needs to be called with `sudo`, completion may ask for password to autocomplete.

## PR Status

- updated PR #1034 to the latest commit
- tested all completions

## How to test

Run the script with:
```
python3 doc/generate_zsh_completion.py
```
It will create a file `yunohost_zsh_completion` in the `doc` folder.
Move and rename the created file to `/usr/local/share/zsh/site-functions/_yunohost` (or `/usr/share/zsh/vendor-completions/_yunohost`, that is where yunohost installation will install it).
Restart zsh to test the completions.