### PR TITLE
[enh] Suggest that some apps could not be installed on the same instance

### DIFF
--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -151,7 +151,7 @@ EOF
         if ((${#problematic_dependencies[@]} != 0)); then
             _ynh_apt_install "${problematic_dependencies[@]}" --dry-run 2>&1 | sed --quiet '/Reading state info/,$p' | grep -v "fix-broken\|Reading state info" >&2
         fi
-        ynh_die "Unable to install apt dependencies"
+        ynh_die "Unable to install apt dependencies, it might be due to a conflict with another app"
     }
     rm --recursive --force "$TMPDIR" # Remove the temp dir.
 


### PR DESCRIPTION
## The problem

Some apps have dependencies conflict between them. So it's only possible to install on the same instance one of the 2 apps in conflict .

Users doesn't understand that well, and we received bug report with title like "Cannot install this app". They don't give the list of apps on the instance so it's difficult to debug a log after months (the person has change the setup etc.)...

## Solution

Here we add a suggestion to explain why there is a dependencies conflict.

## PR Status
Ready

## How to test

...
