### PR TITLE
Split log rm commands into separate shells

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -641,10 +641,10 @@ def tools_basic_space_cleanup():
     """
     subprocess.run("apt autoremove && apt autoclean", shell=True)
     subprocess.run("journalctl --vacuum-size=50M", shell=True)
-    subprocess.run(
-        "rm /var/log/*.gz && rm /var/log/*/*.gz && rm /var/log/*.? && rm /var/log/*/*.?",
-        shell=True,
-    )
+    subprocess.run("rm /var/log/*.gz", shell=True)
+    subprocess.run("rm /var/log/*/*.gz", shell=True)
+    subprocess.run("rm /var/log/*.?", shell=True)
+    subprocess.run("rm /var/log/*/*.?", shell=True)
 
 
 # ############################################ #


### PR DESCRIPTION
otherwise, if one fails, the following ones are not run.

