### PR TITLE
fix: Remove SenderScore from the dnsbl_list.yml file

### DIFF
--- a/share/dnsbl_list.yml
+++ b/share/dnsbl_list.yml
@@ -168,15 +168,6 @@
   ipv6: false
   domain: false
   non_blacklisted_return_code: []
-# Used by GAFAM
-- name: SenderScore Blacklist 
-  dns_server: bl.score.senderscore.com
-  website: https://senderscore.com 
-  ipv4: true
-  ipv6: false
-  domain: false
-# Added cause it supports IPv6
-  non_blacklisted_return_code: []
 - name: AntiCaptcha.NET IPv6
   dns_server: dnsbl6.anticaptcha.net
   website: http://anticaptcha.net/ 


### PR DESCRIPTION
Since March 1st this service is behind a fair-use paywall, which generates lot of alert email confusing people whether their IP/domain is actually blocked, when actually it’s just the service failing.

See: https://knowledge.validity.com/s/articles/Accessing-Validity-reputation-data-through-DNS?language=en_US
     https://forum.yunohost.org/t/senderscore-blacklist-blocklist-because-of-excessive-number-of-queries/30395
