### PR TITLE
Implement git in ynh_setup_source

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -634,5 +634,8 @@ function _ynh_git_clone() {
         else
             git reset --hard origin/"$branch"
         fi
+
+        git submodule update --init --recursive
+
     popd || return 1
 }

--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -616,16 +616,23 @@ function _ynh_git_clone() {
     local url="$1"
     local dest_dir="$2"
     local branch=${3:-master}
+    local commit="$4"
 
     mkdir -p "$dest_dir"
     pushd "$dest_dir" || return 1
         if ! [ -d "$dest_dir/.git" ]; then
             git init -q
             git remote add origin "$url"
-    else
+        else
             git remote set-url origin "$url"
-    fi
+        fi
+    
         git fetch -q --tags --prune origin "$branch"
-        git reset --hard origin/"$branch"
+    
+        if [ -n "$commit" ]; then
+            git checkout -q "$commit"
+        else
+            git reset --hard origin/"$branch"
+        fi
     popd || return 1
 }

--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -207,14 +207,7 @@ ynh_setup_source() {
     elif [[ "$src_format" == "docker" ]]; then
         "$YNH_HELPERS_DIR/vendor/docker-image-extract/docker-image-extract" -p "$src_platform" -o "$dest_dir" "$src_url" 2>&1
     elif [[ "$src_format" == "git" ]]; then
-        if [ -d "$dest_dir/.git" ]; then
-            chown -R root:root "$dest_dir"
-            git -C "$dest_dir" fetch --quiet
-        else
-            git clone "$src_url" "$dest_dir" --quiet
-        fi
-        git -C "$dest_dir" checkout "$src_sum" --quiet
-        git -C "$dest_dir" submodule update --init --recursive
+        _ynh_git_clone "$src_url" "$dest_dir" "master" "$src_sum"
     elif [[ "$src_format" == "zip" ]]; then
         # Zip format
         # Using of a temp directory, because unzip doesn't manage --strip-components

--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -207,6 +207,7 @@ ynh_setup_source() {
     elif [[ "$src_format" == "docker" ]]; then
         "$YNH_HELPERS_DIR/vendor/docker-image-extract/docker-image-extract" -p "$src_platform" -o "$dest_dir" "$src_url" 2>&1
     elif [[ "$src_format" == "git" ]]; then
+        chown -R root:root "$dest_dir"
         _ynh_git_clone "$src_url" "$dest_dir" "master" "$src_sum"
     elif [[ "$src_format" == "zip" ]]; then
         # Zip format

--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -148,7 +148,7 @@ ynh_setup_source() {
 
     if [ "$src_format" = "docker" ]; then
         src_platform="${src_platform:-"linux/$YNH_ARCH"}"
-    else
+    elif [ "$src_format" != "git" ]; then
         [ -n "$src_url" ] || ynh_die "Couldn't parse SOURCE_URL from $src_file_path ?"
 
         # If the file was prefetched but somehow doesn't match the sum, rm and redownload it
@@ -206,6 +206,15 @@ ynh_setup_source() {
         fi
     elif [[ "$src_format" == "docker" ]]; then
         "$YNH_HELPERS_DIR/vendor/docker-image-extract/docker-image-extract" -p "$src_platform" -o "$dest_dir" "$src_url" 2>&1
+    elif [[ "$src_format" == "git" ]]; then
+        if [ -d "$dest_dir/.git" ]; then
+            chown -R root:root "$dest_dir"
+            git -C "$dest_dir" fetch --quiet
+        else
+            git clone "$src_url" "$dest_dir" --quiet
+        fi
+        git -C "$dest_dir" checkout "$src_sum" --quiet
+        git -C "$dest_dir" submodule update --init --recursive
     elif [[ "$src_format" == "zip" ]]; then
         # Zip format
         # Using of a temp directory, because unzip doesn't manage --strip-components


### PR DESCRIPTION
## The problem
- Some packages require a git repository when building the app
- Some packages can't be handle simply with ynh_setup_source because the is some sub-git repository for example https://github.com/misskey-dev/misskey
- Some package upgrade would be improved if using git instead of `--keep="a directory with a lot of stuff"` for example: https://github.com/YunoHost-Apps/mastodon_ynh/issues/424
- Bored to see package linter warning `! Using 'git clone' is not recommended ... most forge do provide the ability to download a proper archive of the code for a specific commit. Please use the 'sources' resource in the manifest.toml in combination with ynh_setup_source. `

## Solution

Implement git in ynh_setup_source

## PR Status

Ready and working

## How to test

A proof of concept has been done on https://github.com/YunoHost-Apps/peertube-search-index_ynh/pull/47
