### PR TITLE
Update main.cf to allow aliases for sender addresses of apps

### DIFF
--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -107,12 +107,12 @@ virtual_alias_domains =
 virtual_minimum_uid = 100
 virtual_uid_maps = static:vmail
 virtual_gid_maps = static:mail
-smtpd_sender_login_maps=
+smtpd_sender_login_maps = unionmap:{
    # Regular Yunohost accounts
    ldap:/etc/postfix/ldap-accounts.cf,
    # Extra maps for app system users who need to send emails
    hash:/etc/postfix/app_senders_login_maps
-
+}
 
 # Dovecot LDA
 virtual_transport = dovecot


### PR DESCRIPTION
If an app registers the sender address _app@doma.in_ **and** a yunohost account configured an alias for the same address the app will not be able to send emails anymore.

postfix asks the first map defined in smtpd_sender_login_maps and finds that the address _app@doma.in_ can be used as a sender address by the yunohost account having configured the alias and **then stops and doesn't look up the second list** for registered apps.

The unionmap instructs postfix to join a list from both sources and then return the match from that joined list which would then contain _yunohost_account_having_registered_alias, appname_ for the lookup of _app@doma.in_.

This allows the yunohost account having registered the alias and the app being registered to use the sender address to send email using that sender **and makes it possible to receive replies to the emails going out from the app**.

Reference: https://serverfault.com/questions/948362/postfix-multiple-smtpd-sender-login-maps

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
