### PR TITLE
provision: reload the firewall only once

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -75,14 +75,11 @@ def firewall_allow(
             "ipv6",
         ]
 
-    changed = False
-
     for p in protocols:
         # Iterate over IP versions to add port
         for i in ipvs:
             if port not in firewall[i][p]:
                 firewall[i][p].append(port)
-                changed = True
             else:
                 ipv = "IPv%s" % i[3]
                 logger.warning(m18n.n("port_already_opened", port=port, ip_version=ipv))
@@ -97,7 +94,7 @@ def firewall_allow(
 
     # Update and reload firewall
     _update_firewall_file(firewall)
-    if (not no_reload) or (changed):
+    if not no_reload:
         return firewall_reload()
 
 
@@ -152,14 +149,11 @@ def firewall_disallow(
     elif upnp_only:
         ipvs = []
 
-    changed = False
-
     for p in protocols:
         # Iterate over IP versions to remove port
         for i in ipvs:
             if port in firewall[i][p]:
                 firewall[i][p].remove(port)
-                changed = True
             else:
                 ipv = "IPv%s" % i[3]
                 logger.warning(m18n.n("port_already_closed", port=port, ip_version=ipv))
@@ -172,7 +166,7 @@ def firewall_disallow(
 
     # Update and reload firewall
     _update_firewall_file(firewall)
-    if (not no_reload) or (changed):
+    if not no_reload:
         return firewall_reload()
 
 

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -38,7 +38,6 @@ def firewall_allow(
     ipv6_only=False,
     no_upnp=False,
     no_reload=False,
-    reload_only_if_change=False,
 ):
     """
     Allow connections on a port
@@ -86,10 +85,7 @@ def firewall_allow(
                 changed = True
             else:
                 ipv = "IPv%s" % i[3]
-                if not reload_only_if_change:
-                    logger.warning(
-                        m18n.n("port_already_opened", port=port, ip_version=ipv)
-                    )
+                logger.warning(m18n.n("port_already_opened", port=port, ip_version=ipv))
         # Add port forwarding with UPnP
         if not no_upnp and port not in firewall["uPnP"][p]:
             firewall["uPnP"][p].append(port)
@@ -101,9 +97,7 @@ def firewall_allow(
 
     # Update and reload firewall
     _update_firewall_file(firewall)
-    if (not reload_only_if_change and not no_reload) or (
-        reload_only_if_change and changed
-    ):
+    if (not no_reload) or (changed):
         return firewall_reload()
 
 
@@ -114,7 +108,6 @@ def firewall_disallow(
     ipv6_only=False,
     upnp_only=False,
     no_reload=False,
-    reload_only_if_change=False,
 ):
     """
     Disallow connections on a port
@@ -169,10 +162,7 @@ def firewall_disallow(
                 changed = True
             else:
                 ipv = "IPv%s" % i[3]
-                if not reload_only_if_change:
-                    logger.warning(
-                        m18n.n("port_already_closed", port=port, ip_version=ipv)
-                    )
+                logger.warning(m18n.n("port_already_closed", port=port, ip_version=ipv))
         # Remove port forwarding with UPnP
         if upnp and port in firewall["uPnP"][p]:
             firewall["uPnP"][p].remove(port)
@@ -182,9 +172,7 @@ def firewall_disallow(
 
     # Update and reload firewall
     _update_firewall_file(firewall)
-    if (not reload_only_if_change and not no_reload) or (
-        reload_only_if_change and changed
-    ):
+    if (not no_reload) or (changed):
         return firewall_reload()
 
 

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1153,9 +1153,7 @@ class AptDependenciesAppResource(AppResource):
 
         for key, values in self.extras.items():
             if isinstance(values.get("packages"), str):
-                values["packages"] = [
-                    value.strip() for value in values["packages"].split(",")
-                ]  # type: ignore
+                values["packages"] = [value.strip() for value in values["packages"].split(",")]  # type: ignore
 
             if isinstance(values.get("packages_from_raw_bash"), str):
                 out, err = self.check_output_bash_snippet(
@@ -1166,9 +1164,7 @@ class AptDependenciesAppResource(AppResource):
                         f"Error while running apt resource packages_from_raw_bash snippet for '{key}' extras:"
                     )
                     logger.error(err)
-                values["packages"] = values.get("packages", []) + [
-                    value.strip() for value in out.split("\n")
-                ]  # type: ignore
+                values["packages"] = values.get("packages", []) + [value.strip() for value in out.split("\n")]  # type: ignore
 
             if (
                 not isinstance(values.get("repo"), str)

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1341,16 +1341,19 @@ class PortsResource(AppResource):
             firewall_reload()
 
     def deprovision(self, context: Dict = {}):
-        from yunohost.firewall import firewall_disallow
+        from yunohost.firewall import firewall_disallow, firewall_list, firewall_reload
+
+        previous_ports = firewall_list(raw=True)
 
         for name, infos in self.ports.items():
             setting_name = f"port_{name}" if name != "main" else "port"
             value = self.get_setting(setting_name)
             self.delete_setting(setting_name)
             if value and str(value).strip():
-                firewall_disallow(
-                    infos["exposed"], int(value), reload_only_if_change=True
-                )
+                firewall_disallow(infos["exposed"], int(value), no_reload=True)
+
+        if firewall_list(raw=True) != previous_ports:
+            firewall_reload()
 
 
 class DatabaseAppResource(AppResource):


### PR DESCRIPTION
## The problem

for now, during the provisionning/deprovisionning, the firewall is reloaded for each added or removed port 

for example:
```text
2100 INFO Provisioning ports...
3459 SUCCESS Firewall reloaded
4904 SUCCESS Firewall reloaded
```

## Solution

check if the port list has changed at the end of the port provisionning/deprovisionning, and if so: reload the firewall

## PR Status

done

## How to test

do a port provisionning/deprovisionning
not tested tho
