### PR TITLE
helpers: ynh_remove_systemd_config: Also remove the systemd service from YunoHost.

### DIFF
--- a/helpers/systemd
+++ b/helpers/systemd
@@ -29,7 +29,7 @@ ynh_add_systemd_config() {
     systemctl daemon-reload
 }
 
-# Remove the dedicated systemd config
+# Remove the dedicated systemd config, and if configured into YunoHost, removes the service.
 #
 # usage: ynh_remove_systemd_config [--service=service]
 # | arg: -s, --service=     - Service name (optionnal, $app by default)
@@ -43,6 +43,10 @@ ynh_remove_systemd_config() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     local service="${service:-$app}"
+
+    if ynh_exec_warn_less yunohost service status "$app" >/dev/null; then
+        yunohost service remove "$app"
+    fi
 
     local finalsystemdconf="/etc/systemd/system/$service.service"
     if [ -e "$finalsystemdconf" ]; then


### PR DESCRIPTION
Every app or almost will do that, because it doesn't make sense to remove the systemd config but not the associated yunohost configuration.

This will clean up a bit the remove scripts.
