### PR TITLE
Add maintenance/pre-commit.sh script

### DIFF
--- a/maintenance/pre-commit.sh
+++ b/maintenance/pre-commit.sh
@@ -1,0 +1,116 @@
+#! /usr/bin/env bash
+
+set -Eeuo pipefail
+
+YUNODIR="$(realpath "$(dirname "$0")"/..)"
+SHFMT="$YUNODIR"/maintenance/shfmt.sh
+
+help() {
+    echo "pre-commit.sh ACTION [LANG]"
+    echo "  Run common pre-commit checks to make CI happy"
+    echo "  ACTIONS:"
+    echo "    - check: provide recommendations"
+    echo "    - fix: apply recommendations automatically"
+    echo "  LANG: python|bash, by default applies to all languages"
+}
+
+check_deps() {
+    for dep in "$@"; do
+        if ! command -v "$dep" > /dev/null 2>&1; then
+            echo "Missing dependency: $dep. Please install it first."
+            exit 1
+        fi
+    done
+}
+
+check_bash() {
+    check_deps shfmt
+    "$SHFMT" -d "$YUNODIR"/helpers/helpers \
+        "$YUNODIR"/helpers/helpers.v2.1.d/* \
+        "$YUNODIR"/helpers/helpers.v2.d/* \
+        "$YUNODIR"/hooks/*
+}
+
+check_python() {
+    check_deps black
+    black --quiet --check "$YUNODIR"/bin \
+        "$YUNODIR"/src
+}
+
+check() {
+    case "$1" in
+        "python")
+            check_python
+            ;;
+        "bash")
+            check_bash
+            ;;
+        "all")
+            check_bash
+            check_python
+            ;;
+        *)
+            echo "Unknown language: $1"
+            exit 1
+            ;;
+    esac
+}
+
+fix_bash() {
+    check_deps shfmt
+    "$SHFMT" -w helpers/helpers
+    "$SHFMT" -w helpers/helpers.v2.1.d/*
+    "$SHFMT" -w helpers/helpers.v2.d/*
+    "$SHFMT" -w hooks/*
+}
+
+fix_python() {
+    check_deps black
+    black --quiet bin
+    black --quiet src
+}
+
+fix() {
+    case "$1" in
+        "python")
+            fix_python
+            ;;
+        "bash")
+            fix_bash
+            ;;
+        "all")
+            fix_bash
+            fix_python
+            ;;
+        *)
+            echo "Unknown language: $1"
+            exit 1
+            ;;
+    esac
+}
+
+run() {
+    case "${1:-check}" in
+        "check")
+            check "${2:-all}"
+            ;;
+        "fix")
+            fix "${2:-all}"
+            ;;
+        "help" | "--help" | "-h")
+            help
+            exit 0
+            ;;
+        "")
+            check "all"
+            ;;
+        *)
+            help
+            echo "Unknown command: $1"
+            exit 1
+            ;;
+    esac
+}
+
+run "$@"
+echo "OK"

--- a/maintenance/shfmt.sh
+++ b/maintenance/shfmt.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
 
 shfmt_args=(
-    --indent 4
-    --keep-padding      # keep column alignment paddings
-    --space-redirects   # redirect operators will be followed by a space
-    --binary-next-line  # binary ops like && and | may start a line
-    --case-indent       # switch cases will be indented
+    -i=4
+    -kp      # keep column alignment paddings
+    -sr   # redirect operators will be followed by a space
+    -bn  # binary ops like && and | may start a line
+    -ci       # switch cases will be indented
 )
 
-shfmt "${shfmt_args[@]}" "$@" \
-    helpers/helpers \
-    helpers/helpers.v2.1.d/* \
-    helpers/helpers.v2.d/* \
-    hooks/*
+shfmt "${shfmt_args[@]}" "$@"


### PR DESCRIPTION
The first commit fixes shfmt.sh which was just... not working?

Second one introduces a script people can use like `maintenance/pre-commit.sh check|fix`. It also works without argument and should be able to be called from any folder. It will check both python and bash formatting.