### PR TITLE
fix logs folders perms

### DIFF
--- a/helpers/logrotate
+++ b/helpers/logrotate
@@ -87,6 +87,8 @@ EOF
 
     # Make sure permissions are correct (otherwise the config file could be ignored and the corresponding logs never rotated)
     chmod 644 "/etc/logrotate.d/$app"
+    mkdir -p "/var/log/$app"
+    chmod 640 "/var/log/$app"
 }
 
 # Remove the app's logrotate config.


### PR DESCRIPTION
## The problem

```
logrotate /etc/logrotate.d/kavita
error: skipping "/var/log/kavita/*.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```
https://forum.yunohost.org/t/logrotate-failed/28507

## Solution

`chmod 640 "/var/log/$app"`

## PR Status

yolo

## How to test

...
