### PR TITLE
Inherit TERM from calling shell

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1886,6 +1886,7 @@ def app_shell(app: str) -> None:
     env = _make_environment_for_app_script(app)
     env["PATH"] = os.environ["PATH"]
     env["YNH_APP_BASEDIR"] = os.path.join(APPS_SETTING_PATH, app)
+    env["TERM"] = os.environ.get("TERM", "xterm-256color")
     subprocess.run(
         [
             "/bin/bash",


### PR DESCRIPTION
## The problem

`yunohost app shell <app>` does not support colors, has broken `nano` etc

## Solution

Inherit `TERM` env variable

## PR Status

`ls --color` works :shrug:

## How to test

`sudo yunohost app shell <app>` and see if term appears borked
