### PR TITLE
Update firewall.py  Choosing a custom ssh port not listed in firewall.xml leads to partial error

### DIFF
--- a/src/firewall.py
+++ b/src/firewall.py
@@ -181,7 +181,7 @@ class YunoFirewall:
     def apply(self, upnp: bool = True) -> bool:
         # FIXME: Ensure SSH is allowed
         ssh_port = _get_ssh_port()
-        if not self.config["tcp"][ssh_port]["open"]:
+        if ssh_port not in self.config["tcp"] or not self.config["tcp"][ssh_port].get("open", False):
             self.open_port("tcp", ssh_port, "SSH port")
 
         # Just leverage regen_conf that will regen the nftables files, reload nftables

--- a/src/firewall.py
+++ b/src/firewall.py
@@ -181,7 +181,7 @@ class YunoFirewall:
     def apply(self, upnp: bool = True) -> bool:
         # FIXME: Ensure SSH is allowed
         ssh_port = _get_ssh_port()
-        if ssh_port not in self.config["tcp"] or not self.config["tcp"][ssh_port].get("open", False):
+        if not self.config["tcp"].get(ssh_port, {}).get("open", False):
             self.open_port("tcp", ssh_port, "SSH port")
 
         # Just leverage regen_conf that will regen the nftables files, reload nftables


### PR DESCRIPTION
fix (?) : handle case when chosen ssh port is not yet listed in firewall.yml

https://github.com/YunoHost/issues/issues/2675

## The problem
Through webadmin or CLI choosing a custom ssh port not listed in `firewall.xml` leads to partial error (custom ssh port set in `/etc/ssh/sshd_config` but not opened in firewall).
E.g. for port 123 :
```
File “/usr/lib/python3/dist-packages/yunohost/firewall.py”, line 184, in apply
if not self.config[“tcp”][ssh_port][“open”]:

KeyError: 123
```
## Solution
Adding a check for ssh_port


