### PR TITLE
WIP: Introduce a new security issue list that is fetched alongside the app catalog, such that the diagnosis reports warnings/errors for older versions of apps or system packages vulnerable to known security issues

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -208,6 +208,8 @@
     "diagnosis_apps_not_in_app_catalog": "This application is not in YunoHost's application catalog. If it was in the past and was removed, you should consider uninstalling this app as it won't receive upgrades and may compromise the integrity and security of your system.",
     "diagnosis_apps_outdated_packaging_format": "This app uses a deprecated packaging format and will soon be unsupported by YunoHost. You should really consider upgrading it.",
     "diagnosis_apps_outdated_ynh_requirement": "This app's installed version only requires yunohost >= 2.x, 3.x or 4.x, which tends to indicate that it's not up to date with recommended packaging practices and helpers. You should really consider upgrading it.",
+    "diagnosis_apps_security_issue_warning": "Application {app} is currently in version '{installed_version}', which is vulnerable to a moderate security issue: {title}. It is recommended to upgrade to '{fixed_in_version}'. More infos: {more_infos}",
+    "diagnosis_apps_security_issue_error": "Application {app} is currently in version '{installed_version}', which is vulnerable to a MAJOR security issue: {title}. It is recommended to upgrade AS SOON AS POSSIBLE to version '{fixed_in_version}'. More infos: {more_infos}",
     "diagnosis_backports_in_sources_list": "It looks like apt (the package manager) is configured to use the backports repository. Unless you really know what you are doing, we strongly discourage installing packages from backports, because it's likely to create unstabilities or conflicts on your system.",
     "diagnosis_basesystem_hardware": "Server hardware architecture is {virt} {arch}",
     "diagnosis_basesystem_hardware_model": "Server model is {model}",


### PR DESCRIPTION
## The problem

Software regularly have security issues because computers™, but we lack a proper way to communicate to the users about the fact that their system may be vulnerable. Posts on the forum are nice but we can't just expect people to come and read the forum every week.

## Solution

cf draft in https://github.com/YunoHost/issues/issues/1438

The diagnosis should trigger a warning/error when finding that an app or system packages is installed and affected by the issue.

The `security.json` should be made available as `security.json` next to the catalog's `apps.json`

`security.json` could be derived from a TOML looking like (syntax to be validated etc) : 

```toml
[apps]
	
    # Two [[ ]] here, because each entry (app id) is associated with a *list* of such infos
    [[apps.opensondage]]
	title = "zomg big vulnerability"
	more_infos = "https://github.com/yunohost-apps/opensondage_ynh/issues/12345"
	fixed_in_version = "1.2.3~ynh1"
	level = "danger"

[system]

	[[system.dovecot]]
	title = "zomg big permission vulnerability"
	more_infos = ""
	fixed_in_version = "2.2.27-3+deb9u5"
	level = "warning"
```

## PR Status

Yoloimplemented

- [ ] collectively validate the syntax/infos for the `security.toml`
- [ ] actually test it
- [ ] implement the system package part
- [ ] we may want to use this to support the case of "app changed name" which can be somehow be argued to fit as a security issue i suppose, but with no `fixed_in_version` ?  we could have an optional `replaced_by: "new_app_id"` key/value
- [ ] ???

## How to test

...