### PR TITLE
[fix] First source patches failure doesn't stop app script

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -351,13 +351,12 @@ ynh_setup_source() {
     if [ -d "$YNH_APP_BASEDIR/sources/patches/" ]; then
         local patches_folder=$(realpath $YNH_APP_BASEDIR/sources/patches/)
         if (($(find $patches_folder -type f -name "${source_id}-*.patch" 2>/dev/null | wc --lines) > "0")); then
-            (
-                cd "$dest_dir"
-                for p in $patches_folder/${source_id}-*.patch; do
-                    echo $p
-                    patch --strip=1 <$p
-                done
-            ) || ynh_die --message="Unable to apply patches"
+            pushd "$dest_dir"
+            for p in $patches_folder/${source_id}-*.patch; do
+                echo $p
+                patch --strip=1 <$p || ynh_die --message="Unable to apply patches"
+            done
+            popd
         fi
     fi
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/2296

## Solution
I simply suggest here to die the script on the first patch failure

## PR Status

Tested

## How to test

 1. Install nextcloud with the oldstable branch
 2. Upgrade nextcloud with the master branch
 3. The upgrade should failed due to `Unable to apply patches` and not silently continue to upgrade the app
