### PR TITLE
Lower logging about failure to retrieve app label

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -250,7 +250,7 @@ def app_info(app, full=False, upgradable=False):
     ret["label"] = permissions.get(app + ".main", {}).get("label")
 
     if not ret["label"]:
-        logger.warning(f"Failed to get label for app {app} ?")
+        logger.debug(f"Failed to get label for app {app}, maybe it is not a webapp?")
         ret["label"] = local_manifest["name"]
     return ret
 


### PR DESCRIPTION
## The problem

Non-webapps that do not have a `main` permission thus get no label. That's expected, there is no need to display it as a warning that can be reiterated a lot of times during some operations.

(e.g. incus, wireguard_client)

## Solution

Lower the warning to debug level.

## PR Status

Ready

## How to test

...
