### PR TITLE
Support domains in cert_alternate_names hook

### DIFF
--- a/src/certificate.py
+++ b/src/certificate.py
@@ -597,12 +597,15 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
                 sanlist += result["stdreturn"]
 
     if sanlist:
+        subsanlist = [f"DNS:{sub}.{domain}" for sub in sanlist if "." not in sub]
+        domainsanlist = [f"DNS:{domain}" for domain in sanlist if "." in domain]
+        sanlist = ", ".join(subsanlist+domainsanlist)
         csr.add_extensions(
             [
                 crypto.X509Extension(
                     b"subjectAltName",
                     False,
-                    (", ".join([f"DNS:{sub}.{domain}" for sub in sanlist])).encode(
+                    sanlist.encode(
                         "utf-8"
                     ),
                 )

--- a/src/certificate.py
+++ b/src/certificate.py
@@ -598,6 +598,7 @@ def _prepare_certificate_signing_request(domain, key_file, output_folder):
 
     if sanlist:
         subsanlist = [f"DNS:{sub}.{domain}" for sub in sanlist if "." not in sub]
+        # This is meant for situation such as cryptpad where we need to be able to have a cert for sandbox-domain.tld (with a dash, not just sandbox.domain.tld)
         domainsanlist = [f"DNS:{domain}" for domain in sanlist if "." in domain]
         sanlist = ", ".join(subsanlist+domainsanlist)
         csr.add_extensions(


### PR DESCRIPTION
## The problem

Cryptpad's sandbox domain can either be:
- `sandbox-domain.example`
- `sandbox.domain.example`

First case cannot be included in the SAN list of the hook.

## Solution

Detect if the hook lists a full domain (if it has a dot), and do not assume it is a subdomain of the app's domain

## PR Status

Ready

## How to test

I'm preparing a PR for Cryptpad to test this.