### PR TITLE
Fix lexicon complaint?

### DIFF
--- a/src/dns.py
+++ b/src/dns.py
@@ -723,28 +723,24 @@ def domain_dns_push(
         registrar: registrar_credentials,
     }
 
-    # Ugly hack to be able to fetch all record types at once:
-    # we initialize a LexiconClient with a dummy type "all"
-    # (which lexicon doesnt actually understands)
-    # then trigger ourselves the authentication + list_records
-    # instead of calling .execute()
-    query = (
-        LexiconConfigResolver()
-        .with_dict(dict_object=base_config)
-        .with_dict(dict_object={"action": "list", "type": "all"})
-    )
-    client = LexiconClient(query)
+    # Get only records for relevant types: A, AAAA, MX, TXT, CNAME, SRV
+    relevant_types = ["A", "AAAA", "MX", "TXT", "CNAME", "SRV", "CAA"]
+    current_records = []
 
-    try:
-        current_records = client.execute()
-    except Exception as e:
-        raise YunohostError("domain_dns_push_failed_to_list", error=str(e))
+    for rtype in relevant_types:
+        query = (
+            LexiconConfigResolver()
+            .with_dict(dict_object=base_config)
+            .with_dict(dict_object={"action": "list", "type": rtype})
+        )
+        client = LexiconClient(query)
+
+        try:
+            current_records.extend(client.execute())
+        except Exception as e:
+            raise YunohostError("domain_dns_push_failed_to_list", error=str(e))
 
     managed_dns_records_hashes = _get_managed_dns_records_hashes(domain)
-
-    # Keep only records for relevant types: A, AAAA, MX, TXT, CNAME, SRV
-    relevant_types = ["A", "AAAA", "MX", "TXT", "CNAME", "SRV", "CAA"]
-    current_records = [r for r in current_records if r["type"] in relevant_types]
 
     # Ignore records which are for a higher-level domain
     # i.e. we don't care about the records for domain.tld when pushing yuno.domain.tld

--- a/src/dns.py
+++ b/src/dns.py
@@ -734,15 +734,9 @@ def domain_dns_push(
         .with_dict(dict_object={"action": "list", "type": "all"})
     )
     client = LexiconClient(query)
-    try:
-        client.provider.authenticate()
-    except Exception as e:
-        raise YunohostValidationError(
-            "domain_dns_push_failed_to_authenticate", domain=domain, error=str(e)
-        )
 
     try:
-        current_records = client.provider.list_records()
+        current_records = client.execute()
     except Exception as e:
         raise YunohostError("domain_dns_push_failed_to_list", error=str(e))
 


### PR DESCRIPTION
## The problem

Multiple complaints in the forums.

## Solution

Get rid of obsolete hack (`provider` is becoming progressively more private API) and just query for relevant records in a loop, burns more API calls but what can you do?

## PR Status

```
# yunohost domain dns push domain.tld
Info: Pushing DNS records…
Info: [....................] > create   A   / *
Info: [#...................] > create   A   / chat
Info: [#...................] > create   A   / @
Info: [##..................] > create   A   / linkwarden
Info: [###.................] > create   A   / penpot
Info: [###.................] > create   A   / readeck
Info: [####................] > create   A   / td1
Info: [#####...............] > create  CAA  / @
Info: [#####...............] > create  MX   / chat
Info: [######..............] > create  MX   / @
Info: [######..............] > create  MX   / linkwarden
Info: [#######.............] > create  MX   / penpot
Info: [########............] > create  MX   / readeck
Info: [########............] > create  MX   / td1
Info: [#########...........] > create  TXT  / _dmarc.chat
Info: [##########..........] > create  TXT  / _dmarc
Info: [##########..........] > create  TXT  / _dmarc.linkwarden
Info: [###########.........] > create  TXT  / _dmarc.penpot
Info: [###########.........] > create  TXT  / _dmarc.readeck
Info: [############........] > create  TXT  / _dmarc.td1
Info: [#############.......] > create  TXT  / chat
Info: [#############.......] > create  TXT  / @
Info: [##############......] > create  TXT  / linkwarden
Info: [###############.....] > create  TXT  / mail._domainkey.chat
Info: [###############.....] > create  TXT  / mail._domainkey
Info: [################....] > create  TXT  / mail._domainkey.linkwarden
Info: [################....] > create  TXT  / mail._domainkey.penpot
Info: [#################...] > create  TXT  / mail._domainkey.readeck
Info: [##################..] > create  TXT  / mail._domainkey.td1
Info: [##################..] > create  TXT  / penpot
Info: [###################.] > create  TXT  / readeck
Info: [####################] > create  TXT  / td1
Success! DNS records updated!
root@circledsquareroot:/# yunohost domain dns suggest domain.tld
Info: This command shows you the *recommended* configuration. It does not actually set up the DNS configuration for you. It is your responsability to configure your DNS zone in your registrar according to this recommendation.
; Basic ipv4/ipv6 records
@ 3600 IN A 11.22.33.44
chat 3600 IN A 11.22.33.44
linkwarden 3600 IN A 11.22.33.44
penpot 3600 IN A 11.22.33.44
readeck 3600 IN A 11.22.33.44
td1 3600 IN A 11.22.33.44

; Mail
@ 3600 IN MX 10 domain.tld.
@ 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc 3600 IN TXT "v=DMARC1; p=none"
chat 3600 IN MX 10 chat.domain.tld.
chat 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey.chat 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc.chat 3600 IN TXT "v=DMARC1; p=none"
linkwarden 3600 IN MX 10 linkwarden.domain.tld.
linkwarden 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey.linkwarden 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc.linkwarden 3600 IN TXT "v=DMARC1; p=none"
penpot 3600 IN MX 10 penpot.domain.tld.
penpot 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey.penpot 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc.penpot 3600 IN TXT "v=DMARC1; p=none"
readeck 3600 IN MX 10 readeck.domain.tld.
readeck 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey.readeck 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc.readeck 3600 IN TXT "v=DMARC1; p=none"
td1 3600 IN MX 10 td1.domain.tld.
td1 3600 IN TXT "v=spf1 a mx -all"
mail._domainkey.td1 3600 IN TXT "v=DKIM1; h=sha256; k=rsa; p=<key>"
_dmarc.td1 3600 IN TXT "v=DMARC1; p=none"



; Extra
* 3600 IN A 11.22.33.44
@ 3600 IN CAA 0 issue "letsencrypt.org"
```

Success?

## How to test

1. Replace the file
2. Add domain
3. Remove domain
4. See domain.tld for suggestions
5. Push the suggestions
7. ...
8. Profit?
