### PR TITLE
chores: update actions/checkout & peter-evans/create-pull-request to nodejs20

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/n_updater.yml
+++ b/.github/workflows/n_updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch the source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run the updater script
@@ -33,7 +33,7 @@ jobs:
       - name: Create Pull Request
         id: cpr
         if: ${{ env.PROCEED == 'true' }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update n to ${{ env.VERSION }}


### PR DESCRIPTION
> The following actions uses node12 which is deprecated and will be forced to run on node16: peter-evans/create-pull-request@v3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, peter-evans/create-pull-request@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.