### PR TITLE
doc: in autoupgrade doc, double slash ends up as single slash in the doc, but double slash is really needed, so further escape the slashes

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -355,9 +355,9 @@ class SourcesResource(AppResource):
         armhf.sha256 = "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865"
 
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset.amd64 = ".*\\.amd64.tar.gz"
-        autoupdate.asset.i386 = ".*\\.386.tar.gz"
-        autoupdate.asset.armhf = ".*\\.arm.tar.gz"
+        autoupdate.asset.amd64 = ".*\\\\.amd64.tar.gz"
+        autoupdate.asset.i386 = ".*\\\\.386.tar.gz"
+        autoupdate.asset.armhf = ".*\\\\.arm.tar.gz"
 
         [resources.sources.zblerg]
         url = "https://zblerg.com/download/zblerg"


### PR DESCRIPTION
## The problem

it generates documentation with only \ instead of two \ in here
```
    autoupdate.asset.amd64 = ".*\.amd64.tar.gz"
    autoupdate.asset.i386 = ".*\.386.tar.gz"
    autoupdate.asset.armhf = ".*\.arm.tar.gz"
```

## Solution

add \\ in the script to get a second \ in the documentation.

## PR Status

...

## How to test

...
