### PR TITLE
helpers: goenv is broken when checking out latest master commit.

### DIFF
--- a/helpers/helpers.v1.d/go
+++ b/helpers/helpers.v1.d/go
@@ -111,43 +111,35 @@ ynh_install_go () {
     test -x /usr/bin/go && mv /usr/bin/go /usr/bin/go_goenv
 
     # Install or update goenv
-    goenv="$(command -v goenv $goenv_install_dir/bin/goenv | head -1)"
-    if [ -n "$goenv" ]; then
-        ynh_print_info --message="goenv already seems installed in \`$goenv'."
-        pushd "${goenv%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/syndbg/goenv.git"; then
-                echo "Trying to update with Git..."
-                git pull -q --tags origin master
-                cd ..
-                ynh_go_try_bash_extension
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing goenv with Git..."
-        mkdir -p $goenv_install_dir
-        pushd $goenv_install_dir
+    mkdir -p $goenv_install_dir
+    pushd "$goenv_install_dir"
+        if ! [ -x "$goenv_install_dir/bin/goenv" ]; then
+            ynh_print_info --message="Downloading goenv..."
             git init -q
-            git remote add -f -t master origin https://github.com/syndbg/goenv.git > /dev/null 2>&1
-            git checkout -q -b master origin/master
-            ynh_go_try_bash_extension
-            goenv=$goenv_install_dir/bin/goenv
-        popd
-    fi
+            git remote add origin https://github.com/syndbg/goenv.git 
+        else
+            ynh_print_info --message="Updating goenv..."
+        fi
+        git fetch -q --tags --prune origin
+        local git_latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+        git checkout -q "$git_latest_tag"
+        ynh_go_try_bash_extension
+        goenv=$goenv_install_dir/bin/goenv
+    popd
 
-    goenv_latest="$(command -v "$goenv_install_dir"/plugins/*/bin/goenv-latest goenv-latest | head -1)"
-    if [ -n "$goenv_latest" ]; then
-        ynh_print_info --message="\`goenv latest' command already available in \`$goenv_latest'."
-        pushd "${goenv_latest%/*/*}"
-            if git remote -v 2>/dev/null | grep "https://github.com/momo-lab/xxenv-latest.git"; then
-                ynh_print_info --message="Trying to update xxenv-latest with git..."
-                git pull -q origin master
-            fi
-        popd
-    else
-        ynh_print_info --message="Installing xxenv-latest with Git..."
-        mkdir -p "${goenv_install_dir}/plugins"
-        git clone -q https://github.com/momo-lab/xxenv-latest.git "${goenv_install_dir}/plugins/xxenv-latest"
-    fi
+    # Install or update xxenv-latest
+    mkdir -p "$goenv_install_dir/plugins/xxenv-latest"
+    pushd "$goenv_install_dir/plugins/xxenv-latest"
+        if ! [ -x "$goenv_install_dir/plugins/xxenv-latest/bin/goenv-latest" ]; then
+            ynh_print_info --message="Downloading xxenv-latest..."
+            git init -q
+            git remote add origin https://github.com/momo-lab/xxenv-latest.git 
+        else
+            ynh_print_info --message="Updating xxenv-latest..."
+        fi
+        local git_latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+        git checkout -q "$git_latest_tag"
+    popd
 
     # Enable caching
     mkdir -p "${goenv_install_dir}/cache"
@@ -224,7 +216,7 @@ ynh_cleanup_go () {
             required_go_versions="${installed_app_go_version}\n${required_go_versions}"
         fi
     done
-    
+
     # Remove no more needed Go versions
     local installed_go_versions=$(goenv versions --bare --skip-aliases | grep -Ev '/')
     for installed_go_version in $installed_go_versions

--- a/helpers/helpers.v1.d/go
+++ b/helpers/helpers.v1.d/go
@@ -154,12 +154,12 @@ ynh_install_go () {
     test -x /usr/bin/go_goenv && mv /usr/bin/go_goenv /usr/bin/go
 
     # Install the requested version of Go
-    local final_go_version=$(goenv latest --print $go_version)
+    local final_go_version=$(goenv latest --print "$go_version")
     ynh_print_info --message="Installation of Go-$final_go_version"
-    goenv install --skip-existing $final_go_version
+    goenv install --skip-existing "$final_go_version"
 
     # Store go_version into the config of this app
-    ynh_app_setting_set --app=$YNH_APP_INSTANCE_NAME --key=go_version --value=$final_go_version
+    ynh_app_setting_set --app="$YNH_APP_INSTANCE_NAME" --key="go_version" --value="$final_go_version"
 
     # Cleanup Go versions
     ynh_cleanup_go
@@ -181,7 +181,7 @@ eval \"\$(goenv init -)\"
 #
 # usage: ynh_remove_go
 ynh_remove_go () {
-    local go_version=$(ynh_app_setting_get --app=$YNH_APP_INSTANCE_NAME --key=go_version)
+    local go_version=$(ynh_app_setting_get --app="$YNH_APP_INSTANCE_NAME" --key="go_version")
 
     # Load goenv path in PATH
     local CLEAR_PATH="$goenv_install_dir/bin:$PATH"
@@ -190,7 +190,7 @@ ynh_remove_go () {
     PATH=$(echo $CLEAR_PATH | sed 's@/usr/local/bin:@@')
 
     # Remove the line for this app
-    ynh_app_setting_delete --app=$YNH_APP_INSTANCE_NAME --key=go_version
+    ynh_app_setting_delete --app="$YNH_APP_INSTANCE_NAME" --key="go_version"
 
     # Cleanup Go versions
     ynh_cleanup_go
@@ -224,7 +224,7 @@ ynh_cleanup_go () {
         if ! `echo ${required_go_versions} | grep "${installed_go_version}" 1>/dev/null 2>&1`
         then
             ynh_print_info --message="Removing of Go-$installed_go_version"
-            $goenv_install_dir/bin/goenv uninstall --force $installed_go_version
+            $goenv_install_dir/bin/goenv uninstall --force "$installed_go_version"
         fi
     done
 


### PR DESCRIPTION
Instead, checkout the latest commit. Same for xxenv-latest.
