### PR TITLE
#2128  adding `issuewild`

### DIFF
--- a/src/dns.py
+++ b/src/dns.py
@@ -139,6 +139,7 @@ def _build_dns_conf(base_domain, include_empty_AAAA_if_no_ipv6=False):
             # if ipv6 available
             {"type": "AAAA", "name": "*", "value": "valid-ipv6", "ttl": 3600},
             {"type": "CAA", "name": "@", "value": "0 issue \"letsencrypt.org\"", "ttl": 3600},
+            {"type": "CAA", "name": "@", "value": "0 issuewild \"letsencrypt.org\"", "ttl": 3600},
         ],
         "example_of_a_custom_rule": [
             {"type": "SRV", "name": "_matrix", "value": "domain.tld.", "ttl": 3600}
@@ -249,6 +250,7 @@ def _build_dns_conf(base_domain, include_empty_AAAA_if_no_ipv6=False):
                 extra.append([f"*{suffix}", ttl, "AAAA", None])
 
             extra.append([basename, ttl, "CAA", '0 issue "letsencrypt.org"'])
+            extra.append([basename, ttl, "CAA", '0 issuewild "letsencrypt.org"'])
 
         ####################
         # Standard records #


### PR DESCRIPTION
## The problem

[Allow Let's encrypt wildcard subdomain certificates in CAA records #2128](https://github.com/YunoHost/issues/issues/2128)

## Solution

> @alexAubin @tituspijean Just add additional CAA resource records in /src/dns.py lines 141 and 251 (dev-branch) with the "issuewild" tag. It is the same record like the "issue" tag:
> 
> ```
> ;; CAA Records
> example.com.	3600	IN	CAA	0 issue     "letsencrypt.org"
> example.com.	3600	IN	CAA	0 issuewild "letsencrypt.org"
> ```
> 
> After that change Let's Encrypt wildcard-certificates can be requested via the DNS-challenge.

https://github.com/YunoHost/issues/issues/2128#issuecomment-1422024694

## PR Status

...

## How to test

...
