### PR TITLE
[Fix] Make slapd listen also on ipv6

### DIFF
--- a/conf/slapd/slapd.default
+++ b/conf/slapd/slapd.default
@@ -21,7 +21,7 @@ SLAPD_PIDFILE=
 # sockets.
 # Example usage:
 # SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
-SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
+SLAPD_SERVICES="ldap://localhost:389/ ldaps:/// ldapi:///"
 
 # If SLAPD_NO_START is set, the init script will not start or restart
 # slapd (but stop will still work).  Uncomment this if you are


### PR DESCRIPTION
## The problem

Some app are configured to connect to LDAP this way: `ldap://localhost:389`.
But currently, slapd listen only on IPv4. On my side I've this result with `ss`:

```
ss -ntlp | grep 389
LISTEN 0      1024       127.0.0.1:389        0.0.0.0:*    users:(("slapd",pid=1434,fd=9)) 
```

We have this issue here: https://forum.yunohost.org/t/seafile-11-0-9-cant-login-with-client/30504/2

## Solution

Configure slapd to listen also on ipv6.

## PR Status

This is ready

## How to test

Tested with netcat and now connection work with IPv4 and IPv6.

We can also test with `ss` with has this result:
```
ss -ntlp | grep 389
LISTEN 0      1024       127.0.0.1:389        0.0.0.0:*    users:(("slapd",pid=1434,fd=9))                                                                                                 
LISTEN 0      1024           [::1]:389           [::]:*    users:(("slapd",pid=1434,fd=8))                                                                                                 
```
