### PR TITLE
[docs] document changelog link for latest_github_release

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -334,7 +334,7 @@ class SourcesResource(AppResource):
 
     `autoupdate.strategy` is expected to be one of :
     - `latest_github_tag` : look for the latest tag (by sorting tags and finding the "largest" version). Then using the corresponding tar.gz url. Tags containing `rc`, `beta`, `alpha`, `start` are ignored, and actually any tag which doesn't look like `x.y.z` or `vx.y.z`
-    - `latest_github_release` : similar to `latest_github_tags`, but starting from the list of releases. Pre- or draft releases are ignored. Releases may have assets attached to them, in which case you can define:
+    - `latest_github_release` : similar to `latest_github_tags`, but starting from the list of releases and provides the changelog link in PR message. Pre- or draft releases are ignored. Releases may have assets attached to them, in which case you can define:
         - `autoupdate.asset = "some regex"` (when there's only one asset to use). The regex is used to find the appropriate asset among the list of all assets
         - or several `autoupdate.asset.$arch = "some_regex"` (when the asset is arch-specific). The regex is used to find the appropriate asset for the specific arch among the list of assets
     - `latest_github_commit` : will use the latest commit on github, and the corresponding tarball. If this is used for the 'main' source, it will also assume that the version is YYYY.MM.DD corresponding to the date of the commit.


### PR DESCRIPTION
## The problem

now with https://github.com/YunoHost/apps/pull/1960 the bot provides the changelog link when the update strategy is set to `latest_github_release`

## Solution

document this behavior

## PR Status

...

## How to test

...
