### PR TITLE
dns: add ionos to list of registrars

### DIFF
--- a/share/registrar_list.toml
+++ b/share/registrar_list.toml
@@ -344,6 +344,11 @@
     
     [inwx.auth_password]
     type = "password"
+
+[ionos]
+    [ionos.api_key]
+    type = "string"
+    redact = true
     
 [joker]
     [joker.auth_token]


### PR DESCRIPTION
This registrar is available in Lexicon 3.19.0+.

## The problem

ionos not yet in list of registrars

## Solution

Added it

## PR Status

Not sure

## How to test

Not sure
