### PR TITLE
Fix backup error message if archive already exists

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,7 @@
     "backup_archive_broken_link": "Could not access the backup archive (broken link to {path})",
     "backup_archive_cant_retrieve_info_json": "Could not load info for archive '{archive}'... The info.json file cannot be retrieved (or is not a valid json).",
     "backup_archive_corrupted": "It looks like the backup archive '{archive}' is corrupted : {error}",
-    "backup_archive_name_exists": "A backup archive with this name already exists.",
+    "backup_archive_name_exists": "A backup archive with the name '{name}' already exists.",
     "backup_archive_name_unknown": "Unknown local backup archive named '{name}'",
     "backup_archive_open_failed": "Could not open the backup archive",
     "backup_archive_system_part_not_available": "System part '{part}' unavailable in this backup",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -23,7 +23,7 @@
     "ask_password": "Mot de passe",
     "backup_app_failed": "Impossible de sauvegarder {app}",
     "backup_archive_app_not_found": "{app} n'a pas été trouvée dans l'archive de la sauvegarde",
-    "backup_archive_name_exists": "Une archive de sauvegarde avec ce nom existe déjà.",
+    "backup_archive_name_exists": "Une archive de sauvegarde avec le nom '{name}' existe déjà.",
     "backup_archive_name_unknown": "L'archive locale de sauvegarde nommée '{name}' est inconnue",
     "backup_archive_open_failed": "Impossible d'ouvrir l'archive de la sauvegarde",
     "backup_cleaning_failed": "Impossible de nettoyer le dossier temporaire de sauvegarde",

--- a/src/backup.py
+++ b/src/backup.py
@@ -2208,7 +2208,7 @@ def backup_create(
 
     # Validate there is no archive with the same name
     if name and name in backup_list()["archives"]:
-        raise YunohostValidationError("backup_archive_name_exists")
+        raise YunohostValidationError("backup_archive_name_exists", name=name)
 
     # By default we backup using the tar method
     if not methods:


### PR DESCRIPTION
## The problem

When the backup of an app fails for some reason because a backup file with the same name already exists, the error message `A backup archive with this name already exists.`. This error message does not give the name of the already existing backup, preventing the user to try and fix the error by himself (by deleting or moving the already existing backup file for example). 

## Solution

Modify the error message to give the name of the already existing file inside it.

## PR Status

The code is ready to be merged. I modified the french and english translations, I don't know if we need the other translations to be modified before this PR is merged or if translate later will do.

## How to test

- `touch /home/yunohost.backup/archives/test-backup-fix.tar`
- `yunohost backup create -n test-backup-fix  --app adguardhome`
And see the modified error message.