### PR TITLE
Use samesite lax for portal cookies

### DIFF
--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -252,7 +252,7 @@ class Authenticator(BaseAuthenticator):
             secure=True,
             httponly=True,
             path="/",
-            samesite="strict" if not is_dev else None,
+            samesite="lax" if not is_dev else None,
             domain=f".{request.get_header('host')}",
             max_age=SESSION_VALIDITY
             - 600,  # remove 1 minute such that cookie expires on the browser slightly sooner on browser side, just to help desimbuigate edge case near the expiration limit
@@ -305,7 +305,7 @@ class Authenticator(BaseAuthenticator):
             secure=True,
             httponly=True,
             path="/",
-            samesite="strict" if not is_dev else None,
+            samesite="lax" if not is_dev else None,
             domain=f".{request.get_header('host')}",
             max_age=SESSION_VALIDITY
             - 600,  # remove 1 minute such that cookie expires on the browser slightly sooner on browser side, just to help desimbuigate edge case near the expiration limit


### PR DESCRIPTION
## The problem

https://github.com/YunoHost-Apps/synapse_ynh/issues/497

After more investigation it seem to be related to the `samesite` settings of the `yunohost.portal` cookie.

So I did 2 test one with yunohost 11 and one with yunohost 12. With this process:
- Install synapse
- Install element (on the yunohost instance)
- Login on the SSO
- Try to login on matrix from the local element instance
  - Pass on Yunohost 11
  - Pass on Yunohost 12
- Try to login on matrix from https://app.element.io (which is a completely other domain)
  - Pass on Yunohost 11
  - Fail on Yunohost 12

Now try to do this small fix on yunohost 12 and see that it solve the issue. 

Note that there was already a discussion about this some year ago here: https://github.com/YunoHost/SSOwat/pull/103

## Solution

Use the same settings than on bullseye for the SSO cookie.

## PR Status

Tested and it fixed the issue

## How to test

Try to connect to a synapse server on a yunohost instance from https://app.element.io
