### PR TITLE
Readme: add images alt text, fix some links and some markdown formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,45 +5,43 @@
 <h1 align="center">YunoHost</h1>
 
 <div align="center">
-
 ![Version](https://img.shields.io/github/v/tag/yunohost/yunohost?label=version&sort=semver)
 [![Pipeline status](https://gitlab.com/yunohost/yunohost/badges/dev/pipeline.svg)](https://gitlab.com/yunohost/yunohost/-/pipelines)
 ![Test coverage](https://gitlab.com/yunohost/yunohost/badges/dev/coverage.svg)
 [![Project license](https://img.shields.io/gitlab/license/yunohost/yunohost)](https://github.com/YunoHost/yunohost/blob/dev/LICENSE)
 [![CodeQL](https://github.com/yunohost/yunohost/workflows/CodeQL/badge.svg)](https://github.com/YunoHost/yunohost/security/code-scanning)
 [![Mastodon Follow](https://img.shields.io/mastodon/follow/28084)](https://mastodon.social/@yunohost)
-
 </div>
 
 YunoHost is an operating system aiming to simplify as much as possible the administration of a server.
 
 This repository corresponds to the core code of YunoHost, mainly written in Python and Bash.
 
-- [Project features](https://yunohost.org/#/whatsyunohost)
+- [Project features](https://yunohost.org/whatsyunohost)
 - [Project website](https://yunohost.org)
 - [Install documentation](https://yunohost.org/install)
 - [Issue tracker](https://github.com/YunoHost/issues)
 
-# Screenshots
+## Screenshots
 
 Webadmin ([Yunohost-Admin](https://github.com/YunoHost/yunohost-admin)) | Single sign-on user portal ([SSOwat](https://github.com/YunoHost/ssowat))
---- |  ---
-![](https://raw.githubusercontent.com/YunoHost/doc/master/images/webadmin.png) | ![](https://raw.githubusercontent.com/YunoHost/doc/master/images/user_panel.png)
+--- | ---
+![Web admin insterface screenshot](https://raw.githubusercontent.com/YunoHost/doc/master/images/webadmin.png) | ![User portal screenshot](https://raw.githubusercontent.com/YunoHost/doc/master/images/user_panel.png)
 
 
 ## Contributing
 
 - You can learn how to get started with developing on YunoHost by reading [this piece of documentation](https://yunohost.org/dev).
-- Come chat with us on the [dev chatroom](https://yunohost.org/#/chat_rooms) !
-- You can help translate YunoHost on our [translation platform](https://translate.yunohost.org/engage/yunohost/?utm_source=widget)
+- Come chat with us on the [dev chatroom](https://yunohost.org/chat_rooms)!
+- You can help translate YunoHost on our [translation platform](https://translate.yunohost.org/engage/yunohost/?utm_source=widget).
 
 <p align="center">
-<img src="https://translate.yunohost.org/widgets/yunohost/-/core/horizontal-auto.svg" alt="Translation status" />
+<img alt="View of the translation rate for the different languages available in YunoHost" src="https://translate.yunohost.org/widgets/yunohost/-/core/horizontal-auto.svg" alt="Translation status" />
 </p>
 
 ## License
 
-As [other components of YunoHost](https://yunohost.org/#/faq_en), this repository is licensed under GNU AGPL v3.
+As [other components of YunoHost](https://yunohost.org/faq), this repository is licensed under GNU AGPL v3.
 
 ## They support us <3
 
@@ -51,16 +49,16 @@ We are thankful for our sponsors providing us with infrastructure and grants!
 
 <div align="center">
 <p style="margin-left:auto;margin-right:auto;">
-<a style="padding: 5px;" href="https://nlnet.nl"><img src="https://user-images.githubusercontent.com/36127788/198088570-823c40bd-7ac3-44e3-a8ee-e7a9f14b47ac.png" width="150px"/></a>
-<a style="padding: 5px;" href="https://www.ngi.eu"><img src="https://user-images.githubusercontent.com/36127788/198088663-daf587b9-fd09-4c00-aaf2-37c803939c94.png" width="130px"/></a>
-<a style="padding: 5px;" href="https://www.codelutin.com"><img src="https://user-images.githubusercontent.com/36127788/198088737-d37b6674-379c-4be4-9d74-b93b6ad318d1.png" width="100px"/></a>
+<a style="padding: 5px;" href="https://nlnet.nl"><img alt="NLnet Foundation" src="https://user-images.githubusercontent.com/36127788/198088570-823c40bd-7ac3-44e3-a8ee-e7a9f14b47ac.png" width="150px"/></a>
+<a style="padding: 5px;" href="https://www.ngi.eu"><img alt="Next Generation Internet" src="https://user-images.githubusercontent.com/36127788/198088663-daf587b9-fd09-4c00-aaf2-37c803939c94.png" width="130px"/></a>
+<a style="padding: 5px;" href="https://www.codelutin.com"><img alt="Code Lutin" src="https://user-images.githubusercontent.com/36127788/198088737-d37b6674-379c-4be4-9d74-b93b6ad318d1.png" width="100px"/></a>
 </p>
 <p style="margin-left:auto;margin-right:auto;">
-<a style="padding: 5px;" href="https://www.globenet.org"><img src="https://user-images.githubusercontent.com/36127788/198088794-751129ab-737d-4d99-9f35-5e01845dcdfe.png" width="150px"/></a>
-<a style="padding: 5px;" href="https://www.gitoyen.net"><img src="https://user-images.githubusercontent.com/36127788/198088931-f16f4af4-57ae-42e9-8d42-fb3e2d8d7ee3.png" width="150px"/></a>
-<a style="padding: 5px;" href="https://tetaneutral.net"><img src="https://user-images.githubusercontent.com/36127788/198088995-3ad9c34d-9807-4ead-934b-44df97d3c552.png" width="90px"/></a>
-<a style="padding: 5px;" href="https://ldn-fai.net"><img src="https://user-images.githubusercontent.com/36127788/198089086-a4089d51-9173-4081-bd2e-fa1ac3378e49.png" width="120px"/></a>
-<a style="padding: 5px;" href="https://www.nbs-system.com"><img src="https://user-images.githubusercontent.com/36127788/198089161-4cc0b7b7-bf56-4798-892e-a76112497921.png" width="130px"/></a>
+<a style="padding: 5px;" href="https://www.globenet.org"><img alt="Globenet" src="https://user-images.githubusercontent.com/36127788/198088794-751129ab-737d-4d99-9f35-5e01845dcdfe.png" width="150px"/></a>
+<a style="padding: 5px;" href="https://www.gitoyen.net"><img alt="Gitoyen" src="https://user-images.githubusercontent.com/36127788/198088931-f16f4af4-57ae-42e9-8d42-fb3e2d8d7ee3.png" width="150px"/></a>
+<a style="padding: 5px;" href="https://tetaneutral.net"><img alt="tetaneutral.net" src="https://user-images.githubusercontent.com/36127788/198088995-3ad9c34d-9807-4ead-934b-44df97d3c552.png" width="90px"/></a>
+<a style="padding: 5px;" href="https://ldn-fai.net"><img alt="LDN (Lorraine Data Network)" src="https://user-images.githubusercontent.com/36127788/198089086-a4089d51-9173-4081-bd2e-fa1ac3378e49.png" width="120px"/></a>
+<a style="padding: 5px;" href="https://www.nbs-system.com"><img alt="NBS System" src="https://user-images.githubusercontent.com/36127788/198089161-4cc0b7b7-bf56-4798-892e-a76112497921.png" width="130px"/></a>
 </p>
 </div>
 


### PR DESCRIPTION
## The problem

- The link in `As [other components of YunoHost](https://yunohost.org/#/faq_en), this repository is licensed under GNU AGPL v3.` is broken
- many pictures does not have a proper alt text

## Solution

- fixed the broken link
- add alt text
- also fixed minor markdown formating

## PR Status

done