### PR TITLE
[fix] Bad catch IPython missing

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -588,7 +588,7 @@ def tools_shell(command=None):
         from IPython import embed
 
         embed()
-    except ImportError:
+    except (ImportError, ModuleNotFoundError):
         logger.warn(
             "You don't have IPython installed, consider installing it as it is way better than the standard shell."
         )


### PR DESCRIPTION
## The problem

```
Traceback (most recent call last):                                                                                            
  File "/usr/lib/python3/dist-packages/yunohost/tools.py", line 588, in tools_shell                                           
    from IPython import embed                                                                                                 
ModuleNotFoundError: No module named 'IPython'
```

## Solution

...

## PR Status

Ready

## How to test

...
