### PR TITLE
Fix BACKUP_CORE_ONLY not set

### DIFF
--- a/helpers/helpers.v2.1.d/backup
+++ b/helpers/helpers.v2.1.d/backup
@@ -56,7 +56,7 @@ ynh_backup() {
     # If backing up core only (used by ynh_backup_before_upgrade),
     # don't backup big data items
     if [[ "$is_data" == true && ("${do_not_backup_data:-0}" -eq 1 || ${BACKUP_CORE_ONLY:-0} -eq 1)   ]]; then
-        if [ "$BACKUP_CORE_ONLY" -eq 1 ]; then
+        if [ "${BACKUP_CORE_ONLY:-0}" -eq 1 ]; then
             ynh_print_info "$target will not be saved, because 'BACKUP_CORE_ONLY' is set."
         else
             ynh_print_info "$target will not be saved, because 'do_not_backup_data' is set."


### PR DESCRIPTION
## The problem

Issue [2512](https://github.com/YunoHost/issues/issues/2512)

## Solution

Add parameter substitution to BACKUP_CORE_ONLY

## PR Status

...

## How to test

...
