### PR TITLE
Fix readonly questions (display_text, etc)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1168,6 +1168,9 @@ def app_install(
     # If packaging_format v2+, save all install questions as settings
     if packaging_format >= 2:
         for question in questions:
+            # Except readonly "questions" that don't even have a value
+            if question.readonly:
+                continue
             # Except user-provider passwords
             # ... which we need to reinject later in the env_dict
             if question.type == "password":


### PR DESCRIPTION
The code did not handle them anymore on the app side…

## The problem

With a display_text for example:

```
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 110, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 503, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 580, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 410, in func_wrapper
    result = func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 1174, in app_install
    app_settings[question.id] = question.value
AttributeError: 'DisplayTextOption' object has no attribute 'value'

```

(untested)