### PR TITLE
helpers: Add a --jinja option to ynh_add_config

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Depends: ${python3:Depends}, ${misc:Depends}
  , rspamd, opendkim-tools, postsrsd, procmail, mailutils
  , redis-server
  , acl
- , git, curl, wget, cron, unzip, jq, bc, at, procps
+ , git, curl, wget, cron, unzip, jq, bc, at, procps, j2cli
  , lsb-release, haveged, fake-hwclock, equivs, lsof, whois
 Recommends: yunohost-admin
  , ntp, inetutils-ping | iputils-ping

--- a/helpers/utils
+++ b/helpers/utils
@@ -489,13 +489,15 @@ ynh_local_curl() {
 # Requires YunoHost version 4.1.0 or higher.
 ynh_add_config() {
     # Declare an array to define the options of this helper.
-    local legacy_args=tdv
-    local -A args_array=([t]=template= [d]=destination=)
+    local legacy_args=tdj
+    local -A args_array=([t]=template= [d]=destination= [j]=jinja)
     local template
     local destination
+    local jinja
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     local template_path
+    jinja="${jinja:-0}"
 
     if [ -f "$YNH_APP_BASEDIR/conf/$template" ]; then
         template_path="$YNH_APP_BASEDIR/conf/$template"
@@ -512,14 +514,20 @@ ynh_add_config() {
     # created a file beforehand to have control over it
     # (cp won't overwrite ownership / modes by default...)
     touch $destination
-    chown root:root $destination
     chmod 640 $destination
-
-    cp -f "$template_path" "$destination"
-
     _ynh_apply_default_permissions $destination
 
-    ynh_replace_vars --file="$destination"
+    if [[ "$jinja" == 1 ]]
+    then
+        # This is ran in a subshell such that the "export" does not "contaminate" the main process
+        (
+            export $(compgen -v)
+            j2 "$template_path" -f env -o $destination
+        )
+    else
+        cp -f "$template_path" "$destination"
+        ynh_replace_vars --file="$destination"
+    fi
 
     ynh_store_file_checksum --file="$destination"
 }
@@ -1088,7 +1096,7 @@ _ynh_apply_default_permissions() {
     # Crons should be owned by root
     # Also we don't want systemd conf, nginx conf or others stuff to be owned by the app,
     # otherwise they could self-edit their own systemd conf and escalate privilege
-    if echo "$target" | grep -q '^/etc/cron\|/etc/php\|/etc/nginx/conf.d\|/etc/fail2ban\|/etc/systemd/system'
+    if grep -qE '^(/etc/cron|/etc/php|/etc/nginx/conf.d|/etc/fail2ban|/etc/systemd/system)' <<< "$target"
     then
         chmod 400 $target
         chown root:root $target

--- a/tests/test_helpers.d/ynhtest_templating.sh
+++ b/tests/test_helpers.d/ynhtest_templating.sh
@@ -1,0 +1,62 @@
+ynhtest_simple_template_app_config() {
+
+    mkdir -p /etc/yunohost/apps/$app/
+    echo "id: $app" > /etc/yunohost/apps/$app/settings.yml
+
+    template="$(mktemp -d -p $VAR_WWW)/template.txt"
+    cat << EOF > $template 
+app=__APP__
+foo=__FOO__
+EOF
+
+    foo="bar"
+    
+    ynh_add_config --template="$template" --destination="$VAR_WWW/config.txt"
+
+    test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
+    test "$(ls -l $VAR_WWW/config.txt | cut -d' ' -f1-4)" == "-rw-r----- 1 ynhtest ynhtest"
+}
+
+ynhtest_simple_template_system_config() {
+
+    mkdir -p /etc/yunohost/apps/$app/
+    echo "id: $app" > /etc/yunohost/apps/$app/settings.yml
+
+    rm -f /etc/cron.d/ynhtest_config
+
+    template="$(mktemp -d -p $VAR_WWW)/template.txt"
+    cat << EOF > $template 
+app=__APP__
+foo=__FOO__
+EOF
+
+    foo="bar"
+    
+    ynh_add_config --template="$template" --destination="/etc/cron.d/ynhtest_config"
+
+    test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
+    test "$(ls -l /etc/cron.d/ynhtest_config | cut -d' ' -f1-4)" == "-r-------- 1 root root"
+
+    rm -f /etc/cron.d/ynhtest_config
+}
+
+ynhtest_jinja_template_app_config() {
+
+    mkdir -p /etc/yunohost/apps/$app/
+    echo "id: $app" > /etc/yunohost/apps/$app/settings.yml
+
+    template="$(mktemp -d -p $VAR_WWW)/template.txt"
+    cat << EOF > $template 
+app={{ app }}
+{% if foo == "bar" %}foo=true{% endif %}
+EOF
+
+    foo="bar"
+    
+    ynh_add_config --template="$template" --destination="$VAR_WWW/config.txt" --jinja
+
+    test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=true')"
+    test "$(ls -l $VAR_WWW/config.txt | cut -d' ' -f1-4)" == "-rw-r----- 1 ynhtest ynhtest"
+}
+
+

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -41,6 +41,10 @@ popd >/dev/null
 
 VAR_WWW=$(mktemp -d)/var/www
 mkdir -p $VAR_WWW
+
+# Needed to check the permission behavior in ynh_add_config x_x
+getent passwd ynhtest &>/dev/null || useradd --system ynhtest
+
 # =========================================================
 
 for TEST_SUITE in $(ls test_helpers.d/*)


### PR DESCRIPTION
## The problem

cf https://github.com/YunoHost-Apps/Experimental_helpers/pull/111

## Solution

add a `--jinja` option to `ynh_add_config` to render the template using jinja. All bash variables are exported in a subshell. The rendering is done using `j2cli` which is available in debian since bullseye

## PR Status

Tested using new unit tests

## How to test

Try rendering a template using `ynh_add_config --template=foo --destination=bar --jinja`
