### PR TITLE
Resolve logger warnings

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -332,7 +332,7 @@ def tools_update(operation_logger, target=None):
         )
 
         # Filter boring message about "apt not having a stable CLI interface"
-        # Also keep track of wether or not we encountered a warning...
+        # Also keep track of whether or not we encountered a warning...
         warnings = []
 
         def is_legit_warning(m):
@@ -513,7 +513,7 @@ def tools_upgrade(operation_logger, target=None):
             # We do this so that the API / webadmin still gets the proper HTTP response
             # It's then up to the webadmin to implement a proper UX process to wait 10 sec and then auto-fresh the webadmin
             cmd = 'at -M now >/dev/null 2>&1 <<< "sleep 10; systemctl restart yunohost-api"'
-            # For some reason subprocess doesn't like the redirections so we have to use bash -c explicity...
+            # For some reason subprocess doesn't like the redirections so we have to use bash -c explicitly...
             subprocess.check_call(["bash", "-c", cmd])
 
         if returncode != 0:
@@ -544,7 +544,7 @@ def tools_shutdown(operation_logger, force=False):
 
     if shutdown:
         operation_logger.start()
-        logger.warn(m18n.n("server_shutdown"))
+        logger.warning(m18n.n("server_shutdown"))
         subprocess.check_call(["systemctl", "poweroff"])
 
 
@@ -562,7 +562,7 @@ def tools_reboot(operation_logger, force=False):
                 reboot = True
     if reboot:
         operation_logger.start()
-        logger.warn(m18n.n("server_reboot"))
+        logger.warning(m18n.n("server_reboot"))
         subprocess.check_call(["systemctl", "reboot"])
 
 
@@ -581,16 +581,16 @@ def tools_shell(command=None):
         exec(command)
         return
 
-    logger.warn("The \033[1;34mldap\033[0m interface is available in this context")
+    logger.warning("The \033[1;34mldap\033[0m interface is available in this context")
     try:
         from IPython import embed
 
         embed()
     except (ImportError, ModuleNotFoundError):
-        logger.warn(
+        logger.warning(
             "You don't have IPython installed, consider installing it as it is way better than the standard shell."
         )
-        logger.warn("Falling back on the standard shell.")
+        logger.warning("Falling back on the standard shell.")
 
         import readline  # will allow Up/Down/History in the console
 
@@ -639,7 +639,7 @@ def tools_migrations_list(pending=False, done=False):
     # Get all migrations
     migrations = _get_migrations_list()
 
-    # Reduce to dictionnaries
+    # Reduce to dictionaries
     migrations = [
         {
             "id": migration.id,
@@ -737,7 +737,7 @@ def tools_migrations_run(
         # migrations to be ran manually by the user, stop there and ask the
         # user to run the migration manually.
         if auto and migration.mode == "manual":
-            logger.warn(m18n.n("migrations_to_be_ran_manually", id=migration.id))
+            logger.warning(m18n.n("migrations_to_be_ran_manually", id=migration.id))
 
             # We go to the next migration
             continue
@@ -765,7 +765,7 @@ def tools_migrations_run(
             # require the --accept-disclaimer option.
             # Otherwise, go to the next migration
             if not accept_disclaimer:
-                logger.warn(
+                logger.warning(
                     m18n.n(
                         "migrations_need_to_accept_disclaimer",
                         id=migration.id,
@@ -782,7 +782,7 @@ def tools_migrations_run(
         operation_logger.start()
 
         if skip:
-            logger.warn(m18n.n("migrations_skip_migration", id=migration.id))
+            logger.warning(m18n.n("migrations_skip_migration", id=migration.id))
             migration.state = "skipped"
             _write_migration_state(migration.id, "skipped")
             operation_logger.success()
@@ -974,7 +974,7 @@ class Migration:
     def run(self):
         raise NotImplementedError()
 
-    # The followings shouldn't be overriden
+    # The followings shouldn't be overridden
 
     def __init__(self, id_):
         self.id = id_


### PR DESCRIPTION
## The problem
The `logger.warn` is deprecated so it throws annoying deprecation warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
## Solution
Migrates to `logger.warning`. Also fixes a few typos along the way.

## PR Status


## How to test
