### PR TITLE
fix (sse): logstreamcache files location

### DIFF
--- a/src/utils/sse.py
+++ b/src/utils/sse.py
@@ -154,7 +154,7 @@ class SSELogStreamingHandler(logging.Handler):
             # Start a new log stream cache, meant to be replayed for client opening
             # the SSE when an operation is already ongoing
             stream_file = (
-                Path(OPERATIONS_PATH) / f"/.{self.operation_id}.logstreamcache"
+                Path(OPERATIONS_PATH) / f".{self.operation_id}.logstreamcache"
             )
             self.log_stream_cache = stream_file.open("w")
         else:


### PR DESCRIPTION
## The problem

Fixes https://github.com/YunoHost/issues/issues/2648

## Solution

```python
>>> from pathlib import Path
>>> OPERATIONS_PATH = "/var/log/yunohost/operations/"
>>> test = "test"
>>> Path(OPERATIONS_PATH) / f"/.{test}.logstreamcache"
PosixPath('/.test.logstreamcache')
>>> Path(OPERATIONS_PATH) / f".{test}.logstreamcache"
PosixPath('/var/log/yunohost/operations/.test.logstreamcache')
```

## PR Status

...

## How to test

...
