### PR TITLE
Remove the tag docker from the code_quality workflow. It doesn't exist anymore.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,8 +13,6 @@ default:
   interruptible: true
 
 code_quality:
-  tags:
-    - docker
   rules:
     - if: $CI_COMMIT_TAG # Only for tags
 


### PR DESCRIPTION
…t anymore.

See https://about.gitlab.com/blog/2023/08/15/removing-tags-from-small-saas-runner-on-linux/

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
