### PR TITLE
fix unset variable in helper 2.1 mysql

### DIFF
--- a/helpers/helpers.v2.1.d/mysql
+++ b/helpers/helpers.v2.1.d/mysql
@@ -33,10 +33,10 @@ ynh_mysql_db_shell() {
     local default_character_set=""
     if [[ -n "$database" ]]; then
         default_character_set=$(mysql -B $database <<< 'show variables like "character_set_database";' | tail -n1 | cut -f2)
-        default_character_set="--default-character-set=$character_set"
+        default_character_set="--default-character-set=$default_character_set"
     fi
 
-    mysql $character_set -B $database
+    mysql $default_character_set -B $database
 }
 
 # Create a database and grant optionnaly privilegies to a user
@@ -93,7 +93,7 @@ ynh_mysql_dump_db() {
     local default_character_set=""
     if [[ -n "$database" ]]; then
         default_character_set=$(mysql -B $database <<< 'show variables like "character_set_database";' | tail -n1 | cut -f2)
-        default_character_set="--default-character-set=$character_set"
+        default_character_set="--default-character-set=$default_character_set"
     fi
 
     mysqldump $default_character_set --single-transaction --skip-dump-date --routines "$database"


### PR DESCRIPTION
## The problem

During an upgrade of wordpress:

> WARNING - /usr/share/yunohost/helpers.v2.1.d/mysql: ligne 36: character_set : variable sans liaison

## Solution

I think there is a typo, replace `character_set` by `default_character_set` should fix the issue

## PR Status

...

## How to test

...
