### PR TITLE
ci(autoblacks): switch from using gitlab CI to github actions for autoblacking code

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -1,0 +1,35 @@
+name: Check / auto apply Black
+on:
+  push:
+      branches:
+          - dev
+jobs:
+  black:
+    name: Check / auto apply black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check files using the black formatter
+        uses: psf/black@stable
+        id: black
+        with:
+          options: "."
+        continue-on-error: true
+      - shell: pwsh
+        id: check_files_changed
+        run: |
+          # Diff HEAD with the previous commit
+          $diff = git diff
+          $HasDiff = $diff.Length -gt 0
+          Write-Host "::set-output name=files_changed::$HasDiff"
+      - name: Create Pull Request
+        if: steps.check_files_changed.outputs.files_changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Format Python code with Black"
+          commit-message: ":art: Format Python code with Black"
+          body: |
+            This pull request uses the [psf/black](https://github.com/psf/black) formatter.
+          base: ${{ github.head_ref }} # Creates pull request onto pull request or commit branch
+          branch: actions/black

--- a/.gitlab/ci/lint.gitlab-ci.yml
+++ b/.gitlab/ci/lint.gitlab-ci.yml
@@ -24,24 +24,3 @@ mypy:
   needs: []
   script:
     - tox -e py39-mypy
-
-black:
-  stage: lint
-  image: "before-install"
-  needs: []
-  before_script:
-    - apt-get update -y && apt-get install git hub -y
-    - git config --global user.email "yunohost@yunohost.org"
-    - git config --global user.name "$GITHUB_USER"
-    - hub clone --branch ${CI_COMMIT_REF_NAME} "https://$GITHUB_TOKEN:x-oauth-basic@github.com/YunoHost/yunohost.git" github_repo
-    - cd github_repo
-  script:
-    # create a local branch that will overwrite distant one
-    - git checkout -b "ci-format-${CI_COMMIT_REF_NAME}" --no-track
-    - tox -e py39-black-run
-    - '[ $(git diff | wc -l) != 0 ] || exit 0'  # stop if there is nothing to commit
-    - git commit -am "[CI] Format code with Black" || true
-    - git push -f origin "ci-format-${CI_COMMIT_REF_NAME}":"ci-format-${CI_COMMIT_REF_NAME}"
-    - hub pull-request -m "[CI] Format code with Black" -b Yunohost:dev -p || true # GITHUB_USER and GITHUB_TOKEN registered here https://gitlab.com/yunohost/yunohost/-/settings/ci_cd
-  only:
-    - tags


### PR DESCRIPTION
## The problem

We've moved all our code base to the autoblacks.yml github action for autoblacking our code but yunohost is still using a gitlab CI job for that.

The gitlab CI job obviously works and there is nothing wrong about it but uniformising everything with one tool is easier to maintain.

## Solution

Use autoblack instead.

## PR Status

Works as expected but I'm waiting for an answer from @kay0u to see if we completely drop the gitlab job or if we convert it into a linting job that fails when black isn't happy.

## How to test

It's a bit hard but you can change the target branch of the script to this MR and push it again and see if a PR is generated but it has already been tested on other projects since quite some time already so testing isn't really needed.
