### PR TITLE
Allow `phpX.Y` as sole dependency for `$phpversion=X.Y`

### DIFF
--- a/helpers/apt
+++ b/helpers/apt
@@ -250,7 +250,7 @@ ynh_install_app_dependencies() {
     # Check for specific php dependencies which requires sury
     # This grep will for example return "7.4" if dependencies is "foo bar php7.4-pwet php-gni"
     # The (?<=php) syntax corresponds to lookbehind ;)
-    local specific_php_version=$(echo $dependencies | grep -oP '(?<=php)[0-9.]+(?=-|\>)' | sort -u)
+    local specific_php_version=$(echo $dependencies | grep -oP '(?<=php)[0-9.]+(?=-|\>|)' | sort -u)
 
     if [[ -n "$specific_php_version" ]]
     then


### PR DESCRIPTION
## The problem

Specifying in chuwiki

```toml
 [resources.apt]
    packages = [
        "php7.4"
    ]
```

does not set `$phpversion`.

## Solution

Allow sole `php7.4` to set `$phpversion`, instead of requiring `php7.4-whatever` (`-` (or for some reason `>` ) is required for previous RegEx to work).

## PR Status

WFM :P

## How to test

#yolo