### PR TITLE
add --after= in the usage section of ynh_read_var_in_file and ynh_write_var_in_file

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -611,6 +611,7 @@ ynh_replace_vars() {
 # usage: ynh_read_var_in_file --file=PATH --key=KEY
 # | arg: -f, --file=     - the path to the file
 # | arg: -k, --key=     - the key to get
+# | arg: -a, --after=     - the line just before the key (in case of multiple lines with the name of the key in the file)
 #
 # This helpers match several var affectation use case in several languages
 # We don't use jq or equivalent to keep comments and blank space in files
@@ -714,6 +715,7 @@ ynh_read_var_in_file() {
 # | arg: -f, --file=     - the path to the file
 # | arg: -k, --key=     - the key to set
 # | arg: -v, --value=     - the value to set
+# | arg: -a, --after=     - the line just before the key (in case of multiple lines with the name of the key in the file)
 #
 # Requires YunoHost version 4.3 or higher.
 ynh_write_var_in_file() {


### PR DESCRIPTION
## The problem

the `--after` argument is not documented for `ynh_read_var_in_file` and `ynh_write_var_in_file`

## Solution

add `--after=` in the usage section of `ynh_read_var_in_file` and `ynh_write_var_in_file`

## PR Status

finished

## How to test

...
