### PR TITLE
YNH_APP_ACTION is not guaranteed to be set

### DIFF
--- a/helpers/helpers.v2.1.d/utils
+++ b/helpers/helpers.v2.1.d/utils
@@ -64,7 +64,7 @@ ynh_abort_if_errors() {
 }
 
 # When running an app script, auto-enable ynh_abort_if_errors except for remove script
-if [[ "${YNH_CONTEXT:-}" != "regenconf" ]] && [[ "${YNH_APP_ACTION}" != "remove" ]]; then
+if [[ "${YNH_CONTEXT:-}" != "regenconf" ]] && [[ "${YNH_APP_ACTION:-}" != "remove" ]]; then
     ynh_abort_if_errors
 fi
 


### PR DESCRIPTION
## The problem

If one source the helpers with `set -u`, we have an error telling that `YNH_APP_ACTION` is empty.

## Solution

In other part of the code, we ensure to test its value defaulting to an empty string. Let's also do that here.

## PR Status

Ready

## How to test

Run `set -u` before sourcing the helpers:
```
root@ynh-dev:/ynh-dev# bash
root@ynh-dev:/ynh-dev# export YNH_HELPERS_VERSION=2.1
root@ynh-dev:/ynh-dev# set -eu
root@ynh-dev:/ynh-dev# source /usr/share/yunohost/helpers
bash: YNH_APP_ACTION: unbound variable
```
