### PR TITLE
remove pkg_resources from pip freeze

### DIFF
--- a/src/migrations/0027_migrate_to_bookworm.py.disabled
+++ b/src/migrations/0027_migrate_to_bookworm.py.disabled
@@ -74,8 +74,9 @@ def _backup_pip_freeze_for_python_app_venvs():
     venvs = _get_all_venvs("/opt/") + _get_all_venvs("/var/www/")
     for venv in venvs:
         # Generate a requirements file from venv
+        # Remove pkg resources from the freeze to avoid an error during the python venv https://stackoverflow.com/a/40167445
         os.system(
-            f"{venv}/bin/pip freeze > {venv}{VENV_REQUIREMENTS_SUFFIX} 2>/dev/null"
+            f"{venv}/bin/pip freeze | grep -E -v 'pkg(-|_)resources==' > {venv}{VENV_REQUIREMENTS_SUFFIX} 2>/dev/null"
         )
 
 


### PR DESCRIPTION
## The problem

`No matching distribution found for pkg_resources==0.0.0` during the python venv migration

## Solution

Remove `pkg_resources` from the freeze

## PR Status

...

## How to test

...
