### PR TITLE
fix/add upnp rules in the nftables conf

### DIFF
--- a/conf/nftables/nftables.d/yunohost-firewall.tpl.conf
+++ b/conf/nftables/nftables.d/yunohost-firewall.tpl.conf
@@ -15,6 +15,9 @@ table inet filter {
         udp dport $udp_ports counter accept;
         {% endif %}
 
+        udp sport 1900 udp dport >= 1024 ip6 saddr { fd00::/8, fe80::/10 } meta pkttype unicast limit rate 4/second burst 20 packets accept comment "Accept UPnP IGD port mapping reply"
+        udp sport 1900 udp dport >= 1024 ip saddr { 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16 } meta pkttype unicast limit rate 4/second burst 20 packets accept comment "Accept UPnP IGD port mapping reply"
+
         iifname "lo" counter accept;
         ip protocol icmp counter accept;
         ip6 nexthdr icmpv6 counter accept;


### PR DESCRIPTION
## The problem

UPnP is not working with the current firewall rules.

## Solution

Add rules to allow the port 1900 for UPnP.
Inspired by https://wiki.archlinux.org/title/Nftables#Workstation

## PR Status

...

## How to test

...
