### PR TITLE
typing: pre pydantic v2

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import tempfile
 import copy
-from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional
+from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional, Union
 from packaging import version
 from logging import getLogger
 from pathlib import Path
@@ -1890,7 +1890,7 @@ def _get_AppConfigPanel():
             form: "FormModel",
             config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
-            exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
+            exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
         ) -> None:
             env = {key: str(value) for key, value in form.dict().items()}
             return_content = self._call_config_script("apply", env=env)

--- a/src/app.py
+++ b/src/app.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import tempfile
 import copy
-from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional, Union
+from typing import TYPE_CHECKING, List, Tuple, Dict, Any, Iterator, Optional
 from packaging import version
 from logging import getLogger
 from pathlib import Path
@@ -1890,7 +1890,7 @@ def _get_AppConfigPanel():
             form: "FormModel",
             config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
-            exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+            exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
         ) -> None:
             env = {key: str(value) for key, value in form.dict().items()}
             return_content = self._call_config_script("apply", env=env)
@@ -1912,7 +1912,7 @@ def _get_AppConfigPanel():
             self._call_config_script(action_id, env=env)
 
         def _call_config_script(
-            self, action: str, env: Union[dict[str, Any], None] = None
+            self, action: str, env: dict[str, Any] | None = None
         ) -> dict[str, Any]:
             from yunohost.hook import hook_exec
 

--- a/src/domain.py
+++ b/src/domain.py
@@ -19,7 +19,7 @@
 import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional
 from collections import OrderedDict
 from logging import getLogger
 
@@ -794,7 +794,7 @@ def _get_DomainConfigPanel():
             form: "FormModel",
             config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
-            exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+            exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
         ) -> None:
             next_settings = {
                 k: v for k, v in form.dict().items() if previous_settings.get(k) != v

--- a/src/domain.py
+++ b/src/domain.py
@@ -19,7 +19,7 @@
 import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 from collections import OrderedDict
 from logging import getLogger
 
@@ -794,7 +794,7 @@ def _get_DomainConfigPanel():
             form: "FormModel",
             config: "ConfigPanelModel",
             previous_settings: dict[str, Any],
-            exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
+            exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
         ) -> None:
             next_settings = {
                 k: v for k, v in form.dict().items() if previous_settings.get(k) != v

--- a/src/settings.py
+++ b/src/settings.py
@@ -19,7 +19,7 @@
 import os
 import subprocess
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -139,7 +139,7 @@ class SettingsConfigPanel(ConfigPanel):
         super().__init__("settings")
 
     def get(
-        self, key: Union[str, None] = None, mode: "ConfigPanelGetMode" = "classic"
+        self, key: str | None = None, mode: "ConfigPanelGetMode" = "classic"
     ) -> Any:
         result = super().get(key=key, mode=mode)
 
@@ -151,8 +151,8 @@ class SettingsConfigPanel(ConfigPanel):
 
     def reset(
         self,
-        key: Union[str, None] = None,
-        operation_logger: Union["OperationLogger", None] = None,
+        key: str | None = None,
+        operation_logger: "OperationLogger" | None = None,
     ) -> None:
         self.filter_key = parse_filter_key(key)
 
@@ -223,7 +223,7 @@ class SettingsConfigPanel(ConfigPanel):
         form: "FormModel",
         config: "ConfigPanelModel",
         previous_settings: dict[str, Any],
-        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+        exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
     ) -> None:
         root_password = form.get("root_password", None)
         root_password_confirm = form.get("root_password_confirm", None)

--- a/src/settings.py
+++ b/src/settings.py
@@ -19,7 +19,7 @@
 import os
 import subprocess
 from logging import getLogger
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 from moulinette import m18n
 from yunohost.utils.error import YunohostError, YunohostValidationError
@@ -152,7 +152,7 @@ class SettingsConfigPanel(ConfigPanel):
     def reset(
         self,
         key: str | None = None,
-        operation_logger: "OperationLogger" | None = None,
+        operation_logger: Union["OperationLogger", None] = None,
     ) -> None:
         self.filter_key = parse_filter_key(key)
 
@@ -223,7 +223,7 @@ class SettingsConfigPanel(ConfigPanel):
         form: "FormModel",
         config: "ConfigPanelModel",
         previous_settings: dict[str, Any],
-        exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
     ) -> None:
         root_password = form.get("root_password", None)
         root_password_confirm = form.get("root_password_confirm", None)

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -21,7 +21,7 @@ import os
 import re
 from collections import OrderedDict
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, cast
 
 from pydantic import BaseModel, Extra, validator
 
@@ -70,11 +70,11 @@ CONFIG_PANEL_VERSION_SUPPORTED = 1.0
 
 class ContainerModel(BaseModel):
     id: str
-    name: Union[Translation, None] = None
+    name: Translation | None = None
     services: list[str] = []
-    help: Union[Translation, None] = None
+    help: Translation | None = None
 
-    def translate(self, i18n_key: Union[str, None] = None) -> None:
+    def translate(self, i18n_key: str | None = None) -> None:
         """
         Translate `ask` and `name` attributes of panels and section.
         This is in place mutation.
@@ -121,10 +121,10 @@ class SectionModel(ContainerModel, OptionsModel):
         - Be careful that the `visible` property should only refer to **previous** options's value. Hence, it should not make sense to have a `visible` property on the very first section.
     """
 
-    visible: Union[bool, str] = True
+    visible: bool | str = True
     optional: bool = True
     is_action_section: bool = False
-    bind: Union[str, None] = None
+    bind: str | None = None
 
     class Config:
         @staticmethod
@@ -138,12 +138,12 @@ class SectionModel(ContainerModel, OptionsModel):
     def __init__(
         self,
         id: str,
-        name: Union[Translation, None] = None,
+        name: Translation | None = None,
         services: list[str] = [],
-        help: Union[Translation, None] = None,
-        visible: Union[bool, str] = True,
+        help: Translation | None = None,
+        visible: bool | str = True,
         optional: bool = True,
-        bind: Union[str, None] = None,
+        bind: str | None = None,
         **kwargs,
     ) -> None:
         options = self.options_dict_to_list(kwargs, optional=optional)
@@ -168,7 +168,7 @@ class SectionModel(ContainerModel, OptionsModel):
 
         return evaluate_simple_js_expression(self.visible, context=context)
 
-    def translate(self, i18n_key: Union[str, None] = None) -> None:
+    def translate(self, i18n_key: str | None = None) -> None:
         """
         Call to `Container`'s `translate` for self translation
         + Call to `OptionsContainer`'s `translate_options` for options translation
@@ -202,7 +202,7 @@ class PanelModel(ContainerModel):
 
     # FIXME what to do with `actions?
     actions: dict[str, Translation] = {"apply": {"en": "Apply"}}
-    bind: Union[str, None] = None
+    bind: str | None = None
     sections: list[SectionModel]
 
     class Config:
@@ -219,10 +219,10 @@ class PanelModel(ContainerModel):
     def __init__(
         self,
         id: str,
-        name: Union[Translation, None] = None,
+        name: Translation | None = None,
         services: list[str] = [],
-        help: Union[Translation, None] = None,
-        bind: Union[str, None] = None,
+        help: Translation | None = None,
+        bind: str | None = None,
         **kwargs,
     ) -> None:
         sections = [data | {"id": name} for name, data in kwargs.items()]
@@ -230,7 +230,7 @@ class PanelModel(ContainerModel):
             id=id, name=name, services=services, help=help, bind=bind, sections=sections
         )
 
-    def translate(self, i18n_key: Union[str, None] = None) -> None:
+    def translate(self, i18n_key: str | None = None) -> None:
         """
         Recursivly mutate translatable attributes to their translation
         """
@@ -262,7 +262,7 @@ class ConfigPanelModel(BaseModel):
     """
 
     version: float = CONFIG_PANEL_VERSION_SUPPORTED
-    i18n: Union[str, None] = None
+    i18n: str | None = None
     panels: list[PanelModel]
 
     class Config:
@@ -293,7 +293,7 @@ class ConfigPanelModel(BaseModel):
     def __init__(
         self,
         version: float,
-        i18n: Union[str, None] = None,
+        i18n: str | None = None,
         **kwargs,
     ) -> None:
         panels = [data | {"id": name} for name, data in kwargs.items()]
@@ -313,19 +313,19 @@ class ConfigPanelModel(BaseModel):
             for option in section.options:
                 yield option
 
-    def get_panel(self, panel_id: str) -> Union[PanelModel, None]:
+    def get_panel(self, panel_id: str) -> PanelModel | None:
         for panel in self.panels:
             if panel.id == panel_id:
                 return panel
         return None
 
-    def get_section(self, section_id: str) -> Union[SectionModel, None]:
+    def get_section(self, section_id: str) -> SectionModel | None:
         for section in self.sections:
             if section.id == section_id:
                 return section
         return None
 
-    def get_option(self, option_id: str) -> Union[AnyOption, None]:
+    def get_option(self, option_id: str) -> AnyOption | None:
         for option in self.options:
             if option.id == option_id:
                 return option
@@ -386,13 +386,13 @@ class ConfigPanelModel(BaseModel):
 # ╰───────────────────────────────────────────────────────╯
 
 if TYPE_CHECKING:
-    FilterKey = Sequence[Union[str, None]]
+    FilterKey = Sequence[str | None]
     RawConfig = OrderedDict[str, Any]
     RawSettings = dict[str, Any]
     ConfigPanelGetMode = Literal["classic", "full", "export"]
 
 
-def parse_filter_key(key: Union[str, None] = None) -> "FilterKey":
+def parse_filter_key(key: str | None = None) -> "FilterKey":
     if key and key.count(".") > 2:
         raise YunohostError(
             f"The filter key {key} has too many sub-levels, the max is 3.",
@@ -407,13 +407,13 @@ def parse_filter_key(key: Union[str, None] = None) -> "FilterKey":
 
 class ConfigPanel:
     entity_type = "config"
-    save_path_tpl: Union[str, None] = None
+    save_path_tpl: str | None = None
     config_path_tpl = "/usr/share/yunohost/config_{entity_type}.toml"
     save_mode = "full"
     settings_must_be_defined: bool = False
     filter_key: "FilterKey" = (None, None, None)
-    config: Union[ConfigPanelModel, None] = None
-    form: Union["FormModel", None] = None
+    config: ConfigPanelModel | None = None
+    form: "FormModel" | None = None
     raw_settings: "RawSettings" = {}
     hooks: "Hooks" = {}
 
@@ -470,7 +470,7 @@ class ConfigPanel:
         }
 
     def get(
-        self, key: Union[str, None] = None, mode: "ConfigPanelGetMode" = "classic"
+        self, key: str | None = None, mode: "ConfigPanelGetMode" = "classic"
     ) -> Any:
         self.filter_key = parse_filter_key(key)
         self.config, self.form = self._get_config_panel(prevalidate=False)
@@ -542,11 +542,11 @@ class ConfigPanel:
 
     def set(
         self,
-        key: Union[str, None] = None,
+        key: str | None = None,
         value: Any = None,
-        args: Union[str, None] = None,
-        args_file: Union[str, None] = None,
-        operation_logger: Union["OperationLogger", None] = None,
+        args: str | None = None,
+        args_file: str | None = None,
+        operation_logger: "OperationLogger" | None = None,
     ) -> None:
         self.filter_key = parse_filter_key(key)
         panel_id, section_id, option_id = self.filter_key
@@ -631,10 +631,10 @@ class ConfigPanel:
 
     def run_action(
         self,
-        key: Union[str, None] = None,
-        args: Union[str, None] = None,
-        args_file: Union[str, None] = None,
-        operation_logger: Union["OperationLogger", None] = None,
+        key: str | None = None,
+        args: str | None = None,
+        args_file: str | None = None,
+        operation_logger: "OperationLogger" | None = None,
     ) -> None:
         #
         # FIXME : this stuff looks a lot like set() ...
@@ -717,7 +717,7 @@ class ConfigPanel:
         def filter_keys(
             data: "RawConfig",
             key: str,
-            model: Union[Type[ConfigPanelModel], Type[PanelModel], Type[SectionModel]],
+            model: Type[ConfigPanelModel] | Type[PanelModel] | Type[SectionModel],
         ) -> "RawConfig":
             # filter in keys defined in model, filter out panels/sections/options that aren't `key`
             return OrderedDict(
@@ -824,7 +824,7 @@ class ConfigPanel:
         config: ConfigPanelModel,
         form: "FormModel",
         prefilled_answers: dict[str, Any] = {},
-        action_id: Union[str, None] = None,
+        action_id: str | None = None,
         hooks: "Hooks" = {},
     ) -> "FormModel":
         # FIXME could be turned into a staticmethod
@@ -880,7 +880,7 @@ class ConfigPanel:
         form: "FormModel",
         config: ConfigPanelModel,
         previous_settings: dict[str, Any],
-        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
+        exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
     ) -> None:
         """
         Save settings in yaml file.

--- a/src/utils/configpanel.py
+++ b/src/utils/configpanel.py
@@ -21,7 +21,7 @@ import os
 import re
 from collections import OrderedDict
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, cast
+from typing import TYPE_CHECKING, Any, Iterator, Literal, Sequence, Type, Union, cast
 
 from pydantic import BaseModel, Extra, validator
 
@@ -413,7 +413,7 @@ class ConfigPanel:
     settings_must_be_defined: bool = False
     filter_key: "FilterKey" = (None, None, None)
     config: ConfigPanelModel | None = None
-    form: "FormModel" | None = None
+    form: Union["FormModel", None] = None
     raw_settings: "RawSettings" = {}
     hooks: "Hooks" = {}
 
@@ -546,7 +546,7 @@ class ConfigPanel:
         value: Any = None,
         args: str | None = None,
         args_file: str | None = None,
-        operation_logger: "OperationLogger" | None = None,
+        operation_logger: Union["OperationLogger", None] = None,
     ) -> None:
         self.filter_key = parse_filter_key(key)
         panel_id, section_id, option_id = self.filter_key
@@ -634,7 +634,7 @@ class ConfigPanel:
         key: str | None = None,
         args: str | None = None,
         args_file: str | None = None,
-        operation_logger: "OperationLogger" | None = None,
+        operation_logger: Union["OperationLogger", None] = None,
     ) -> None:
         #
         # FIXME : this stuff looks a lot like set() ...
@@ -880,7 +880,7 @@ class ConfigPanel:
         form: "FormModel",
         config: ConfigPanelModel,
         previous_settings: dict[str, Any],
-        exclude: "AbstractSetIntStr" | "MappingIntStrAny" | None = None,
+        exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
     ) -> None:
         """
         Save settings in yaml file.

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -741,7 +741,7 @@ class BaseInputOption(BaseOption):
 
 
 class BaseStringOption(BaseInputOption):
-    default: str | None
+    default: str | None = None
     pattern: Pattern | None = None
     _annotation = str
 
@@ -873,7 +873,7 @@ class ColorOption(BaseInputOption):
     """
 
     type: Literal[OptionType.color] = OptionType.color
-    default: str | None
+    default: str | None = None
     _annotation = Color
 
     @staticmethod
@@ -926,7 +926,7 @@ class NumberOption(BaseInputOption):
 
     # `number` and `range` are exactly the same, but `range` does render as a slider in web-admin
     type: Literal[OptionType.number, OptionType.range] = OptionType.number
-    default: int | None
+    default: int | None = None
     min: int | None = None
     max: int | None = None
     step: int | None = None
@@ -1118,7 +1118,7 @@ class DateOption(BaseInputOption):
     """
 
     type: Literal[OptionType.date] = OptionType.date
-    default: str | None
+    default: str | None = None
     _annotation = datetime.date
 
     @classmethod
@@ -1148,7 +1148,7 @@ class TimeOption(BaseInputOption):
     """
 
     type: Literal[OptionType.time] = OptionType.time
-    default: str | int | None
+    default: str | int | None = None
     _annotation = datetime.time
 
     @classmethod
@@ -1181,7 +1181,7 @@ class EmailOption(BaseInputOption):
     """
 
     type: Literal[OptionType.email] = OptionType.email
-    default: EmailStr | None
+    default: EmailStr | None = None
     _annotation = EmailStr
 
 
@@ -1289,7 +1289,7 @@ class FileOption(BaseInputOption):
     # `FilePath` for CLI (path must exists and must be a file)
     # `bytes` for API (a base64 encoded file actually)
     accept: list[str] | None = None  # currently only used by the web-admin
-    default: str | None
+    default: str | None = None
     _annotation = str  # TODO could be Path at some point
     _upload_dirs: set[str] = set()
 
@@ -1482,7 +1482,7 @@ class SelectOption(BaseChoicesOption):
     type: Literal[OptionType.select] = OptionType.select
     filter: Literal[None] = None
     choices: list[Any] | dict[str, Any] | None
-    default: str | None
+    default: str | None = None
     _annotation = str
 
 
@@ -1519,7 +1519,7 @@ class TagsOption(BaseChoicesOption):
     choices: list[str] | None = None
     pattern: Pattern | None = None
     icon: str | None = None
-    default: str | list[str] | None
+    default: str | list[str] | None = None
     _annotation = str
 
     @staticmethod

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -33,6 +33,7 @@ from typing import (
     Annotated,
     Any,
     Callable,
+    ClassVar,
     Iterable,
     Literal,
     Mapping,
@@ -614,7 +615,7 @@ class BaseInputOption(BaseOption):
     optional: bool = False  # FIXME keep required as default?
     default: Any = None
     _annotation: Any = Any
-    _none_as_empty_str: bool = True
+    _none_as_empty_str: ClassVar[bool] = True
 
     @validator("default", pre=True)
     def check_empty_default(value: Any) -> Any:
@@ -828,7 +829,7 @@ class PasswordOption(BaseInputOption):
     default: Literal[None] = None
     redact: Literal[True] = True
     _annotation = str
-    _forbidden_chars: str = FORBIDDEN_PASSWORD_CHARS
+    _forbidden_chars: ClassVar[str] = FORBIDDEN_PASSWORD_CHARS
 
     def _get_field_attrs(self) -> dict[str, Any]:
         attrs = super()._get_field_attrs()
@@ -1002,8 +1003,8 @@ class BooleanOption(BaseInputOption):
     no: Any = 0
     default: bool | int | str | None = 0
     _annotation = bool | int | str
-    _yes_answers: set[str] = {"1", "yes", "y", "true", "t", "on"}
-    _no_answers: set[str] = {"0", "no", "n", "false", "f", "off"}
+    _yes_answers: ClassVar[set[str]] = {"1", "yes", "y", "true", "t", "on"}
+    _no_answers: ClassVar[set[str]] = {"0", "no", "n", "false", "f", "off"}
     _none_as_empty_str = False
 
     @staticmethod
@@ -1291,7 +1292,7 @@ class FileOption(BaseInputOption):
     accept: list[str] | None = None  # currently only used by the web-admin
     default: str | None = None
     _annotation = str  # TODO could be Path at some point
-    _upload_dirs: set[str] = set()
+    _upload_dirs: ClassVar[set[str]] = set()
 
     @property
     def _validators(self) -> dict[str, Callable]:


### PR DESCRIPTION
Update some config panel + form typing for upcoming migration to pydantic v2

- use `|` instead of `Union`
- use `ClassVar` for class private attributes
- repeat default values for Options attribute (required in pydantic-v2)
