### PR TITLE
remove --message in helpers2.1

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -478,7 +478,7 @@ ynh_spawn_app_shell() {
 # | arg: -s, --size= - Amount of SWAP to add in Mb.
 ynh_add_swap() {
     if systemd-detect-virt --container --quiet; then
-        ynh_print_warn --message="You are inside a container/VM. swap will not be added, but that can cause troubles for the app $app. Please make sure you have enough RAM available."
+        ynh_print_warn "You are inside a container/VM. swap will not be added, but that can cause troubles for the app $app. Please make sure you have enough RAM available."
         return
     fi
 
@@ -498,7 +498,7 @@ ynh_add_swap() {
 
     # Swap on SD card only if it's is specified
     if ynh_is_main_device_a_sd_card && [ "$SD_CARD_CAN_SWAP" == "0" ]; then
-        ynh_print_warn --message="The main mountpoint of your system '/' is on an SD card, swap will not be added to prevent some damage of this one, but that can cause troubles for the app $app. If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
+        ynh_print_warn "The main mountpoint of your system '/' is on an SD card, swap will not be added to prevent some damage of this one, but that can cause troubles for the app $app. If you still want activate the swap, you can relaunch the command preceded by 'SD_CARD_CAN_SWAP=1'"
         return
     fi
 

--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -132,7 +132,7 @@ EOF
     # Install the fake package without its dependencies with dpkg --force-depends
     if ! LC_ALL=C dpkg-deb --build "${TMPDIR}/${app_ynh_deps}" "${TMPDIR}/${app_ynh_deps}.deb" > "${TMPDIR}/dpkg_log" 2>&1; then
         cat "${TMPDIR}/dpkg_log" >&2
-        ynh_die --message="Unable to install dependencies"
+        ynh_die "Unable to install dependencies"
     fi
     # Don't crash in case of error, because is nicely covered by the following line
     LC_ALL=C dpkg --force-depends --install "${TMPDIR}/${app_ynh_deps}.deb" 2>&1 | tee "${TMPDIR}/dpkg_log" || true


### PR DESCRIPTION
## The problem

"--message" comes with the message for some helpers2.1 (e.g. https://ci-apps-dev.yunohost.org/ci/job/12302)

## Solution

Remove them as they are not needed anymore.

## PR Status

Ready

## How to test

...
