### PR TITLE
fix: allow secondaries instances of apps_that_need_external_auth_mayb…

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1704,7 +1704,7 @@ def app_ssowatconf():
         protect_against_basic_auth_spoofing = app_settings.get("protect_against_basic_auth_spoofing")
         if protect_against_basic_auth_spoofing is not None:
             permissions[perm_name]["protect_against_basic_auth_spoofing"] = protect_against_basic_auth_spoofing not in [False, "False", "false", "0", 0]
-        elif app_id in apps_that_need_external_auth_maybe:
+        elif app_id.split("__")[0] in apps_that_need_external_auth_maybe:
             permissions[perm_name]["protect_against_basic_auth_spoofing"] = False
 
         # Next: portal related


### PR DESCRIPTION
allow secondaries instances of apps_that_need_external_auth_maybe to be recognized

## The problem

https://forum.yunohost.org/t/beta-stage-testing-for-yunohost-12-0-bookworm-and-bullseye-bookworm-migration/30496/113?u=nath5394
## Solution

...

## PR Status

Tested on my instance, ok

## How to test
Regen ssowat conf `yunohost app ssowatconf`
Ensure that protect_against_basic_auth_spoofing is set to false for all nextcloud permissions and instances

```
grep nextcloud. /etc/ssowat/conf.json -A 3
        "nextcloud.api": {
            "auth_header": false,
            "protect_against_basic_auth_spoofing": false,
            "public": true,

--
        "nextcloud.main": {
            "auth_header": "basic-with-password",
            "protect_against_basic_auth_spoofing": false,
            "public": true,
```
```

grep nextcloud__ /etc/ssowat/conf.json -A 3
        "nextcloud__4.api": {
            "auth_header": false,
            "protect_against_basic_auth_spoofing": false,
            "public": true,
--
        "nextcloud__4.main": {
            "auth_header": "basic-with-password",
            "protect_against_basic_auth_spoofing": false,
            "public": true,

