### PR TITLE
Fix app_action_run operation logger instanciation

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1963,7 +1963,7 @@ def app_action_run(
             raise YunohostValidationError("Unknown app action {action}", raw_msg=True)
         return
     else:
-        operation_logger = OperationLogger("app_action_run", app)
+        operation_logger = OperationLogger("app_action_run", [("app", app)])
         AppConfigPanel, _ = _get_AppConfigPanel()
         config_panel = AppConfigPanel(app)
         return config_panel.run_action(


### PR DESCRIPTION
## The problem

I am trying to add a button in the config panel for Silverbullet ([commit](https://github.com/YunoHost-Apps/silverbullet_ynh/commit/50b3d9ebcb66d055c20e21d906c58261179ffff8)).
When I click on the button, I get the below error:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/moulinette/interfaces/api.py", line 430, in process
    ret = self.actionsmap.process(arguments, timeout=30, route=_route)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/moulinette/actionsmap.py", line 579, in process
    return func(**arguments)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/app.py", line 1964, in app_action_run
    operation_logger = OperationLogger("app_action_run", app)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 614, in __init__
    self.parent = self.parent_logger()
                  ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 648, in parent_logger
    return instance.name
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/yunohost/log.py", line 802, in name
    name.append(self.related_to[0][1])
                ~~~~~~~~~~~~~~~~~~^^^
IndexError: string index out of range
```

## Solution

`OperationLogger` constructor is called with the wrong argument type.
The second argument is expected to be an array of tuple.
Based on other call sites of the constructor, I have deduced the first element of the tuple should simply be `"app"`, but I am not 100% sure.

## PR Status

Ready to be reviewed

## How to test

Install Silverbullet in this commit: https://github.com/YunoHost-Apps/silverbullet_ynh/commit/50b3d9ebcb66d055c20e21d906c58261179ffff8

And click on the button "Fix the domain in notes".