### PR TITLE
add komgo to the exemption list of basic_auth

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1818,6 +1818,7 @@ def app_ssowatconf() -> None:
             "baikal",
             "ihatemoney",
             "keeweb",
+            "komga",
             "monica",
             "my_webdav",
             "nextcloud",


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/komga-premiere-install-et-sso-first-install-and-sso/36520/3?u=tho

## Solution

Add komga to the list

## PR Status

ready

## How to test

Adapt /usr/lib/python3/dist-packages/yunohost/app.py and install the app.
