### PR TITLE
logrotate: fix generated config file perms

### DIFF
--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -53,6 +53,8 @@
 # You can find some more explainations about how to make a regex here :
 # https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
 #
+# Note that the logfile need to exist before to call this helper !!
+#
 # To validate your regex you can test with this command:
 # ```
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -53,8 +53,6 @@
 # You can find some more explainations about how to make a regex here :
 # https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
 #
-# Note that the logfile need to exist before to call this helper !!
-#
 # To validate your regex you can test with this command:
 # ```
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf

--- a/helpers/logrotate
+++ b/helpers/logrotate
@@ -99,6 +99,7 @@ $logfile {
 EOF
     mkdir --parents $(dirname "$logfile")                              # Create the log directory, if not exist
     cat ${app}-logrotate | $customtee /etc/logrotate.d/$app >/dev/null # Append this config to the existing config file, or replace the whole config file (depending on $customtee)
+	chmod 644 "$logfile"                                               # Make sure permissions are correct (otherwise the config file could be ignored and the corresponding logs never rotated)
 }
 
 # Remove the app's logrotate config.


### PR DESCRIPTION
## The problem

Logrotate generated config files could have wrong permissions and in this case the log files are never rotated
See:
https://github.com/YunoHost/issues/issues/2242 and https://github.com/YunoHost-Apps/gotosocial_ynh/issues/110

## Solution

Add a chmod to ensure that the generated config file permissions are correct

## PR Status

Could be reviewed and maybe merged
Not tested tho 

## How to test

...
