### PR TITLE
Helpers API PoC (NB : this is not intented to be merged)

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -629,3 +629,21 @@ function _ynh_git_clone() {
         git reset --hard origin/"$branch"
     popd || return 1
 }
+
+
+function ynh_new_systemctl() {
+    _ynh_helper_api "$@"
+}
+
+function _ynh_helper_api() {
+   local request="{\"cmd\": \"${FUNCNAME[1]}\", \"args\": \"$@\"}"
+   echo "Calling helper api with:"
+   echo "$request" | jq
+   cat <<< "$request" >&"$YNH_HELPERAPI_OUT"
+   local ret
+   read -u $YNH_HELPERAPI_IN ret
+
+   echo "Got return data:"
+   echo "$ret" | jq
+
+}

--- a/src/utils/process.py
+++ b/src/utils/process.py
@@ -21,6 +21,7 @@
 import logging
 import os
 import subprocess
+import json
 
 # FIXME: wtf ? what was that x_x
 # Prevent to import subprocess only for common classes
@@ -75,11 +76,19 @@ def call_async_output(args, callback, **kwargs) -> int | None:
     kwargs["stdout"] = LogPipe(callback[0], log_queue)
     kwargs["stderr"] = LogPipe(callback[1], log_queue)
     stdinfo = LogPipe(callback[2], log_queue) if len(callback) >= 3 else None
-    if stdinfo:
-        kwargs["pass_fds"] = [stdinfo.fdWrite]
+    helperapi = HelperAPI()
+
+    if stdinfo or helperapi:
         if "env" not in kwargs:
             kwargs["env"] = os.environ
-        kwargs["env"]["YNH_STDINFO"] = str(stdinfo.fdWrite)
+        kwargs["pass_fds"] = []
+        if stdinfo:
+            kwargs["pass_fds"] += [stdinfo.fdWrite]
+            kwargs["env"]["YNH_STDINFO"] = str(stdinfo.fdWrite)
+        if helperapi:
+            kwargs["pass_fds"] += [helperapi.fdWriteToYnh, helperapi.fdReadFromYnh]
+            kwargs["env"]["YNH_HELPERAPI_OUT"] = str(helperapi.fdWriteToYnh)
+            kwargs["env"]["YNH_HELPERAPI_IN"] = str(helperapi.fdReadFromYnh)
 
     if "env" in kwargs and not all(isinstance(v, str) for v in kwargs["env"].values()):
         logger.warning(
@@ -109,6 +118,8 @@ def call_async_output(args, callback, **kwargs) -> int | None:
         kwargs["stderr"].close()
         if stdinfo:
             stdinfo.close()
+        if helperapi:
+            helperapi.close()
 
     return p.poll()
 
@@ -128,6 +139,57 @@ else:
     from threading import Thread  # type: ignore[assignment]
 
     FileObjectThread = os.fdopen  # type: ignore[assignment,misc]
+
+
+def ynh_systemctl(args):
+    service, action = args.split()
+
+    p = subprocess.run(["systemctl", action, service])
+    return {"returncode": p.returncode, "data": {}, "error": {}}
+
+class HelperAPI(Thread):
+
+    def __init__(self):
+        """Setup the object with a logger and a loglevel
+        and start the thread
+        """
+        Thread.__init__(self)
+        self.daemon = False
+
+        self.fdReadFromScript, self.fdWriteToYnh = os.pipe()
+        self.fdReadFromYnh, self.fdWriteToScript = os.pipe()
+        self.pipeReaderFromScript = FileObjectThread(self.fdReadFromScript, "rb")
+
+        self.start()
+
+    def run(self):
+
+        helpers = {
+            "ynh_new_systemctl": ynh_systemctl
+        }
+
+        for cmd in iter(self.pipeReaderFromScript.readline, b""):
+            try:
+                cmd = json.loads(cmd.decode("utf-8").strip("\n"))
+            except Exception as e:
+                msg = f"Failed to parse cmd from helper API: {cmd}. Error: {e}"
+                logger.warning(msg)
+                ret = {"returncode": 128, "data": {}, "error": f}
+                os.write(self.fdWriteToScript, bytes((json.dumps(ret) + "\n").encode()))
+            else:
+                logger.info(f"Received cmd: {cmd}")
+                ret = helpers[cmd['cmd']](cmd['args'])
+                logger.info(f"Answering: {ret}")
+                os.write(self.fdWriteToScript, bytes((json.dumps(ret) + "\n").encode()))
+
+        self.pipeReaderFromScript.close()
+        os.close(self.fdWriteToScript)
+
+    def close(self):
+        os.close(self.fdWriteToYnh)
+        #os.close(self.fdWriteToScript)
+
+
 
 
 class LogPipe(Thread):  # type: ignore[valid-type,misc] # Don't know why mypy doesnt like this


### PR DESCRIPTION
## The problem

Followup of a discussion / experiment these past few days : I was doing some research about packaging v3, specifically the fact that

1. we want to reduce the bash helper codebase because it's hell to read, write, maintain, make it robust..
2. the fact that the scripts are to be run as root but there are clearly a few situations where we'll want to run a few things requiring root privileges (for example : defining/updating a setting, calling "systemctl restart" or whatev)

of course there's the `before/after_<action>_as_root` but it'll probably be cumbersome to rely on this only for recurring actions such as updating settings etc ... there's also the idea of adding temporary sudo permissions but not great from a security pov because it's hard to properly define the perimeter of what should be allowed and what shouldnt be (+ the risk that the temporary sudo isnt reverted somehow)

Anyway I had this idea that the bash script could "order" some actions to the yunohost process (which does run as root). I made a POC to add the proper file descriptors for bi-directional communication between the script and the yunohost process, it seems to be working fine so i think i'll continue digging this idea


## Solution

...

## PR Status

...

## How to test

This PR + this test snippet : 

```bash
YNH_HELPERS_VERSION=2.1
source /usr/share/yunohost/helpers

ynh_new_systemctl postfix restart

sleep 3

ynh_new_systemctl dovecot restart

echo "Script completed"
```

And then assuming the snippet was created as `/root/tests.sh` : 

```
python3 -c "import logging;
logging.basicConfig();
callbacks = [lambda l: print('INFO:', l), lambda l: print('WARN:', l)];
from yunohost.utils.process import call_async_output;
call_async_output(['bash', '/root/tests.sh'], callbacks)"
```

yield : 

```
INFO: Calling helper api with:
INFO: {
INFO:   "cmd": "ynh_new_systemctl",
INFO:   "args": "postfix restart"
INFO: }
INFO: Got return data:
INFO: {
INFO:   "returncode": 0,
INFO:   "data": {},
INFO:   "error": {}
INFO: }
INFO: Calling helper api with:
INFO: {
INFO:   "cmd": "ynh_new_systemctl",
INFO:   "args": "dovecot restart"
INFO: }
INFO: Got return data:
INFO: {
INFO:   "returncode": 0,
INFO:   "data": {},
INFO:   "error": {}
INFO: }
INFO: Script completed
```

(not sure why we don't see the messages from the core but whatev)

