### PR TITLE
Fix yaml hashtag handling from config panel's custom getter

### DIFF
--- a/helpers/helpers.v2.1.d/config
+++ b/helpers/helpers.v2.1.d/config
@@ -25,7 +25,7 @@ _ynh_app_config_get_one() {
     local getter="get__${short_setting}"
     # Get value from getter if exists
     if type -t $getter 2> /dev/null | grep -q '^function$' 2> /dev/null; then
-        old[$short_setting]="$($getter)"
+        old[$short_setting]="\"$($getter)\""
         formats[${short_setting}]="yaml"
 
     elif [[ "$bind" == *"("* ]] && type -t "get__${bind%%(*}" 2> /dev/null | grep -q '^function$' 2> /dev/null; then


### PR DESCRIPTION
## The problem

Cf. Point 1 there: https://github.com/YunoHost/issues/issues/2501

## Solution

Add quotes to the getter ouput so that `read_yaml` does not read `#` as a comment sign.

## PR Status

Tested successfully with fontcompare_ynh.
I also tried to run `yunohost app config get $app --full --debug` with a few other apps (including borg_ynh which has some custom getters defined, and YAML output looked clean for each of them (additional quotes did not seem to break anything).

## How to test
Before the fix:
- install fontcompare_ynh (not yet catalog, waiting for this issue to be solved): https://github.com/YunoHost-Apps/fontcompare_ynh
- go to app config panel in webadmin
- pick different colors than default's and save
- refresh page, you will notice that the color you chose have disappeared from config panel (although they have been correctly applied to the app)
- running `yunohost app config get fontcompare --full --debug` will show `None` as values for `background_color` and `font_color`. 

After the fix:
- running `yunohost app config get fontcompare --full --debug` will show `#{HTML_COLOR_CODE}` as values for `background_color` and `font_color`. 
