### PR TITLE
helpers: Do not wait for dpkg lock when calling ynh_package_is_installed

### DIFF
--- a/helpers/apt
+++ b/helpers/apt
@@ -45,25 +45,19 @@ ynh_wait_dpkg_free() {
 #
 # example: ynh_package_is_installed --package=yunohost && echo "installed"
 #
-# usage: ynh_package_is_installed --package=name [--wait_dpkg_free]
-# | arg: -p, --package=          - the package name to check
-# | arg: -l, --wait_dpkg_free=   - wait for dpkg to be free.
-# |                                Note that waiting on dpkg free could take about 0.2s on quick platform
-# |                                and about 2 seconds on slow platform so in case of multiple call it could be slow
+# usage: ynh_package_is_installed --package=name
+# | arg: -p, --package=     - the package name to check
 # | ret: 0 if the package is installed, 1 else.
+#
+# Requires YunoHost version 2.2.4 or higher.
 ynh_package_is_installed() {
     # Declare an array to define the options of this helper.
-    local legacy_args=pl
-    local -A args_array=([p]=package= [l]=wait_dpkg_free=)
+    local legacy_args=p
+    local -A args_array=([p]=package=)
     local package
-    local wait_dpkg_free
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
-    wait_dpkg_free="${wait_dpkg_free:-0}"
 
-    if [ "$wait_dpkg_free" -eq 1 ]; then
-        ynh_wait_dpkg_free
-    fi
     dpkg-query --show --showformat='${Status}' "$package" 2>/dev/null \
         | grep --count "ok installed" &>/dev/null
 }

--- a/helpers/apt
+++ b/helpers/apt
@@ -45,20 +45,25 @@ ynh_wait_dpkg_free() {
 #
 # example: ynh_package_is_installed --package=yunohost && echo "installed"
 #
-# usage: ynh_package_is_installed --package=name
-# | arg: -p, --package=     - the package name to check
+# usage: ynh_package_is_installed --package=name [--wait_dpkg_free]
+# | arg: -p, --package=          - the package name to check
+# | arg: -l, --wait_dpkg_free=   - wait for dpkg to be free.
+# |                                Note that waiting on dpkg free could take about 0.2s on quick platform
+# |                                and about 2 seconds on slow platform so in case of multiple call it could be slow
 # | ret: 0 if the package is installed, 1 else.
-#
-# Requires YunoHost version 2.2.4 or higher.
 ynh_package_is_installed() {
     # Declare an array to define the options of this helper.
-    local legacy_args=p
-    local -A args_array=([p]=package=)
+    local legacy_args=pl
+    local -A args_array=([p]=package= [l]=wait_dpkg_free=)
     local package
+    local wait_dpkg_free
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
+    wait_dpkg_free="${wait_dpkg_free:-0}"
 
-    ynh_wait_dpkg_free
+    if [ "$wait_dpkg_free" -eq 1 ]; then
+        ynh_wait_dpkg_free
+    fi
     dpkg-query --show --showformat='${Status}' "$package" 2>/dev/null \
         | grep --count "ok installed" &>/dev/null
 }


### PR DESCRIPTION
## The problem

Waiting on `ynh_wait_dpkg_free` could be really slow

On a quick machine
```
# time ynh_wait_dpkg_free

real    0m0.183s
user    0m0.059s
sys     0m0.093s
```

On slow machine (like raspi):
```
# time ynh_wait_dpkg_free

real    0m2.223s
user    0m0.602s
sys     0m1.484s
```

When we have multiple call  of `ynh_package_is_installed`  on the same package it could be really slow.

## Solution

From my analyse `ynh_wait_dpkg_free` was added into `ynh_package_is_installed` probably just by generality to ensure that all apt helper wait on dpkg before to run but without a specific need.

I think we can remove this by default and add a specific option to enable it if specific need.

## PR Status

Tested with monitorix https://github.com/YunoHost-Apps/monitorix_ynh/pull/55 and it work well

## How to test

Just run the helper `ynh_package_is_installed` with the option that you want to test.
