### PR TITLE
[fix] Remove resolver with timeout

### DIFF
--- a/conf/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/conf/dnsmasq/plain/resolv.dnsmasq.conf
@@ -18,6 +18,8 @@ nameserver 185.233.100.100
 nameserver 2a0c:e300::100
 nameserver 185.233.100.101
 nameserver 2a0c:e300::101
+# (DE) AS250
+nameserver 194.150.168.168
 # (DE) Ideal-Hosting
 nameserver 2001:1608:10:25::1c04:b12f
 nameserver 2001:1608:10:25::9249:d69b

--- a/conf/dnsmasq/plain/resolv.dnsmasq.conf
+++ b/conf/dnsmasq/plain/resolv.dnsmasq.conf
@@ -18,11 +18,8 @@ nameserver 185.233.100.100
 nameserver 2a0c:e300::100
 nameserver 185.233.100.101
 nameserver 2a0c:e300::101
-# (DE) AS250
-nameserver 194.150.168.168
 # (DE) Ideal-Hosting
 nameserver 2001:1608:10:25::1c04:b12f
-nameserver 84.200.70.40
 nameserver 2001:1608:10:25::9249:d69b
 # DNS4all
 nameserver 194.0.5.3


### PR DESCRIPTION
## The problem
If DNS resolution doesn't work, mails could be refused (rdns, spf, dkim in error) and other apps could be broken...

```
dig +short A wikipedia.org @194.150.168.168
;; communications error to 194.150.168.168#53: timed out
;; communications error to 194.150.168.168#53: timed out
;; communications error to 194.150.168.168#53: timed out
;; no servers could be reached
```

```
# dig +short A wikipedia.org @84.200.70.40
;; communications error to 84.200.70.40#53: timed out
;; communications error to 84.200.70.40#53: timed out
;; communications error to 84.200.70.40#53: timed out
;; no servers could be reached
```

```
$ dig A wikipedia.org @84.200.70.40
;; communications error to 84.200.70.40#53: timed out
185.15.59.224
```

## Solution
Temp fix: Remove those resolvers
Better fix for future, setup a local resolver with unbound ?

## PR Status

Ready

## How to test

...
