### PR TITLE
Add ynh_add_swap and ynh_smart_mktemp to official helpers

### DIFF
--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -456,3 +456,148 @@ ynh_spawn_app_shell() {
         # Spawn the app shell
         su -s /bin/bash $app
 }
+
+# Add swap
+#
+# usage: ynh_add_swap --size=SWAP in Mb
+# | arg: -s, --size= - Amount of SWAP to add in Mb.
+ynh_add_swap () {
+  if systemd-detect-virt --container --quiet; then
+    ynh_print_warn --message="You are inside a container/VM. swap will not be added, but that can cause troubles for the app $app. Please make sure you have enough RAM available."
+    return
+  fi
+
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [s]=size= )
+	local size
+	# Manage arguments with getopts
+	ynh_handle_getopts_args "$@"
+
+	local swap_max_size=$(( $size * 1024 ))
+
+	local free_space=$(df --output=avail / | sed 1d)
+	# Because we don't want to fill the disk with a swap file, divide by 2 the available space.
+	local usable_space=$(( $free_space / 2 ))
+
+ 	SD_CARD_CAN_SWAP=${SD_CARD_CAN_SWAP:-0}
+
+	# Swap on SD card only if it's is specified
+	if ynh_is_main_device_a_sd_card && [ "$SD_CARD_CAN_SWAP" == "0" ]
+	then
+		ynh_print_warn --message="The main mountpoint of your system '/' is on an SD card, swap will not be added to prevent some damage of this one, but that can cause troubles for the app $app. If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
+		return
+	fi
+
+	# Compare the available space with the size of the swap.
+	# And set a acceptable size from the request
+	if [ $usable_space -ge $swap_max_size ]
+	then
+		local swap_size=$swap_max_size
+	elif [ $usable_space -ge $(( $swap_max_size / 2 )) ]
+	then
+		local swap_size=$(( $swap_max_size / 2 ))
+	elif [ $usable_space -ge $(( $swap_max_size / 3 )) ]
+	then
+		local swap_size=$(( $swap_max_size / 3 ))
+	elif [ $usable_space -ge $(( $swap_max_size / 4 )) ]
+	then
+		local swap_size=$(( $swap_max_size / 4 ))
+	else
+		echo "Not enough space left for a swap file" >&2
+		local swap_size=0
+	fi
+
+	# If there's enough space for a swap, and no existing swap here
+	if [ $swap_size -ne 0 ] && [ ! -e /swap_$app ]
+	then
+		# Create file
+		truncate -s 0 /swap_$app
+		
+		# set the No_COW attribute on the swapfile with chattr
+		chattr +C /swap_$app
+		
+		# Preallocate space for the swap file, fallocate may sometime not be used, use dd instead in this case
+		if ! fallocate -l ${swap_size}K /swap_$app
+		then
+			dd if=/dev/zero of=/swap_$app bs=1024 count=${swap_size}
+		fi
+		chmod 0600 /swap_$app
+		# Create the swap
+		mkswap /swap_$app
+		# And activate it
+		swapon /swap_$app
+		# Then add an entry in fstab to load this swap at each boot.
+		echo -e "/swap_$app swap swap defaults 0 0 #Swap added by $app" >> /etc/fstab
+	fi
+}
+
+ynh_del_swap () {
+	# If there a swap at this place
+	if [ -e /swap_$app ]
+	then
+		# Clean the fstab
+		sed -i "/#Swap added by $app/d" /etc/fstab
+		# Desactive the swap file
+		swapoff /swap_$app
+		# And remove it
+		rm /swap_$app
+	fi
+}
+
+# Check if the device of the main mountpoint "/" is an SD card
+#
+# [internal]
+#
+# return 0 if it's an SD card, else 1
+ynh_is_main_device_a_sd_card () {
+  if [ "$(systemd-detect-virt)" != "none" ]; then
+    # Assume virtualization does not take place on SD card
+    return 1
+  fi
+
+	local main_device=$(lsblk --output PKNAME --noheadings $(findmnt / --nofsroot --uniq --output source --noheadings --first-only))
+
+	if echo $main_device | grep --quiet "mmc" && [ $(tail -n1 /sys/block/$main_device/queue/rotational) == "0" ]
+	then
+		return 0
+	else
+		return 1
+	fi
+}
+
+# Check available space before creating a temp directory.
+#
+# usage: ynh_smart_mktemp --min_size="Min size"
+#
+# | arg: -s, --min_size= - Minimal size needed for the temporary directory, in Mb
+ynh_smart_mktemp () {
+    # Declare an array to define the options of this helper.
+    declare -Ar args_array=( [s]=min_size= )
+    local min_size
+    # Manage arguments with getopts
+    ynh_handle_getopts_args "$@"
+
+    min_size="${min_size:-300}"
+    # Transform the minimum size from megabytes to kilobytes
+    min_size=$(( $min_size * 1024 ))
+
+    # Check if there's enough free space in a directory
+    is_there_enough_space () {
+            local free_space=$(df --output=avail "$1" | sed 1d)
+            test $free_space -ge $min_size
+    }
+
+    if is_there_enough_space /tmp; then
+            local tmpdir=/tmp
+    elif is_there_enough_space /var; then
+            local tmpdir=/var
+    elif is_there_enough_space /; then
+            local tmpdir=/   
+    elif is_there_enough_space /home; then
+            local tmpdir=/home
+    else
+            ynh_die "Insufficient free space to continue..."
+    fi
+
+    echo "$(mktemp --directory --tmpdir="$tmpdir")"
+}


### PR DESCRIPTION
These two helpers are widely used and have been part of experimental helpers for over 5 years. Maybe it's time to include them so scripts don't have to include their own custom version?

Case in point, i found 3 different versions of `ynh_add_swap` used across apps:

- one that does `chattr +C`, which will not work on most filesystems like ext4
- one that checks for LXC (or LXD?) virtualization and skips the swap setup (because it would fail)
- one that does neither

In this PR, ynh_add_swap checks that no virtualization is used at all otherwise it just skips the setup.