### PR TITLE
Add a workaround for warnings issued for yarn when adding extra repo …

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1214,6 +1214,15 @@ class AptDependenciesAppResource(AppResource):
             key: values for key, values in self.extras.items() if values["packages"]
         }
 
+        # Yarn repository is now provided by the core.
+        # Let's "move" any extra apt resources depending on yarn to the standard packages list.
+        for key in list(self.extras.keys()):
+            if self.extras[key]["repo"] == "deb https://dl.yarnpkg.com/debian/ stable main" \
+            and self.extras[key]["packages"] == [ "yarn" ]:
+                self.packages.append("yarn")
+                del self.extras[key]
+
+
     def provision_or_update(self, context: Dict = {}):
 
         if self.helpers_version >= 2.1:


### PR DESCRIPTION
## The problem

> `21582 WARNING W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/fab-manager.list:1 and /etc/apt/sources.list.d/yarn.list:1`

## Solution

don't install the repository when it's yarn