### PR TITLE
fix(helpers): YNH_J2_FILTERS_FILE_PATH may not exist

### DIFF
--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -111,7 +111,7 @@ ynh_config_add() {
         (   
             # shellcheck disable=SC2046
             export $(compgen -v)
-            if [ -z ${YNH_J2_FILTERS_FILE_PATH+x} ]; then
+            if [ -z "${YNH_J2_FILTERS_FILE_PATH:-}" ]; then
                 j2 "$template_path" -f env -o "$destination"
             else
                 j2 "$template_path" -f env \


### PR DESCRIPTION
## The problem
A uninitialized env var was blocking upgrade for apps like forgejo and element (maybe more but at least those)
`Warning: /usr/share/yunohost/helpers.v2.1.d/templating: line 114: YNH_J2_FILTERS_FILE_PATH : unbound variable`

## Solution
Test the existance of `YNH_J2_FILTERS_FILE_PATH`

## PR Status

...

## How to test

...
