### PR TITLE
Fix ynh_add_swap helper

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -522,8 +522,8 @@ ynh_add_swap() {
         # Create file
         truncate -s 0 "/swap_$app"
 
-        # set the No_COW attribute on the swapfile with chattr
-        chattr +C "/swap_$app"
+        # try to set the No_COW attribute on the swapfile with chattr (depending of the filesystem type)
+        chattr +C "/swap_$app" 2> /dev/null
 
         # Preallocate space for the swap file, fallocate may sometime not be used, use dd instead in this case
         if ! fallocate -l ${swap_size}K "/swap_$app"; then


### PR DESCRIPTION

## The problem

`chattr +C` is possible on a btrfs filesystem but for example produce an error on ext4
it could produce an error and stop the script even if it's not important

## Solution

Redirect its output to /dev/null and continue the script

## PR Status

...

## How to test

...
