### PR TITLE
Allow ignoring of YNH version.

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -869,6 +869,10 @@ app:
                     full: --force
                     help: Do not ask confirmation if the app is not safe to use (low quality, experimental or 3rd party), or when the app displays a post-install notification
                     action: store_true
+                -i:
+                    full: --ignore-yunohost-version
+                    help: Attempt to install the app even if your YunoHost version is below the required one
+                    action: store_true
 
         ### app_remove()
         remove:
@@ -907,6 +911,10 @@ app:
                 -c:
                     full: --continue-on-failure
                     help: Continue to upgrade apps even if one or more upgrade failed
+                    action: store_true
+                -i:
+                    full: --ignore-yunohost-version
+                    help: Attempt to install the app even if your YunoHost version is below the required one
                     action: store_true
 
         ### app_change_url()

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -914,7 +914,7 @@ app:
                     action: store_true
                 -i:
                     full: --ignore-yunohost-version
-                    help: Attempt to install the app even if your YunoHost version is below the required one
+                    help: Attempt to upgrade the app even if your YunoHost version is below the required one
                     action: store_true
 
         ### app_change_url()

--- a/src/app.py
+++ b/src/app.py
@@ -669,7 +669,7 @@ def app_upgrade(
                         "confirm_app_insufficient_ram", params=values, force=force
                     )
                 elif name == "required_yunohost_version" and ignore_yunohost_version:
-                    logger.warning(m18n.n(err **values))
+                    logger.warning(m18n.n(err, **values))
                 else:
                     raise YunohostValidationError(err, **values)
 

--- a/src/app.py
+++ b/src/app.py
@@ -1109,7 +1109,7 @@ def app_install(
                     "confirm_app_insufficient_ram", params=values, force=force
                 )
             elif name == "required_yunohost_version" and ignore_yunohost_version:
-                logger.warning(m18n.n(err **values))
+                logger.warning(m18n.n(err, **values))
             else:
                 raise YunohostValidationError(err, **values)
 

--- a/src/app.py
+++ b/src/app.py
@@ -542,6 +542,7 @@ def app_upgrade(
     force=False,
     no_safety_backup=False,
     continue_on_failure=False,
+    ignore_yunohost_version=False,
 ):
     """
     Upgrade app
@@ -667,6 +668,8 @@ def app_upgrade(
                     _ask_confirmation(
                         "confirm_app_insufficient_ram", params=values, force=force
                     )
+                elif name == "required_yunohost_version" and ignore_yunohost_version:
+                    logger.waring(m18n.n(err), **values)
                 else:
                     raise YunohostValidationError(err, **values)
 
@@ -1037,6 +1040,7 @@ def app_install(
     args=None,
     no_remove_on_failure=False,
     force=False,
+    ignore_yunohost_version=False,
 ):
     """
     Install apps
@@ -1104,6 +1108,8 @@ def app_install(
                 _ask_confirmation(
                     "confirm_app_insufficient_ram", params=values, force=force
                 )
+            elif name == "required_yunohost_version" and ignore_yunohost_version:
+                logger.waring(m18n.n(err), **values)
             else:
                 raise YunohostValidationError(err, **values)
 

--- a/src/app.py
+++ b/src/app.py
@@ -669,7 +669,7 @@ def app_upgrade(
                         "confirm_app_insufficient_ram", params=values, force=force
                     )
                 elif name == "required_yunohost_version" and ignore_yunohost_version:
-                    logger.waring(m18n.n(err), **values)
+                    logger.warning(m18n.n(err **values))
                 else:
                     raise YunohostValidationError(err, **values)
 
@@ -1109,7 +1109,7 @@ def app_install(
                     "confirm_app_insufficient_ram", params=values, force=force
                 )
             elif name == "required_yunohost_version" and ignore_yunohost_version:
-                logger.waring(m18n.n(err), **values)
+                logger.warning(m18n.n(err **values))
             else:
                 raise YunohostValidationError(err, **values)
 


### PR DESCRIPTION
## The problem

Some apps require 12.x even though they should work on 11.x.
The idea is to merge this to `dev` then backport to `bullseye`.

## Solution

Allow users to ignore required YNH version, even if it may break.

## PR Status

To be tested.

## How to test

Install Nextcloud 30.x on YNH 11.x
