### PR TITLE
add redis database configuration

### DIFF
--- a/conf/rspamd/redis.conf
+++ b/conf/rspamd/redis.conf
@@ -1,0 +1,2 @@
+# set redis server
+servers = "127.0.0.1";

--- a/hooks/conf_regen/31-rspamd
+++ b/hooks/conf_regen/31-rspamd
@@ -13,6 +13,8 @@ do_pre_regen() {
         "${pending_dir}/etc/rspamd/local.d/dkim_signing.conf"
     install -D -m 644 rspamd.sieve \
         "${pending_dir}/etc/dovecot/global_script/rspamd.sieve"
+	install -D -m 644 redis.conf \
+		"${pending_dir}/etc/rspamd/local.d/redis.conf"
 }
 
 do_post_regen() {


### PR DESCRIPTION
https://github.com/YunoHost/issues/issues/2266

without this rspamd does not use the redis database