### PR TITLE
Fix missleading example for ynh_setup_source

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -75,7 +75,7 @@ fi
 # usage: ynh_setup_source --dest_dir=dest_dir [--source_id=source_id] [--keep="file1 file2"] [--full_replace]
 # | arg: -d, --dest_dir=     - Directory where to setup sources
 # | arg: -s, --source_id=    - Name of the source, defaults to `main` (when the sources resource exists in manifest.toml) or (legacy) `app` otherwise
-# | arg: -k, --keep=         - Space-separated list of files/folders that will be backup/restored in $dest_dir, such as a config file you don't want to overwrite. For example 'conf.json secrets.json logs/'
+# | arg: -k, --keep=         - Space-separated list of files/folders that will be backup/restored in $dest_dir, such as a config file you don't want to overwrite. For example 'conf.json secrets.json logs' (no trailing `/` for folders)
 # | arg: -r, --full_replace= - Remove previous sources before installing new sources
 #
 # #### New 'sources' resources


### PR DESCRIPTION

## The problem
There shouldn't be any trailing / for folders for ynh_setup_source, otherwise `folder/` will be restored in `folder/folder`

## Solution
better example shown in command line, and in autogenerated doc

## PR Status

...

## How to test

...
