### PR TITLE
fix ynh_apt_install_dependencies_from_extra_repository

### DIFF
--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -280,7 +280,7 @@ EOF
     local apps_auto_installed
     mapfile -t apps_auto_installed < <(apt-mark showauto "${packages[@]}")
     _ynh_apt_install "${packages[@]}"
-    if ((${#apps_auto_installed[@]} == 0)); then
+    if ((${#apps_auto_installed[@]} != 0)); then
         apt-mark auto "${apps_auto_installed[@]}"
     fi
 


### PR DESCRIPTION
## The problem

I had an error because `apt-mark auto` was called without any argument.

## Solution

We want a non-empty array here

## PR Status

...

## How to test

...
