### PR TITLE
[enh] Reload firewall disable resolve IP

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -256,7 +256,7 @@ def firewall_reload(skip_upnp=False):
 
     # IPv4
     try:
-        process.check_output("iptables -w -L")
+        process.check_output("iptables -n -w -L")
     except process.CalledProcessError as e:
         logger.debug(
             "iptables seems to be not available, it outputs:\n%s",
@@ -289,7 +289,7 @@ def firewall_reload(skip_upnp=False):
 
     # IPv6
     try:
-        process.check_output("ip6tables -L")
+        process.check_output("ip6tables -n -L")
     except process.CalledProcessError as e:
         logger.debug(
             "ip6tables seems to be not available, it outputs:\n%s",


### PR DESCRIPTION
## The problem
When reloading the firewall, it can take several minutes when we have many IPs banned by Fail2Ban.
This is due to the use of the iptables/ip6tables command without the `-n` flag, so a reverse DNS resolution of each IP is requested.

Here's an example I have: 
```
# iptables -n -v -L f2b-sshd | wc -l
454

# time iptables -v -L f2b-sshd
real	4m33.729s
user	0m0.085s
sys	0m0.149s

# time iptables -n -v -L f2b-sshd
real	0m0.010s
user	0m0.010s
sys	0m0.000s
```
## Solution
Added the -n flag to the `iptable` and `ip6table` commands

## PR Status
 - Currently test on a YunoHost by running the command `yunohost firewall reload`. 

## How to test
- Run `yunohost firewall reload`
