### PR TITLE
Confusion between `NotImplemented` and `NotImplementedError`

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -1825,7 +1825,7 @@ class BackupMethod:
                         size=str(size),
                     )
                 )
-            except NotImplemented:
+            except NotImplementedError:
                 raise YunohostError("backup_unable_to_organize_files")
             else:
                 if i != "y" and i != "Y":
@@ -2323,7 +2323,7 @@ def backup_restore(name, system=[], apps=[], force=False):
                 i = Moulinette.prompt(
                     m18n.n("restore_confirm_yunohost_installed", answers="y/N")
                 )
-            except NotImplemented:
+            except NotImplementedError:
                 pass
             else:
                 if i == "y" or i == "Y":

--- a/src/tools.py
+++ b/src/tools.py
@@ -534,7 +534,7 @@ def tools_shutdown(operation_logger, force=False):
         try:
             # Ask confirmation for server shutdown
             i = Moulinette.prompt(m18n.n("server_shutdown_confirm", answers="y/N"))
-        except NotImplemented:
+        except NotImplementedError:
             pass
         else:
             if i.lower() == "y" or i.lower() == "yes":
@@ -553,7 +553,7 @@ def tools_reboot(operation_logger, force=False):
         try:
             # Ask confirmation for restoring
             i = Moulinette.prompt(m18n.n("server_reboot_confirm", answers="y/N"))
-        except NotImplemented:
+        except NotImplementedError:
             pass
         else:
             if i.lower() == "y" or i.lower() == "yes":


### PR DESCRIPTION
## The problem

Moulinette.prompt may raise NotImplementedError exception, but not NotImplemented, which is not an exception

prompt raise:
- [`NotEmplementedError`](https://github.com/YunoHost/moulinette/blob/61610ce976fc4fbdd77d5d988d5269c18c4c3f3b/moulinette/interfaces/api.py#L553)
- [`MoulinetteError`](https://github.com/YunoHost/moulinette/blob/61610ce976fc4fbdd77d5d988d5269c18c4c3f3b/moulinette/interfaces/cli.py#L569)
- [`MoulinetteValidationError`](https://github.com/YunoHost/moulinette/blob/61610ce976fc4fbdd77d5d988d5269c18c4c3f3b/moulinette/interfaces/cli.py#L636)

## Solution

...

## PR Status

...

## How to test

...
