### PR TITLE
add support for downloading tar-files

### DIFF
--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -23,10 +23,10 @@
 # ##### Optional flags in the 'sources' resource
 #
 # ```text
-# format    = "tar.gz"/xz/bz2    # automatically guessed from the extension of the URL, but can be set explicitly. Will use `tar` to extract
-#             "zip"              # automatically guessed from the extension of the URL, but can be set explicitly. Will use `unzip` to extract
-#             "docker"           # useful to extract files from an already-built docker image (instead of rebuilding them locally). Will use `docker-image-extract` to extract
-#             "whatever"         # an arbitrary value, not really meaningful except to imply that the file won't be extracted
+# format    = "tar.gz"/xz/bz2/tar # automatically guessed from the extension of the URL, but can be set explicitly. Will use `tar` to extract
+#             "zip"               # automatically guessed from the extension of the URL, but can be set explicitly. Will use `unzip` to extract
+#             "docker"            # useful to extract files from an already-built docker image (instead of rebuilding them locally). Will use `docker-image-extract` to extract
+#             "whatever"          # an arbitrary value, not really meaningful except to imply that the file won't be extracted
 #
 # in_subdir = true    # default, there's an intermediate subdir in the archive before accessing the actual files
 #             false   # sources are directly in the archive root
@@ -107,6 +107,8 @@ ynh_setup_source() {
         elif [[ "$src_url" =~ ^.*\.tar\.bz2$ ]]
         then
             src_format="tar.bz2"
+        elif [[ "$src_url" =~ ^.*\.tar$ ]]
+            src_format="tar"
         elif [[ -z "$src_extract" ]]
         then
             src_extract="false"
@@ -212,7 +214,7 @@ ynh_setup_source() {
             fi
             strip="--strip-components $sub_dirs"
         fi
-        if [[ "$src_format" =~ ^tar.gz|tar.bz2|tar.xz$ ]]; then
+        if [[ "$src_format" =~ ^tar.gz|tar.bz2|tar.xz|tar$ ]]; then
             tar --extract --file=$src_filename --directory="$dest_dir" $strip
         else
             ynh_die "Archive format unrecognized."


### PR DESCRIPTION
this is needed for invoiceninja, see https://github.com/YunoHost-Apps/invoiceninja5_ynh/pull/280

## The problem

"tar" is not a recognized extension for `ynh_setup_source`. This breaks downloading tar-files during installation.

## Solution

Add tar-support.

## PR Status

done

## How to test

...
