### PR TITLE
Update ynh_mysql_connect_as in mysql helper

### DIFF
--- a/helpers/mysql
+++ b/helpers/mysql
@@ -14,16 +14,25 @@
 # Requires YunoHost version 2.2.4 or higher.
 ynh_mysql_connect_as() {
     # Declare an array to define the options of this helper.
-    local legacy_args=upd
-    local -A args_array=([u]=user= [p]=password= [d]=database=)
+    local legacy_args=updc
+    local -A args_array=( [u]=user= [p]=password= [d]=database= [c]=default_character_set= )
     local user
     local password
     local database
+    local default_character_set
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     database="${database:-}"
+    default_character_set="${default_character_set:-}"
 
-    mysql --user="$user" --password="$password" --batch "$database"
+    if [ -n "$default_character_set" ]
+    then
+        default_character_set="--default-character-set=$default_character_set"
+    else
+        default_character_set="--default-character-set=latin1"
+    fi
+
+    mysql --user="$user" --password="$password" "$default_character_set" --batch "$database"
 }
 
 # Execute a command as root user


### PR DESCRIPTION
Update ynh_mysql_connect_as() helper to be able, when restoring a database, to specify --default-character-set="xxx", xxx being latin1 or utf8mb4

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
