### PR TITLE
helpers: Further simplify the change url helper

### DIFF
--- a/helpers/nginx
+++ b/helpers/nginx
@@ -53,19 +53,6 @@ ynh_change_url_nginx_config() {
     local old_nginx_conf_path=/etc/nginx/conf.d/$old_domain.d/$app.conf
     local new_nginx_conf_path=/etc/nginx/conf.d/$new_domain.d/$app.conf
 
-    # Change the path in the NGINX config file
-    if [ $change_path -eq 1 ]
-    then
-        # Make a backup of the original NGINX config file if modified
-        ynh_backup_if_checksum_is_different --file="$old_nginx_conf_path"
-        # Set global variables for NGINX helper
-        domain="$old_domain"
-        path="$new_path"
-        path_url="$new_path"
-        # Create a dedicated NGINX config
-        ynh_add_nginx_config
-    fi
-
     # Change the domain for NGINX
     if [ $change_domain -eq 1 ]
     then
@@ -73,6 +60,17 @@ ynh_change_url_nginx_config() {
         mv "$old_nginx_conf_path" "$new_nginx_conf_path"
         ynh_store_file_checksum --file="$new_nginx_conf_path"
     fi
+
+    # Change the path in the NGINX config file
+    if [ $change_path -eq 1 ]
+    then
+        # Make a backup of the original NGINX config file if modified
+        ynh_backup_if_checksum_is_different --file="$old_nginx_conf_path"
+        # Set global variables for NGINX helper
+        path="$new_path"
+        path_url="$new_path"
+        # Create a dedicated NGINX config
+        ynh_add_nginx_config
+    fi
     ynh_systemd_action --service_name=nginx --action=reload
 }
-

--- a/helpers/nginx
+++ b/helpers/nginx
@@ -44,33 +44,22 @@ ynh_remove_nginx_config() {
 }
 
 
-# Move / regen the nginx config in a change url context
+# Regen the nginx config in a change url context
 #
 # usage: ynh_change_url_nginx_config
 #
 # Requires YunoHost version 11.1.9 or higher.
 ynh_change_url_nginx_config() {
+
+    # Make a backup of the original NGINX config file if manually modified
+    # (nb: this is possibly different from the same instruction called by
+    # ynh_add_config inside ynh_add_nginx_config because the path may have 
+    # changed if we're changing the domain too...)
     local old_nginx_conf_path=/etc/nginx/conf.d/$old_domain.d/$app.conf
-    local new_nginx_conf_path=/etc/nginx/conf.d/$new_domain.d/$app.conf
+    ynh_backup_if_checksum_is_different --file="$old_nginx_conf_path"
+    ynh_delete_file_checksum --file="$old_nginx_conf_path"
+    ynh_secure_remove --file="$old_nginx_conf_path"
 
-    # Change the domain for NGINX
-    if [ $change_domain -eq 1 ]
-    then
-        ynh_delete_file_checksum --file="$old_nginx_conf_path"
-        mv "$old_nginx_conf_path" "$new_nginx_conf_path"
-        ynh_store_file_checksum --file="$new_nginx_conf_path"
-    fi
-
-    # Change the path in the NGINX config file
-    if [ $change_path -eq 1 ]
-    then
-        # Make a backup of the original NGINX config file if modified
-        ynh_backup_if_checksum_is_different --file="$old_nginx_conf_path"
-        # Set global variables for NGINX helper
-        path="$new_path"
-        path_url="$new_path"
-        # Create a dedicated NGINX config
-        ynh_add_nginx_config
-    fi
-    ynh_systemd_action --service_name=nginx --action=reload
+    # Regen the nginx conf
+    ynh_add_nginx_config
 }

--- a/src/app.py
+++ b/src/app.py
@@ -478,6 +478,8 @@ def app_change_url(operation_logger, app, domain, path):
     env_dict["old_path"] = old_path
     env_dict["new_domain"] = domain
     env_dict["new_path"] = path
+    env_dict["domain"] = domain
+    env_dict["path"] = path
     env_dict["change_path"] = "1" if old_path != path else "0"
     env_dict["change_domain"] = "1" if old_domain != domain else "0"
 


### PR DESCRIPTION
## The problem

In change url script we need workaround like [this](https://github.com/YunoHost-Apps/seafile_ynh/blob/master/scripts/change_url#L14-L15) because path and domain are the old one and so somethings are set with old values.

## Solution

Set correctly the domain and path with new values.

## PR Status

Patch on helper was tested here: https://github.com/YunoHost-Apps/seafile_ynh/blob/master/scripts/change_url#L27-L52

