### PR TITLE
[bookworm] Return auth cookie valid for whole main domain.

### DIFF
--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -199,6 +199,7 @@ class Authenticator(BaseAuthenticator):
             path="/",
             # Doesn't this cause issues ? May cause issue if the portal is on different subdomain than the portal API ? Will surely cause issue for development similar to CORS ?
             samesite="strict" if not is_dev else None,
+            domain=f".{request.get_header('host')}",
         )
 
         # Create the session file (expiration mechanism)


### PR DESCRIPTION
## The problem
If app specify private path it's impossible to access as `yunohost.portal` cookie is not forwarded when app is installed on subdomain.

## Solution
Return cookie valid for `.domain.tld`, just like old `SSOWat` did. Come to think about it we should return cookies valid for all domains?

## PR Status
It worked once.

## How to test
Install LimeSurvey from https://github.com/orhtej2/limesurvey_ynh/tree/patch-2 and see if you can access admin.