### PR TITLE
app: add "support_purge" to app info

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -237,6 +237,10 @@ def app_info(app, full=False, upgradable=False):
     ret["supports_config_panel"] = os.path.exists(
         os.path.join(setting_path, "config_panel.toml")
     )
+    ret["supports_purge"] = (
+        local_manifest["packaging_format"] >= 2
+        and local_manifest["resources"].get("data_dir") is not None
+    )
 
     ret["permissions"] = permissions
     ret["label"] = permissions.get(app + ".main", {}).get("label")


### PR DESCRIPTION
add `supports_purge` bool to `yunohost app info {app} --full` so that webadmin can display a checkbox to purge the app's data dir at app removal
