### PR TITLE
[enh] UPNP: various fixes and improvements

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -200,13 +200,13 @@ class YunoUPnP:
         self.firewall.open_port("udp", self.UPNP_PORT, self.UPNP_PORT_COMMENT)
 
     def find_gid(self) -> bool:
-        upnpc = miniupnpc.UPnP()
-        upnpc.localport = self.UPNP_PORT
-        upnpc.discoverdelay = 3000
+        self.upnpc = miniupnpc.UPnP()
+        self.upnpc.localport = self.UPNP_PORT
+        self.upnpc.discoverdelay = 3000
         # Discover UPnP device(s)
         logger.debug("discovering UPnP devices...")
         try:
-            nb_dev = upnpc.discover()
+            nb_dev = self.upnpc.discover()
         except Exception:
             logger.warning("Failed to find any UPnP device on the network")
             nb_dev = -1
@@ -216,7 +216,7 @@ class YunoUPnP:
         logger.debug("found %d UPnP device(s)", int(nb_dev))
         try:
             # Select UPnP device
-            upnpc.selectigd()
+            self.upnpc.selectigd()
         except Exception:
             logger.debug("unable to select UPnP device", exc_info=1)
             return False

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -232,6 +232,8 @@ class YunoUPnP:
             logger.warning("Can't use UPnP to open '%s'" % port)
             return False
 
+        protocol = protocol.upper()
+
         # Clean the mapping of this port
         if self.upnpc.getspecificportmapping(port, protocol):
             try:
@@ -254,6 +256,13 @@ class YunoUPnP:
         if self.upnpc is None:
             self.find_gid()
         assert self.upnpc is not None
+
+        # FIXME: how should we handle port ranges ?
+        if not isinstance(port, int):
+            logger.warning("Can't use UPnP to open '%s'" % port)
+            return False
+
+        protocol = protocol.upper()
 
         if self.upnpc.getspecificportmapping(port, protocol):
             try:


### PR DESCRIPTION
## The problem

- typo `upnpc` -> `self.upnpc`
- `sudo yunohost firewall upnp --debug` was crashing with:
```
26   DEBUG   acquiring lock...
32   DEBUG   lock has been acquired
52   DEBUG   loading python module yunohost.firewall took 0.020s
52   DEBUG   processing action 'yunohost.firewall.upnp'
59   DEBUG   discovering UPnP devices...
3063 DEBUG   found 1 UPnP device(s)
3069 DEBUG   unable to add port 22 using UPnP
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/yunohost/firewall.py", line 245, in open_port
    self.upnpc.addportmapping(
Exception: UnknownError
3146 DEBUG   action executed in 3.094s
3146 DEBUG   lock has been released
3146 ERROR   Could not open port via UPnP
```
- Ports remained open when upnp was disabled

## Solution

- fix typo
- The `UnknownError` exception occurs when the protocol is not recognized. Use "TCP" instead of "tcp" (same for "UDP") fix the problem.
- Close all ports if they have been opened by us

## PR Status

Tested on my server

## How to test

...
