### PR TITLE
Add GREP env variable to filter tests to run

### DIFF
--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -73,6 +73,9 @@ done
 
 # Hack to list all known function, keep only those starting by ynhtest_
 TESTS=$(declare -F | grep ' ynhtest_' | awk '{print $3}')
+if [ -n "${GREP:-}" ]; then
+    TESTS="$(grep -i "$GREP" <<< "$TESTS")"
+fi
 
 global_result=0
 


### PR DESCRIPTION
## The problem

It takes long to run all the helpers tests

## Solution

Add a `GREP` env variable to filter the tests to run.

## PR Status

Ready to be reviewed

## How to test

Usage to grep for example `ynhtest_jinja_template_app_config` and `ynhtest_simple_template_app_config`:
```
$ GREP="app_config" bash test_helpers.sh
``` 