### PR TITLE
Fix logos/icons initial fetch

### DIFF
--- a/src/app_catalog.py
+++ b/src/app_catalog.py
@@ -248,7 +248,7 @@ def _update_apps_catalog() -> None:
                 logger.debug(f"Failed to download logo {logo_hash} : {e}")
                 return False
 
-        results = ThreadPool(8).imap_unordered(fetch_logo, logos_to_download)
+        results = ThreadPool(2).imap_unordered(fetch_logo, logos_to_download)
         for result in results:
             # Is this even needed to iterate on the results ?
             pass


### PR DESCRIPTION
8 parallel downloads seem to trigger some anti-DoS and/or saturate https://apps.yunohost.org/ , making the update fail and leaving all icons broken without explanation except a weird ssl error in the logs (cf. below). Use a more reasonable default.

Not sure if there's anything to gain in parallelizing this kind of remote update in the first place.

Reports:
https://forum.yunohost.org/t/absence-dicone-pour-les-app/37708 https://forum.yunohost.org/t/app-catalog-does-not-load-logos/37727/3

Log:
2025-07-27 12:42:17,830 DEBUG    yunohost.app_catalog.fetch_logo - Failed to download logo c7216620e6bb965fae113aa37b0fb01878575962f20c0838b8ab4ecfdf13c804 : HTTPSConnectionPool(host='app.yunohost.org', port=443): Max retries exceeded with url: /default/v3/logos/c7216620e6bb965fae113aa37b0fb01878575962f20c0838b8ab4ecfdf13c804.png (Caused by SSLError(SSLZeroReturnError(6, 'TLS/SSL connection has been closed (EOF) (_ssl.c:992)')))

## The problem

...

## Solution

...

## PR Status

...

## How to test

...
