### PR TITLE
fix: ynh_string_random could return empty strings if the filter is too restrictive

### DIFF
--- a/helpers/helpers.v1.d/string
+++ b/helpers/helpers.v1.d/string
@@ -39,9 +39,7 @@ ynh_string_random() {
     length=${length:-24}
     filter=${filter:-'A-Za-z0-9'}
 
-    dd if=/dev/urandom bs=1 count=1000 2> /dev/null \
-        | tr --complement --delete "$filter" \
-        | sed --quiet 's/\(.\{'"$length"'\}\).*/\1/p'
+    tr -dc "$filter" < /dev/urandom | head -c "$length"
 }
 
 # Substitute/replace a string (or expression) by another in a file

--- a/helpers/helpers.v2.1.d/string
+++ b/helpers/helpers.v2.1.d/string
@@ -36,9 +36,7 @@ ynh_string_random() {
     filter=${filter:-'A-Za-z0-9'}
     # ===========================================
 
-    dd if=/dev/urandom bs=1 count=1000 2> /dev/null \
-        | tr --complement --delete "$filter" \
-        | sed --quiet 's/\(.\{'"$length"'\}\).*/\1/p'
+    tr -dc "$filter" < /dev/urandom | head -c "$length"
 }
 
 # Substitute/replace a string (or expression) by another in a file


### PR DESCRIPTION
## The problem

While working on https://github.com/YunoHost-Apps/outline_ynh/pull/143, I discovered that the generated secrets (with `--filter=a-f0-9`) were oftentimes empty.
https://ci-apps-dev.yunohost.org/ci/job/12877

## Solution

@Salamandar proposed a way to make sure the required length is respected.

## PR Status

...

## How to test

...
