### PR TITLE
Fix nginx template for TLS passthrough

### DIFF
--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -43,7 +43,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     {% else %}
-    listen 127.0.0.1:444 ssl http2;
+    listen 127.0.0.1:444 ssl proxy_protocol;
     port_in_redirect off;
     set_real_ip_from 127.0.0.1/32;
     real_ip_header proxy_protocol;


### PR DESCRIPTION
The backend servers should listen with proxy_protocol, not http!

## The problem

> Code d’erreur : SSL_ERROR_RX_RECORD_TOO_LONG
