### PR TITLE
fix ldap write access for admin users

### DIFF
--- a/conf/slapd/config.ldif
+++ b/conf/slapd/config.ldif
@@ -159,7 +159,7 @@ olcAccess: {2}to dn.base=""
 # can read everything.
 olcAccess: {3}to *
     by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" write
-    by group/groupOfNames/member.exact="cn=admins,ou=groups,dc=yunohost,dc=org" write
+    by group/groupOfNamesYnh/member.exact="cn=admins,ou=groups,dc=yunohost,dc=org" write
     by * read
 #
 olcAddContentAcl: FALSE


### PR DESCRIPTION
Admin users are unable to modify ldap entries, getting following error: 0x32 (LDAP_INSUFFICIENT_ACCESS)