### PR TITLE
[fix] Return a fail code if a mono upgrade failed

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1233,12 +1233,8 @@ def app_upgrade(
                 app_, current_manifest, new_manifest, workdir, no_safety_backup
             )
         except YunohostError as e:
-            # If upgrading a single app from the webadmin : re-raise the Exception
-            if (
-                Moulinette.interface.type == "api"
-                and raw_requested_targets
-                and len(requested_targets) == 1
-            ):
+            # If upgrading a single app : re-raise the Exception
+            if raw_requested_targets and len(requested_targets) == 1:
                 raise e
 
             failed_to_upgrade_apps[app_] = str(e)


### PR DESCRIPTION
## The problem

The CI says green even if some app upgrade failed (and the app page is curlable with 200 status code...)

## Solution

Return an error code by raising an execption if we upgrade only one app

## PR Status

Testing

## How to test

...
