### PR TITLE
fix(nginx): remove deprecated OCSP

### DIFF
--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -60,14 +60,6 @@ server {
 
     more_set_headers "Strict-Transport-Security : max-age=63072000; includeSubDomains; preload";
     {%- endif %}
-    {%- if domain_cert_ca == "letsencrypt" %}
-    # OCSP settings
-    ssl_stapling on;
-    ssl_stapling_verify on;
-    ssl_trusted_certificate /etc/yunohost/certs/{{ domain }}/crt.pem;
-    resolver 1.1.1.1 9.9.9.9 valid=300s;
-    resolver_timeout 5s;
-    {%- endif %}
     {%- if mail_enabled == "True" %}
 
     location ^~ '/.well-known/autoconfig/mail/' {


### PR DESCRIPTION
Closes https://github.com/YunoHost/issues/issues/2593

## PR Status

Ready to merge

## How to test

...
