### PR TITLE
trying to fix #1886

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -26,7 +26,7 @@ from glob import glob
 from datetime import datetime
 
 from moulinette import m18n
-from yunohost.diagnosis import diagnosis_ignore, diagnosis_unignore
+from yunohost.diagnosis import _diagnosis_ignore
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils.process import check_output
 from moulinette.utils.log import getActionLogger
@@ -297,9 +297,7 @@ def service_enable(names):
         names = [names]
     for name in names:
         if _run_service_command("enable", name):
-            services = _get_services()
-            if name in services:
-                diagnosis_unignore({"services": [{"service": name}]})
+            _diagnosis_ignore(remove_filter="services", list=f"service={name}")
             logger.success(m18n.n("service_enabled", service=name))
         else:
             raise YunohostError(
@@ -319,9 +317,7 @@ def service_disable(names):
         names = [names]
     for name in names:
         if _run_service_command("disable", name):
-            services = _get_services()
-            if name in services:
-                diagnosis_ignore({"services": [{"service": name}]})
+            _diagnosis_ignore(add_filter="services", list=f"service={name}")
             logger.success(m18n.n("service_disabled", service=name))
         else:
             raise YunohostError(

--- a/src/service.py
+++ b/src/service.py
@@ -297,7 +297,7 @@ def service_enable(names):
         names = [names]
     for name in names:
         if _run_service_command("enable", name):
-            _diagnosis_ignore(remove_filter="services", list=f"service={name}")
+            _diagnosis_ignore(remove_filter=["services", f"service={name}"])
             logger.success(m18n.n("service_enabled", service=name))
         else:
             raise YunohostError(
@@ -317,7 +317,7 @@ def service_disable(names):
         names = [names]
     for name in names:
         if _run_service_command("disable", name):
-            _diagnosis_ignore(add_filter="services", list=f"service={name}")
+            _diagnosis_ignore(add_filter=["services", f"service={name}"])
             logger.success(m18n.n("service_disabled", service=name))
         else:
             raise YunohostError(

--- a/src/service.py
+++ b/src/service.py
@@ -26,7 +26,7 @@ from glob import glob
 from datetime import datetime
 
 from moulinette import m18n
-from yunohost.diagnosis import _diagnosis_ignore
+from yunohost.diagnosis import diagnosis_ignore, diagnosis_unignore
 from yunohost.utils.error import YunohostError, YunohostValidationError
 from moulinette.utils.process import check_output
 from moulinette.utils.log import getActionLogger
@@ -297,7 +297,7 @@ def service_enable(names):
         names = [names]
     for name in names:
         if _run_service_command("enable", name):
-            _diagnosis_ignore(remove_filter=["services", f"service={name}"])
+            diagnosis_unignore(["services", f"service={name}"])
             logger.success(m18n.n("service_enabled", service=name))
         else:
             raise YunohostError(
@@ -317,7 +317,7 @@ def service_disable(names):
         names = [names]
     for name in names:
         if _run_service_command("disable", name):
-            _diagnosis_ignore(add_filter=["services", f"service={name}"])
+            diagnosis_ignore(["services", f"service={name}"])
             logger.success(m18n.n("service_disabled", service=name))
         else:
             raise YunohostError(


### PR DESCRIPTION
## The problem

#1886 doesn't work... like really:
```text
yunohost service disable gitea
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 77, in <module>
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 110, in cli
    Cli(
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 500, in run
    ret = self.actionsmap.process(args, timeout=timeout)
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 574, in process
    return func(**arguments)
  File "/usr/lib/python3/dist-packages/yunohost/service.py", line 324, in service_disable
    diagnosis_ignore({"services": [{"service": name}]})
  File "/usr/lib/python3/dist-packages/yunohost/diagnosis.py", line 212, in diagnosis_ignore
    return _diagnosis_ignore(add_filter=filter, list=list)
  File "/usr/lib/python3/dist-packages/yunohost/diagnosis.py", line 283, in _diagnosis_ignore
    category, criterias = validate_filter_criterias(add_filter)
  File "/usr/lib/python3/dist-packages/yunohost/diagnosis.py", line 269, in validate_filter_criterias
    category = filter_[0]
KeyError: 0
```

## Solution

fix the command
also remove an irrelevant `if`

## PR Status

~~not done
doesn't work either (the service isn't ignored or unignored in the diagnosis for now, but without any error) but wip~~

done, tested working

## How to test

deactivate a service, see if the diagnosis raises an error, then re-activate the service

```text
yunohost diagnosis show --issues
reports:
  description: État des services
  id: services
  items:
    details: Vous pouvez essayer de redémarrer le service, et si cela ne fonctionne pas, consultez les journaux de service dans le webadmin (à partir de la ligne de commande, vous pouvez le faire avec 'yunohost service restart gitea' et 'yunohost service log gitea' ).
    status: ERROR
    summary: Le service gitea est dead :-(

yunohost service disable gitea
Succès ! Added a services diagnosis filter
Succès ! Le service 'gitea' ne sera plus lancé au démarrage du système.

yunohost diagnosis show --issues
reports:

yunohost service enable gitea
Succès ! Removed a services diagnosis filter
Succès ! Le service 'gitea' sera désormais lancé automatiquement au démarrage du système.

yunohost diagnosis show --issues
reports:
  description: État des services
  id: services
  items:
    details: Vous pouvez essayer de redémarrer le service, et si cela ne fonctionne pas, consultez les journaux de service dans le webadmin (à partir de la ligne de commande, vous pouvez le faire avec 'yunohost service restart gitea' et 'yunohost service log gitea' ).
    status: ERROR
    summary: Le service gitea est dead :-(
```
