### PR TITLE
Fix ynh_safe_rm: check if target is not a broken symlink before erorring out.

### DIFF
--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -168,7 +168,7 @@ ynh_safe_rm() {
 
     if [[ -z "$target" ]]; then
         ynh_print_warn "ynh_safe_rm called with empty argument, ignoring."
-    elif [[ ! -e $target ]]; then
+    elif [[ ! -e "$target" ]] && [[ ! -L "$target" ]]; then
         ynh_print_info "'$target' wasn't deleted because it doesn't exist."
     elif ! _acceptable_path_to_delete "$target"; then
         ynh_print_warn "Not deleting '$target' because it is not an acceptable path to delete."


### PR DESCRIPTION
## The problem

[yunohost/issues#2253](https://github.com/YunoHost/issues/issues/2253)

## Solution

Before erroring out before file doesn't exist, we need to check two things:
* ! test -e target (target doesn't exist, or target is a broken symlink)
* ! test -L target (target is NOT a symlink)

## PR Status

...

## How to test

...
