### PR TITLE
[fix] ynh_spawn_app_shell: ensure to list all units, including dead/empty ones

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -434,7 +434,7 @@ ynh_spawn_app_shell() {
 
     # Load the app's service name, or default to $app
     service=${service:-$app}
-    if systemctl list-units | grep -q "$service.service"; then
+    if systemctl list-units -a | grep -q "$service.service"; then
         # Load the Environment variables from the app's service
         local env_var=$(systemctl show "$service.service" -p "Environment" --value)
         [ -n "${env_var:-}" ] && export "${env_var?}"


### PR DESCRIPTION
## The problem

Some services like borg are only run at regular intervals, but the rest of the time are inactive (dead).

But still they have a systemd service that can be read and whose env variables can be retrieved from it.

steps to reproduce:
1. Use borg version `1.4.1~ynh3`, you may run `yunohost app shell borg` and then `borg list`
2. Use the testing branch as of today (PR: https://github.com/YunoHost-Apps/borg_ynh/pull/230) which includes the migration to helpers 2.1, you may run `yunohost app shell borg` but can't run `borg list` anymore.

The reason is that the `$PATH` env variable as set by the service is not loaded.

## Solution

For this, use the `-a` option to list all services, including the dead ones.

## PR Status

Ready!

## How to test

Use the testing branch, use the patched version of the helper, and try again the step 2 described above.