### PR TITLE
On CI tests, run apt update before install

### DIFF
--- a/.gitlab/ci/install.gitlab-ci.yml
+++ b/.gitlab/ci/install.gitlab-ci.yml
@@ -16,6 +16,7 @@ upgrade:
   extends: .install-stage
   image: "core-tests"
   script:
+    - apt update
     - DEBIAN_FRONTEND=noninteractive SUDO_FORCE_REMOVE=yes apt --assume-yes -o Dpkg::Options::="--force-confold" --allow-downgrades install ${CI_PROJECT_DIR}/*.deb
 
 
@@ -23,5 +24,6 @@ install-postinstall:
   extends: .install-stage
   image: "before-install"
   script:
+    - apt update
     - DEBIAN_FRONTEND=noninteractive SUDO_FORCE_REMOVE=yes apt --assume-yes -o Dpkg::Options::="--force-confold" --allow-downgrades install ${CI_PROJECT_DIR}/*.deb
     - yunohost tools postinstall -d domain.tld -u syssa -F 'Syssa Mine' -p the_password --ignore-dyndns --force-diskspace


### PR DESCRIPTION
This is required when our pull requests add new dependencies that were not installed in preinstall incus images
