### PR TITLE
[enh] add xz decompression for sources

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -201,6 +201,9 @@ ynh_setup_source() {
             elif [[ "$src_url" =~ ^.*\.tar\.bz2$ ]]
             then
                 src_format="tar.bz2"
+            elif [[ "$src_url" =~ ^.*\.xz$ ]]
+            then
+                src_format="xz"
             elif [[ -z "$src_extract" ]]
             then
                 src_extract="false"
@@ -329,6 +332,13 @@ ynh_setup_source() {
             unzip -quo $src_filename -d "$dest_dir"
         fi
         ynh_secure_remove --file="$src_filename"
+    elif [[ "$src_format" == "xz" ]]; then
+        if [[ -z "$src_rename" ]]; then
+            xz -d --stdout $src_filename > "$dest_dir/$(basename $src_filename)"
+        else
+            xz -d --stdout $src_filename > "$dest_dir/$src_rename"
+        fi
+
     else
         local strip=""
         if [ "$src_in_subdir" != "false" ]; then


### PR DESCRIPTION
## The problem
Forgejo application is a single executable file. It is released compressed in xz format (https://codeberg.org/forgejo/forgejo/releases)
Yunohost does not allow to extract such archives with `ynh_setup_source` helper. The extraction has to be done in `install` script.
Since Yunohost supports `tar.xz` format (and many others), it should supports `xz` format as well.

## Solution
Update `ynh_setup_source` helper to introduce the `xz` format.

## PR Status
Ready to test

## How to test
- get forgejo package source (https://github.com/YunoHost-Apps/forgejo_ynh)
- remove `format` and `extract` configuration from `[resources.sources.main]`
- set `rename` configuration to «forgejo» in `[resources.sources.main]`
- remove extraction line in `scripts/install` (`xz -d "$install_dir/forgejo.xz"`)
- install the app
