### PR TITLE
Add yunohost-portal to the --version output

### DIFF
--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -26,7 +26,7 @@ from yunohost.utils.error import YunohostError
 
 logger = logging.getLogger("yunohost.utils.packages")
 
-YUNOHOST_PACKAGES = ["yunohost", "yunohost-admin", "moulinette", "ssowat"]
+YUNOHOST_PACKAGES = ["yunohost", "yunohost-admin", "yunohost-portal", "moulinette", "ssowat"]
 
 
 def debian_version():


### PR DESCRIPTION
## The problem

...

## Solution

...

## PR Status

...

## How to test

Tested on my side:

```
# yunohost --version
yunohost: 
  repo: unstable
  version: 12.0.3+202408311800
yunohost-admin: 
  repo: unstable
  version: 12.0.2+202408311815
yunohost-portal: 
  repo: testing
  version: 12.0.2
moulinette: 
  repo: unstable
  version: 12.0.2+202408311815
ssowat: 
  repo: unstable
  version: 12.0.1+202407262030
```