### PR TITLE
Use single quote to return value to config panel

### DIFF
--- a/helpers/config
+++ b/helpers/config
@@ -151,7 +151,7 @@ for panel_name, panel in loaded_toml.items():
                 bind_section = bind_section + bind_panel_file
             else:
                 bind_section = regex + bind_section + bind_panel_file
-            
+
         for name, param in section.items():
             if not isinstance(param, dict):
                 continue
@@ -204,8 +204,7 @@ _ynh_app_config_show() {
                 ynh_return "${short_setting}:"
                 ynh_return "$(echo "${old[$short_setting]}" | sed 's/^/  /g')"
             else
-                ynh_return "${short_setting}: "'"'"$(echo "${old[$short_setting]}" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\n\n/g')"'"'
-
+                ynh_return "${short_setting}: '$(echo "${old[$short_setting]}" | sed "s/'/''/g" | sed ':a;N;$!ba;s/\n/\n\n/g')'"
             fi
         fi
     done


### PR DESCRIPTION
## The problem

Where are some issues with config panel when we use secial char on values. By example `\+33` as yunohost settings shown on config panel fail because `\` mean to escape next char but the next char should not be excaped and we have this error:
```
yaml.scanner.ScannerError: while scanning a double-quoted scalar
```

## Solution

Following the specification of yaml (https://yaml.org/spec/1.2.2/#single-quoted-style), when we use single quote we only need to escape single quote. By this we avoid to need to escape multiple other chars which could be complicated.

Tested on synapse and it solve issues for `allowed_local_3pids_email` and `allowed_local_3pids_msisdn` settings which was problematic.

## PR Status

Tested on my side and it worked well

## How to test

On any app which show an app settings into the config panel. Put some special char on app settings and check that config panel work and show correct values.
