### PR TITLE
apps: add mailbox/IMAP support for apps that declared a system user with mail enabled

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -57,7 +57,7 @@ userdb {
 
 userdb {
   driver = passwd-file
-  args = /etc/dovecot/app-senders-passwd
+  args = username_format=%n /etc/dovecot/app-senders-passwd
 }
 
 protocol imap {

--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -93,14 +93,14 @@ recipient_delimiter = +
 inet_interfaces = all
 
 #### Fit to the maximum message size to 25mb, more than allowed by GMail or Yahoo ####
-# /!\ This size is the size of the attachment in base64. 
+# /!\ This size is the size of the attachment in base64.
 # BASE64_SIZE_IN_BYTE = ORIGINAL_SIZE_IN_MEGABYTE * 1,37 *1024*1024 + 980
 # See https://serverfault.com/questions/346895/postfix-mail-size-counting
 message_size_limit = 35914708
 
 # Virtual Domains Control
 virtual_mailbox_domains = ldap:/etc/postfix/ldap-domains.cf
-virtual_mailbox_maps = ldap:/etc/postfix/ldap-accounts.cf
+virtual_mailbox_maps = ldap:/etc/postfix/ldap-accounts.cf,hash:/etc/postfix/app_senders_login_maps
 virtual_mailbox_base =
 virtual_alias_maps = ldap:/etc/postfix/ldap-aliases.cf,ldap:/etc/postfix/ldap-groups.cf
 virtual_alias_domains =

--- a/src/app.py
+++ b/src/app.py
@@ -3267,7 +3267,7 @@ def regen_mail_app_user_config_for_dovecot_and_postfix(only=None):
         if dovecot:
             hashed_password = _hash_user_password(settings["mail_pwd"])
             dovecot_passwd.append(
-                f"{app}:{hashed_password}::::::allow_nets=::1,127.0.0.1/24,local"
+                f"{app}:{hashed_password}::::::allow_nets=::1,127.0.0.1/24,local,mail={mail_user}@{mail_domain}"
             )
         if postfix:
             mail_user = settings.get("mail_user", app)

--- a/src/app.py
+++ b/src/app.py
@@ -3264,14 +3264,15 @@ def regen_mail_app_user_config_for_dovecot_and_postfix(only=None):
         if "domain" not in settings or "mail_pwd" not in settings:
             continue
 
+        mail_user = settings.get("mail_user", app)
+        mail_domain = settings.get("mail_domain", settings["domain"])
+
         if dovecot:
             hashed_password = _hash_user_password(settings["mail_pwd"])
             dovecot_passwd.append(
                 f"{app}:{hashed_password}::::::allow_nets=::1,127.0.0.1/24,local,mail={mail_user}@{mail_domain}"
             )
         if postfix:
-            mail_user = settings.get("mail_user", app)
-            mail_domain = settings.get("mail_domain", settings["domain"])
             postfix_map.append(f"{mail_user}@{mail_domain} {app}")
 
     if dovecot:


### PR DESCRIPTION
## The problem

Mail reply from app don't work

## Solution

Add missing account registration on postfix for apps

## PR Status

Tested local and it worked

## How to test

Install an app which support fully mail stack and replay by mail.
