### PR TITLE
Update getopts to accept arguments that are valid arguments to echo

### DIFF
--- a/helpers/getopts
+++ b/helpers/getopts
@@ -77,9 +77,9 @@ ynh_handle_getopts_args() {
                 # And replace long option (value of the option_flag) by the short option, the option_flag itself
                 # (e.g. for [u]=user, --user will be -u)
                 # Replace long option with = (match the beginning of the argument)
-                arguments[arg]="$(echo "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]}/-${option_flag} /")"
+                arguments[arg]="$(printf '%s\n' "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]}/-${option_flag} /")"
                 # And long option without = (match the whole line)
-                arguments[arg]="$(echo "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]%=}$/-${option_flag} /")"
+                arguments[arg]="$(printf '%s\n' "${arguments[arg]}" | sed "s/^--${args_array[$option_flag]%=}$/-${option_flag} /")"
             done
         done
 


### PR DESCRIPTION
The usage of `echo` to output arguments to to a pipe leads to the problem that arguments that are valid to `echo` itself cannot be processed:

```
root@yt:~# TEST='-n'
root@yt:~# printf '%s\n' $TEST
-n
root@yt:~# echo "$TEST"
root@yt:~# echo "debug $TEST"
debug -n
```

Replacing `echo` with `printf` improves the situation.