### PR TITLE
fix/tools_update: return upgradable apps, not all apps

### DIFF
--- a/src/tools.py
+++ b/src/tools.py
@@ -466,7 +466,7 @@ def tools_update(
 
     return {
         "system": upgradable_system_packages_per_categories,
-        "apps": apps,
+        "apps": upgradable_apps,
         "important_yunohost_upgrade": important_yunohost_upgrade,
         "pending_migrations": pending_migrations,
         "last_apt_update": last_apt_update_in_seconds,


### PR DESCRIPTION
## The problem

`apps` contains all the apps installed, not the upgradable ones

## Solution

use `upgradable_apps ` instead

## PR Status

...

## How to test

...
