### PR TITLE
The p value of a DMARC record can take the values none, quarantine or reject

### DIFF
--- a/src/diagnosers/12-dnsrecords.py
+++ b/src/diagnosers/12-dnsrecords.py
@@ -215,6 +215,11 @@ class MyDiagnoser(Diagnoser):
                     for part in current
                     if not part.startswith("ip4:") and not part.startswith("ip6:")
                 }
+            if "v=DMARC1" in r["value"]:
+                for param in current:
+                    key, value = param.split("=")
+                    if key == "p":
+                        return value in ["none", "quarantine", "reject"]
             return expected == current
         elif r["type"] == "MX":
             # For MX, we want to ignore the priority


### PR DESCRIPTION
## The problem

The DNS record DMARC has multiple parameters. One is p and can take 3 values: none, quarantine or reject.
Today the diagnosis throws a warning if the DMARC record is not exactly "v=DMARC1; p=none" although a valid record could be "v=DMARC1; p=quarantine;pct=100;rua=mailto:dmarc@mydomain"

## Solution

When the diagnosis is run, we only check that the p parameter has a value from none, quarantine or reject. We don't check anything else, as it can take many different values

## PR Status

I don't know what to put here

## How to test

Change the DMARC record of your domain with different values:
-  "v=DMARC1; p=none" is valid
-   "v=DMARC1; p=quarantine" is valid
-   "v=DMARC1; p=reject" is valid
-   "v=DMARC1; p=bullshit" is invalid
-   "v=DMARC1; p=quarantine;pct=100;rua=mailto:dmarc@mydomain" is valid
