### PR TITLE
'internal' is a reserved TLD for private networks

### DIFF
--- a/src/utils/dns.py
+++ b/src/utils/dns.py
@@ -21,7 +21,7 @@ from typing import List
 
 from moulinette.utils.filesystem import read_file
 
-SPECIAL_USE_TLDS = ["home.arpa", "local", "localhost", "onion", "test"]
+SPECIAL_USE_TLDS = ["home.arpa", "internal", "local", "localhost", "onion", "test"]
 
 YNH_DYNDNS_DOMAINS = ["nohost.me", "noho.st", "ynh.fr"]
 


### PR DESCRIPTION
cf. https://www.icann.org/en/board-activities-and-meetings/materials/approved-resolutions-special-meeting-of-the-icann-board-29-07-2024-en#section2.a