### PR TITLE
[enh] Add help on ssh port

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -460,6 +460,7 @@
     "global_settings_setting_ssh_password_authentication": "Password authentication",
     "global_settings_setting_ssh_password_authentication_help": "Allow password authentication for SSH",
     "global_settings_setting_ssh_port": "SSH port",
+    "global_settings_setting_ssh_port_help": "A port lower than 1024 is preferred to prevent usurpation attempts by non-administrator services on the remote machine. You should also avoid using a port already in use, such as 80 or 443.",
     "global_settings_setting_ssowat_panel_overlay_enabled": "Enable the small 'YunoHost' portal shortcut square on apps",
     "global_settings_setting_user_strength": "User password strength requirements",
     "global_settings_setting_user_strength_help": "These requirements are only enforced when initializing or changing the password",


### PR DESCRIPTION
## The problem

1025+ port could be listen as non root, so an evil user could overload the server to make ssh killed by oom_reaper and next run it's own fake daemon to gain access to the server by collecting password.

## Solution

Advice to use a port under 1024.

## PR Status

Ready

## How to test

...
