### PR TITLE
fix(regen_conf/ldap): sometime those directories permissions changes and it breaks ldap

### DIFF
--- a/hooks/conf_regen/06-slapd
+++ b/hooks/conf_regen/06-slapd
@@ -38,6 +38,9 @@ EOF
     # Enforce permissions
     chown -R openldap:openldap /etc/ldap/schema/
     usermod -aG ssl-cert openldap
+    # if those aren't done slapd won't start
+    chmod o+x /host-certificates/live/
+    chmod o+x /host-certificates/archive/
 
     # (Re-)init data according to default ldap entries
     echo '  Initializing LDAP with YunoHost DB structure'


### PR DESCRIPTION
## The problem

On saperlipopette slapd refused to start because it couldn't access the certificates because the permissions of the directories were too restrictive.

The error message was:

```
main: TLS init def ctx failed: -1
```

## Solution

Fix the permissions of the folders so slapd can access the certificates.

## PR Status

I guess it's fine since it has been tested in prod? I'm not 100% sure about this solutions.

## How to test

Fucked up folders permissions, try to restart slapd, run regen-conf for ldap and see that it now works.
