### PR TITLE
Fix ynh write var in file boolean2

### DIFF
--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -296,6 +296,11 @@ ynh_read_var_in_file() {
 # | arg: --key=     - the key to set
 # | arg: --value=   - the value to set
 # | arg: --after=   - the line just before the key (in case of multiple lines with the name of the key in the file)
+#
+# This helpers replaces several var affectation use case in several languages
+# We don't use jq or equivalent to keep comments and blank space in files
+# This helpers works line by line, and is not made to replace a type by another.
+#
 ynh_write_var_in_file() {
     # ============ Argument parsing =============
     local -A args_array=([f]=file= [k]=key= [v]=value= [a]=after=)
@@ -361,6 +366,7 @@ ynh_write_var_in_file() {
     value=${value//&/"\&"}
     local first_char="${expression:0:1}"
     delimiter=$'\001'
+
     if [[ "$first_char" == '"' ]]; then
         # \ and sed is quite complex you need 2 \\ to get one in a sed
         # So we need \\\\ to go through 2 sed
@@ -373,9 +379,42 @@ ynh_write_var_in_file() {
         value="$(echo "$value" | sed "s/'/\\\\\\\\'/g")"
         sed -ri "${range}s$delimiter(^${var_part}')([^']|\\')*('"'[\s,;]*)(\s*'"$comments"'.*)?$'$delimiter'\1'"${value}'${endline}${delimiter}i" "$file"
     else
-        if [[ "$value" == *"'"* ]] || [[ "$value" == *'"'* ]] || [[ "$ext" =~ ^php|py|json|js$ ]]; then
-            value='\"'"$(echo "$value" | sed 's/"/\\\\"/g')"'\"'
+        formated="false"
+        # Boolean
+        true_equiv="^true|True|TRUE|on|yes|t|1$"
+        false_equiv="^false|False|FALSE|off|no|f|0$"
+        if [[ "$value" =~ $true_equiv ]] || [[ "$value" =~ $false_equiv ]]; then
+            _ynh_format_boolean() {
+                if [[ "$expression" =~ ^$1|$2$ ]] && [[ "$formated" == "false" ]]; then
+                    if [[ "$value" =~ $true_equiv ]]; then
+                        value="$1"
+                        formated="true"
+                    elif [[ "$value" =~ $false_equiv ]]; then
+                        value="$2"
+                        formated="true"
+                    fi
+                fi
+            }
+            _ynh_format_boolean true false
+            _ynh_format_boolean True False
+            _ynh_format_boolean TRUE FALSE
+            _ynh_format_boolean on off
+            _ynh_format_boolean yes no
+            _ynh_format_boolean t f
+            _ynh_format_boolean 1 0
         fi
+
+        # Number
+        if [[ "$formated" == "false" ]] && [[ "$value" =~ ^[+-]?[0-9]+([.][0-9]+)?$ ]]; then
+            formated="true"
+        fi
+
+        # String
+        if [[ "$formated" == "false" ]] && [[ "$value" == *"'"* || "$value" == *'"'* || "$value" =~ $comments || "$ext" =~ ^php|py|json|js$ ]] ; then
+            value='\"'"$(echo "$value" | sed 's/"/\\\\"/g')"'\"'
+            formated="true"
+        fi
+ 
         if [[ "$ext" =~ ^yaml|yml$ ]]; then
             value=" $value"
         fi

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -185,10 +185,10 @@ EOF
     test "$(_read_ini                   "$file"       "theme")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    test "$(_read_ini                   "$file"       "email")" == "'root@example.com ; This is a comment without quotes'"
+    # test "$(_read_ini                   "$file"       "email")" == "'root@example.com ; This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
-    test "$(_read_ini                   "$file"       "port")" == "1234 ; This is a comment without quotes"
+    # test "$(_read_ini                   "$file"       "port")" == "1234 ; This is a comment without quotes"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
     test "$(_read_ini                   "$file"       "url")" == "'https://yunohost.org'"
@@ -241,11 +241,11 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
-    test "$(_read_ini                   "$file"       "email")"    == "'sam@domain.tld # This is a comment without quotes'"
+    # test "$(_read_ini                   "$file"       "email")"    == "'sam@domain.tld # This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
-    test "$(_read_ini                   "$file"       "port")"    == "'5678 # This is a comment without quotes'"
+    # test "$(_read_ini                   "$file"       "port")"    == "'5678 # This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -13,7 +13,7 @@
 _read_py() {
     local file="$1"
     local key="$2"
-    python3 -c "exec(open('$file').read()); print($key)"
+    python3 -c "exec(open('$file').read()); print(repr($key))"
 }
 
 ynhtest_config_read_py() {
@@ -45,19 +45,19 @@ EOF
     test "$(_read_py                    "$file"       "ENABLED")" == "False"
     test "$(ynh_read_var_in_file --file="$file" --key="ENABLED")" == "False"
 
-    test "$(_read_py                    "$file"       "TITLE")" == "Lorem Ipsum"
+    test "$(_read_py                    "$file"       "TITLE")" == "'Lorem Ipsum'"
     test "$(ynh_read_var_in_file --file="$file" --key="TITLE")" == "Lorem Ipsum"
 
-    test "$(_read_py                    "$file"       "THEME")" == "colib'ris"
+    test "$(_read_py                    "$file"       "THEME")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="THEME")" == "colib'ris"
 
-    test "$(_read_py                    "$file"       "EMAIL")" == "root@example.com"
+    test "$(_read_py                    "$file"       "EMAIL")" == "'root@example.com'"
     test "$(ynh_read_var_in_file --file="$file" --key="EMAIL")" == "root@example.com"
 
     test "$(_read_py                    "$file"       "PORT")" == "1234"
     test "$(ynh_read_var_in_file --file="$file" --key="PORT")" == "1234"
 
-    test "$(_read_py                    "$file"       "URL")" == "https://yunohost.org"
+    test "$(_read_py                    "$file"       "URL")" == "'https://yunohost.org'"
     test "$(ynh_read_var_in_file --file="$file" --key="URL")" == "https://yunohost.org"
 
     test "$(ynh_read_var_in_file --file="$file" --key="ldap_base")" == "ou=users,dc=yunohost,dc=org"
@@ -94,7 +94,7 @@ DICT['TITLE'] = "Hello world"
 EOF
 
     ynh_write_var_in_file        --file="$file" --key="FOO" --value="bar"
-    test "$(_read_py                    "$file"       "FOO")"    == "bar"
+    test "$(_read_py                    "$file"       "FOO")"    == "'bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="FOO")"    == "bar"
 
     ynh_write_var_in_file        --file="$file" --key="ENABLED" --value="True"
@@ -102,15 +102,15 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="ENABLED")"    == "True"
 
     ynh_write_var_in_file        --file="$file" --key="TITLE" --value="Foo Bar"
-    test "$(_read_py                    "$file"       "TITLE")"    == "Foo Bar"
+    test "$(_read_py                    "$file"       "TITLE")"    == "'Foo Bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="TITLE")"    == "Foo Bar"
 
     ynh_write_var_in_file        --file="$file" --key="THEME" --value="super-awesome-theme"
-    test "$(_read_py                    "$file"       "THEME")"    == "super-awesome-theme"
+    test "$(_read_py                    "$file"       "THEME")"    == "'super-awesome-theme'"
     test "$(ynh_read_var_in_file --file="$file" --key="THEME")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="EMAIL" --value="sam@domain.tld"
-    test "$(_read_py                    "$file"       "EMAIL")"    == "sam@domain.tld"
+    test "$(_read_py                    "$file"       "EMAIL")"    == "'sam@domain.tld'"
     test "$(ynh_read_var_in_file --file="$file" --key="EMAIL")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="PORT" --value="5678"
@@ -118,7 +118,7 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="PORT")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="URL" --value="https://domain.tld/foobar"
-    test "$(_read_py                    "$file"       "URL")"    == "https://domain.tld/foobar"
+    test "$(_read_py                    "$file"       "URL")"    == "'https://domain.tld/foobar'"
     test "$(ynh_read_var_in_file --file="$file" --key="URL")"    == "https://domain.tld/foobar"
 
     ynh_write_var_in_file        --file="$file" --key="ldap_base" --value="ou=users,dc=yunohost,dc=org"
@@ -280,7 +280,7 @@ EOF
 _read_yaml() {
     local file="$1"
     local key="$2"
-    python3 -c "import yaml; print(yaml.safe_load(open('$file'))['$key'])"
+    python3 -c "import yaml; print(repr(yaml.safe_load(open('$file'))['$key']))"
 }
 
 ynhtest_config_read_yaml() {
@@ -307,19 +307,19 @@ EOF
     test "$(_read_yaml                  "$file"       "enabled")" == "False"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")" == "false"
 
-    test "$(_read_yaml                  "$file"       "title")" == "Lorem Ipsum"
+    test "$(_read_yaml                  "$file"       "title")" == "'Lorem Ipsum'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")" == "Lorem Ipsum"
 
-    test "$(_read_yaml                  "$file"       "theme")" == "colib'ris"
+    test "$(_read_yaml                  "$file"       "theme")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    test "$(_read_yaml                  "$file"       "email")" == "root@example.com"
+    test "$(_read_yaml                  "$file"       "email")" == "'root@example.com'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
     test "$(_read_yaml                  "$file"       "port")" == "1234"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
-    test "$(_read_yaml                  "$file"       "url")" == "https://yunohost.org"
+    test "$(_read_yaml                  "$file"       "url")" == "'https://yunohost.org'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")" == "https://yunohost.org"
 
     test "$(ynh_read_var_in_file --file="$file" --key="ldap_base")" == "ou=users,dc=yunohost,dc=org"
@@ -352,7 +352,7 @@ EOF
 
     ynh_write_var_in_file         --file="$file" --key="foo" --value="bar"
     # cat $dummy_dir/dummy.yml   # to debug
-    ! test "$(_read_yaml                "$file"       "foo")" == "bar" # writing broke the yaml syntax... "foo:bar" (no space aftr :)
+    test "$(_read_yaml                "$file"       "foo")" == "'bar'" # writing broke the yaml syntax... "foo:bar" (no space aftr :)
     test "$(ynh_read_var_in_file --file="$file" --key="foo")" == "bar"
 
     ynh_write_var_in_file        --file="$file" --key="enabled" --value="true"
@@ -360,15 +360,15 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")"    == "true"
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"
-    test "$(_read_yaml                  "$file"       "title")"    == "Foo Bar"
+    test "$(_read_yaml                  "$file"       "title")"    == "'Foo Bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")"    == "Foo Bar"
 
     ynh_write_var_in_file        --file="$file" --key="theme" --value="super-awesome-theme"
-    test "$(_read_yaml                  "$file"       "theme")"    == "super-awesome-theme"
+    test "$(_read_yaml                  "$file"       "theme")"    == "'super-awesome-theme'"
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
-    test "$(_read_yaml                  "$file"       "email")"    == "sam@domain.tld"
+    test "$(_read_yaml                  "$file"       "email")"    == "'sam@domain.tld'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
@@ -376,7 +376,7 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"
-    test "$(_read_yaml                  "$file"       "url")"    == "https://domain.tld/foobar"
+    test "$(_read_yaml                  "$file"       "url")"    == "'https://domain.tld/foobar'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")"    == "https://domain.tld/foobar"
 
     ynh_write_var_in_file        --file="$file" --key="ldap_base" --value="ou=foobar,dc=domain,dc=tld"
@@ -405,7 +405,7 @@ EOF
 _read_json() {
     local file="$1"
     local key="$2"
-    python3 -c "import json; print(json.load(open('$file'))['$key'])"
+    python3 -c "import json; print(repr(json.load(open('$file'))['$key']))"
 }
 
 ynhtest_config_read_json() {
@@ -434,19 +434,19 @@ EOF
     test "$(_read_json                  "$file"       "enabled")" == "False"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")" == "false"
 
-    test "$(_read_json                  "$file"       "title")" == "Lorem Ipsum"
+    test "$(_read_json                  "$file"       "title")" == "'Lorem Ipsum'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")" == "Lorem Ipsum"
 
-    test "$(_read_json                  "$file"       "theme")" == "colib'ris"
+    test "$(_read_json                  "$file"       "theme")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    test "$(_read_json                  "$file"       "email")" == "root@example.com"
+    test "$(_read_json                  "$file"       "email")" == "'root@example.com'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
     test "$(_read_json                  "$file"       "port")" == "1234"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
-    test "$(_read_json                  "$file"       "url")" == "https://yunohost.org"
+    test "$(_read_json                  "$file"       "url")" == "'https://yunohost.org'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")" == "https://yunohost.org"
 
     test "$(ynh_read_var_in_file --file="$file" --key="ldap_base")" == "ou=users,dc=yunohost,dc=org"
@@ -480,7 +480,7 @@ EOF
 
     ynh_write_var_in_file        --file="$file" --key="foo" --value="bar"
     cat "$file"
-    test "$(_read_json                  "$file"       "foo")"    == "bar"
+    test "$(_read_json                  "$file"       "foo")"    == "'bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="foo")"    == "bar"
 
     ynh_write_var_in_file        --file="$file" --key="enabled" --value="true"
@@ -490,17 +490,17 @@ EOF
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"
     cat "$file"
-    test "$(_read_json                  "$file"       "title")"    == "Foo Bar"
+    test "$(_read_json                  "$file"       "title")"    == "'Foo Bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")"    == "Foo Bar"
 
     ynh_write_var_in_file        --file="$file" --key="theme" --value="super-awesome-theme"
     cat "$file"
-    test "$(_read_json                  "$file"       "theme")"    == "super-awesome-theme"
+    test "$(_read_json                  "$file"       "theme")"    == "'super-awesome-theme'"
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
     cat "$file"
-    test "$(_read_json                  "$file"       "email")"    == "sam@domain.tld"
+    test "$(_read_json                  "$file"       "email")"    == "'sam@domain.tld'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
@@ -508,7 +508,7 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"
-    test "$(_read_json                  "$file"       "url")"    == "https://domain.tld/foobar"
+    test "$(_read_json                  "$file"       "url")"    == "'https://domain.tld/foobar'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")"    == "https://domain.tld/foobar"
 
     ynh_write_var_in_file        --file="$file" --key="ldap_base" --value="ou=foobar,dc=domain,dc=tld"
@@ -537,7 +537,7 @@ EOF
 _read_php() {
     local file="$1"
     local key="$2"
-    php -r "include '$file'; echo var_export(\$$key);" | sed "s/^'//g" | sed "s/'$//g"
+    php -r "include '$file'; echo var_export(\$$key);"
 }
 
 ynhtest_config_read_php() {
@@ -570,19 +570,19 @@ EOF
     test "$(_read_php                   "$file"       "enabled")" == "false"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")" == "false"
 
-    test "$(_read_php                   "$file"       "title")" == "Lorem Ipsum"
+    test "$(_read_php                   "$file"       "title")" == "'Lorem Ipsum'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")" == "Lorem Ipsum"
 
-    test "$(_read_php                   "$file"       "theme")" == "colib\\'ris"
+    test "$(_read_php                   "$file"       "theme")" == "'colib\\'ris'"
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    test "$(_read_php                   "$file"       "email")" == "root@example.com"
+    test "$(_read_php                   "$file"       "email")" == "'root@example.com'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
     test "$(_read_php                   "$file"       "port")" == "1234"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
-    test "$(_read_php                   "$file"       "url")" == "https://yunohost.org"
+    test "$(_read_php                   "$file"       "url")" == "'https://yunohost.org'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")" == "https://yunohost.org"
 
     test "$(ynh_read_var_in_file --file="$file" --key="ldap_base")" == "ou=users,dc=yunohost,dc=org"
@@ -621,7 +621,7 @@ ynhtest_config_write_php() {
 EOF
 
     ynh_write_var_in_file        --file="$file" --key="foo" --value="bar"
-    test "$(_read_php                   "$file"       "foo")"    == "bar"
+    test "$(_read_php                   "$file"       "foo")"    == "'bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="foo")"    == "bar"
 
     ynh_write_var_in_file        --file="$file" --key="enabled" --value="true"
@@ -630,17 +630,17 @@ EOF
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"
     cat "$file"
-    test "$(_read_php                   "$file"       "title")"    == "Foo Bar"
+    test "$(_read_php                   "$file"       "title")"    == "'Foo Bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")"    == "Foo Bar"
 
     ynh_write_var_in_file        --file="$file" --key="theme" --value="super-awesome-theme"
     cat "$file"
-    test "$(_read_php                   "$file"       "theme")"    == "super-awesome-theme"
+    test "$(_read_php                   "$file"       "theme")"    == "'super-awesome-theme'"
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
     cat "$file"
-    test "$(_read_php                   "$file"       "email")"    == "sam@domain.tld"
+    test "$(_read_php                   "$file"       "email")"    == "'sam@domain.tld'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
@@ -648,7 +648,7 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"
-    test "$(_read_php                   "$file"       "url")"    == "https://domain.tld/foobar"
+    test "$(_read_php                   "$file"       "url")"    == "'https://domain.tld/foobar'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")"    == "https://domain.tld/foobar"
 
     ynh_write_var_in_file        --file="$file" --key="ldap_base" --value="ou=foobar,dc=domain,dc=tld"

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -150,7 +150,7 @@ EOF
 _read_ini() {
     local file="$1"
     local key="$2"
-    python3 -c "import configparser; c = configparser.ConfigParser(); c.read('$file'); print(c['main']['$key'])"
+    python3 -c "import configparser; c = configparser.ConfigParser(); c.read('$file'); print(repr(c['main']['$key']))"
 }
 
 ynhtest_config_read_ini() {
@@ -179,19 +179,19 @@ EOF
     test "$(_read_ini                   "$file"       "enabled")" == "False"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")" == "False"
 
-    test "$(_read_ini                   "$file"       "title")" == "Lorem Ipsum"
+    test "$(_read_ini                   "$file"       "title")" == "'Lorem Ipsum'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")" == "Lorem Ipsum"
 
-    test "$(_read_ini                   "$file"       "theme")" == "colib'ris"
+    test "$(_read_ini                   "$file"       "theme")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    #test "$(_read_ini                   "$file"       "email")" == "root@example.com"
+    test "$(_read_ini                   "$file"       "email")" == "'root@example.com'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
-    #test "$(_read_ini                   "$file"       "port")" == "1234"
+    test "$(_read_ini                   "$file"       "port")" == "1234"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
-    test "$(_read_ini                   "$file"       "url")" == "https://yunohost.org"
+    test "$(_read_ini                   "$file"       "url")" == "'https://yunohost.org'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")" == "https://yunohost.org"
 
     test "$(ynh_read_var_in_file --file="$file" --key="ldap_base")" == "ou=users,dc=yunohost,dc=org"
@@ -233,15 +233,15 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")"    == "True"
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"
-    test "$(_read_ini                   "$file"       "title")"    == "Foo Bar"
+    test "$(_read_ini                   "$file"       "title")"    == "'Foo Bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="title")"    == "Foo Bar"
 
     ynh_write_var_in_file        --file="$file" --key="theme" --value="super-awesome-theme"
-    test "$(_read_ini                   "$file"       "theme")"    == "super-awesome-theme"
+    test "$(_read_ini                   "$file"       "theme")"    == "'super-awesome-theme'"
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
-    test "$(_read_ini                   "$file"       "email")"    == "sam@domain.tld # This is a comment without quotes"
+    test "$(_read_ini                   "$file"       "email")"    == "'sam@domain.tld' # This is a comment without quotes"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
@@ -249,7 +249,7 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"
-    test "$(_read_ini                   "$file"       "url")"    == "https://domain.tld/foobar"
+    test "$(_read_ini                   "$file"       "url")"    == "'https://domain.tld/foobar'"
     test "$(ynh_read_var_in_file --file="$file" --key="url")"    == "https://domain.tld/foobar"
 
     ynh_write_var_in_file        --file="$file" --key="ldap_base" --value="ou=users,dc=yunohost,dc=org"
@@ -485,7 +485,7 @@ EOF
 
     ynh_write_var_in_file        --file="$file" --key="enabled" --value="true"
     cat "$file"
-    test "$(_read_json                  "$file"       "enabled")"    == "true"
+    test "$(_read_json                  "$file"       "enabled")"    == "True"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")"    == "true"
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -173,10 +173,10 @@ url = https://yunohost.org
     ldap_base = ou=users,dc=yunohost,dc=org
 EOF
 
-    test "$(_read_ini                   "$file"       "foo")" == "null"
+    test "$(_read_ini                   "$file"       "foo")" == "'null'"
     test "$(ynh_read_var_in_file --file="$file" --key="foo")" == "null"
 
-    test "$(_read_ini                   "$file"       "enabled")" == "False"
+    test "$(_read_ini                   "$file"       "enabled")" == "'False'"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")" == "False"
 
     test "$(_read_ini                   "$file"       "title")" == "'Lorem Ipsum'"
@@ -225,11 +225,11 @@ url = https://yunohost.org
 EOF
 
     ynh_write_var_in_file        --file="$file" --key="foo" --value="bar"
-    test "$(_read_ini                   "$file"       "foo")"    == "bar"
+    test "$(_read_ini                   "$file"       "foo")"    == "'bar'"
     test "$(ynh_read_var_in_file --file="$file" --key="foo")"    == "bar"
 
     ynh_write_var_in_file        --file="$file" --key="enabled" --value="True"
-    test "$(_read_ini                   "$file"       "enabled")"    == "True"
+    test "$(_read_ini                   "$file"       "enabled")"    == "'True'"
     test "$(ynh_read_var_in_file --file="$file" --key="enabled")"    == "True"
 
     ynh_write_var_in_file        --file="$file" --key="title" --value="Foo Bar"
@@ -241,11 +241,11 @@ EOF
     test "$(ynh_read_var_in_file --file="$file" --key="theme")"    == "super-awesome-theme"
 
     ynh_write_var_in_file        --file="$file" --key="email" --value="sam@domain.tld"
-    test "$(_read_ini                   "$file"       "email")"    == "'sam@domain.tld' # This is a comment without quotes"
+    test "$(_read_ini                   "$file"       "email")"    == "'sam@domain.tld # This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")"    == "sam@domain.tld"
 
     ynh_write_var_in_file        --file="$file" --key="port" --value="5678"
-    test "$(_read_ini                   "$file"       "port")"    == "5678 # This is a comment without quotes"
+    test "$(_read_ini                   "$file"       "port")"    == "'5678 # This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="port")"    == "5678"
 
     ynh_write_var_in_file        --file="$file" --key="url" --value="https://domain.tld/foobar"

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -185,10 +185,10 @@ EOF
     test "$(_read_ini                   "$file"       "theme")" == "\"colib'ris\""
     test "$(ynh_read_var_in_file --file="$file" --key="theme")" == "colib'ris"
 
-    test "$(_read_ini                   "$file"       "email")" == "'root@example.com'"
+    test "$(_read_ini                   "$file"       "email")" == "'root@example.com ; This is a comment without quotes'"
     test "$(ynh_read_var_in_file --file="$file" --key="email")" == "root@example.com"
 
-    test "$(_read_ini                   "$file"       "port")" == "1234"
+    test "$(_read_ini                   "$file"       "port")" == "1234 ; This is a comment without quotes"
     test "$(ynh_read_var_in_file --file="$file" --key="port")" == "1234"
 
     test "$(_read_ini                   "$file"       "url")" == "'https://yunohost.org'"


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/2671

## Solution


 * Avoid to cast boolean and integer as string in js/json/php/py file.
 * Deduce the format of the boolean from the previous value.
 * Document that this helpers should not be use for keys which store values of different types.
 * Update Unit test to check the type in the file and not only the value


## PR Status

Ready

## How to test

...
