### PR TITLE
Provision database when calling ynh_redis_get_free_db

### DIFF
--- a/helpers/helpers.v2.1.d/redis
+++ b/helpers/helpers.v2.1.d/redis
@@ -41,6 +41,10 @@ ynh_redis_get_free_db() {
 
     test "$db" -eq -1 && ynh_die "No available Redis databases..."
 
+    # Reserve this Database by simply setting a string.
+    # Also let's indicate which app is used for debugging.
+    redis-cli -n "$db" SET __YNH_PROVISIONNED "$app"
+
     echo "$db"
 }
 


### PR DESCRIPTION
## The problem

When we call redis_get_free_db, the user may assume that it reserves the database returned. But in fact it does not until a key is created in this DB.
The result is the following:
 ```bash
 # Let's assume redis is fresly installed and thus empty
 redis_db_1=$(ynh_redis_get_free_db) # returns 1
 redis_db_2=$(ynh_redis_get_free_db) # returns 1 too
 ```

## Solution

This commit ensures that a key is set in the database. Furthermore, it is assigned to the name of the app, to facilitate the debugging.

## PR Status

I guess ready to be reviewed.

I have made a workaround to the issue involving the same logic: https://github.com/YunoHost-Apps/docs_ynh/pull/32

If I may criticize my own work, the function name makes think of a getter, which was the case until now (it now alters the state of the system).

I would agree if that PR gets rejected in favor of other approaches, like waiting for #2122 or implementing for the version 2.1 of the helper an alternate method that would have this signature instead: `ynh_redis_provision_redis --key="BASH_VAR_NAME_TO_BE_SET"`)

## How to test

 - Install this app with this commit: https://github.com/YunoHost-Apps/docs_ynh/commit/f494c27e57cd6c887c3da1bc4b7a49b5dfc17389
 - Inspect the values of `redis_db` and `celery_redis_db` in `/etc/yunohost/apps/docs/settings.yml` (or through `yunohost app setting docs XXX`)