### PR TITLE
[HELPER] Set ynh default php version to default debian php version

### DIFF
--- a/helpers/helpers.v2.1.d/php
+++ b/helpers/helpers.v2.1.d/php
@@ -19,7 +19,11 @@
 #
 
 # (this is used in the apt helpers, big meh ...)
-readonly YNH_DEFAULT_PHP_VERSION=7.4
+DEBIAN_DEFAULT_PHP_VERSION=$(curl -fsSL "https://packages.debian.org/$YNH_DEBIAN_VERSION/php" \
+    | grep -Eo "/$YNH_DEBIAN_VERSION/php[0-9].[0-9]" \
+    | tail -n1 | sed "s@^/$YNH_DEBIAN_VERSION/php@@")
+    
+readonly YNH_DEFAULT_PHP_VERSION=$( [[ ! -z ${DEBIAN_DEFAULT_PHP_VERSION} ]] && echo ${DEBIAN_DEFAULT_PHP_VERSION} || echo "8.2" )
 
 # Create a dedicated PHP-FPM config
 #

--- a/helpers/helpers.v2.1.d/php
+++ b/helpers/helpers.v2.1.d/php
@@ -19,9 +19,7 @@
 #
 
 # (this is used in the apt helpers, big meh ...)
-DEBIAN_DEFAULT_PHP_VERSION=$(curl -fsSL "https://packages.debian.org/$YNH_DEBIAN_VERSION/php" \
-    | grep -Eo "/$YNH_DEBIAN_VERSION/php[0-9].[0-9]" \
-    | tail -n1 | sed "s@^/$YNH_DEBIAN_VERSION/php@@")
+DEBIAN_DEFAULT_PHP_VERSION=$(apt-cache depends php | grep -Eo "php[0-9].[0-9]" | sed "s@^php@@")
     
 readonly YNH_DEFAULT_PHP_VERSION=$( [[ ! -z ${DEBIAN_DEFAULT_PHP_VERSION} ]] && echo ${DEBIAN_DEFAULT_PHP_VERSION} || echo "8.2" )
 


### PR DESCRIPTION
## The problem

current default php version for ynh is 7.4 and does not rely to default debian php version

## Solution

retrieve the debian default php version and use it
(not sure that the curl command is the best way but it's a working idea)

## PR Status

...

## How to test

I use it here : https://github.com/YunoHost-Apps/zwiicms_ynh/blob/1c96e467db03d66f1c17b90483fe5ae5ee2c4cdf/manifest.toml#L75
