### PR TITLE
[fix] Remove unavailable dns resolvers

### DIFF
--- a/conf/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/conf/dnsmasq/plain/resolv.dnsmasq.conf
@@ -18,23 +18,12 @@ nameserver 185.233.100.100
 nameserver 2a0c:e300::100
 nameserver 185.233.100.101
 nameserver 2a0c:e300::101
-# (DE) CCC Berlin
-nameserver 195.160.173.53
 # (DE) AS250
 nameserver 194.150.168.168
 # (DE) Ideal-Hosting
-nameserver 84.200.69.80
 nameserver 2001:1608:10:25::1c04:b12f
 nameserver 84.200.70.40
 nameserver 2001:1608:10:25::9249:d69b
-# (DK) censurfridns
-nameserver 91.239.100.100
-nameserver 2001:67c:28a4::
-nameserver 89.233.43.71
-nameserver 2a01:3a0:53:53::
-# Mullvad
-nameserver 194.242.2.2
-nameserver 2a07:e340::2
 # DNS4all
 nameserver 194.0.5.3
 nameserver 2001:678:8::3


### PR DESCRIPTION
## The problem
A lot of our dns resolvers list doesn't answer anymore (several german resolvers). Sometimes dnsmasq doesn't answer anymore...

## Solution

Remove them

Better solution: consider configuring an internal resolver with unbound to avoid this kind of mess

## PR Status

Ready

## How to test

...
