### PR TITLE
Change default value of show_other_domains_apps to True

### DIFF
--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -27,7 +27,7 @@ i18n = "domain_config"
 
         [feature.portal.show_other_domains_apps]
         type = "boolean"
-        default = false
+        default = true
 
         [feature.portal.portal_title]
         type = "string"

--- a/src/portal.py
+++ b/src/portal.py
@@ -75,7 +75,7 @@ def _get_portal_settings(
         "portal_theme": "system",
         "portal_tile_theme": "simple",
         "portal_title": "YunoHost",
-        "show_other_domains_apps": False,
+        "show_other_domains_apps": True,
         "domain": domain,
     }
 


### PR DESCRIPTION
Not having other domains' apps is a special use case, and newbies will just want to see all apps.
It's more intuitive to set it to True
