### PR TITLE
Helpers doc: Insist about case restrictions

### DIFF
--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -40,6 +40,8 @@
 #   `__VAR_1__`    by `$var_1`
 #   `__VAR_2__`    by `$var_2`
 #
+# For this to work, template tags must be in uppercase and variables names must be in lowercase (for instance `__MY_var__` or `$myVar` would not be replaced as expected).
+#
 # Special case for `__PATH__/` which is replaced by `/` instead of `//` if `$path` is `/`
 #
 # ##### When --jinja is enabled
@@ -112,7 +114,7 @@ ynh_config_add() {
 
     if [[ "$jinja" == 1 ]]; then
         # This is ran in a subshell such that the "export" does not "contaminate" the main process
-        (   
+        (
             # shellcheck disable=SC2046
             export $(compgen -v)
             j2 "$template_path" -f env \
@@ -141,6 +143,8 @@ ynh_config_add() {
 #   `__APP__`      by `$app`
 #   `__VAR_1__`    by `$var_1`
 #   `__VAR_2__`    by `$var_2`
+#
+# For this to work, template tags must be in uppercase and variables names must be in lowercase (for instance `__MY_var__` or `$myVar` would not be replaced as expected).
 #
 # Special case for `__PATH__/` which is replaced by `/` instead of `//` if `$path` is `/`
 _ynh_replace_vars() {


### PR DESCRIPTION
I was wondering whether the magic would match template tags with variables names with camelCase, but the answer is no.
This PR suggests to insist that the respective case for template tags and variables names must be strictly respected.