### PR TITLE
Fix "Both" protocol for firewall allow/disallow

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -405,9 +405,13 @@ def firewall_allow(
     no_reload: bool = False,
     reload_only_if_change: bool = False,
 ) -> None:
-    return firewall_open(
-        port, protocol.lower(), "", not no_upnp, no_reload, reload_only_if_change
-    )
+    if protocol == "Both":
+        firewall_open(port, "tcp", "", not no_upnp, no_reload, reload_only_if_change)
+        firewall_open(port, "udp", "", not no_upnp, no_reload, reload_only_if_change)
+    else:
+        firewall_open(
+            port, protocol.lower(), "", not no_upnp, no_reload, reload_only_if_change
+        )
 
 
 def firewall_disallow(
@@ -419,7 +423,13 @@ def firewall_disallow(
     no_reload: bool = False,
     reload_only_if_change: bool = False,
 ) -> None:
-    firewall_close(port, protocol.lower(), upnp_only, no_reload, reload_only_if_change)
+    if protocol == "Both":
+        firewall_close(port, "tcp", upnp_only, no_reload, reload_only_if_change)
+        firewall_close(port, "udp", upnp_only, no_reload, reload_only_if_change)
+    else:
+        firewall_close(
+            port, protocol.lower(), upnp_only, no_reload, reload_only_if_change
+        )
 
     if os.environ.get("YNH_APP_ACTION", "") == "remove":
         ports_to_keep = [53, 1900]


### PR DESCRIPTION
## The problem

"Both" is not accepted for the cmd:

`yunohost firewall allow Both 1234"

```
❯ sudo yunohost firewall allow Both 1234
Traceback (most recent call last):
  File "/usr/bin/yunohost", line 108, in <module>
    main()
  File "/usr/bin/yunohost", line 97, in main
    yunohost.cli(
  File "/usr/lib/python3/dist-packages/yunohost/__init__.py", line 41, in cli
    ret = moulinette.cli(
          ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/moulinette/__init__.py", line 140, in cli
    ).run(args, output_as=output_as, timeout=timeout)
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/cli.py", line 521, in run
    ret = self.actionsmap.process(args, timeout=timeout)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 579, in process
    return func(**arguments)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/firewall.py", line 461, in firewall_allow
    return firewall_open(
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/firewall.py", line 405, in firewall_open
    firewall.open_port(protocol, port, comment, upnp)
  File "/usr/lib/python3/dist-packages/yunohost/firewall.py", line 107, in open_port
    protocol, port = self._validate_port(protocol, port)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/firewall.py", line 101, in _validate_port
    raise ValueError(f"protocol should be tcp or udp, not {protocol}")
ValueError: protocol should be tcp or udp, not both
```

## Solution

...

## PR Status

Yolo commit

## How to test

...
