### PR TITLE
configpanel: error adjust to hint if the bind key wasn't found

### DIFF
--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -529,7 +529,7 @@ class ConfigPanel:
                     continue
                 else:
                     raise YunohostError(
-                        f"Config panel question '{option['id']}' should be initialized with a value during install or upgrade.",
+                        f"Config panel question '{option['id']}' should be initialized with a value during install or upgrade. (Or maybe the bind key wasn't found?)",
                         raw_msg=True,
                     )
             value = self.values[option["id"]]


### PR DESCRIPTION
## The problem

if a config panel bind key was not found in the app config file, the showed error is misleading: `Config panel question '{option['id']}' should be initialized with a value during install or upgrade.`

## Solution

i would like to put a different message to differenciate the two errors, but the script logic doesn't seem to allow it, so i just put a small hint at the end

## PR Status

done

## How to test

put a key bind that is NOT in the config file, so the script will not found it
