### PR TITLE
app.py, helpers: Reword YNH_APP_UPGRADE_TYPE

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -248,7 +248,7 @@ ynh_setup_source() {
         if test -e "$local_src"; then
             cp $local_src $src_filename
         fi
-        
+
         [ -n "$src_url" ] || ynh_die "Couldn't parse SOURCE_URL from $src_file_path ?"
 
         # If the file was prefetched but somehow doesn't match the sum, rm and redownload it
@@ -990,15 +990,11 @@ ynh_app_package_version() {
 # This helper should be used to avoid an upgrade of an app, or the upstream part
 # of it, when it's not needed
 #
-# You can force an upgrade, even if the package is up to date, with the `--force` (or `-F`) argument :
-# ```
-# sudo yunohost app upgrade <appname> --force
-# ```
 # Requires YunoHost version 3.5.0 or higher.
 ynh_check_app_version_changed() {
     local return_value=${YNH_APP_UPGRADE_TYPE}
 
-    if [ "$return_value" == "UPGRADE_FULL" ] || [ "$return_value" == "UPGRADE_FORCED" ] || [ "$return_value" == "DOWNGRADE_FORCED" ]; then
+    if [ "$return_value" == "UPGRADE_SAME" ] || [ "$return_value" == "DOWNGRADE" ]; then
         return_value="UPGRADE_APP"
     fi
 

--- a/src/app.py
+++ b/src/app.py
@@ -653,23 +653,18 @@ def app_upgrade(
                     manifest.get("remote", {}).get("revision", "?"),
                 )
                 continue
-            elif app_current_version > app_new_version:
-                upgrade_type = "DOWNGRADE_FORCED"
+
+            if app_current_version > app_new_version:
+                upgrade_type = "DOWNGRADE"
             elif app_current_version == app_new_version:
-                upgrade_type = "UPGRADE_FORCED"
+                upgrade_type = "UPGRADE_SAME"
             else:
-                app_current_version_upstream, app_current_version_pkg = str(
-                    app_current_version
-                ).split("~ynh")
-                app_new_version_upstream, app_new_version_pkg = str(
-                    app_new_version
-                ).split("~ynh")
+                app_current_version_upstream, _ = str(app_current_version).split("~ynh")
+                app_new_version_upstream, _ = str(app_new_version).split("~ynh")
                 if app_current_version_upstream == app_new_version_upstream:
                     upgrade_type = "UPGRADE_PACKAGE"
-                elif app_current_version_pkg == app_new_version_pkg:
-                    upgrade_type = "UPGRADE_APP"
                 else:
-                    upgrade_type = "UPGRADE_FULL"
+                    upgrade_type = "UPGRADE_APP"
 
         # Check requirements
         for name, passed, values, err in _check_manifest_requirements(


### PR DESCRIPTION
* remove UPGRADE_FULL
* rename DOWNGRADE_FORCED -> DOWNGRADE
* rename UPGRADE_FORCED -> UPGRADE_SAME
* keep the helper ynh_check_app_version_changed behaviour for reverse compatibility.

I renamed because IMHO those `_FORCED` suffixes are not really useful, and not actually used the way they should:
https://github.com/search?q=org%3AYunoHost-Apps+UPGRADE_FORCED&type=code

## The problem

useless code

## Solution

remove code
