### PR TITLE
Document keywords in settings' keys that trigger value masking in the logs

### DIFF
--- a/helpers/helpers.v1.d/setting
+++ b/helpers/helpers.v1.d/setting
@@ -41,6 +41,9 @@ ynh_app_setting_get() {
 
 # Set an application setting
 #
+# When choosing the setting key name, note that including the following keywords will make the associated setting's value appear masked in the debug logs (cf. [related code](https://github.com/YunoHost/yunohost/blob/216210d5e97070b85c96ebb4548c6abf36987771/src/log.py#L571)): `pwd`, `pass`, `passwd`, `password`, `passphrase`, `secret\w*` (regex),  `\w+key` (regex), `token`, `PASSPHRASE` 
+# This is meant to allow sharing the logs while preserving confidential data, but having this in mind is useful would you expect to see those values while debugging your scripts.
+#
 # usage: ynh_app_setting_set --app=app --key=key --value=value
 # | arg: -a, --app=     - the application id
 # | arg: -k, --key=     - the setting name to set

--- a/helpers/helpers.v2.1.d/setting
+++ b/helpers/helpers.v2.1.d/setting
@@ -38,6 +38,9 @@ ynh_app_setting_get() {
 
 # Set an application setting
 #
+# When choosing the setting key name, note that including the following keywords will make the associated setting's value appear masked in the debug logs (cf. [related code](https://github.com/YunoHost/yunohost/blob/216210d5e97070b85c96ebb4548c6abf36987771/src/log.py#L571)): `pwd`, `pass`, `passwd`, `password`, `passphrase`, `secret\w*` (regex),  `\w+key` (regex), `token`, `PASSPHRASE` 
+# This is meant to allow sharing the logs while preserving confidential data, but having this in mind is useful would you expect to see those values while debugging your scripts.
+#
 # usage: ynh_app_setting_set --key=key --value=value
 # | arg: --app=     - the application id (global $app by default)
 # | arg: --key=     - the setting name to set


### PR DESCRIPTION
This is not such high-level info, but I couldn't think of a more relevant place for it to be seen.