### PR TITLE
Add swap helpers.

### DIFF
--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -114,25 +114,41 @@ ynh_require_ram() {
 # | arg: -s, --size= - Amount of SWAP to add in Mib.
 ynh_add_swap () {
     # Declare an array to define the options of this helper.
-    declare -Ar args_array=( [s]=size= )
+    local -A args_array=( [s]=size= )
     local size
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
+
+    # Could be moved to an argument
+    swapfile_dir="$(realpath /)"
+    swapfile_path="$(realpath "$swapfile_dir/swap_file")"
+
+    # Early warning exit: Can't swap inside LXD
+    if [[ "$(systemd-detect-virt)" == "lxc" ]]; then
+        ynh_print_warn --message="You are inside a LXC container, swap will not be added."
+        ynh_print_warn --message="That can cause troubles for $app. Please make sure you have more than $((size/1024))G of RAM/swap available."
+        return
+    fi
+
+    # Early warning exit: Preserve SD cards and do not swap on them
+    if ynh_is_on_sd_card --dir="$swapfile_dir" && [[ "${SD_CARD_CAN_SWAP:-0}" == "0" ]]; then
+        ynh_print_warn --message="Swap files on an SD card is not recommended, swap will not be added."
+        ynh_print_warn --message="That can cause troubles for $app. Please make sure you have more than $((size/1024))G of RAM/swap available."
+        ynh_print_warn --message="If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
+        return
+    fi
+
+    # Early warning exit: swapfile already exists
+    if [ -f "$swapfile_path" ]; then
+        ynh_print_warn --message="Swap file $swapfile_path already exists!"
+        return
+    fi
 
     local swap_max_size=$(( $size * 1024 ))
 
     local free_space=$(df --output=avail / | sed 1d)
     # Because we don't want to fill the disk with a swap file, divide by 2 the available space.
     local usable_space=$(( $free_space / 2 ))
-
-    SD_CARD_CAN_SWAP=${SD_CARD_CAN_SWAP:-0}
-
-    # Swap on SD card only if it's is specified
-    if ynh_is_on_sd_card --dir="$swapfile_dir" && [ "$SD_CARD_CAN_SWAP" == "0" ]
-    then
-        ynh_print_warn --message="The main mountpoint of your system '/' is on an SD card, swap will not be added to prevent some damage to it. If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
-        return
-    fi
 
     # Configure swappiness
     if [ ! -e /etc/sysctl.d/999-ynhswap.conf ]

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -104,10 +104,14 @@ ynh_require_ram() {
     fi
 }
 
-# Add swap
+
+# Ask the creation of a swap file for the application.
+# The helper might or might not create the swap file, considering the machine's configuration.
 #
-# usage: ynh_add_swap --size=SWAP in MiB
-# | arg: -s, --size= - Amount of SWAP to add in MiB.
+# [packagingv1]
+#
+# usage: ynh_add_swap --size=SWAP in Mib
+# | arg: -s, --size= - Amount of SWAP to add in Mib.
 ynh_add_swap () {
     # Declare an array to define the options of this helper.
     declare -Ar args_array=( [s]=size= )
@@ -181,6 +185,10 @@ ynh_add_swap () {
     fi
 }
 
+# Delete the swap file created for the app by ynh_add_swap.
+#
+# [packagingv1]
+#
 ynh_del_swap () {
     # If there a swap at this place
     if [ -e /swap_file ]

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -190,16 +190,20 @@ ynh_add_swap () {
 # [packagingv1]
 #
 ynh_del_swap () {
-    # If there a swap at this place
-    if [ -e /swap_file ]
-    then
-        # Clean the fstab
-        sed -i "/#Swap added by YunoHost config panel/d" /etc/fstab
-        # Desactive the swap file
-        swapoff /swap_file
-        # And remove it
-        rm /swap_file
+    # Could be moved to an argument
+    swapfile_dir="$(realpath /)"
+    swapfile_path="$(realpath "$swapfile_dir/swap_file")"
+
+    if [ ! -f "$swapfile_path" ]; then
+        return
     fi
+
+    # Clean the fstab...
+    sed -i "/#Swap added by $app/d" /etc/fstab
+    # Desactive the swap file...
+    swapoff "$swapfile_path"
+    # And remove it.
+    rm "$swapfile_path"
 }
 
 # Check if the device of the provided directory is an SD card

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -144,36 +144,27 @@ ynh_add_swap () {
         return
     fi
 
-    local swap_max_size=$(( $size * 1024 ))
+    local swap_max_size_kb=$(( size * 1024 ))
 
-    local free_space=$(df --output=avail / | sed 1d)
+    local free_space_kb
+    free_space_kb=$(df --block-size=K --output=avail "$swapfile_dir" | sed 1d | sed -e 's/K$//')
     # Because we don't want to fill the disk with a swap file, divide by 2 the available space.
-    local usable_space=$(( $free_space / 2 ))
+    local usable_space_kb=$(( free_space_kb / 2 ))
+
+    # Compare the available space with the size of the swap.
+    # And set a acceptable size from the request
+    size_space_ratio=$(( swap_max_size_kb / usable_space_kb + 1 ))
+    if (( size_space_ratio > 4)); then
+        ynh_print_warn --message="Not enough space for a swap file at $swapfile_path."
+        return
+    fi
+    swap_size_kb=$(( swap_max_size_kb / size_space_ratio ))
 
     # Configure swappiness
     if [ ! -e /etc/sysctl.d/999-ynhswap.conf ]
     then
         echo "vm.swappiness=10" > /etc/sysctl.d/999-ynhswap.conf
         sysctl --quiet --system
-    fi
-
-    # Compare the available space with the size of the swap.
-    # And set a acceptable size from the request
-    if [ $usable_space -ge $swap_max_size ]
-    then
-        swap_size=$swap_max_size
-    elif [ $usable_space -ge $(( $swap_max_size / 2 )) ]
-    then
-        swap_size=$(( $swap_max_size / 2 ))
-    elif [ $usable_space -ge $(( $swap_max_size / 3 )) ]
-    then
-        swap_size=$(( $swap_max_size / 3 ))
-    elif [ $usable_space -ge $(( $swap_max_size / 4 )) ]
-    then
-        swap_size=$(( $swap_max_size / 4 ))
-    else
-        echo "Not enough space left for a swap file" >&2
-        swap_size=0
     fi
 
     # If there's enough space for a swap, and no existing swap here

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -121,7 +121,7 @@ ynh_add_swap () {
 
     # Could be moved to an argument
     swapfile_dir="$(realpath /)"
-    swapfile_path="$(realpath "$swapfile_dir/swap_file")"
+    swapfile_path="$(realpath "$swapfile_dir/swap_yunohost")"
 
     # Early warning exit: Can't swap inside LXD
     if [[ "$(systemd-detect-virt)" == "lxc" ]]; then
@@ -161,8 +161,7 @@ ynh_add_swap () {
     swap_size_kb=$(( swap_max_size_kb / size_space_ratio ))
 
     # Configure swappiness
-    if [ ! -e /etc/sysctl.d/999-ynhswap.conf ]
-    then
+    if [ ! -f /etc/sysctl.d/999-yunohost-swap.conf ]; then
         echo "vm.swappiness=10" > /etc/sysctl.d/999-ynhswap.conf
         sysctl --quiet --system
     fi
@@ -191,7 +190,7 @@ ynh_add_swap () {
 ynh_del_swap () {
     # Could be moved to an argument
     swapfile_dir="$(realpath /)"
-    swapfile_path="$(realpath "$swapfile_dir/swap_file")"
+    swapfile_path="$(realpath "$swapfile_dir/swap_yunohost")"
 
     if [ ! -f "$swapfile_path" ]; then
         return

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -167,29 +167,21 @@ ynh_add_swap () {
         sysctl --quiet --system
     fi
 
-    # If there's enough space for a swap, and no existing swap here
-    if [ $swap_size -ne 0 ] && [ ! -e /swap_file ]
-    then
-        # Create file
-        truncate -s 0 /swap_file
+    # Workaround for some copy-on-write filesystems like btrfs.
+    # Create the file
+    truncate -s 0 "$swapfile_path"
+    # Set the No_COW attribute on the swapfile with chattr
+    chattr +C "$swapfile_path" || true
+    # Set the final file size
+    dd if=/dev/zero of="$swapfile_path" bs=1024 count="$swap_size_kb"
+    chmod 0600 "$swapfile_path"
 
-        # set the No_COW attribute on the swapfile with chattr
-        # let's not fail here, as some filesystems like ext4 do not support COW
-        chattr +C /swap_file || true
-
-        # Preallocate space for the swap file, fallocate may sometime not be used, use dd instead in this case
-        if ! fallocate -l ${swap_size}K /swap_file
-        then
-            dd if=/dev/zero of=/swap_file bs=1024 count=${swap_size}
-        fi
-        chmod 0600 /swap_file
-        # Create the swap
-        mkswap /swap_file
-        # And activate it
-        swapon /swap_file
-        # Then add an entry in fstab to load this swap at each boot.
-        echo -e "/swap_file swap swap defaults 0 0 #Swap added by YunoHost config panel" >> /etc/fstab
-    fi
+    # Create the swap
+    mkswap "$swapfile_path"
+    # And activate it
+    swapon "$swapfile_path"
+    # Then add an entry in fstab to load this swap at each boot.
+    echo -e "$swapfile_path swap swap defaults 0 0 #Swap added by $app" >> /etc/fstab
 }
 
 # Delete the swap file created for the app by ynh_add_swap.

--- a/helpers/helpers.v1.d/hardware
+++ b/helpers/helpers.v1.d/hardware
@@ -128,7 +128,7 @@ ynh_add_swap () {
     SD_CARD_CAN_SWAP=${SD_CARD_CAN_SWAP:-0}
 
     # Swap on SD card only if it's is specified
-    if ynh_is_main_device_a_sd_card && [ "$SD_CARD_CAN_SWAP" == "0" ]
+    if ynh_is_on_sd_card --dir="$swapfile_dir" && [ "$SD_CARD_CAN_SWAP" == "0" ]
     then
         ynh_print_warn --message="The main mountpoint of your system '/' is on an SD card, swap will not be added to prevent some damage to it. If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
         return
@@ -202,16 +202,24 @@ ynh_del_swap () {
     fi
 }
 
-# Check if the device of the main mountpoint "/" is an SD card
+# Check if the device of the provided directory is an SD card
 #
 # [internal]
 #
-# return 0 if it's an SD card, else 1
-ynh_is_main_device_a_sd_card () {
-    local main_device=$(lsblk --output PKNAME --noheadings $(findmnt / --nofsroot --uniq --output source --noheadings --first-only))
+# usage: ynh_is_on_sd_card --dir=/
+# | arg: -d, --dir= - Directory to check
+ynh_is_on_sd_card () {
+    # Declare an array to define the options of this helper.
+    local -A args_array=( [d]=dir= )
+    local dir
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
 
-    if echo $main_device | grep --quiet "mmc" && [ $(tail -n1 /sys/block/$main_device/queue/rotational) == "0" ]
-    then
+    device_dev=$(findmnt --nofsroot --uniq --output source --noheadings --first-only --target "$dir")
+    device_pkname=$(lsblk --output PKNAME --noheadings "$device_dev")
+    device_rotational=$(lsblk --output ROTA --noheadings "$device_dev")
+
+    if [[ "$device_pkname" == *"mmc"* ]] && [[ "$device_rotational" == "0" ]]; then
         return 0
     else
         return 1


### PR DESCRIPTION
This provides yunohost 2 things:
* Remove duplication and centralize code and bugfixes for easier maintainance
* The day the core supports swap, or we want to change the logic, these helpers can be changed to empty shells.

## The problem

swap helpers everywhere in the apps.