### PR TITLE
Enh: Make auto dns feature optional

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -401,6 +401,7 @@
     "domain_dns_registrar_managed_in_parent_domain": "This domain is a subdomain of {parent_domain_link}. DNS registrar configuration should be managed in {parent_domain}'s configuration panel.",
     "domain_dns_registrar_not_supported": "YunoHost could not automatically detect the registrar handling this domain. You should manually configure your DNS records following the documentation at https://yunohost.org/dns.",
     "domain_dns_registrar_supported": "YunoHost automatically detected that this domain is handled by the registrar **{registrar}**. If you want, YunoHost will automatically configure this DNS zone, if you provide it with the appropriate API credentials. You can find documentation on how to obtain your API credentials on this page: https://yunohost.org/registar_api_{registrar}. (You can also manually configure your DNS records following the documentation at https://yunohost.org/dns )",
+    "domain_dns_registrar_use_auto": "Use automatic DNS feature",
     "domain_dns_registrar_yunohost": "This domain is a nohost.me / nohost.st / ynh.fr and its DNS configuration is therefore automatically handled by YunoHost without any further configuration. (see the 'yunohost dyndns update' command)",
     "domain_dyndns_already_subscribed": "You have already subscribed to a DynDNS domain",
     "domain_exists": "The domain already exists",

--- a/src/app.py
+++ b/src/app.py
@@ -68,7 +68,7 @@ from yunohost.app_catalog import (  # noqa
 if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
-    from yunohost.utils.configpanel import RawSettings
+    from yunohost.utils.configpanel import RawSettings, ConfigPanelModel
     from yunohost.utils.form import FormModel
 
 logger = getLogger("yunohost.app")
@@ -1860,6 +1860,7 @@ def _get_AppConfigPanel():
         def _apply(
             self,
             form: "FormModel",
+            config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
             exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
         ) -> None:

--- a/src/dns.py
+++ b/src/dns.py
@@ -556,9 +556,15 @@ def _get_registrar_config_section(domain):
                 f"Registrar {registrar} unknown / Should be added to YunoHost's registrar_list.toml by the development team!"
             )
             registrar_credentials = {}
+        else:
+            registrar_infos["use_auto_dns"] = {
+                "type": "boolean",
+                "ask": m18n.n("domain_dns_registrar_use_auto"),
+                "default": True
+            }
         for credential, infos in registrar_credentials.items():
             infos["default"] = infos.get("default", "")
-            infos["optional"] = infos.get("optional", "False")
+            infos["visible"] = "use_auto_dns == true"
         registrar_infos.update(registrar_credentials)
 
     return registrar_infos

--- a/src/dns.py
+++ b/src/dns.py
@@ -591,8 +591,7 @@ def domain_dns_push(operation_logger, domain, dry_run=False, force=False, purge=
     _assert_domain_exists(domain)
 
     if is_special_use_tld(domain):
-        logger.info(m18n.n("domain_dns_conf_special_use_tld"))
-        return {}
+        raise YunohostValidationError("domain_dns_conf_special_use_tld")
 
     if not registrar or registrar == "None":  # yes it's None as a string
         raise YunohostValidationError("domain_dns_push_not_applicable", domain=domain)

--- a/src/dns.py
+++ b/src/dns.py
@@ -522,6 +522,8 @@ def _get_registrar_config_section(domain):
     elif is_special_use_tld(dns_zone):
         registrar_infos["infos"]["ask"] = m18n.n("domain_dns_conf_special_use_tld")
 
+        return registrar_infos
+
     try:
         registrar = _relevant_provider_for_domain(dns_zone)[0]
     except ValueError:

--- a/src/domain.py
+++ b/src/domain.py
@@ -773,6 +773,18 @@ def _get_DomainConfigPanel():
                     self.entity, next_settings["recovery_password"]
                 )
 
+            if "use_auto_dns" in next_settings and not next_settings["use_auto_dns"]:
+                # disable auto dns by reseting every registrar form values
+                options = [
+                    option
+                    for option in config.get_section("registrar").options
+                    if not option.readonly
+                    and option.id != "use_auto_dns"
+                    and hasattr(form, option.id)
+                ]
+                for option in options:
+                    setattr(form, option.id, option.default)
+
             custom_css = next_settings.pop("custom_css", "").strip()
             if custom_css:
                 write_to_file(f"/usr/share/yunohost/portal/customassets/{self.entity}.custom.css", custom_css)

--- a/src/domain.py
+++ b/src/domain.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
     from yunohost.utils.configpanel import RawConfig
-    from yunohost.utils.form import FormModel
+    from yunohost.utils.form import FormModel, ConfigPanelModel
     from yunohost.utils.configpanel import RawSettings
 
 logger = getLogger("yunohost.domain")
@@ -749,6 +749,7 @@ def _get_DomainConfigPanel():
         def _apply(
             self,
             form: "FormModel",
+            config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
             exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
         ) -> None:
@@ -831,7 +832,9 @@ def _get_DomainConfigPanel():
                     str(portal_settings_path), portal_settings, sort_keys=True, indent=4
                 )
 
-            super()._apply(form, previous_settings, exclude={"recovery_password"})
+            super()._apply(
+                form, config, previous_settings, exclude={"recovery_password"}
+            )
 
             # Reload ssowat if default app changed
             if "default_app" in next_settings or "enable_public_apps_page" in next_settings:

--- a/src/domain.py
+++ b/src/domain.py
@@ -672,6 +672,7 @@ def domain_config_set(
 
 def _get_DomainConfigPanel():
     from yunohost.utils.configpanel import ConfigPanel
+    from yunohost.dns import _set_managed_dns_records_hashes
 
     class DomainConfigPanel(ConfigPanel):
         entity_type = "domain"
@@ -773,7 +774,8 @@ def _get_DomainConfigPanel():
                     self.entity, next_settings["recovery_password"]
                 )
 
-            if "use_auto_dns" in next_settings and not next_settings["use_auto_dns"]:
+            remove_auto_dns_feature = "use_auto_dns" in next_settings and not next_settings["use_auto_dns"]
+            if remove_auto_dns_feature:
                 # disable auto dns by reseting every registrar form values
                 options = [
                     option
@@ -847,6 +849,10 @@ def _get_DomainConfigPanel():
             super()._apply(
                 form, config, previous_settings, exclude={"recovery_password"}
             )
+
+            # Also remove `managed_dns_records_hashes` in settings which are not handled by the config panel
+            if remove_auto_dns_feature:
+                _set_managed_dns_records_hashes(self.entity, [])
 
             # Reload ssowat if default app changed
             if "default_app" in next_settings or "enable_public_apps_page" in next_settings:

--- a/src/settings.py
+++ b/src/settings.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from yunohost.log import OperationLogger
     from yunohost.utils.configpanel import (
         ConfigPanelGetMode,
+        ConfigPanelModel,
         RawSettings,
     )
     from yunohost.utils.form import FormModel
@@ -220,6 +221,7 @@ class SettingsConfigPanel(ConfigPanel):
     def _apply(
         self,
         form: "FormModel",
+        config: "ConfigPanelModel",
         previous_settings: dict[str, Any],
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
     ) -> None:
@@ -245,7 +247,7 @@ class SettingsConfigPanel(ConfigPanel):
             )
 
         # First save settings except virtual + default ones
-        super()._apply(form, previous_settings, exclude=self.virtual_settings)
+        super()._apply(form, config, previous_settings, exclude=self.virtual_settings)
         next_settings = {
             k: v
             for k, v in form.dict(exclude=self.virtual_settings).items()

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -573,7 +573,7 @@ class ConfigPanel:
             operation_logger.start()
 
         try:
-            self._apply(self.form, previous_settings)
+            self._apply(self.form, self.config, previous_settings)
         except YunohostError:
             raise
         # Script got manually interrupted ...
@@ -866,6 +866,7 @@ class ConfigPanel:
     def _apply(
         self,
         form: "FormModel",
+        config: ConfigPanelModel,
         previous_settings: dict[str, Any],
         exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
     ) -> None:

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -313,7 +313,19 @@ class ConfigPanelModel(BaseModel):
             for option in section.options:
                 yield option
 
-    def get_option(self, option_id) -> Union[AnyOption, None]:
+    def get_panel(self, panel_id: str) -> Union[PanelModel, None]:
+        for panel in self.panels:
+            if panel.id == panel_id:
+                return panel
+        return None
+
+    def get_section(self, section_id: str) -> Union[SectionModel, None]:
+        for section in self.sections:
+            if section.id == section_id:
+                return section
+        return None
+
+    def get_option(self, option_id: str) -> Union[AnyOption, None]:
         for option in self.options:
             if option.id == option_id:
                 return option


### PR DESCRIPTION
## The problem
- For the auto dns push feature, we can't remove a registrar API key and other unknown auth fields.
- Special domains infos are not correctly displayed

## Solution

- add a new boolean `use_auto_dns` in the DNS section to choose to use the auto dns feature or not (default to true for compatibility)
  - when setting false, remove all auth fields values + managed_dns_records_hashes` in settings
- make registrar auth fields optional and add `visible` prop depending on `use_auto_dns`
- fix special-use tld case
- add some helpers methods on `ConfigPanelModel` + also pass config model to `ConfigPanel._apply` 

## PR Status
OK

Fix https://github.com/YunoHost/issues/issues/2293
