### PR TITLE
let dovecot create folders on first login

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -65,11 +65,38 @@ protocol imap {
   mail_plugins = $mail_plugins imap_quota antispam
 }
 
-
 protocol lda {
   auth_socket_path = /var/run/dovecot/auth-master
   mail_plugins = quota sieve
   postmaster_address = postmaster@{{ main_domain }}
+}
+
+namespace inbox {
+  inbox = yes
+
+  mailbox Drafts {
+    special_use = \Drafts
+    auto = subscribe
+  }
+  mailbox Junk {
+    special_use = \Junk
+    auto = subscribe
+  }
+  mailbox Trash {
+    special_use = \Trash
+    auto = subscribe
+  }
+  mailbox Sent {
+    special_use = \Sent
+    auto = subscribe
+  }
+  mailbox "Sent Messages" {
+    special_use = \Sent
+  }
+  mailbox "Archive" {
+    special_use = \Archive
+    auto = subscribe
+  }
 }
 
 protocol sieve {


### PR DESCRIPTION
tells dovecot to create standard folders on first login if they do not exist and which folder names are used for special purposes like archive, spam/junk, sent, etc.

https://github.com/YunoHost/issues/issues/1456

This part of the solution creates new folders on first login. Missing patches to close the issue:

* adjust `antispam_spam` & `antispam_trash` for rspamd integration
* change global sieve script into a user sieve script that is copied on user creation (hook)