### PR TITLE
Fix the SSL config for the yunohost.org domain

### DIFF
--- a/bin/yunoprompt
+++ b/bin/yunoprompt
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fetch x509 fingerprint
-x509_fingerprint=$(openssl x509  -in /etc/yunohost/certs/yunohost.org/crt.pem -noout -fingerprint -sha256 | cut -d= -f2)
+x509_fingerprint=$(openssl x509  -in /etc/yunohost/certs/yunohost/crt.pem -noout -fingerprint -sha256 | cut -d= -f2)
 
 
 # Fetch SSH fingerprints

--- a/conf/nginx/yunohost_admin.conf
+++ b/conf/nginx/yunohost_admin.conf
@@ -11,8 +11,8 @@ server {
 
     include /etc/nginx/conf.d/security.conf.inc;
 
-    ssl_certificate /etc/yunohost/certs/yunohost.org/crt.pem;
-    ssl_certificate_key /etc/yunohost/certs/yunohost.org/key.pem;
+    ssl_certificate /etc/yunohost/certs/yunohost/crt.pem;
+    ssl_certificate_key /etc/yunohost/certs/yunohost/key.pem;
 
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
     more_set_headers "Referrer-Policy : 'same-origin'";

--- a/conf/slapd/config.ldif
+++ b/conf/slapd/config.ldif
@@ -50,8 +50,8 @@ olcPidFile: /var/run/slapd/slapd.pid
 olcReverseLookup: FALSE
 olcThreads: 16
 # TLS Support
-olcTLSCertificateFile: /etc/yunohost/certs/yunohost.org/crt.pem
-olcTLSCertificateKeyFile: /etc/yunohost/certs/yunohost.org/key.pem
+olcTLSCertificateFile: /etc/yunohost/certs/yunohost/crt.pem
+olcTLSCertificateKeyFile: /etc/yunohost/certs/yunohost/key.pem
 olcTLSVerifyClient: never
 olcTLSProtocolMin: 0.0
 # The tool-threads parameter sets the actual amount of cpu's that is used

--- a/hooks/conf_regen/02-ssl
+++ b/hooks/conf_regen/02-ssl
@@ -4,9 +4,9 @@ set -e
 
 ssl_dir="/usr/share/yunohost/ssl"
 template_dir="/usr/share/yunohost/conf/ssl"
-ynh_ca="/etc/yunohost/certs/yunohost.org/ca.pem"
-ynh_crt="/etc/yunohost/certs/yunohost.org/crt.pem"
-ynh_key="/etc/yunohost/certs/yunohost.org/key.pem"
+ynh_ca="/etc/yunohost/certs/yunohost/ca.pem"
+ynh_crt="/etc/yunohost/certs/yunohost/crt.pem"
+ynh_key="/etc/yunohost/certs/yunohost/key.pem"
 
 regen_local_ca() {
 
@@ -15,7 +15,7 @@ regen_local_ca() {
     echo -e "\n# Creating local certification authority with domain=$domain\n"
 
     # create certs and SSL directories
-    mkdir -p "/etc/yunohost/certs/yunohost.org"
+    mkdir -p "/etc/yunohost/certs/yunohost"
     mkdir -p "${ssl_dir}/"{ca,certs,crl,newcerts}
 
     pushd ${ssl_dir}


### PR DESCRIPTION
Store yunohost CA certs in a directory named yunohost, not yunohost.org, to allow the actual yunohost.org domain to be installed

(untested)