### PR TITLE
Displaying multiline data correctly in _ynh_app_config_show

### DIFF
--- a/helpers/helpers.v2.1.d/config
+++ b/helpers/helpers.v2.1.d/config
@@ -174,9 +174,9 @@ _ynh_app_config_show() {
         if [[ "${old[$short_setting]}" != YNH_NULL ]]; then
             if [[ "${formats[$short_setting]}" == "yaml" ]]; then
                 ynh_return "${short_setting}:"
-                ynh_return "$(echo "${old[$short_setting]}" | sed 's/^/  /g')"
+                ynh_return "$(echo -e "${old[$short_setting]}" | sed 's/^/  /g')"
             else
-                ynh_return "${short_setting}: '$(echo "${old[$short_setting]}" | sed "s/'/''/g" | sed ':a;N;$!ba;s/\n/\n\n/g')'"
+                ynh_return "${short_setting}: '$(echo -e "${old[$short_setting]}" | sed "s/'/''/g" | sed ':a;N;$!ba;s/\n/\n\n/g')'"
             fi
         fi
     done


### PR DESCRIPTION
## The problem

As of YNH 12.1.3, if a custom getter in an app returns a multiline string, it will eventually get displayed in the config panel input box (e.g. in text box) as a single line string.

## Solution

The proposed solution here is to change `echo` to `echo -e` in `_ynh_app_config_show()` helper so that it allows interpretation for newline characters.
Thus, multiline string output by the custom getter should be as such: `line1\n\nline2\n\nline3` (single newline character is not enough, likely due to other layers of code (not investigated in this PR but which remind me of https://github.com/YunoHost/issues/issues/2501).
That way it will get displayed in the config panel (tested for `text` input only) as:
```
line1
line2
line3
```  

## PR Status

Ready to merge as I don't believe it could impact negatively other custom getters.
Note that I am not very sure of when is actually triggered the portion of the modified helper after `else` instruction, maybe double newline would be too much here. 

TODO: update the doc depending on whether that PR is accepted: https://doc.yunohost.org/en/packaging_config_panels

## How to test

Cf. custom getter for `marl_ynh` config panel: https://github.com/YunoHost-Apps/marl_ynh/blob/31fbaad1c035630ed541361975c8af4d09025b8b/scripts/config#L76 

You can install the app and then run `yunohost app config get marl --full --debug` to see whether YAML output includes multiline or singleline entry for `archives_paths` parameter.