### PR TITLE
Fix form prompt when option is a "choice" but with no options

### DIFF
--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -2153,9 +2153,10 @@ def prompt_or_validate_form(
                 value = prefilled_answers[option.id]
             elif interactive:
                 value = option.humanize(value, option)
-                choices = (
-                    option.choices if isinstance(option, BaseChoicesOption) else []
-                )
+                if isinstance(option, BaseChoicesOption) and option.choices is not None:
+                    choices = option.choices
+                else:
+                    choices = []
                 value = Moulinette.prompt(
                     message=option._get_prompt_message(value),
                     is_password=isinstance(option, PasswordOption),


### PR DESCRIPTION
prompt might be called with words = None instead of an empty list.

```
Unhandled exception in event loop:
  File "/usr/lib/python3/dist-packages/prompt_toolkit/buffer.py", line 1939, in new_coroutine
    await coroutine(*a, **kw)
  File "/usr/lib/python3/dist-packages/prompt_toolkit/eventloop/async_context_manager.py", line 79, in __aexit__
    await self.gen.athrow(typ, value, traceback)
  File "/usr/lib/python3/dist-packages/prompt_toolkit/eventloop/async_generator.py", line 42, in aclosing
    yield thing
  File "/usr/lib/python3/dist-packages/prompt_toolkit/buffer.py", line 1763, in async_completer
    async for completion in async_generator:
  File "/usr/lib/python3/dist-packages/prompt_toolkit/completion/base.py", line 326, in get_completions_async
    async for completion in completer.get_completions_async(
  File "/usr/lib/python3/dist-packages/prompt_toolkit/completion/base.py", line 202, in get_completions_async
    for item in self.get_completions(document, complete_event):
  File "/usr/lib/python3/dist-packages/prompt_toolkit/completion/word_completer.py", line 84, in get_completions
    for a in words:

Exception 'NoneType' object is not iterable
```