### PR TITLE
Helpers v2.1 : download composer globally in /opt/yunohost/composer

### DIFF
--- a/helpers/helpers.v1.d/sources
+++ b/helpers/helpers.v1.d/sources
@@ -267,8 +267,11 @@ ynh_setup_source() {
         for patchfile in "$patches_folder/"*.patch; do
             echo "$patchfile"
             if ! patch --strip=1 < "$patchfile"; then
-                ynh_print_warn --message="Warn your packagers /!\\ patch $patchfile failed to apply"
-            fi
+                if ynh_in_ci_tests; then
+                    ynh_die --message"Patch $patchfile failed to apply!"
+                else
+                    ynh_print_warn --message="Warn your packagers /!\\ patch $patchfile failed to apply"
+                fi            fi
         done
         popd
     fi

--- a/helpers/helpers.v1.d/sources
+++ b/helpers/helpers.v1.d/sources
@@ -60,7 +60,7 @@
 # - Uncompress the archive to `$dest_dir`.
 #   - If `in_subdir` is true, the first level directory of the archive will be removed.
 #   - If `in_subdir` is a numeric value, the N first level directories will be removed.
-# - Patches named `sources/patches/${src_id}-*.patch` will be applied to `$dest_dir`
+# - Patches named `sources/patches/${src_id}/*.patch` will be applied to `$dest_dir`
 # - Extra files in `sources/extra_files/$src_id` will be copied to dest_dir
 #
 # Requires YunoHost version 2.6.4 or higher.
@@ -261,16 +261,16 @@ ynh_setup_source() {
     fi
 
     # Apply patches
-    if [ -d "$YNH_APP_BASEDIR/sources/patches/" ]; then
-        local patches_folder=$(realpath $YNH_APP_BASEDIR/sources/patches/)
-        if (($(find $patches_folder -type f -name "${source_id}-*.patch" 2>/dev/null | wc --lines) > "0")); then
-            pushd "$dest_dir"
-            for p in $patches_folder/${source_id}-*.patch; do
-                echo $p
-                patch --strip=1 <$p || ynh_print_warn --message="Packagers /!\\ patch $p failed to apply"
-            done
-            popd
-        fi
+    local patches_folder=$(realpath "$YNH_APP_BASEDIR/patches/$source_id")
+    if [ -d "$patches_folder" ]; then
+        pushd "$dest_dir"
+        for patchfile in "$patches_folder/"*.patch; do
+            echo "$patchfile"
+            if ! patch --strip=1 < "$patchfile"; then
+                ynh_print_warn --message="Warn your packagers /!\\ patch $patchfile failed to apply"
+            fi
+        done
+        popd
     fi
 
     # Add supplementary files

--- a/helpers/helpers.v2.1.d/composer
+++ b/helpers/helpers.v2.1.d/composer
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+composer_install_dir="/opt/yunohost/composer"
+
 # Install and initialize Composer in the given directory
 #
 # The installed version is defined by `$composer_version` which should be defined
@@ -13,16 +15,27 @@ ynh_composer_install() {
 
     [[ -n "${composer_version}" ]] || ynh_die "\$composer_version should be defined before calling ynh_composer_install. (In the past, this was called \$YNH_COMPOSER_VERSION)"
 
-    [[ ! -e "$workdir/composer.phar" ]] || ynh_safe_rm $workdir/composer.phar
-
     local composer_url="https://getcomposer.org/download/$composer_version/composer.phar"
+    local composer_phar_path="$composer_install_dir/composer_${composer_version}.phar"
+
+    # Remove legacy composer.phar in work directory
+    if [ -f "$workdir/composer.phar" ]; then
+        ynh_safe_rm "$workdir/composer.phar"
+    fi
+
+    # Early exit if already downloaded
+    if [ -f "$composer_phar_path" ]; then
+        return
+    fi
+
+    mkdir -p "$composer_install_dir"
 
     # NB. we have to declare the var as local first,
     # otherwise 'local foo=$(false) || echo 'pwet'" does'nt work
     # because local always return 0 ...
     local out
     # Timeout option is here to enforce the timeout on dns query and tcp connect (c.f. man wget)
-    out=$(wget --tries 3 --no-dns-cache --timeout 900 --no-verbose --output-document=$workdir/composer.phar $composer_url 2>&1) \
+    out=$(wget --tries 3 --no-dns-cache --timeout 900 --no-verbose --output-document="$composer_phar_path" "$composer_url" 2>&1) \
         || ynh_die "$out"
 }
 
@@ -36,10 +49,11 @@ ynh_composer_install() {
 # usage: ynh_composer_exec commands
 ynh_composer_exec() {
     local workdir="${composer_workdir:-$install_dir}"
+    local composer_phar_path="$composer_install_dir/composer_${composer_version}.phar"
 
     COMPOSER_HOME="$workdir/.composer" \
     COMPOSER_MEMORY_LIMIT=-1 \
     sudo -E -u "${composer_user:-$app}" \
-    php${php_version} "$workdir/composer.phar" $@ \
+    "php${php_version}" "$composer_phar_path" $@ \
         -d "$workdir" --no-interaction --no-ansi 2>&1
 }


### PR DESCRIPTION
* download composer globally in /opt/yunohost/composer
* ~~replace --full_replace with --no_clean~~ (disappeared?)
* ~~ynh_in_ci~~ (included in helpers 2.1)
* ~~ynh_setup_source: change the path to the patches~~
* ~~ynh_setup_source: patch failure is now fatal in CI.~~