### PR TITLE
automatically ignore the service in diagnosis if it has been deactivated with the ynh cli

### DIFF
--- a/src/diagnosis.py
+++ b/src/diagnosis.py
@@ -309,7 +309,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
 
         configuration["ignore_filters"][category].append(criterias)
         _diagnosis_write_configuration(configuration)
-        logger.success("Filter added")
+        logger.success(f"Added a {category} diagnosis filter")
         return
 
     if remove_filter:
@@ -327,7 +327,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
 
         configuration["ignore_filters"][category].remove(criterias)
         _diagnosis_write_configuration(configuration)
-        logger.success("Filter removed")
+        logger.success(f"Removed a {category} diagnosis filter")
         return
 
 

--- a/src/diagnosis.py
+++ b/src/diagnosis.py
@@ -304,7 +304,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
             configuration["ignore_filters"][category] = []
 
         if criterias in configuration["ignore_filters"][category]:
-            logger.warning("This filter already exists.")
+            logger.warning(f"(There is already a diagnosis {category} filter with these criterias)")
             return
 
         configuration["ignore_filters"][category].append(criterias)
@@ -322,7 +322,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
             configuration["ignore_filters"][category] = []
 
         if criterias not in configuration["ignore_filters"][category]:
-            logger.warning("This filter does not exists.")
+            logger.warning(f"(There is no such diagnosis {category} filter with these criterias to remove)")
 
         configuration["ignore_filters"][category].remove(criterias)
         _diagnosis_write_configuration(configuration)

--- a/src/diagnosis.py
+++ b/src/diagnosis.py
@@ -323,6 +323,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
 
         if criterias not in configuration["ignore_filters"][category]:
             logger.warning(f"(There is no such diagnosis {category} filter with these criterias to remove)")
+            return
 
         configuration["ignore_filters"][category].remove(criterias)
         _diagnosis_write_configuration(configuration)

--- a/src/diagnosis.py
+++ b/src/diagnosis.py
@@ -322,7 +322,7 @@ def _diagnosis_ignore(add_filter=None, remove_filter=None, list=False):
             configuration["ignore_filters"][category] = []
 
         if criterias not in configuration["ignore_filters"][category]:
-            raise YunohostValidationError("This filter does not exists.")
+            logger.warning("This filter does not exists.")
 
         configuration["ignore_filters"][category].remove(criterias)
         _diagnosis_write_configuration(configuration)

--- a/src/service.py
+++ b/src/service.py
@@ -26,6 +26,7 @@ from glob import glob
 from datetime import datetime
 
 from moulinette import m18n
+from yunohost.utils.diagnosis import diagnosis_ignore, diagnosis_unignore
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils.process import check_output
 from moulinette.utils.log import getActionLogger
@@ -296,6 +297,9 @@ def service_enable(names):
         names = [names]
     for name in names:
         if _run_service_command("enable", name):
+            services = _get_services()
+            if name in services:
+                diagnosis_unignore({"services": [{"service": name}]})
             logger.success(m18n.n("service_enabled", service=name))
         else:
             raise YunohostError(
@@ -315,6 +319,9 @@ def service_disable(names):
         names = [names]
     for name in names:
         if _run_service_command("disable", name):
+            services = _get_services()
+            if name in services:
+                diagnosis_ignore({"services": [{"service": name}]})
             logger.success(m18n.n("service_disabled", service=name))
         else:
             raise YunohostError(

--- a/src/service.py
+++ b/src/service.py
@@ -26,7 +26,7 @@ from glob import glob
 from datetime import datetime
 
 from moulinette import m18n
-from yunohost.utils.diagnosis import diagnosis_ignore, diagnosis_unignore
+from yunohost.diagnosis import diagnosis_ignore, diagnosis_unignore
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils.process import check_output
 from moulinette.utils.log import getActionLogger

--- a/src/tools.py
+++ b/src/tools.py
@@ -41,7 +41,6 @@ from yunohost.app_catalog import (
 )
 from yunohost.domain import domain_add
 from yunohost.firewall import firewall_upnp
-from yunohost.service import service_start, service_enable
 from yunohost.regenconf import regen_conf
 from yunohost.utils.system import (
     _dump_sources_list,
@@ -156,6 +155,7 @@ def tools_postinstall(
     force_diskspace=False,
     overwrite_root_password=True,
 ):
+    from yunohost.service import _run_service_command
     from yunohost.dyndns import _dyndns_available, dyndns_unsubscribe
     from yunohost.utils.dns import is_yunohost_dyndns_domain
     from yunohost.utils.password import (
@@ -270,8 +270,8 @@ def tools_postinstall(
     os.system("touch /etc/yunohost/installed")
 
     # Enable and start YunoHost firewall at boot time
-    service_enable("yunohost-firewall")
-    service_start("yunohost-firewall")
+    _run_service_command("enable", "yunohost-firewall")
+    _run_service_command("start", "yunohost-firewall")
 
     regen_conf(names=["ssh"], force=True)
 


### PR DESCRIPTION
## The problem

if the user deactivate some services, the diagnosis will raises errors because the service is not 	active

that's dumb, if the user deactivated a service using the ynh cli, ynh should know the service is deactivated on purpose

## Solution

automatically ignore the service in diagnosis if it has been deactivated with the ynh cli

## PR Status

done

## How to test

deactivate a service, see if the diagnosis raises an error, then re-activate the service
