### PR TITLE
[fix] List root ssh keys

### DIFF
--- a/src/ssh.py
+++ b/src/ssh.py
@@ -172,7 +172,7 @@ def _get_user_for_ssh(username, attrs=None):
             "username": "root",
             "fullname": "",
             "mail": "",
-            "home_path": root_unix.pw_dir,
+            "homeDirectory": root_unix.pw_dir,
         }
 
     # TODO escape input using https://www.python-ldap.org/doc/html/ldap-filter.html


### PR DESCRIPTION
## The problem

When we try to list ssh keys we get this message.

```
# yunohost user ssh list-keys root
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 110, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 503, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 580, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/user.py", line 1430, in user_ssh_list_keys
    return yunohost.ssh.user_ssh_list_keys(username)
  File "/usr/lib/python3/dist-packages/yunohost/ssh.py", line 36, in user_ssh_list_keys
    user["homeDirectory"][0], ".ssh", "authorized_keys"
```
KeyError: 'homeDirectory'

## Solution

Make `_get_use_for_ssh()` returns a dict with good keys 

## PR Status

Ready

## How to test

```
yunohost user ssh list-keys root
```
