### PR TITLE
improve dovecots rspamd integration

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -119,8 +119,8 @@ plugin {
   antispam_debug_target = syslog
   antispam_verbose_debug = 0
   antispam_backend = pipe
-  antispam_spam = Junk;SPAM
-  antispam_trash = Trash
+  antispam_spam_pattern_ignorecase = junk;spam
+  antispam_trash_pattern_ignorecase = trash;papierkorb;deleted messages
   antispam_pipe_program = /usr/bin/rspamc
   antispam_pipe_program_args = -h;localhost:11334;-P;q1
   antispam_pipe_program_spam_arg = learn_spam


### PR DESCRIPTION
For rspamd being able to learn ham or spam from messages being moved into spam/junk folders or out of them dovecot needs to know how spam/junk folders and trash folders are named.

The former rules narrowed the folders being recognized as spam/trash down to just 'Junk, SPAM, Trash' (case-senistive).

Since users and admins can change the foldernames and write their own seive filters to use those folders I think it is a big improvement if more folders will be recognized.

The change is supposed to accept some more commonly used folder names for spam and trash in a case-insensitive manner.