### PR TITLE
ssowatconf: change auth_header from None to false

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1694,7 +1694,7 @@ def app_ssowatconf():
             else:
                 auth_header = "basic-without-password"
         else:
-            auth_header = None
+            auth_header = False
 
         permissions[perm_name] = {
             "users": perm_info["corresponding_users"],


### PR DESCRIPTION
## The problem

In the ssowatconf, all my api permissions have the field `auth_header: null`

## Solution

I think the correct value is `false` instead of `null`

## PR Status

Yolo applying this patch and `yunohost app ssowatconf`

## How to test

...
