### PR TITLE
Migration don't rebuilt venv for homeassistant and immich

### DIFF
--- a/src/migrations/0030_rebuild_python_venv_in_bookworm.py
+++ b/src/migrations/0030_rebuild_python_venv_in_bookworm.py
@@ -57,6 +57,8 @@ class MyMigration(Migration):
 
     ignored_python_apps = [
         "diacamma",  # Does an ugly sed in the sites-packages/django_auth_ldap3_ad
+        "homeassistant", # uses a custom version of Python
+        "immich", # uses a custom version of Python
         "kresus",  # uses virtualenv instead of venv, with --system-site-packages (?)
         "librephotos",  # runs a setup.py ? not sure pip freeze / pip install -r requirements.txt is gonna be equivalent ..
         "mautrix",  # install stuff from a .tar.gz


### PR DESCRIPTION
see https://forum.yunohost.org/t/yunohost-12-0-beta-bookworm/30496/84

## The problem

the migration process kill that 2 apps as they use a custom python version

## Solution

add them to the ignore list

## PR Status

...

## How to test

...
