### PR TITLE
2.1 helpers: check if patches dir exists before getting realpath

### DIFF
--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -224,8 +224,8 @@ ynh_setup_source() {
     fi
 
     # Apply patches
-    local patches_folder=$(realpath "$YNH_APP_BASEDIR/patches/$source_id")
-    if [ -d "$patches_folder" ]; then
+    if [ -d "$YNH_APP_BASEDIR/patches/" ]; then
+        local patches_folder=$(realpath "$YNH_APP_BASEDIR/patches/$source_id")
         pushd "$dest_dir"
         for patchfile in "$patches_folder/"*.patch; do
             echo "Applying $patchfile"


### PR DESCRIPTION
## The problem

> Setting up source files...
> WARN: realpath: /var/cache/yunohost/app_tmp_work_dirs/app_ww4ms3a9/patches/main: Aucun fichier ou dossier de ce type

when installing feber, which uses helpers 2.1: https://github.com/YunoHost-Apps/feber_ynh/blob/master/manifest.toml#L23

and doesn't have a `patches` directory

## Solution

check if the `patches` directory exists before trying to get its realpath

## PR Status

done

## How to test

...
