### PR TITLE
helpers: Fix typo in ynh_read_manifest documentation

### DIFF
--- a/helpers/helpers.v1.d/utils
+++ b/helpers/helpers.v1.d/utils
@@ -943,9 +943,9 @@ ynh_secure_remove() {
 
 # Read the value of a key in a ynh manifest file
 #
-# usage: ynh_read_manifest --manifest="manifest.json" --key="key"
-# | arg: -m, --manifest=    - Path of the manifest to read
-# | arg: -k, --key=         - Name of the key to find
+# usage: ynh_read_manifest --manifest="manifest.json" --manifest_key="key"
+# | arg: -m, --manifest=      - Path of the manifest to read
+# | arg: -k, --manifest_key=  - Name of the key to find
 # | ret: the value associate to that key
 #
 # Requires YunoHost version 3.5.0 or higher.


### PR DESCRIPTION
in [line 955](https://github.com/chri2/yunohost/blob/2bd76986a8e6d67bd8b9865cbb694ac1ec35383a/helpers/helpers.v1.d/utils#L955) the parameter is named different than in the functions help