### PR TITLE
Prevent yet another Node and Corepack madness

### DIFF
--- a/helpers/nodejs
+++ b/helpers/nodejs
@@ -74,6 +74,8 @@ ynh_use_nodejs() {
     ynh_node_load_PATH="PATH=$node_PATH"
     # Same var but in lower case to be compatible with ynh_replace_vars...
     ynh_node_load_path="PATH=$node_PATH"
+    # Prevent yet another Node and Corepack madness, with Corepack wanting the user to confirm download of Yarn
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 }
 
 # Install a specific version of nodejs


### PR DESCRIPTION
## The problem

Node's corepack uselessly asking to confirm downloading Yarn

## Solution

Let's set this to `0`: https://github.com/nodejs/corepack/blob/119fd2f43850f8a76d2d179850f094eeacc47e45/sources/httpUtils.ts#L69

## PR Status

Ready

## How to test

...
