### PR TITLE
Fix PHP sourcing in helpers 2.1 + don't flood bash salad when opening "yunohost app shell"

### DIFF
--- a/helpers/helpers.v1.d/getopts
+++ b/helpers/helpers.v1.d/getopts
@@ -64,6 +64,9 @@
 #
 # Requires YunoHost version 3.2.2 or higher.
 ynh_handle_getopts_args() {
+    # Trick to only re-enable debugging if it was set before
+    local xtrace_enable=$(set +o | grep xtrace)
+
     # Manage arguments only if there's some provided
     set +o xtrace # set +x
     if [ $# -ne 0 ]; then
@@ -197,9 +200,6 @@ ynh_handle_getopts_args() {
         if [ "${arguments[0]:0:1}" != "-" ]; then
             # If not, enter in legacy mode and manage the arguments as positionnal ones..
             # Dot not echo, to prevent to go through a helper output. But print only in the log.
-            set -x
-            echo "! Helper used in legacy mode !" > /dev/null
-            set +x
             local i
             for i in $(seq 0 $((${#arguments[@]} - 1))); do
                 # Try to use legacy_args as a list of option_flag of the array args_array
@@ -229,5 +229,5 @@ ynh_handle_getopts_args() {
             parse_arg "${arguments[@]}"
         fi
     fi
-    set -o xtrace # set -x
+    eval "$xtrace_enable"
 }

--- a/helpers/helpers.v1.d/setting
+++ b/helpers/helpers.v1.d/setting
@@ -125,6 +125,8 @@ ynh_app_setting_delete() {
 # [internal]
 #
 ynh_app_setting() {
+    # Trick to only re-enable debugging if it was set before
+    local xtrace_enable=$(set +o | grep xtrace)
     set +o xtrace # set +x
     ACTION="$1" APP="$2" KEY="$3" VALUE="${4:-}" python3 - << EOF
 import os, yaml, sys
@@ -150,7 +152,7 @@ else:
     with open(setting_file, "w") as f:
         yaml.safe_dump(settings, f, default_flow_style=False)
 EOF
-    set -o xtrace # set -x
+    eval "$xtrace_enable"
 }
 
 # Check availability of a web path

--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -397,17 +397,16 @@ ynh_user_list() {
 
 # Spawn a Bash shell with the app environment loaded
 #
-# usage: ynh_spawn_app_shell "appname"
+# usage: ynh_spawn_app_shell
 #
 # examples:
-#   ynh_spawn_app_shell "foobar" <<< 'echo "$USER"'
-#   ynh_spawn_app_shell "foobar" < /tmp/some_script.bash
+#   ynh_spawn_app_shell <<< 'echo "$USER"'
+#   ynh_spawn_app_shell < /tmp/some_script.bash
 #
 # The spawned shell will have environment variables loaded and environment files sourced
 # from the app's service configuration file (defaults to $app.service, overridable by the packager with `service` setting).
 # If the app relies on a specific PHP version, then `php` will be aliased that version. The PHP command will also be appended with the `phpflags` settings.
 ynh_spawn_app_shell() {
-    local app=$1
 
     # Force Bash to be used to run this helper
     [[ $0 =~ \/?bash$ ]] || ynh_die "Please use Bash as shell"
@@ -419,52 +418,49 @@ ynh_spawn_app_shell() {
     id -u "$app" &> /dev/null || ynh_die "There is no \"$app\" system user"
 
     # Make sure the app has an install_dir setting
-    local install_dir=$(ynh_app_setting_get --app=$app --key=install_dir)
-    [ -n "$install_dir" ] || ynh_die "$app has no install_dir setting (does it use packaging format >=2?)"
-
-    # Load the app's service name, or default to $app
-    local service=$(ynh_app_setting_get --app=$app --key=service)
-    [ -z "$service" ] && service=$app
+    [ -n "${install_dir:-}" ] || ynh_die "$app has no install_dir setting!"
 
     # Export HOME variable
     export HOME=$install_dir
 
-    # Load the Environment variables from the app's service
-    local env_var=$(systemctl show $service.service -p "Environment" --value)
-    [ -n "$env_var" ] && export $env_var
-
     # Force `php` to its intended version
     # We use `eval`+`export` since `alias` is not propagated to subshells, even with `export`
-    local phpversion=$(ynh_app_setting_get --app=$app --key=php_version)
-    local phpflags=$(ynh_app_setting_get --app=$app --key=phpflags)
-    if [ -n "$phpversion" ]; then
-        eval "php() { php${phpversion} ${phpflags} \"\$@\"; }"
+    if [ -n "${php_version:-}" ]; then
+        eval "php() { php${php_version} ${phpflags:-} \"\$@\"; }"
         export -f php
     fi
 
-    # Source the EnvironmentFiles from the app's service
-    local env_files=($(systemctl show $service.service -p "EnvironmentFiles" --value))
-    if [ ${#env_files[*]} -gt 0 ]; then
-        # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.
-        set -a
-        for file in ${env_files[*]}; do
-            [[ $file = /* ]] && source $file
-        done
-        set +a
+    # Load the app's service name, or default to $app
+    service=${service:-$app}
+    if systemctl list-units | grep -q "$service.service"
+    then
+        # Load the Environment variables from the app's service
+        local env_var=$(systemctl show $service.service -p "Environment" --value)
+        [ -n "${env_var:-}" ] && export $env_var
+
+        # Source the EnvironmentFiles from the app's service
+        local env_files=($(systemctl show $service.service -p "EnvironmentFiles" --value))
+        if [ ${#env_files[*]} -gt 0 ]; then
+            # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.
+            set -a
+            for file in ${env_files[*]}; do
+                [[ $file = /* ]] && source $file
+            done
+            set +a
+        fi
     fi
 
     # Activate the Python environment, if it exists
-    if [ -f $install_dir/venv/bin/activate ]; then
+    if [ -f "$install_dir/venv/bin/activate" ]; then
         # set -/+a enables and disables new variables being automatically exported. Needed when using `source`.
         set -a
-        source $install_dir/venv/bin/activate
+        source "$install_dir/venv/bin/activate"
         set +a
     fi
 
     # cd into the WorkingDirectory set in the service, or default to the install_dir
     local env_dir=$(systemctl show $service.service -p "WorkingDirectory" --value)
-    [ -z $env_dir ] && env_dir=$install_dir
-    cd $env_dir
+    cd "${env_dir:-$install_dir}"
 
     # Spawn the app shell
     su -s /bin/bash $app

--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -435,7 +435,7 @@ ynh_spawn_app_shell() {
 
     # Force `php` to its intended version
     # We use `eval`+`export` since `alias` is not propagated to subshells, even with `export`
-    local phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+    local phpversion=$(ynh_app_setting_get --app=$app --key=php_version)
     local phpflags=$(ynh_app_setting_get --app=$app --key=phpflags)
     if [ -n "$phpversion" ]; then
         eval "php() { php${phpversion} ${phpflags} \"\$@\"; }"

--- a/src/app.py
+++ b/src/app.py
@@ -1562,7 +1562,6 @@ def app_shell(app):
         app -- App ID
 
     """
-
     subprocess.run(
         [
             "/bin/bash",

--- a/src/app.py
+++ b/src/app.py
@@ -1752,7 +1752,6 @@ def app_ssowatconf():
 
         setting_path = os.path.join(APPS_SETTING_PATH, app_id)
         local_manifest = _get_manifest_of_app(setting_path)
-        helpers_version = local_manifest["integration"]["helpers_version"] 
 
         app_domain = uris[0].split("/")[0]
         # get "topest" domain

--- a/src/app.py
+++ b/src/app.py
@@ -1562,12 +1562,14 @@ def app_shell(app):
         app -- App ID
 
     """
+
     subprocess.run(
         [
             "/bin/bash",
             "-c",
             "source /usr/share/yunohost/helpers && ynh_spawn_app_shell " + app,
-        ]
+        ],
+        env=_make_environment_for_app_script(app)
     )
 
 
@@ -1750,6 +1752,7 @@ def app_ssowatconf():
 
         setting_path = os.path.join(APPS_SETTING_PATH, app_id)
         local_manifest = _get_manifest_of_app(setting_path)
+        helpers_version = local_manifest["integration"]["helpers_version"] 
 
         app_domain = uris[0].split("/")[0]
         # get "topest" domain


### PR DESCRIPTION
## The problem

YunoHost/issues#2467 - apps with helpers 2.1 don't get PHP sourced correctly in shell

## Solution

Use helpers 2.1 for spawning the shell

## PR Status

WFM

## How to test

1. Install `castopod` or `lychee`
2. `yunohost app shell castopod`
3. `php --version` should NOT be 7.4
