### PR TITLE
Make app restore more easy to debug with no-remove-on-failure option

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1158,6 +1158,9 @@ backup:
                 --force:
                     help: Force restauration on an already installed system
                     action: store_true
+                --no-remove-on-failure:
+                    help: For app only, debug option to avoid removing the app on a failed restore
+                    action: store_true
 
         ### backup_list()
         list:

--- a/src/backup.py
+++ b/src/backup.py
@@ -865,7 +865,7 @@ class RestoreManager:
         return restore_manager.result
     """
 
-    def __init__(self, name, method="tar"):
+    def __init__(self, name, method="tar", no_remove_on_failure=False):
         """
         RestoreManager constructor
 
@@ -892,6 +892,7 @@ class RestoreManager:
         self.name = name
         self.method = BackupMethod.create(method, self)
         self.targets = BackupRestoreTargetsManager()
+        self.no_remove_on_failure = no_remove_on_failure
 
     #
     # Misc helpers                                                          #
@@ -1469,7 +1470,8 @@ class RestoreManager:
                 # Cleaning temporary scripts directory
                 shutil.rmtree(tmp_workdir_for_app, ignore_errors=True)
 
-                app_remove(app_instance_name, force_workdir=app_workdir)
+                if not self.no_remove_on_failure:
+                    app_remove(app_instance_name, force_workdir=app_workdir)
 
                 logger.error(failure_message_with_debug_instructions)
 
@@ -2202,7 +2204,7 @@ def backup_create(
     }
 
 
-def backup_restore(name, system=[], apps=[], force=False):
+def backup_restore(name, system=[], apps=[], force=False, no_remove_on_failure=False):
     """
     Restore from a local backup archive
 
@@ -2211,6 +2213,8 @@ def backup_restore(name, system=[], apps=[], force=False):
         force -- Force restauration on an already installed system
         system -- List of system parts to restore
         apps -- List of application names to restore
+        no_remove_on_failure -- Only for apps, avoid to remove the app in case of the restore fail.
+                                Mainly useful for debug
     """
 
     #
@@ -2226,7 +2230,7 @@ def backup_restore(name, system=[], apps=[], force=False):
     # Initialize                                                            #
     #
 
-    restore_manager = RestoreManager(name)
+    restore_manager = RestoreManager(name, no_remove_on_failure=no_remove_on_failure)
 
     restore_manager.set_system_targets(system)
     restore_manager.set_apps_targets(apps)

--- a/src/backup.py
+++ b/src/backup.py
@@ -1472,6 +1472,8 @@ class RestoreManager:
 
                 if not self.no_remove_on_failure:
                     app_remove(app_instance_name, force_workdir=app_workdir)
+                else:
+                    logger.error(f"The restore of {app_instance_name} failed, but was not cleaned up as requested by --no-remove-on-failure.")
 
                 logger.error(failure_message_with_debug_instructions)
 


### PR DESCRIPTION
## The problem

We have a possibility to avoid to remove the app if the app install fail. It's really useful for debuging. For app restore we don't have it and it could be not easy to understand why the restore fail when the app are removed.

## Solution

Add the same feature than for app install.

## PR Status

Ready but not tested at all.

## How to test

Try app restore of app which fail on restore.
