### PR TITLE
Fix link to autoupdate_app_sources.py in resources documentation

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -388,7 +388,7 @@ class SourcesResource(AppResource):
 
     Strictly speaking, this has nothing to do with the actual app install. `autoupdate` is expected to contain metadata for automatic maintenance / update of the app sources info in the manifest. It is meant to be a simpler replacement for "autoupdate" Github workflow mechanism.
 
-    The infos are used by this script : <https://github.com/YunoHost/apps/blob/master/tools/autoupdate_app_sources/autoupdate_app_sources.py> which is ran by the YunoHost infrastructure periodically and will create the corresponding pull request automatically.
+    The infos are used by this script : <https://github.com/YunoHost/apps_tools/blob/main/autoupdate_app_sources/autoupdate_app_sources.py> which is ran by the YunoHost infrastructure periodically and will create the corresponding pull request automatically.
 
     The script will rely on the code repo specified in `code` in the upstream section of the manifest.
 


### PR DESCRIPTION
## The problem

Broken link after YunoHost/apps repository split.
