### PR TITLE
Fix _app_upgradable() for legacy/old apps: settings was not set

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -138,6 +138,7 @@ def app_info(app, full=False, upgradable=False):
         "description": _value_for_locale(local_manifest["description"]),
         "name": permissions.get(app + ".main", {}).get("label", local_manifest["name"]),
         "version": local_manifest.get("version", "-"),
+        "settings": settings,
     }
 
     if "domain" in settings and "path" in settings:
@@ -168,8 +169,6 @@ def app_info(app, full=False, upgradable=False):
 
             ret["current_version"] = f" ({current_revision})"
             ret["new_version"] = f" ({new_revision})"
-
-    ret["settings"] = settings
 
     if not full:
         return ret


### PR DESCRIPTION
## The problem

For some apps we get a weird behaviour:

```
215  INFO Now upgrading glowingbear...
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 110, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 503, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 580, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 617, in app_upgrade
    app_dict = app_info(app_instance_name, full=True)
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 159, in app_info
    ret["upgradable"] = _app_upgradable({**ret, "from_catalog": from_catalog})
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 290, in _app_upgradable
    settings = app_infos["settings"]
KeyError: 'settings'
```

## Solution

Set "settings" just a little bit sooner in the app_infos.