### PR TITLE
apps/helpers2.1: Properly detect 'is_data' (data dir or log folder) when calling ynh_backup

### DIFF
--- a/helpers/helpers.v2.1.d/backup
+++ b/helpers/helpers.v2.1.d/backup
@@ -43,7 +43,7 @@ ynh_backup() {
         else
             ynh_print_info "$target will not be saved, because 'do_not_backup_data' is set."
         fi
-        return 1
+        return 0
     fi
 
     # ==============================================================================

--- a/helpers/helpers.v2.1.d/backup
+++ b/helpers/helpers.v2.1.d/backup
@@ -27,7 +27,7 @@ ynh_backup() {
     local is_data=false
 
     # If the path starts with /var/log/$app or $data_dir
-    if ([[ -n "${app:-}" ]] && [[ "$target" == "/var/log/$app*" ]]) || ([[ -n "${data_dir:-}" ]] && [[ "$target" == "$data_dir*" ]]); then
+    if ([[ -n "${app:-}" ]] && [[ "$target" =~ ^/var/log/$app/?\*?$ ]]) || ([[ -n "${data_dir:-}" ]] && [[ "$target" =~ ^$data_dir ]]); then
         is_data=true
     fi
 


### PR DESCRIPTION
## The problem

`ynh_backup "$data_dir"` runs (is elgible) during pre-upgrade backup.

## Solution

Properly match paths?

## PR Status

we may consider extracting `is_in_dir` from `_ynh_apply_default_permissions` as it contains this logic already.

## How to test

1. Install `filebrowser_ynh` (an app confirmed to use `data_dir` and helpers v2.1, use different app if needed)
2. Upload any file
3.a `yunohost app upgrade filebrowser -F`

Created backup should not include `data_dir`.

3b. Create backup (from cli, webadmin, whatever), choose `filebrowser`

Created backup should include `data_dir`.
