### PR TITLE
Fixed string formatting for custom methods.

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -766,9 +766,9 @@ class BackupManager:
         """Apply backup methods"""
 
         for method in self.methods:
-            logger.debug(m18n.n("backup_applying_method_" + method.method_name))
+            logger.debug(m18n.n("backup_applying_method_" + method.method_name, method=method.method))
             method.mount_and_backup()
-            logger.debug(m18n.n("backup_method_" + method.method_name + "_finished"))
+            logger.debug(m18n.n("backup_method_" + method.method_name + "_finished", method=method.method))
 
     def _compute_backup_size(self):
         """


### PR DESCRIPTION
## The problem

```
Failed to format translated string 'backup_applying_method_custom': 'Calling the custom backup method '{method}'…' with arguments '()' and '{}, raising error: KeyError('method') (don't panic this is just a warning)
/var/www/borg/logging.conf') ... falling back to regular copy.
Failed to format translated string 'backup_method_custom_finished': 'Custom backup method '{method}' finished' with arguments '()' and '{}, raising error: KeyError('method') (don't panic this is just a warning)
```

during Borg backup.

## Solution

Supply missing named parameters for format, they'll be ignored for 'copy' and 'tar' methods.

## PR Status

Tested once on live system, worked.

## How to test

1. Run custom backup (restic, borg)
2. Sift through logs - there should be no i18n errors.

example output:

```
Calling the custom backup method 'borg_app'…
Custom backup method 'borg_app' finished
```