### PR TITLE
Fix install from equivs

### DIFF
--- a/helpers/helpers.v1.d/apt
+++ b/helpers/helpers.v1.d/apt
@@ -196,9 +196,6 @@ ynh_package_install_from_equivs() {
     # Install missing dependencies with ynh_package_install
     ynh_wait_dpkg_free
 
-    # Remove the double commas because dpkg-deb doesn't like them
-    sed --in-place 's@,,@,@g' "$controlfile"
-
     cp "$controlfile" "${TMPDIR}/${pkgname}/DEBIAN/control"
 
     # Install the fake package without its dependencies with dpkg --force-depends
@@ -327,7 +324,7 @@ Section: misc
 Priority: optional
 Package: ${dep_app}-ynh-deps
 Version: ${version}
-Depends: ${dependencies}
+Depends: ${dependencies//,,/,}
 Architecture: all
 Maintainer: root@localhost
 Description: Fake package for ${app} (YunoHost app) dependencies

--- a/helpers/helpers.v1.d/apt
+++ b/helpers/helpers.v1.d/apt
@@ -200,7 +200,7 @@ ynh_package_install_from_equivs() {
 
     # Install the fake package without its dependencies with dpkg --force-depends
     if ! LC_ALL=C dpkg-deb --build "${TMPDIR}/${pkgname}" "${TMPDIR}/${pkgname}.deb" > "${TMPDIR}/dpkg_log" 2>&1; then
-        cat ${TMPDIR}/dpkg_log >&2
+        cat "${TMPDIR}/dpkg_log" >&2
         ynh_die --message="Unable to install dependencies"
     fi
     # Don't crash in case of error, because is nicely covered by the following line

--- a/helpers/helpers.v1.d/apt
+++ b/helpers/helpers.v1.d/apt
@@ -195,13 +195,19 @@ ynh_package_install_from_equivs() {
     # Install the fake package without its dependencies with dpkg
     # Install missing dependencies with ynh_package_install
     ynh_wait_dpkg_free
+
+    # Remove the double commas because dpkg-deb doesn't like them
+    sed --in-place 's@,,@,@g' "$controlfile"
+
     cp "$controlfile" "${TMPDIR}/${pkgname}/DEBIAN/control"
-    (
-        cd "$TMPDIR"
-        # Install the fake package without its dependencies with dpkg --force-depends
-        LC_ALL=C dpkg-deb --build ${pkgname} ${pkgname}.deb > ./dpkg_log 2>&1 || { cat ./dpkg_log; false; }
-        LC_ALL=C dpkg --force-depends --install "./${pkgname}.deb" 2>&1 | tee ./dpkg_log
-    )
+
+    # Install the fake package without its dependencies with dpkg --force-depends
+    if ! LC_ALL=C dpkg-deb --build "${TMPDIR}/${pkgname}" "${TMPDIR}/${pkgname}.deb" > "${TMPDIR}/dpkg_log" 2>&1; then
+        cat ${TMPDIR}/dpkg_log >&2
+        ynh_die --message="Unable to install dependencies"
+    fi
+    # Don't crash in case of error, because is nicely covered by the following line
+    LC_ALL=C dpkg --force-depends --install "${TMPDIR}/${pkgname}.deb" 2>&1 | tee "${TMPDIR}/dpkg_log" || true
 
     ynh_package_install --fix-broken \
         || { # If the installation failed

--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -105,7 +105,7 @@ Section: misc
 Priority: optional
 Package: ${app_ynh_deps}
 Version: ${version}
-Depends: ${dependencies}
+Depends: ${dependencies//,,/,}
 Architecture: all
 Maintainer: root@localhost
 Description: Fake package for ${app} (YunoHost app) dependencies
@@ -116,13 +116,13 @@ EOF
 
     _ynh_wait_dpkg_free
 
-    (
-        # NB: this is in a subshell (though not sure why exactly not just use pushd/popd...)
-        cd "$TMPDIR"
-        # Install the fake package without its dependencies with dpkg --force-depends
-        LC_ALL=C dpkg-deb --build ${app_ynh_deps} ${app_ynh_deps}.deb > ./dpkg_log 2>&1 || { cat ./dpkg_log; false; }
-        LC_ALL=C dpkg --force-depends --install "./${app_ynh_deps}.deb" > ./dpkg_log 2>&1
-    )
+    # Install the fake package without its dependencies with dpkg --force-depends
+    if ! LC_ALL=C dpkg-deb --build "${TMPDIR}/${app_ynh_deps}" "${TMPDIR}/${app_ynh_deps}.deb" > "${TMPDIR}/dpkg_log" 2>&1; then
+        cat "${TMPDIR}/dpkg_log" >&2
+        ynh_die --message="Unable to install dependencies"
+    fi
+    # Don't crash in case of error, because is nicely covered by the following line
+    LC_ALL=C dpkg --force-depends --install "${TMPDIR}/${app_ynh_deps}.deb" 2>&1 | tee "${TMPDIR}/dpkg_log" || true
 
     # Then install the missing dependencies with apt install
     _ynh_apt_install --fix-broken || {


### PR DESCRIPTION
## The problem

in the control file to manage dependencies, there are double commas which make `dpkg-deb --build` crash silently because we run it in a subshell

example: https://ci-apps-dev.yunohost.org/ci/job/17894

## Solution

...

## PR Status

Tested with helpvers v1

## How to test

...
