### PR TITLE
Fix `yunohost app shell` when `systemctl show` outputs ` (ignore_error=no)`

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -441,7 +441,7 @@ ynh_spawn_app_shell() {
 
         # Source the EnvironmentFiles from the app's service
         local -a env_files
-        mapfile -t env_files < <(systemctl show "$service.service" -p "EnvironmentFiles" --value | sed 's| (ignore_errors=yes)||')
+        mapfile -t env_files < <(systemctl show "$service.service" -p "EnvironmentFiles" --value | sed 's| (ignore_errors=\w*)||')
         if [ ${#env_files[*]} -gt 0 ]; then
             for file in "${env_files[@]}"; do
                 if [[ $file = /* ]]; then


### PR DESCRIPTION
## The problem

Similar issue to here: https://github.com/systemd/systemd/issues/14723

I got a case where `yunohost app shell` could not work. In fact, `systemctl show [...] -p EnvironmentFiles --value` returned `/path/to/somefile.env (ignore_error=no)`


## Solution

I just strip any string matching ` (ignore_error=...)`, assuming that it can only be followed by words and digits.

## PR Status

Ready

## How to test

`yunohost app shell <app>`

I can provide a more detailed example of how to reproduce if you want to (I am developing a package for which I got the issue).