### PR TITLE
Copy over patches when checking out x_x

### DIFF
--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -211,8 +211,8 @@ ynh_setup_source() {
     fi
 
     # Apply patches
-    if [ -d "$YNH_APP_BASEDIR/patches/" ]; then
-        local patches_folder=$(realpath "$YNH_APP_BASEDIR/patches/$source_id")
+    if [ -d "$YNH_APP_BASEDIR/sources/patches/" ]; then
+        local patches_folder=$(realpath "$YNH_APP_BASEDIR/sources/patches/$source_id")
         pushd "$dest_dir"
         for patchfile in "$patches_folder/"*.patch; do
             echo "Applying $patchfile"

--- a/src/app.py
+++ b/src/app.py
@@ -94,6 +94,7 @@ APP_FILES_TO_COPY = [
     "conf",
     "hooks",
     "doc",
+    "sources",
 ]
 
 


### PR DESCRIPTION
## The problem

Apps using helpers v2.1 fail to apply patches, even properly moved to `sources/patches/$source_id/`

## Solution

Copy over patches during checkout, look in the right directory.

## PR Status

Tested once (worked!)

## How to test

Install Wallabag from https://github.com/YunoHost-Apps/wallabag2_ynh/tree/move_patches, log in (should work with LDAP patch applied).
