### PR TITLE
#2445: Pass email, username and fullname as header for ssowat

### DIFF
--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -210,8 +210,11 @@ class Authenticator(BaseAuthenticator):
         if not user_is_allowed_on_domain(username, request.get_header("host")):
             raise YunohostAuthenticationError("unable_authenticate")
 
-        return {"user": username, "pwd": encrypt(password), "email": ldap_user_infos["mail"][0],
-                "fullname": ldap_user_infos["cn"][0]}
+        return {"user": username, 
+                      "pwd": encrypt(password),
+                      "email": ldap_user_infos["mail"][0],
+                      "fullname": ldap_user_infos["cn"][0]
+        }
 
     def set_session_cookie(self, infos):
         from bottle import response, request

--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -205,7 +205,7 @@ class Authenticator(BaseAuthenticator):
             if con:
                 con.unbind_s()
 
-            ldap_user_infos = _get_ldap_interface().search("ou=users", "uid=" + username, attrs=["cn", "mail"])[0]
+            ldap_user_infos = _get_ldap_interface().search("ou=users", f"uid={username}", attrs=["cn", "mail"])[0]
 
         if not user_is_allowed_on_domain(username, request.get_header("host")):
             raise YunohostAuthenticationError("unable_authenticate")

--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -210,8 +210,8 @@ class Authenticator(BaseAuthenticator):
         if not user_is_allowed_on_domain(username, request.get_header("host")):
             raise YunohostAuthenticationError("unable_authenticate")
 
-        return {"user": username, "pwd": encrypt(password), "email": ldap_user_infos["mail"],
-                "user_fullname": ldap_user_infos["cn"]}
+        return {"user": username, "pwd": encrypt(password), "email": ldap_user_infos["mail"][0],
+                "fullname": ldap_user_infos["cn"][0]}
 
     def set_session_cookie(self, infos):
         from bottle import response, request
@@ -220,7 +220,7 @@ class Authenticator(BaseAuthenticator):
         assert "user" in infos
         assert "pwd" in infos
         assert "email" in infos
-        assert "user_fullname" in infos
+        assert "fullname" in infos
 
         # Create a session id, built as <user_hash> + some random ascii
         # Prefixing with the user hash is meant to provide the ability to invalidate all this user's session


### PR DESCRIPTION
## Releated PR

https://github.com/YunoHost/doc/pull/2509
https://github.com/YunoHost/SSOwat/pull/231
https://github.com/YunoHost/package_linter/pull/164

## The problem

https://github.com/YunoHost/issues/issues/2445

## Solution

Add in the HTTP header some HEADER with the information with the authenticated user.

### Details

We have 3 case of usage of the SSO (maybe more ??)

1. The application only use the Authentication header with the user information (not the password), trust this information and automatically authenticate the user. In some case the header could be also the user email, we have this case with seafile.
2. The application, use the auth basic information, with the user and password and if the credential are OK, the user is authenticated. This is the case by example for SOGo, which use also the password to transmit the credential to the mail server.
3. Not really a SSO case but some app provide some API like for caldav/cardav and the authentication from the client application is send with basic authentication. In this case the server will also check the credential.

The problematic issue is mainly about the first use case. In Yunohost 11 we had some authentication header which was used in some app, but from what I know it was not really documented exactly how the app should be configured.

In Yunohost 12, it was considered that all app should just use the user information from the auth basic and if needed convert the auth basic header into a specific header with the user information with this instruction in nginx (which work only for PHP)
```
fastcgi_param REMOTE_USER     $remote_user;
```
The issue that we have with this, is that we trust the user information without checking the credential. In the case 2 it's done but not in the case one. It's why a mechanism was probably added, by default, to don't pass the external basic auth information and only pass the auth basic header if they come from ssowat. But this break the case 3, so it's why we have the special app settings to disable this.

So the idea of this PR is to improve the security and to standardize the way we implement the SSO into the apps.

For the case 1, to me it's not a good idea to retrieve the information from the auth basic header as we don't check the password and sometime we must allow that the client send this header so we can't trust it. So to solve this I introduced a new HTTP header `YNH_USER`. This header can be fully trusted because it it's set only by ssowat and if no user is authenticated, ssowat ensure that this header are not set. So there are no spoofing risk. For some app I also introduced some more header like `YNH_USER_EMAIL` and `YNH_USER_FULLNAME`. Note this can be useful by example for an app which can read the HTTP header but is not connected to LDAP. By this way the app can populate the user information from the authentication header.

For the case 2 and 3 this PR don't change anything. Maybe at some point when we are sure that all app use correctly the authentication header, we can just remove the special app settings which allow the auth basic from the client and enable it by default (if there are no more risk around this but this should be discussed at some point).

In PHP with this change, we will have theses HEADER which should be used for authentication:

- `Ynh-User` : yunohost-user
- `Ynh-User-Email`: user-email
- `Ynh-User-Fullname`: user-fullname

Since this PR, php app don't need any more this `fastcgi_param REMOTE_USER     $remote_user;` as ssowat already set all needed header.

For other app we will have theses HTTP header which should be used for authentication:
- `YNH_USER_FULLNAME`: user-fullname
- `YNH_USER_EMAIL`: user-email
- `YNH_USER`: yunohost-user

I updated also the documentation here which give also some details of how it work: https://github.com/YunoHost/doc/pull/2509

### ~~TODO in seconds step~~

~~Update the documentation according theses changes~~ done here: https://github.com/YunoHost/doc/pull/2509

~~Add into the package linter some check for this. Maybe the solution would be to prohibit the usage of the `REMOTE_USER` header since the app require Yunohost 12. For the app which still support Yunohost 11 we still need to allow it.~~ -> done https://github.com/YunoHost/package_linter/pull/164

## PR Status

Ready

## How to test

For php:

1. Install my webapp
4. Edit the php file and add this code
```
<p><?php var_dump(getallheaders()); ?></p>
<p><?php var_dump($_SERVER); ?></p>
```
5. See the header send by ssowat.

For other apps:

1. Install redirect_ynh and configure to send trafic on `127.0.0.1:8000`.
2. Copy this mini python webserver: https://gist.github.com/phrawzty/62540f146ee5e74ea1ab
4. Run this python script.
6. See the header send by ssowat.