### PR TITLE
[helpers v2.1]: ynh_remove_systemd_config: Also remove the systemd service f…

### DIFF
--- a/.github/workflows/releases_from_tags.yaml
+++ b/.github/workflows/releases_from_tags.yaml
@@ -1,0 +1,33 @@
+name: Automatically write releases when tags appear
+
+on:
+  push:
+    tags: [ "debian/*" ]
+
+
+jobs:
+  pre-release:
+    name: Generate releases
+    runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0 # Fetch all tags
+
+      - name: Patch tag name
+        id: patch-tag-name
+        run: echo "version=$(echo ${{ github.ref }} | sed 's|refs/tags/debian/||')" >> $GITHUB_OUTPUT
+
+      - name: Create Release for Tag
+        id: release_tag
+        uses: Akryum/release-tag@v4.0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: YunoHost ${{ steps.patch-tag-name.outputs.version }}
+          tag_name: ${{ github.ref }}

--- a/helpers/helpers.v1.d/systemd
+++ b/helpers/helpers.v1.d/systemd
@@ -47,7 +47,7 @@ ynh_add_systemd_config() {
     systemctl daemon-reload
 }
 
-# Remove the dedicated systemd config
+# Remove the dedicated systemd config, and if configured into YunoHost, removes the service.
 #
 # usage: ynh_remove_systemd_config [--service=service]
 # | arg: -s, --service=     - Service name (optionnal, $app by default)
@@ -61,6 +61,10 @@ ynh_remove_systemd_config() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
     local service="${service:-$app}"
+
+    if ynh_exec_warn_less yunohost service status "$app" >/dev/null; then
+        yunohost service remove "$app"
+    fi
 
     local finalsystemdconf="/etc/systemd/system/$service.service"
     if [ -e "$finalsystemdconf" ]; then


### PR DESCRIPTION
…rom YunoHost.

Every app or almost will do that, because it doesn't make sense to remove the systemd config but not the associated yunohost configuration.

This will clean up a bit the remove scripts.

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
