### PR TITLE
Forms: serialize None values as empty string.

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1905,7 +1905,10 @@ def _get_AppConfigPanel():
             previous_settings: dict[str, Any],
             exclude: Union["AbstractSetIntStr", "MappingIntStrAny", None] = None,
         ) -> None:
-            env = {key: str(value) for key, value in form.dict().items()}
+            # Transform None to '', as None is not recognized as a value by Yaml and would be otherwise
+            # deserialized as a string ("None").
+            # The empty string is deserialized as None by form.py Option classes.
+            env = {key: str(value if value is not None else '') for key, value in form.dict().items()}
             return_content = self._call_config_script("apply", env=env)
 
             # If the script returned validation error


### PR DESCRIPTION
## The problem

Before this commit, None values were serialized into yaml as None, which is considered as a string by yaml.
This led to errors when deserializing (for example, when the option is a Number).

## Solution

With this commit, None values are serialized as empty strings, which are serialized as None by the BaseInputOption.

## PR Status

Ready!
(I don't see existing tests, if there are I will be happy to add some)

## How to test

#### Before applying the patch

Try this branch which is a proof of concept of the issue ([diff](https://github.com/YunoHost-Apps/borg_ynh/compare/test-config-empty-value?expand=1)):
```
yunohost app install https://github.com/YunoHost-Apps/borg_ynh/tree/test-config-empty-value
```

Configure as you wish, for example:
```
In which borg repository location do you want to backup your files ?: /tmp/
Provide a strong passphrase to encrypt your backups. No blank space: 
Should Borg backup your YunoHost configuration? [yes | no]: no
Should Borg backup emails and user home directories? [yes | no]: no
Which apps should Borg backup ?: borg
When and at which frequency should the backups be performed?: Daily
Do you want admin to receive mail notifications on backups ? [always | errors_only | never]: errors_only
```

Then set an empty value to the setting:
```
yunohost app config set borg__2 main.advanced.logs_retention -v ""
```

And then, try to read it:
```
# yunohost app config get borg__2 main.advanced.logs_retention
Error: Pick a valid value for the argument 'logs_retention': Must be a number
```

In the settings.yml, you get this line:
```yml
logs_retention: None
```

(None is considered as a string, therefore read as "None")

#### After applying the patch

Set again an empty value to the setting:
```
yunohost app config set borg__2 main.advanced.logs_retention -v ""
```

When you read it, you have no error:
```
# yunohost app config get borg__2 main.advanced.logs_retention
```

In the settings.yml, you get this line:
```yml
logs_retention: ''
```