### PR TITLE
Fix helper `ynh_app_config_get_one`

### DIFF
--- a/helpers/helpers.v1.d/config
+++ b/helpers/helpers.v1.d/config
@@ -46,7 +46,7 @@ _ynh_app_config_get_one() {
     # Get multiline text from settings or from a full file
     elif [[ "$type" == "text" ]]; then
         if [[ "$bind" == "settings" ]]; then
-            old[$short_setting]="$(ynh_app_setting_get $app $short_setting)"
+            old[$short_setting]="$(ynh_app_setting_get --app="$app" --key="$short_setting")"
         elif [[ "$bind" == *":"* ]]; then
             ynh_die --message="For technical reasons, multiline text '${short_setting}' can't be stored automatically  in a variable file, you have to create custom getter/setter"
         else

--- a/helpers/helpers.v2.1.d/config
+++ b/helpers/helpers.v2.1.d/config
@@ -46,7 +46,7 @@ _ynh_app_config_get_one() {
     # Get multiline text from settings or from a full file
     elif [[ "$type" == "text" ]]; then
         if [[ "$bind" == "settings" ]]; then
-            old[$short_setting]="$(ynh_app_setting_get "$app" "$short_setting")"
+            old[$short_setting]="$(ynh_app_setting_get --app="$app" --key="$short_setting")"
         elif [[ "$bind" == *":"* ]]; then
             ynh_die "For technical reasons, multiline text '${short_setting}' can't be stored automatically  in a variable file, you have to create custom getter/setter"
         else


### PR DESCRIPTION
## The problem

`ynh_app_config_get_one $short_setting $type $bind` fails when `$type = "text"` and `$bind = "settings"` trigering a config panel read error.  

## Solution

This is due to current "subhelper" `_ynh_app_config_get_one` calling `ynh-app-setting-get` with the wrong syntax. It is now updated as per the syntax described both for [helpers v2.1](https://doc.yunohost.org/en/packaging_apps_helpers_v2.1#ynh-app-setting-get) and [helpers v1](https://github.com/YunoHost/yunohost/blob/6830ebc6cea29a2d713fab14f8cbdc02b134cde8/helpers/helpers.v1.d/setting#L23)

## PR Status

Tested successfully with both CLI (`yunohost app config get marl --full --debug`) & webUI (displaying config panel) using testing branch of `marl_ynh` in which `archives_paths` config option falls into the problematic case.