### PR TITLE
WIP: Don't add yarn repository when requested in app manifest

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1231,6 +1231,10 @@ class AptDependenciesAppResource(AppResource):
         if self.packages:
             script += " ".join([ynh_apt_install_dependencies, *self.packages])
         for repo, values in self.extras.items():
+            # SPECIAL CASE: yarn is already preconfigured -> skip it
+            if "dl.yarnpkg.com/debian" in values["repo"]:
+                continue
+
             script += "\n" + " ".join(
                 [
                     ynh_apt_install_dependencies_from_extra_repository,


### PR DESCRIPTION
Apparently with the new helpers declaring an extra repository for Yarn [doesn't work](https://github.com/YunoHost-Apps/glitchsoc_ynh/pull/309). At least on the CI, and on my own bookworm server, it appears that yarn repository is already configured in `/etc/apt/sources.list.d/yarn.list`.

I'm not sure if this is by default or if it was installed at some point, for example via `ynh-dev`. If it's not supposed to be installed by default, i could add a check whether `/etc/apt/sources.list.d/yarn.list` already exists.