### PR TITLE
Use the new repo.yunohost.org debian repository

### DIFF
--- a/helpers/helpers.v1.d/apt
+++ b/helpers/helpers.v1.d/apt
@@ -558,9 +558,9 @@ ynh_remove_extra_repo() {
 # | arg: -a, --append       - Do not overwrite existing files.
 # | arg: -t, --trusted      - Add trusted=yes to the repository (not recommended)
 #
-# Example for a repo like deb http://forge.yunohost.org/debian/ stretch stable
+# Example for a repo like deb http://repo.yunohost.org/debian/ stretch stable
 #                             uri                               suite   component
-# ynh_add_repo --uri=http://forge.yunohost.org/debian/ --suite=stretch --component=stable
+# ynh_add_repo --uri=http://repo.yunohost.org/debian/ --suite=stretch --component=stable
 #
 # Requires YunoHost version 3.8.1 or higher.
 ynh_add_repo() {

--- a/src/migrations/0027_migrate_to_bookworm.py
+++ b/src/migrations/0027_migrate_to_bookworm.py
@@ -99,7 +99,7 @@ class MyMigration(Migration):
         # Add new apt .deb signing key
         #
 
-        new_apt_key = "https://forge.yunohost.org/yunohost_bookworm.asc"
+        new_apt_key = "https://repo.yunohost.org/keys/yunohost_bookworm.asc"
         os.system(f'wget --timeout 900 --quiet "{new_apt_key}" --output-document=- | gpg --dearmor >"/usr/share/keyrings/yunohost-bookworm.gpg"')
 
         # Add Sury key even if extra_php_version.list was already there,
@@ -419,7 +419,7 @@ class MyMigration(Migration):
                 "-e 's@ bullseye/updates @ bookworm-security @g' "
                 "-e 's@ bullseye-@ bookworm-@g' "
                 "-e '/non-free-firmware/!s@ non-free@ non-free non-free-firmware@g' "
-                "-e 's@deb.*http://forge.yunohost.org@deb [signed-by=/usr/share/keyrings/yunohost-bookworm.gpg] http://forge.yunohost.org@g' "
+                "-e 's@deb.*http://repo.yunohost.org@deb [signed-by=/usr/share/keyrings/yunohost-bookworm.gpg] http://repo.yunohost.org@g' "
             )
             os.system(command)
 


### PR DESCRIPTION
<untested>
I suggested to use a unified domain for "built stuff we serve", repo.yunohost.org. It could be nice to use it before releasing bookworm.