### PR TITLE
fix(helpers): YNH_APP_BASEDIR missing for app shell

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1885,6 +1885,7 @@ def app_shell(app: str) -> None:
 
     env = _make_environment_for_app_script(app)
     env["PATH"] = os.environ["PATH"]
+    env["YNH_APP_BASEDIR"] = os.path.join(APPS_SETTING_PATH, app)
     subprocess.run(
         [
             "/bin/bash",


### PR DESCRIPTION
## The problem

```
yunohost app shell outline
cat: /home/titus/yunohost/manifest.toml: No such file or directory
outline@test:~$ echo $PATH
(PATH is missing the node directory)
```

## Solution

Add YNH_APP_BASEDIR in the environment.

```
yunohost app shell outline
outline@test:~$ echo $PATH
/opt/node_n/n/versions/node/20.19.5/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

## PR Status

Ready

## How to test

...
