### PR TITLE
tools: make_changelog.sh enhancements

### DIFF
--- a/maintenance/make_changelog.sh
+++ b/maintenance/make_changelog.sh
@@ -12,6 +12,7 @@ echo ""
 
 git log $LAST_RELEASE.. -n 10000 --first-parent --pretty=tformat:'  - %b%s (%h)' \
 | sed -E "s&Merge .*#([0-9]+).*\$& \([#\1]\(http://github.com/YunoHost/$REPO/pull/\1\)\)&g" \
+| sed -E "/Co-authored-by: .* <.*>/d" \
 | grep -v "Translations update from Weblate" \
 | tac
 

--- a/maintenance/make_changelog.sh
+++ b/maintenance/make_changelog.sh
@@ -2,8 +2,8 @@ VERSION="?"
 RELEASE="testing"
 REPO=$(basename $(git rev-parse --show-toplevel))
 REPO_URL=$(git remote get-url origin)
-ME=$(git config --global --get user.name)
-EMAIL=$(git config --global --get user.email)
+ME=$(git config --get user.name)
+EMAIL=$(git config --get user.email)
 
 LAST_RELEASE=$(git tag --list 'debian/11.*'  --sort="v:refname" | tail -n 1)
 


### PR DESCRIPTION
## The problem

- the `--global` in `git config --global --get` prevent to temporaryly set a name and email for the release
- if we squash a PR, we get boresome "co-authored" lines

## Solution

- remove the `--global`
- filter "co-authored" lines

## PR Status

done

## How to test

...
