### PR TITLE
helpers: fix ampersands (&) breaking file templating because it is a special sed char (issues#2470)

### DIFF
--- a/helpers/helpers.v1.d/templating
+++ b/helpers/helpers.v1.d/templating
@@ -103,7 +103,7 @@ ynh_add_config() {
 
     if [[ "$jinja" == 1 ]]; then
         # This is ran in a subshell such that the "export" does not "contaminate" the main process
-        (   
+        (
             export $(compgen -v)
             j2 "$template_path" -f env -o $destination
         )
@@ -194,6 +194,7 @@ ynh_replace_vars() {
         match_string=${match_string//${delimit}/"\\${delimit}"}
         replace_string="${!one_var}"
         replace_string=${replace_string//\\/\\\\}
+        replace_string=${replace_string//&/\\&}
         replace_string=${replace_string//${delimit}/"\\${delimit}"}
 
         # Actually replace (sed is used instead of ynh_replace_string to avoid triggering an epic amount of debug logs)

--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -112,7 +112,7 @@ ynh_config_add() {
 
     if [[ "$jinja" == 1 ]]; then
         # This is ran in a subshell such that the "export" does not "contaminate" the main process
-        (   
+        (
             # shellcheck disable=SC2046
             export $(compgen -v)
             j2 "$template_path" -f env \
@@ -172,6 +172,7 @@ _ynh_replace_vars() {
         match_string=${match_string//${delimit}/"\\${delimit}"}
         replace_string="${!one_var}"
         replace_string=${replace_string//\\/\\\\}
+        replace_string=${replace_string//&/\\&}
         replace_string=${replace_string//${delimit}/"\\${delimit}"}
 
         # Actually replace (sed is used instead of ynh_replace_string to avoid triggering an epic amount of debug logs)

--- a/tests/test_helpers.v2.1.d/ynhtest_templating.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_templating.sh
@@ -9,14 +9,16 @@ ynhtest_simple_template_app_config() {
     cat << EOF > "$template"
 app=__APP__
 foo=__FOO__
+passwd=__WITH_SPECIAL_CHARS__
 EOF
 
     foo="bar"
+    with_special_chars="hello&world"
     install_dir="$VAR_WWW"
 
     ynh_config_add --template="$template" --destination="$VAR_WWW/config.txt"
 
-    test "$(cat "$VAR_WWW/config.txt")" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
+    test "$(cat "$VAR_WWW/config.txt")" == "$(echo -ne 'app=ynhtest\nfoo=bar\npasswd=hello&world')"
     # shellcheck disable=SC2012
     test "$(ls -l "$VAR_WWW/config.txt" | cut -d' ' -f1-4)" == "-rw------- 1 ynhtest ynhtest"
 }

--- a/tests/test_helpers.v2.d/ynhtest_templating.sh
+++ b/tests/test_helpers.v2.d/ynhtest_templating.sh
@@ -4,16 +4,18 @@ ynhtest_simple_template_app_config() {
     echo "id: $app" > /etc/yunohost/apps/$app/settings.yml
 
     template="$(mktemp -d -p $VAR_WWW)/template.txt"
-    cat << EOF > $template 
+    cat << EOF > $template
 app=__APP__
 foo=__FOO__
+passwd=__WITH_SPECIAL_CHARS__
 EOF
 
     foo="bar"
-    
+    with_special_chars="hello&world"
+
     ynh_add_config --template="$template" --destination="$VAR_WWW/config.txt"
 
-    test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
+    test "$(cat "$VAR_WWW/config.txt")" == "$(echo -ne 'app=ynhtest\nfoo=bar\npasswd=hello&world')"
     test "$(ls -l $VAR_WWW/config.txt | cut -d' ' -f1-4)" == "-rw-r----- 1 ynhtest ynhtest"
 }
 
@@ -25,16 +27,16 @@ ynhtest_simple_template_system_config() {
     rm -f /etc/cron.d/ynhtest_config
 
     template="$(mktemp -d -p $VAR_WWW)/template.txt"
-    cat << EOF > $template 
+    cat << EOF > $template
 app=__APP__
 foo=__FOO__
 EOF
 
     foo="bar"
-    
+
     ynh_add_config --template="$template" --destination="/etc/cron.d/ynhtest_config"
 
-    test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
+    test "$(cat /etc/cron.d/ynhtest_config)" == "$(echo -ne 'app=ynhtest\nfoo=bar')"
     test "$(ls -l /etc/cron.d/ynhtest_config | cut -d' ' -f1-4)" == "-r-------- 1 root root"
 
     rm -f /etc/cron.d/ynhtest_config
@@ -46,13 +48,13 @@ ynhtest_jinja_template_app_config() {
     echo "id: $app" > /etc/yunohost/apps/$app/settings.yml
 
     template="$(mktemp -d -p $VAR_WWW)/template.txt"
-    cat << EOF > $template 
+    cat << EOF > $template
 app={{ app }}
 {% if foo == "bar" %}foo=true{% endif %}
 EOF
 
     foo="bar"
-    
+
     ynh_add_config --template="$template" --destination="$VAR_WWW/config.txt" --jinja
 
     test "$(cat $VAR_WWW/config.txt)" == "$(echo -ne 'app=ynhtest\nfoo=true')"


### PR DESCRIPTION
## The problem

Fixes https://github.com/YunoHost/issues/issues/2470

## Solution

Escape ampersands (`&`) with `\\&` so it is treated as a special character. Quoting sed manpage:

> **s/regexp/replacement/**
>   Attempt  to  match  regexp against the pattern space.  If successful, replace that portion matched with replacement.  **The replacement may contain the special character & to refer to that portion of
>   the pattern space which matched**, and the special escapes \1 through \9 to refer to the corresponding matching sub-expressions in the regexp.
> 

## PR Status

Ready to be reviewed, the test pass.

## How to test

```
$ bash test_helpers.sh 2
$ bash test_helpers.sh 2.1
```