### PR TITLE
helpers2.1: skip apt update when cache was already updated less than 30 minutes ago

### DIFF
--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -351,7 +351,7 @@ _ynh_apt() {
     # Optimization when just calling apt update : check if the cache was
     # already refreshed in the last 30 min, which should be enough and prevent
     # unecessary traffic and annoying wait time during app dependency installs etc
-    if [[ "$@" == "update" ]]
+    if [[ "$*" == "update" ]]
     then
         # trick from https://stackoverflow.com/a/205710
         local aptcache="/var/cache/apt/pkgcache.bin"


### PR DESCRIPTION
## The problem

It's annoying to wait like half a minute everytime you run app installs on low connectivity because of apt update

## Solution

Skip apt update when cache is not older than 30 minutes

## PR Status

Tested

## How to test

Run something like idk, my_webapp install two times in a row
