### PR TITLE
Fix app mail - Add main domain into hosts file

### DIFF
--- a/hooks/conf_regen/43-dnsmasq
+++ b/hooks/conf_regen/43-dnsmasq
@@ -83,6 +83,11 @@ do_post_regen() {
     short_hostname=$(hostname -s)
     grep -q "127.0.0.1.*$short_hostname" /etc/hosts || echo -e "\n127.0.0.1\t$short_hostname" >>/etc/hosts
 
+    # For SMTP connexion from apps wich request valid certificate we need to force main domain to point to localhost ip
+    # because connexion on external ip is forbinden by mail server for apps.
+    main_domain=$(yunohost domain main-domain --output-as plain)
+    grep -q "127.0.0.1.*$main_domain" /etc/hosts || echo -e "\n127.0.0.1\t$main_domain" >>/etc/hosts
+
     [[ -n "$regen_conf_files" ]] || return 0
 
     # Remove / disable services likely to conflict with dnsmasq


### PR DESCRIPTION
## The problem

Some apps like synapse need to send email but don't have option to allow invalid certificate. In this case the target server defined on the app must match with the certificate provided by postfix (or dovecot in reception case). But currently it's not possible as postfix (and dovecot) are configured to only accept app connexion on local IP (so 127.0.0.1 or ::1).

So for instance we have a server with main domain `yolo.xyz`.

In synapse to send email we have mainly 2 solutions:

- smtp_server: "localhost" -> this case don't work because the postfix will provide a certificate for `yolo.xyz` but the SMTP client expect to receive a certificate for the configured domain, so `localhost` in this case.
- smtp_server: "yolo.xyz" -> this case don't work too because the connection from SMTP client is made into the external interface (like `eth0`) and postfix don't allow app connection from external interface.

## Solution

To solve this I thought about 2 potential solutions:

1. Add on the hosts file the main domain so the SMTP client configured to point to `yolo.xyz` will resolve this to 127.0.0.1 and so the connection will be with a matching certificate to the configured domain. And on postfix side the connection will be on local interface so it will be happy.
2. Allow app connection from external IP. So we can configure the SMTP client to point to `yolo.xyz`. The provided certificate will match with the configured domain. And if postfix is configured to allow external connection from app there will be no problem.

This PR implement the first solution which I think is the best one.

## PR Status

Tested on my side and it work well.

## How to test

Run regen-conf for dnsmasq and ping main domain and see that ping go directly to `127.0.0.1`.
