### PR TITLE
[fix] Upnp open port only when open and upnp are enabled in conf

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -297,7 +297,7 @@ class YunoUPnP:
 
         for protocol in ["tcp", "udp"]:
             for port, info in firewall.config[protocol].items():
-                if self.enabled():
+                if self.enabled() and info["open"] and info["upnp"]:
                     status = status and self.open_port(protocol, port, info["comment"])
                 else:
                     status = status and self.close_port(protocol, port)


### PR DESCRIPTION
## The problem

Ports are open even when `open` or `upnp` field are set to `False`

## Solution

...

## PR Status

...

## How to test

...
