### PR TITLE
get the root domain instead of his closest parent

### DIFF
--- a/src/certificate.py
+++ b/src/certificate.py
@@ -789,7 +789,7 @@ def _check_domain_is_ready_for_ACME(domain):
         or {}
     )
 
-    parent_domain = _get_parent_domain_of(domain, return_self=True)
+    parent_domain = _get_parent_domain_of(domain, return_self=True, topest=True)
 
     dnsrecords = (
         Diagnoser.get_cached_report(


### PR DESCRIPTION
## The problem

I receive mails:

> An attempt for renewing the certificate for domain a.b.domain.tld failed with the following
error :
>
> There is no diagnosis result for domain a.b.domain.tld yet. Please re-run a diagnosis for categories 'DNS records' and 'Web' in the diagnosis section to check if the domain is ready for Let's Encrypt. (Or if you know what you are doing, use '--no-checks' to turn off these checks.)

While the diagnosis is all green.

## Solution

In `_check_domain_is_ready_for_ACME` we want the root domain instead of his closest parent to check dns records.

There is probably an edge case where domain a.b.domain.tld and b.domain.tld are on a server, and domain.tld is on another one

this edge case can be corrected by iterating on all parent domains. But is it really something? 

## PR Status

Done, tested on my server

## How to test

...
