### PR TITLE
fix a typo in ruby helper

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1809,7 +1809,7 @@ class RubyAppResource(AppResource):
             # Use half of available CPUs for compiling
             # The trick with 1 + ...  -1 is to prevent having '0' when there's only one CPU available.
             NB_CPU_TO_USE="$(( 1 + ($(grep -c ^processor /proc/cpuinfo) - 1) / 2 ))"
-            export MAKE_OPTS="-j$(NB_CPU_TO_USE)"
+            export MAKE_OPTS="-j$NB_CPU_TO_USE"
             {self.rbenv} install --skip-existing '{ruby_version}' 2>&1
             if {self.rbenv} alias --list | grep --quiet '{self.app} '; then
                 {self.rbenv} alias {self.app} --remove


### PR DESCRIPTION
## The problem

```
23617 WARNING ./provision_or_update_ruby: line 11: NB_CPU_TO_USE: command not found
```

## Solution

...

## PR Status

Ready

## How to test

...
