### PR TITLE
helpers: add a new ynh_app_setting_set_default to replace the unecessarily complex 'if [ -z ${foo:-} ]' trick

### DIFF
--- a/helpers/helpers.v1.d/setting
+++ b/helpers/helpers.v1.d/setting
@@ -52,6 +52,42 @@ ynh_app_setting_set() {
     fi
 }
 
+# Set an application setting but only if the "$key" variable ain't set yet
+#
+# Note that it doesn't just define the setting but ALSO define the $foobar variable
+#
+# Hence it's meant as a replacement for this legacy overly complex syntax:
+#
+# if [ -z "${foo:-}" ]
+# then
+#     foo="bar"
+#     ynh_app_setting_set --key="foo" --value="$foo"
+# fi
+#
+# usage: ynh_app_setting_set_default --app=app --key=key --value=value
+# | arg: -a, --app=     - the application id
+# | arg: -k, --key=     - the setting name to set
+# | arg: -v, --value=   - the default setting value to set
+#
+# Requires YunoHost version 11.1.16 or higher.
+ynh_app_setting_set_default() {
+    local _globalapp=${app-:}
+    # Declare an array to define the options of this helper.
+    local legacy_args=akv
+    local -A args_array=([a]=app= [k]=key= [v]=value=)
+    local app
+    local key
+    local value
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+    app="${app:-$_globalapp}"
+
+    if [ -z "${!key:-}" ]; then
+        eval $key=\$value
+        ynh_app_setting "set" "$app" "$key" "$value"
+    fi
+}
+
 # Delete an application setting
 #
 # usage: ynh_app_setting_delete --app=app --key=key

--- a/helpers/helpers.v2.1.d/setting
+++ b/helpers/helpers.v2.1.d/setting
@@ -42,6 +42,41 @@ ynh_app_setting_set() {
     ynh_app_setting "set" "$app" "$key" "$value"
 }
 
+# Set an application setting but only if the "$key" variable ain't set yet
+#
+# Note that it doesn't just define the setting but ALSO define the $foobar variable
+#
+# Hence it's meant as a replacement for this legacy overly complex syntax:
+#
+# if [ -z "${foo:-}" ]
+# then
+#     foo="bar"
+#     ynh_app_setting_set --key="foo" --value="$foo"
+# fi
+#
+# usage: ynh_app_setting_set_default --app=app --key=key --value=value
+# | arg: -a, --app=     - the application id
+# | arg: -k, --key=     - the setting name to set
+# | arg: -v, --value=   - the default setting value to set
+#
+# Requires YunoHost version 11.1.16 or higher.
+ynh_app_setting_set_default() {
+    # ============ Argument parsing =============
+    local _globalapp=${app-:}
+    local -A args_array=([a]=app= [k]=key= [v]=value=)
+    local app
+    local key
+    local value
+    ynh_handle_getopts_args "$@"
+    app="${app:-$_globalapp}"
+    # ===========================================
+
+    if [ -z "${!key:-}" ]; then
+        eval $key=\$value
+        ynh_app_setting "set" "$app" "$key" "$value"
+    fi
+}
+
 # Delete an application setting
 #
 # usage: ynh_app_setting_delete --app=app --key=key


### PR DESCRIPTION
## The problem

Boring `if [ -z ${foo:-} ]` trick all over the place in upgrade scripts

## Solution

`ynh_app_setting_set_default --key=foo --value=bar`

## PR Status

Sort of yolo

## How to test

...
