### PR TITLE
Add home.arpa as special TLD

### DIFF
--- a/src/utils/dns.py
+++ b/src/utils/dns.py
@@ -21,7 +21,7 @@ from typing import List
 
 from moulinette.utils.filesystem import read_file
 
-SPECIAL_USE_TLDS = ["local", "localhost", "onion", "test"]
+SPECIAL_USE_TLDS = [ "home.arpa", "local", "localhost", "onion", "test"]
 
 YNH_DYNDNS_DOMAINS = ["nohost.me", "noho.st", "ynh.fr"]
 

--- a/src/utils/dns.py
+++ b/src/utils/dns.py
@@ -21,7 +21,7 @@ from typing import List
 
 from moulinette.utils.filesystem import read_file
 
-SPECIAL_USE_TLDS = [ "home.arpa", "local", "localhost", "onion", "test"]
+SPECIAL_USE_TLDS = ["home.arpa", "local", "localhost", "onion", "test"]
 
 YNH_DYNDNS_DOMAINS = ["nohost.me", "noho.st", "ynh.fr"]
 


### PR DESCRIPTION
OK, I concede it is technically not a TLD, but it fits the special case list for domains.

As per https://www.rfc-editor.org/rfc/rfc8375.html, domains ending by `home.arpa` are expected to solely be used locally.