### PR TITLE
Fix tls_passthrough_list regex pattern, the regex should match the whole list and not individual elts?

### DIFF
--- a/share/config_global.toml
+++ b/share/config_global.toml
@@ -172,7 +172,7 @@ i18n = "global_settings_setting"
         [misc.tls_passthrough.tls_passthrough_list]
         type = "tags"
         # Regex is just <domain regex>;<destination>;<port>
-        pattern.regexp = '^(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}));(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?([^\W_]{2,}|[0-9]{1,3})));[0-9]{1,}$'
+        pattern.regexp = '^(?!,)(,?(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}));(([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?([^\W_]{2,}|[0-9]{1,3})));[0-9]{1,})+$'
         pattern.error = "You should specify a list of items formatted as DOMAIN;DESTINATION;DESTPORT, such as yolo.test;192.168.1.42;443"
         default = ""
         visible = "tls_passthrough_enabled"


### PR DESCRIPTION
## The problem

```
List of forwarding: repo.yunohost.org;repo.local;443,release-creator.yunohost.org;repo.local;443,install.yunohost.org;repo.local;443,build.yunohost.org;repo.local;443,forge.yunohost.org;repo.local;443
Error: You should specify a list of items formatted as DOMAIN;DESTINATION;DESTPORT, such as yolo.test;192.168.1.42;443
```

## Solution

pattern matches "no comma at the beginning" and then yeah, comma separated list