### PR TITLE
helpers: run composer as the app user

### DIFF
--- a/helpers/php
+++ b/helpers/php
@@ -533,7 +533,7 @@ ynh_composer_exec() {
     fi
 
     COMPOSER_HOME="$workdir/.composer" COMPOSER_MEMORY_LIMIT=-1 \
-        php${phpversion} "$workdir/composer.phar" $commands \
+        sudo -u "$app" php${phpversion} "$workdir/composer.phar" $commands \
         -d "$workdir" --no-interaction --no-ansi 2>&1
 }
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/2367
we can't use `ynh_exec_as "$app" ynh_composer_exec` and composer cries about running as root

## Solution

edit the `ynh_composer_exec` to run composer as the `$app` user
we can't choose the user but idk if that would be a good thing: an app has to stay in its own box 

## PR Status

yolodone

## How to test

...
