### PR TITLE
helpers: fix 'ls: cannot access <folder> No such file or directory' errors on CI

### DIFF
--- a/helpers/utils
+++ b/helpers/utils
@@ -843,7 +843,7 @@ ynh_get_debian_release() {
 _acceptable_path_to_delete() {
     local file=$1
 
-    local forbidden_paths=$(ls -d / /* /{var,home,usr}/* /etc/{default,sudoers.d,yunohost,cron*} /etc/yunohost/{apps,domains,hooks.d} /opt/yunohost)
+    local forbidden_paths=$(ls -d / /* /{var,home,usr}/* /etc/{default,sudoers.d,yunohost,cron*} /etc/yunohost/{apps,domains,hooks.d} /opt/yunohost 2> /dev/null)
 
     # Legacy : A couple apps still have data in /home/$app ...
     if [[ -n "${app:-}" ]]


### PR DESCRIPTION
## The problem

YunoHost/yunohost#1810 generates warnings on CI tests jobs:

https://ci-apps-dev.yunohost.org/ci/job/15001
```text
7690 INFO [#+++................] > Setting up source files...
8879 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
8879 WARNING ls: cannot access '/opt/yunohost': No such file or directory
8928 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
8928 WARNING ls: cannot access '/opt/yunohost': No such file or directory
```

https://ci-apps-dev.yunohost.org/ci/job/15036
```text
486  INFO [++++++++++..........] > Removing NGINX web server configuration...
502  WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
502  WARNING ls: cannot access '/opt/yunohost': No such file or directory
1035 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
1035 WARNING ls: cannot access '/opt/yunohost': No such file or directory
1227 WARNING ls: cannot access '/etc/yunohost/hooks.d': No such file or directory
1228 WARNING ls: cannot access '/opt/yunohost': No such file or directory
```

## Solution

ignore the standard error

## PR Status

done

## How to test

```bash
ls -d / /* /{var,home,usr}/* /fictive-path

ls -d / /* /{var,home,usr}/* /fictive-path 2> /dev/null
```