### PR TITLE
fail2ban: make sure the logfile exists

### DIFF
--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -102,6 +102,11 @@ ignoreregex =
     ynh_add_config --template="f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
     ynh_add_config --template="f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
+    # Create the logfile if it doesn't exist, as fail2ban require an existing file
+    if [ ! -f "$logpath" ]; then
+        touch "$logpath"
+    fi
+
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 
     local fail2ban_error="$(journalctl --no-hostname --unit=fail2ban | tail --lines=50 | grep "WARNING.*$app.*")"

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -105,8 +105,8 @@ ignoreregex =
     mkdir -p "/var/log/$app"
     if [ ! -f "$logpath" ]; then
         touch "$logpath"
-        chown -R "$app:$app" "$logpath"
-        chmod -R u=rwX,g=rX,o= "$logpath"
+        chown -R "$app:$app" "/var/log/$app"
+        chmod -R u=rwX,g=rX,o= "/var/log/$app"
     fi
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -100,9 +100,13 @@ ignoreregex =
     ynh_add_config --template="f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
     ynh_add_config --template="f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
-    # Create the logfile if it doesn't exist, as fail2ban require an existing file
+    # Create the folder and logfile if they doesn't exist,
+    # as fail2ban require an existing logfile before configuration
+    mkdir -p "/var/log/$app"
     if [ ! -f "$logpath" ]; then
         touch "$logpath"
+        chown -R "$app:$app" "$logpath"
+        chmod -R u=rwX,g=rX,o= "$logpath"
     fi
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -53,8 +53,6 @@
 # You can find some more explainations about how to make a regex here :
 # https://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Filters
 #
-# Note that the logfile need to exist before to call this helper !!
-#
 # To validate your regex you can test with this command:
 # ```
 # fail2ban-regex /var/log/YOUR_LOG_FILE_PATH /etc/fail2ban/filter.d/YOUR_APP.conf


### PR DESCRIPTION
## The problem

if the logfile doesn't exists (as in a fresh install), the helper will return an error because fail2ban WANTS the file to already exist

so in my packages, I do a `touch LOGFILE` before the helper to get around the problem

but it's better to fix that issue in the core

## Solution

verify if the logfile exists, if not, create it:

```bash
# Create the logfile if it doesn't exist, as fail2ban require an existing file
if [ ! -f "$logpath" ]; then
    touch "$logpath"
fi
```

## PR Status

ready but not tested

## How to test

...
