### PR TITLE
Add jinja filter to load and dump json, yaml and toml

### DIFF
--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -50,6 +50,25 @@
 # For a full documentation of jinja's syntax you can refer to [the official Jinja documentation](https://jinja.palletsprojects.com/en/3.1.x/templates/).
 #
 # Note that in YunoHost context, all variables are from shell variables and therefore are strings
+# To help handling complex data Jinja engine are executed with theses additional filters:
+# - from_json: load a string as Json and return an object
+# - from_yaml: load a string as Yaml and return an object
+# - from_toml: load a string as Toml and return an object
+# - to_json: serialize to string an object to Json
+# - to_yaml: serialize to string an object to Yaml
+# - to_toml: serialize to string an object to Toml
+#
+# So by example, if you want to convert a json string `$my_json` to Toml, you can to this way:
+# {{ my_json | from_json | to_toml }}
+# Or you can iterate on a Json list `my_list='["a", "b", "c"]'` this way:
+# {% for i in my_list | from_json %}
+#  value {{ i }}
+# {% endfor }}
+#
+# which will result:
+# value a
+# value b
+# value c
 #
 # ##### Keeping track of manual changes by the admin
 #
@@ -89,10 +108,12 @@ ynh_config_add() {
 
     if [[ "$jinja" == 1 ]]; then
         # This is ran in a subshell such that the "export" does not "contaminate" the main process
-        (   
+        (
             # shellcheck disable=SC2046
             export $(compgen -v)
-            j2 "$template_path" -f env -o "$destination"
+            j2 "$template_path" -f env \
+                --filters "$YNH_J2_FILTERS_FILE_PATH" \
+                -o "$destination"
         )
     else
         cp -f "$template_path" "$destination"

--- a/src/hook.py
+++ b/src/hook.py
@@ -29,6 +29,7 @@ from logging import getLogger
 
 from moulinette import Moulinette, m18n
 
+from .utils import jinja_filters
 from .utils.error import YunohostError, YunohostValidationError
 from .utils.file_utils import cp, read_yaml
 
@@ -473,6 +474,9 @@ def _hook_exec_bash(path, args, chdir, env, user, return_format, loggers):
     # Apps that need the HOME var should define it in the app scripts
     if "HOME" in _env:
         del _env["HOME"]
+
+    # Pass jinja filters path for template helper
+    env["YNH_J2_FILTERS_FILE_PATH"] = jinja_filters.__file__
 
     returncode = call_async_output(command, loggers, shell=False, cwd=chdir, env=_env)
 

--- a/src/utils/jinja_filters.py
+++ b/src/utils/jinja_filters.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2025 YunoHost Contributors
+#
+# This file is part of YunoHost (see https://yunohost.org)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import json
+import yaml
+import toml
+
+"""
+Set of jinja filter to improve the usage of Jinja when called from bash script with simple variable with string.
+The main issue is that when called from bash we can't pass complex data structure and sometime we to iterate over
+complexe data structure. Theses set of filters was made mainly to fix this issue and make it more natural the usage
+of the variable in the templates.
+"""
+
+
+def from_json(value: str):
+    """
+    Load a string as Json and return an object
+    """
+    return json.loads(value)
+
+
+def from_yaml(value: str):
+    """
+    Load a string as Yaml and return an object
+    """
+    return yaml.safe_load(value)
+
+
+def from_toml(value: str):
+    """
+    Load a string as Toml and return an object
+    """
+    return toml.loads(value)
+
+
+def to_json(value: object) -> str:
+    """
+    Serialize to string an object to Json
+    """
+    return json.dumps(value)
+
+
+def to_yaml(value: object) -> str:
+    """
+    Serialize to string an object to Yaml
+    """
+    return yaml.safe_dump(value)
+
+
+def to_toml(value) -> str:
+    """
+    Serialize to string an object to Toml
+    """
+    return toml.dumps(value)


### PR DESCRIPTION
## The problem

Iterating over complex data in template is a pain, because ne need delimiter and it's not strong solution

By example, this part of code could be simplified with jinja filters: https://github.com/YunoHost-Apps/forgejo_ynh/blob/75750de715f852989780ddb95f86d43410cc8253/scripts/login_source.sql#L34-L37

## Solution

Use json, toml or yaml serialization and decode in template with filters

## PR Status

Tested locally and it seem working

## How to test

Just made a file `test.j2` with: 
```
from json to yaml
{{ hellovar | from_json | to_yaml }}

from json to json

{{ hellovar | from_json | to_json }}

from json to toml

{{ hellovar | from_json | to_toml }}

from yaml to json

{{ hellovaryaml | from_yaml | to_json }}

from toml to json

{{ hellovartoml | from_toml | to_json }}
```
And then run `j2 test.j2 --filters /usr/lib/python3/dist-packages/yunohost/utils/jinja_filters.py`
