### PR TITLE
fix the fail2ban helper when using using --use_template arg

### DIFF
--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -103,10 +103,15 @@ ignoreregex =
     # if "$logpath" doesn't exist (as if using --use_template argument), assign
     # "$logpath" using the one in the package's conf/f2b_jail.conf template
     if [ -z "$logpath" ]; then
-        # the first sed deleteds possibles spaces and the second one extract the path
+        # the first sed deletes possibles spaces and the second one extract the path
         logpath=$(grep logpath "$YNH_APP_BASEDIR/conf/f2b_jail.conf" | sed "s/ //g" | sed "s/logpath=//g")
-        # replace the '__APP__' by the real app name in the path
-        logpath=${logpath//__APP__/$app}
+        # replace any '__VAR__' by their real variable using ynh_replace_vars
+        # in some hacky way because ynh_replace_vars supports only files ^^'
+        tempdir="$(mktemp -d)"
+        echo "$logpath" > "$tempdir/process-logpath"
+        ynh_replace_vars --file="$tempdir/process-logpath"
+        logpath="$(cat "$tempdir/process-logpath")"
+        rm -r "$tempdir"
     fi
 
     # Create the folder and logfile if they doesn't exist,
@@ -114,9 +119,10 @@ ignoreregex =
     mkdir -p "/var/log/$app"
     if [ ! -f "$logpath" ]; then
         touch "$logpath"
-        chown -R "$app:$app" "/var/log/$app"
-        chmod -R u=rwX,g=rX,o= "/var/log/$app"
     fi
+    # Make sure log folder's permissions are correct
+    chown -R "$app:$app" "/var/log/$app"
+    chmod -R u=rwX,g=rX,o= "/var/log/$app"
 
     ynh_systemd_action --service_name=fail2ban --action=reload --line_match="(Started|Reloaded) Fail2Ban Service" --log_path=systemd
 

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -104,14 +104,7 @@ ignoreregex =
     # "$logpath" using the one in the package's conf/f2b_jail.conf template
     if [ -z "$logpath" ]; then
         # the first sed deletes possibles spaces and the second one extract the path
-        logpath=$(grep logpath "$YNH_APP_BASEDIR/conf/f2b_jail.conf" | sed "s/ //g" | sed "s/logpath=//g")
-        # replace any '__VAR__' by their real variable using ynh_replace_vars
-        # in some hacky way because ynh_replace_vars supports only files ^^'
-        tempdir="$(mktemp -d)"
-        echo "$logpath" > "$tempdir/process-logpath"
-        ynh_replace_vars --file="$tempdir/process-logpath"
-        logpath="$(cat "$tempdir/process-logpath")"
-        rm -r "$tempdir"
+        logpath=$(grep logpath "/etc/fail2ban/jail.d/$app.conf" | sed "s/ //g" | sed "s/logpath=//g")
     fi
 
     # Create the folder and logfile if they doesn't exist,

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -100,6 +100,15 @@ ignoreregex =
     ynh_add_config --template="f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"
     ynh_add_config --template="f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
+    # if "$logpath" doesn't exist (as if using --use_template argument), assign
+    # "$logpath" using the one in the package's conf/f2b_jail.conf template
+    if [ -z "$logpath" ]; then
+        # the first sed deleteds possibles spaces and the second one extract the path
+        logpath=$(grep logpath "$YNH_APP_BASEDIR/conf/f2b_jail.conf" | sed "s/ //g" | sed "s/logpath=//g")
+        # replace the '__APP__' by the real app name in the path
+        logpath=$(sed "s/__APP__/$app/g")
+    fi
+
     # Create the folder and logfile if they doesn't exist,
     # as fail2ban require an existing logfile before configuration
     mkdir -p "/var/log/$app"

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -102,7 +102,7 @@ ignoreregex =
 
     # if "$logpath" doesn't exist (as if using --use_template argument), assign
     # "$logpath" using the one in the previously generated fail2ban conf file
-    if [ -z "$logpath" ]; then
+    if [ -z "${logpath:-}" ]; then
         # the first sed deletes possibles spaces and the second one extract the path
         logpath=$(grep logpath "/etc/fail2ban/jail.d/$app.conf" | sed "s/ //g" | sed "s/logpath=//g")
     fi

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -101,7 +101,7 @@ ignoreregex =
     ynh_add_config --template="f2b_filter.conf" --destination="/etc/fail2ban/filter.d/$app.conf"
 
     # if "$logpath" doesn't exist (as if using --use_template argument), assign
-    # "$logpath" using the one in the package's conf/f2b_jail.conf template
+    # "$logpath" using the one in the previously generated fail2ban conf file
     if [ -z "$logpath" ]; then
         # the first sed deletes possibles spaces and the second one extract the path
         logpath=$(grep logpath "/etc/fail2ban/jail.d/$app.conf" | sed "s/ //g" | sed "s/logpath=//g")

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -106,7 +106,7 @@ ignoreregex =
         # the first sed deleteds possibles spaces and the second one extract the path
         logpath=$(grep logpath "$YNH_APP_BASEDIR/conf/f2b_jail.conf" | sed "s/ //g" | sed "s/logpath=//g")
         # replace the '__APP__' by the real app name in the path
-        logpath=$(sed "s/__APP__/$app/g")
+        logpath=${logpath//__APP__/$app}
     fi
 
     # Create the folder and logfile if they doesn't exist,

--- a/helpers/fail2ban
+++ b/helpers/fail2ban
@@ -74,7 +74,7 @@ ynh_add_fail2ban_config() {
     ports=${ports:-http,https}
     use_template="${use_template:-0}"
 
-    if [ $use_template -ne 1 ]; then
+    if [ "$use_template" -ne 1 ]; then
         # Usage 1, no template. Build a config file from scratch.
         test -n "$logpath" || ynh_die --message="ynh_add_fail2ban_config expects a logfile path as first argument and received nothing."
         test -n "$failregex" || ynh_die --message="ynh_add_fail2ban_config expects a failure regex as second argument and received nothing."
@@ -86,7 +86,7 @@ port = __PORTS__
 filter = __APP__
 logpath = __LOGPATH__
 maxretry = __MAX_RETRY__
-" >$YNH_APP_BASEDIR/conf/f2b_jail.conf
+" >"$YNH_APP_BASEDIR/conf/f2b_jail.conf"
 
         echo "
 [INCLUDES]
@@ -94,7 +94,7 @@ before = common.conf
 [Definition]
 failregex = __FAILREGEX__
 ignoreregex =
-" >$YNH_APP_BASEDIR/conf/f2b_filter.conf
+" >"$YNH_APP_BASEDIR/conf/f2b_filter.conf"
     fi
 
     ynh_add_config --template="f2b_jail.conf" --destination="/etc/fail2ban/jail.d/$app.conf"


### PR DESCRIPTION
## The problem

when the fail2ban helper is used with the --use_template argument, the `logpath` variable is not assigned, so there's an unbound error 

thanks to @Psycojoker who helped me to understand the bug ^w^

## Solution

if `logpath` doesn't exist, get the logpath from the template and assign it to the `logpath` variable
replace any `__VAR__` in the logpath by their real variable using ynh_replace_vars

## PR Status

yolo

## How to test

...
