### PR TITLE
WIP: OIDC with Authelia

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -695,6 +695,7 @@
     "migrations_skip_migration": "Skipping migration {id}…",
     "migrations_success_forward": "Migration {id} completed",
     "migrations_to_be_ran_manually": "Migration {id} has to be run manually. Please go to Tools → Migrations on the webadmin page, or run `yunohost tools migrations run`.",
+    "must_provide_password_to_edit_user_profile": "You need to provide the user password to edit user informations.",
     "nftables_unavailable": "You cannot play with nftables here. You are either in a container or your kernel does not support it",
     "noninteractive_task": "Non-interactive task",
     "not_enough_disk_space": "Not enough free space on '{path}'",

--- a/share/actionsmap-portal.yml
+++ b/share/actionsmap-portal.yml
@@ -14,16 +14,22 @@ portal:
         me:
             action_help: Allow user to fetch their own infos
             api: GET /me
+            authentication:
+                api: null
 
         ### portal_apps()
         apps:
             action_help: Allow users to fetch lit of apps they have access to
             api: GET /me/apps
+            authentication:
+                api: null
 
         ### portal_update()
         update:
             action_help: Allow user to update their infos (display name, mail aliases/forward, password, ...)
             api: PUT /update
+            authentication:
+                api: null
             arguments:
                 --fullname:
                     help: The full name of the user. For example 'Camille Dupont'

--- a/src/portal.py
+++ b/src/portal.py
@@ -44,13 +44,14 @@ ADMIN_ALIASES = ["root", "admin", "admins", "webmaster", "postmaster", "abuse"]
 def _get_user_infos(
     user_attrs: list[str],
 ) -> tuple[str, str, dict[str, Any]]:
-    auth = Auth().get_session_cookie()
-    username = auth["user"]
+    from bottle import request
+    domain = request.get_header("host")
+    username = request.get_header("Ynh-User")
     result = _get_ldap_interface().search("ou=users", f"uid={username}", user_attrs)
     if not result:
         raise YunohostValidationError("user_unknown", user=username)
 
-    return username, auth["host"], result[0]
+    return username, domain, result[0]
 
 
 def _get_portal_settings(
@@ -136,7 +137,9 @@ def portal_public():
     portal_settings = _get_portal_settings()
 
     try:
-        Auth().get_session_cookie()
+        # TODO handle this case...
+        #Auth().get_session_cookie()
+        pass
     except Exception:
         if "portal_user_intro" in portal_settings:
             del portal_settings["portal_user_intro"]
@@ -313,6 +316,8 @@ def portal_update(
             raise YunohostValidationError("invalid_password", path="currentpassword")
     else:
         # Otherwise we use the encrypted password stored in the cookie
+        # TODO we need a to fix this case without having the password because authelia don't provide any password
+        raise NotImplemented()
         ldap_interface = LDAPInterface(
             username, Auth().get_session_cookie(decrypt_pwd=True)["pwd"]
         )


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/676

## Solution

Replace the current SSO (ssowat by Authelia with provide natively OIDC)

## PR Status

Work in progress

Related PR: https://github.com/YunoHost/yunohost-portal/pull/34

## How to test

- Checkout the branch
- Install Authelia

## TODO

- [x] (WIP) Fix portal API to work with Authelia
- [ ] add new authelia configuration
- [ ] handle the debian packaging of authelia as dependency
- [ ] rework nginx config
- [ ] migrate permission handling from ssowat to Authelia
- [ ] cleanup all dependency to ssowat and replace it with Authelia
- [ ] rework the way we handle the portal domain. With authelia the portal domain for example.com could be by example -auth.example. com, so we need to add a way to be able to define the portal domain for each main domains.
- [ ] provide a compatibility layer for nginx config of apps (ideally we need to provide it for packaging v1,v2) and we can maybe introduced a new recommended configuration for packaging v3 with breaking change ? cf #2070 
- [ ] provide a new resources for apps for OIDC configuration
- [ ] probably we need to write a migration for some stuff... ?