### PR TITLE
Fix dump script log extract for debugging

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -745,7 +745,7 @@ class OperationLogger:
         # 2019-10-19 16:10:27,611: DEBUG - + mysql -u piwigo --password=********** -B piwigo
         # And we just want the part starting by "DEBUG - "
         lines = [line for line in lines if ":" in line.strip()]
-        lines = [line.strip().split(": ", 1)[1] for line in lines]
+        lines = [line.strip().split(": ", 1)[-1] for line in lines]
         # And we ignore boring/irrelevant lines
         # Annnnnnd we also ignore lines matching [number] + such as
         # 72971 [37m[1mDEBUG [m29739 + ynh_exit_properly


### PR DESCRIPTION
## The problem

When a script fails, we get sometimes:
```
ERROR Could not upgrade gitlab: Something unexpected went wrong: 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/yunohost/hook.py", line 538, in hook_exec_with_script_debug_if_failure
    operation_logger.dump_script_log_extract_for_debugging()
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 749, in dump_script_log_extract_for_debugging
    lines = [line.strip().split(": ", 1)[1] for line in lines]
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 749, in <listcomp>
    lines = [line.strip().split(": ", 1)[1] for line in lines]
IndexError: list index out of range
```
https://ci-apps-dev.yunohost.org/ci/job/10016

## Solution

...

## PR Status

...

## How to test

...
