### PR TITLE
fix (nftables): drop policy and allow icmpv6

### DIFF
--- a/conf/nftables/nftables.d/yunohost-firewall.tpl.conf
+++ b/conf/nftables/nftables.d/yunohost-firewall.tpl.conf
@@ -7,6 +7,7 @@ define udp_ports = { {{ udp_ports.strip().split(' ') | join(', ') }} }
 
 table inet filter {
     chain input {
+        policy drop;
         ct state related,established counter accept;
 
         tcp dport $tcp_ports counter accept;
@@ -16,5 +17,6 @@ table inet filter {
 
         iifname "lo" counter accept;
         ip protocol icmp counter accept;
+        ip6 nexthdr icmpv6 counter accept;
     }
 }


### PR DESCRIPTION
drop policy is needed, otherwise we do not restrict any traffic
icpmv6 is needed, otherwise servers do not answer to ping6

Cheers to @clement-parisot!

## PR Status

Ready

## How to test

...
