### PR TITLE
Add generales var in config panel like domain, path, etc

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1993,7 +1993,10 @@ ynh_app_config_run $1
             }
         )
         app_script_env = _make_environment_for_app_script(app)
-        env.update(app_script_env)
+        # Note that we only need to update settings wich are not already set
+        # The settings from config panel should be keep as it is
+        app_script_env.update(env)
+        env = app_script_env
 
         ret, values = hook_exec(config_script, args=[action], env=env)
         if ret != 0:

--- a/src/app.py
+++ b/src/app.py
@@ -1992,6 +1992,8 @@ ynh_app_config_run $1
                 "YNH_APP_PACKAGING_FORMAT": str(manifest["packaging_format"]),
             }
         )
+        app_script_env = _make_environment_for_app_script(app)
+        env.update(app_script_env)
 
         ret, values = hook_exec(config_script, args=[action], env=env)
         if ret != 0:


### PR DESCRIPTION
## The problem

- In config panel not all app variables are available and it limit some config file to edit correctly

## Solution

- Add env var as same as for others scripts.

## PR Status

Tested on my side and it provide the necessary variables.

## How to test

Run the config panel script (`config`) and check with `env` command that `domain`, `path`... are provided.
