### PR TITLE
Fix ynh_restore_everything

### DIFF
--- a/helpers/helpers.v2.1.d/backup
+++ b/helpers/helpers.v2.1.d/backup
@@ -194,7 +194,7 @@ ynh_restore_everything() {
     # For each destination path begining by $REL_DIR
     cat ${YNH_BACKUP_CSV} | tr --delete $'\r' | grep --only-matching --no-filename --perl-regexp "^\".*\",\"$REL_DIR.*\"$" \
         | while read line; do
-            local ARCHIVE_PATH=$(echo "$line" | grep --only-matching --no-filename --perl-regexp "^\".*\",\"$REL_DIR\K.*(?=\"$)")
+            local ARCHIVE_PATH=$(echo "$line" | grep --only-matching --no-filename --perl-regexp "^\"\K.*(?=\",\"$REL_DIR.*\"$)")
             ynh_restore "$ARCHIVE_PATH"
         done
 }


### PR DESCRIPTION
## The problem

Helper 2.1 `ynh_restore_everything` don't work.

We end with an error like this:
```
 Exception: Original path for "etc/nginx/conf.d/ynh-11-app-c.dev.tille.ch.d/sogo.conf" not found
```

The reason of this is that in the helper we get the second collum on of the CSV and we need to take the first on which have the backup source path (so the target restore path)

## Solution

Tested and if fixed the issue

## PR Status

Ready

## How to test

Test an app which use this helper with the fix and without and see the difference.
