### PR TITLE
Document the possibility of using regex in <permission>.url property

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -574,7 +574,7 @@ class PermissionsResource(AppResource):
     ```
 
     ### Properties (for each perm name)
-    - `url`: The relative URI corresponding to this permission. Typically `/` or `/something`. This property may be omitted for non-web permissions.
+    - `url`: The relative URI corresponding to this permission. Typically `/` or `/something`. This property may be omitted for non-web permissions. Can also be a regex, prefixed by `re:` like `re:/api/[A-Z]*$`.
     - `show_tile`: (default: `true` if `url` is defined) Wether or not a tile should be displayed for that permission in the user portal
     - `allowed`: (default: nobody) The group initially allowed to access this perm, if `init_{perm}_permission` is not defined in the manifest questions. Note that the admin may tweak who is allowed/unallowed on that permission later on, this is only meant to **initialize** the permission.
     - `auth_header`: (default: `true`) Define for the URL of this permission, if SSOwat pass the authentication header to the application. Default is true


### PR DESCRIPTION
## The problem

In manifest.toml, using regexp in `<permission>.url` [is implemented and works](https://github.com/YunoHost/yunohost/blob/54e5aaefa308c542d85d59bc443e858a45937731/src/permission.py#L387-L390), but [is a secret](https://doc.yunohost.org/en/packaging_apps_resources#properties-for-each-perm-), from documentation standpoint !

## Solution

Document it :)

## PR Status

Ready

