### PR TITLE
resources.py apt: Fix when multiple extras are passed

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1176,10 +1176,10 @@ class AptDependenciesAppResource(AppResource):
                     raw_msg=True,
                 )
 
-            # Drop 'extras' entries associated to no packages
-            self.extras = {
-                key: values for key, values in self.extras.items() if values["packages"]
-            }
+        # Drop 'extras' entries associated to no packages
+        self.extras = {
+            key: values for key, values in self.extras.items() if values["packages"]
+        }
 
     def provision_or_update(self, context: Dict = {}):
         script = " ".join(["ynh_install_app_dependencies", *self.packages])


### PR DESCRIPTION
A wrong indentation leads to code executed at every for loop iteration. If multiple apt.extras resources, this fails at the first iteration.
