### PR TITLE
Remove useless dict lookup, as the keys are always the same two

### DIFF
--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -479,8 +479,10 @@ class ConfigPanel:
             "changes_validated",
             "result",
             "max_progression",
+            # 'properties' and 'defaults' are used in format_description levels
+            "properties",
+            "defaults",
         ]
-        forbidden_keywords += format_description["sections"]
 
         for _, _, option in self._iterate():
             if option["id"] in forbidden_keywords:


### PR DESCRIPTION
## The problem

It's not clear what dict += list is.

## Solution

dict += list == dict + list.keys()
(but dict + list is TypeError)

But in fact, we don't need this operation at all because the keys don't change so just remove that part.