### PR TITLE
TLS passthrough: Allow a destination domain to be configured

### DIFF
--- a/conf/nginx/tls_passthrough.conf
+++ b/conf/nginx/tls_passthrough.conf
@@ -3,14 +3,14 @@ stream {
 
     map $ssl_preread_server_name $name {
         {% for domain_ip in domain_ip_map %}
-        {{ domain_ip.split(":")[0] }} {{ domain_ip.split(":")[0].replace('.', '_') }};
+        {{ domain_ip.split(";")[0] }} {{ domain_ip.split(";")[0].replace('.', '_') }};
         {% endfor %}
         default https_default_backend;
     }
 
     {% for domain_ip in domain_ip_map %}
-    upstream {{ domain_ip.split(":")[0].replace('.', '_') }} {
-        server {{ domain_ip.split(":")[1] }}:443;
+    upstream {{ domain_ip.split(";")[0].replace('.', '_') }} {
+        server {{ domain_ip.split(";")[1] }}:{{ domain_ip.split(";")[2] }};
     }
     {% endfor %}
 

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -79,8 +79,9 @@ do_pre_regen() {
         ynh_render_template "tls_passthrough.conf" "${tls_passthrough_enabled}"
         for tls_passthrough_domain_and_ip in $(echo "$tls_passthrough_list" | sed 's/,/\n/g')
         do
-            export tls_passthrough_domain=$(echo $tls_passthrough_domain_and_ip | awk -F: '{print $1}')
-            export tls_passthrough_ip=$(echo $tls_passthrough_domain_and_ip | awk -F: '{print $2}')
+            export tls_passthrough_domain=$(echo $tls_passthrough_domain_and_ip | awk -F; '{print $1}')
+            export tls_passthrough_ip=$(echo $tls_passthrough_domain_and_ip | awk -F; '{print $2}')
+            export tls_passthrough_port=$(echo $tls_passthrough_domain_and_ip | awk -F; '{print $3}')
             ynh_render_template "tls_passthrough_server.conf" "${nginx_conf_dir}/${tls_passthrough_domain}.forward80.conf"
         done
     else

--- a/locales/en.json
+++ b/locales/en.json
@@ -438,7 +438,7 @@
     "global_settings_setting_tls_passthrough_enabled": "Enable TLS-passthrough / SNI-based forwarding",
     "global_settings_setting_tls_passthrough_enabled_help": "This is an advanced feature to reverse-proxy an entire domain to another machine *without* decrypting the traffic. Useful when you want to expose several machines behind the same IP but still allow each machine to handle the SSL termination. BUT you must be absolutely aware that no fail2ban protection will work on the proxied machines (iptables cannot ban malicious traffic as all IP packets appear as coming from the front server)",
     "global_settings_setting_tls_passthrough_list": "List of forwarding",
-    "global_settings_setting_tls_passthrough_list_help": "Should be a list of DOMAIN:IPv4, such as domain.tld:1.2.3.4",
+    "global_settings_setting_tls_passthrough_list_help": "Should be a list of DOMAIN;DESTINATION;PORT, such as domain.tld;192.168.1.42;443 or domain.tld;server.local;8123",
     "global_settings_setting_admin_strength_help": "These requirements are only enforced when initializing or changing the password",
     "global_settings_setting_backup_compress_tar_archives": "Compress backups",
     "global_settings_setting_backup_compress_tar_archives_help": "When creating new backups, compress the archives (.tar.gz) instead of uncompressed archives (.tar). N.B. : enabling this option means create lighter backup archives, but the initial backup procedure will be significantly longer and heavy on CPU.",

--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -191,8 +191,8 @@ name = "Other"
 
         [misc.tls_passthrough.tls_passthrough_list]
         type = "tags"
-        # Regex is just <domain regex>:<ip regex>
-        pattern.regexp = '^([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}):((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$'
-        pattern.error = "You should specify a list of items formatted as DOMAIN:IPv4, such as yolo.test:12.34.56.78"
+        # Regex is just <domain regex>;<destination>;<port>
+        pattern.regexp = '^(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}));(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?([^\W_]{2,}|[0-9]{1,3})));[0-9]{1,}$'
+        pattern.error = "You should specify a list of items formatted as DOMAIN;DESTINATION;DESTPORT, such as yolo.test;192.168.1.42;443"
         default = ""
         visible = "tls_passthrough_enabled"


### PR DESCRIPTION
That allows a domain to be configured as well as an IP as destination for TLS passthourgh.

Also we now can (and need to) specify a destination port.