### PR TITLE
Fix helpers: actually that might be a bad idea to read arguments

### DIFF
--- a/helpers/helpers
+++ b/helpers/helpers
@@ -2,14 +2,8 @@
 # Entrypoint for the helpers scripts
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-if [[ -n "${1:-}" ]]; then
-    # helpers version can be passed as first when sourcing.
-    YNH_HELPERS_VERSION="$1"
-else
-    # ...or as environment variable set from manifest
-    # ...or default to 1
-    YNH_HELPERS_VERSION=${YNH_HELPERS_VERSION:-1}
-fi
+# Helpers version can be specified via an environment variable or default to 1.
+YNH_HELPERS_VERSION=${YNH_HELPERS_VERSION:-1}
 
 # This is a trick to later only restore set -x if it was set when calling this script
 readonly XTRACE_ENABLE=$(set +o | grep xtrace)


### PR DESCRIPTION
If `source helpers` has no arguments passed, $@ is the main script arguments.
