### PR TITLE
conf_regen: nginx: Remove file left by the bookworm migration.

### DIFF
--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -160,6 +160,9 @@ do_pre_regen() {
     # disable default site
     mkdir -p "${nginx_dir}/sites-enabled"
     touch "${nginx_dir}/sites-enabled/default"
+
+    # Remove the file left by the bookworm migration
+    touch "${pending_dir}/usr/sbin/policy-rc.d"
 }
 
 do_post_regen() {

--- a/src/utils/udisks2_interfaces.py
+++ b/src/utils/udisks2_interfaces.py
@@ -109,7 +109,7 @@ class DiskResult:
 The following interfaces were generated using the `python -m sdbus gen-from-file` command.
 See: https://python-sdbus.readthedocs.io/en/latest/code_generator.html
 Udisks2's dbus interface descriptors are available at:
-https://github.com/storaged-project/udisks/blob/2.10.x-branch/data/org.freedesktop.UDisks2.xml  
+https://github.com/storaged-project/udisks/blob/2.10.x-branch/data/org.freedesktop.UDisks2.xml
 """
 
 
@@ -857,7 +857,9 @@ class NVMeController(  # type: ignore[call-arg]
         raise NotImplementedError
 
 
-class AtaDisk(Disk, AtaController): ...
+class AtaDisk(Disk, AtaController):
+    ...
 
 
-class NvmeDisk(Disk, NVMeController): ...
+class NvmeDisk(Disk, NVMeController):
+    ...


### PR DESCRIPTION
This file was tampering with the logrotate config of nginx. See https://github.com/YunoHost/issues/issues/2549

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
