### PR TITLE
Automatically apply permissions for stuff provisioned with `ynh_setup_source`.

### DIFF
--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -247,7 +247,5 @@ ynh_setup_source() {
     fi
     rm -rf /var/cache/yunohost/files_to_keep_during_setup_source/
 
-    if [ -n "${install_dir:-}" ] && [ "$dest_dir" == "$install_dir" ]; then
-        _ynh_apply_default_permissions $dest_dir
-    fi
+    _ynh_apply_default_permissions $dest_dir
 }

--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -228,9 +228,14 @@ _ynh_apply_default_permissions() {
     # App files can have files of their own
     if ynh_system_user_exists --username="$app"; then
         # If this is a file in $install_dir or $data_dir : it should be owned and read+writable by $app only
-        if [ -f "$target" ] && (is_in_dir "$target" "${install_dir:-}" || is_in_dir "$target" "${data_dir:-}" || is_in_dir "$target" "/etc/$app"); then
-            chmod 600 "$target"
-            chown "$app:$app" "$target"
+        if (is_in_dir "$target" "${install_dir:-}" || is_in_dir "$target" "${data_dir:-}" || is_in_dir "$target" "/etc/$app"); then
+            if [ -d "$target" ]; then
+              chmod -R o+rwX "$target"
+              chown -R "$app:$app" "$target"
+            else
+              chmod 600 "$target"
+              chown "$app:$app" "$target"
+            fi
             return
         fi
         # If this is the install dir (so far this is the only way this helper is called with a directory - along with $data_dir via ynh_restore?)

--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -230,7 +230,7 @@ _ynh_apply_default_permissions() {
         # If this is a file in $install_dir or $data_dir : it should be owned and read+writable by $app only
         if (is_in_dir "$target" "${install_dir:-}" || is_in_dir "$target" "${data_dir:-}" || is_in_dir "$target" "/etc/$app"); then
             if [ -d "$target" ]; then
-              chmod -R o+rwX "$target"
+              chmod -R u+rwX "$target"
               chown -R "$app:$app" "$target"
             else
               chmod 600 "$target"


### PR DESCRIPTION
## The problem

- `ynh_setup_source "$install_dir/subpath"` is excluded from default permissions
- adding subdirectory to `$install_dir` is exempt from default permissions, unlike adding a file there.

## Solution

Subdirectories of `$install_dir` and `$data_dir` get `$app:$app` `o+rwX` ownership & permissions by default, in line with files added there.

## PR Status

It worked once when installing YunoHost-Apps/syncserver-rs_ynh#58

## How to test

Install an app that uses helpers v2.1 (duh) and provisions sources into a subdirectory.
