### PR TITLE
Revert "Protect more path on ynh secure remove"

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -843,7 +843,7 @@ ynh_get_debian_release() {
 _acceptable_path_to_delete() {
     local file=$1
 
-    local forbidden_paths=$(ls -d / /* /{var,home,usr}/* /etc/{default,sudoers.d,yunohost,cron*} /etc/yunohost/{apps,domains,hooks.d} /opt/yunohost)
+    local forbidden_paths=$(ls -d / /* /{var,home,usr}/* /etc/{default,sudoers.d,yunohost,cron*})
 
     # Legacy : A couple apps still have data in /home/$app ...
     if [[ -n "${app:-}" ]]


### PR DESCRIPTION
Reverts YunoHost/yunohost#1810

It looks like this improvement had unwanted side effects. Examples, among plenty of apps:

https://ci-apps-dev.yunohost.org/ci/job/15001
```
7690 INFO [#+++................] > Setting up source files...
8879 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
8879 WARNING ls: cannot access '/opt/yunohost': No such file or directory
8928 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
8928 WARNING ls: cannot access '/opt/yunohost': No such file or directory
```

https://ci-apps-dev.yunohost.org/ci/job/15036
```
486  INFO [++++++++++..........] > Removing NGINX web server configuration...
502  WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
502  WARNING ls: cannot access '/opt/yunohost': No such file or directory
1035 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
1035 WARNING ls: cannot access '/opt/yunohost': No such file or directory
1227 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
1228 WARNING ls: cannot access '/opt/yunohost': No such file or directory
```

Feel free to propose a more elegant solution.