### PR TITLE
[fix] Allow apps to be installed on / if another app is using /.well-known/

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2983,7 +2983,7 @@ def _get_conflicting_apps(domain, path, ignore_app=None):
             if a["id"] == ignore_app:
                 continue
             if path == p or (
-                not path.startswith("/.well-known/") and (path == "/" or p == "/")
+                not (path.startswith("/.well-known/") or p.startswith("/.well-known/")) and (path == "/" or p == "/")
             ):
                 conflicts.append((p, a["id"], a["label"]))
 


### PR DESCRIPTION
## The problem

PR #1647 added the ability to install `/.well-known/` entries on domains, that already have an app on `/`. However, if you try this the other way around (install app on `/` after `/.well-known/` entry) you get an error. This also breaks updating for the app installed on `/`.

## Solution

Update the conflict detection

## PR Status

Works on my machine™

## How to test

Install an app that supports putting its `/.well-known/` entries on a separate domain (I used `conduit`) and then install another app on the root of the same domain.
