### PR TITLE
Allow to force-adding aliases for special groups

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -322,6 +322,7 @@ user:
                             extra:
                                 pattern: *pattern_username
 
+                ### user_group_add_mailalias()
                 add-mailalias:
                     action_help: Add mail aliases to group
                     api: PUT /users/groups/<groupname>/aliases/<aliases>
@@ -336,6 +337,11 @@ user:
                           metavar: MAIL
                           extra:
                               pattern: *pattern_email
+                        --force:
+                            help: Ignore warnings about special groups
+                            action: store_true
+
+                ### user_group_remove_mailalias()
                 remove-mailalias:
                     action_help: Remove mail aliases to group
                     api: DELETE /users/groups/<groupname>/aliases/<aliases>
@@ -348,8 +354,9 @@ user:
                           help: Mail aliases to remove
                           nargs: "+"
                           metavar: MAIL
-
-
+                        --force:
+                            help: Ignore warnings about special groups
+                            action: store_true
 
         permission:
             subcategory_help: Manage permissions

--- a/src/user.py
+++ b/src/user.py
@@ -1363,12 +1363,12 @@ def user_group_remove(groupname, usernames, force=False, sync_perm=True):
     )
 
 
-def user_group_add_mailalias(groupname, aliases):
-    return user_group_update(groupname, add_mailalias=aliases, sync_perm=False)
+def user_group_add_mailalias(groupname, aliases, force=False):
+    return user_group_update(groupname, add_mailalias=aliases, force=force, sync_perm=False)
 
 
-def user_group_remove_mailalias(groupname, aliases):
-    return user_group_update(groupname, remove_mailalias=aliases, sync_perm=False)
+def user_group_remove_mailalias(groupname, aliases, force=False):
+    return user_group_update(groupname, remove_mailalias=aliases, force=force, sync_perm=False)
 
 
 #


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/mail-alias-for-all-users/29781

[This line](https://github.com/YunoHost/yunohost/blob/6aa9d0537284406c91687b63403789a339741776/src/user.py#L1145) mentions that the edition of `all_users` group can be allowed/forced with `--force`, but neither the actions maps nor the `user_group_add_mailalias` or `user_group_remove_mailalias` support that flag.

## Solution

...

## PR Status

Ready

## How to test

```
yunohost user group add-mailalias all_users everyone@domain.tld
# should display an error
yunohost user group add-mailalias all_users everyone@domain.tld --force
# should work
```