### PR TITLE
fix(helpers): do not fail if subdir already exists

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1123,7 +1123,7 @@ class DatadirAppResource(AppResource):
         for subdir in self.subdirs:
             full_path = os.path.join(self.dir, subdir)
             if not os.path.isdir(full_path):
-                mkdir(full_path, parents=True)
+                mkdir(full_path, parents=True, force=True)
 
         owner, owner_perm = self.owner.split(":")
         group, group_perm = self.group.split(":")


### PR DESCRIPTION
## The problem

I'm a bit surprised this was not caught before. If subdirs are set for a data directory in the manifest, upgrades will fail because they already exist.
Encountered when manually testing https://github.com/YunoHost-Apps/headplane_ynh/pull/42:

```
58247 INFO    Updating sources...
58247 DEBUG   Prefetching asset main: https://github.com/tale/headplane/archive/refs/tags/v0.6.1.tar.gz ...
73481 INFO    Updating system_user...
73514 INFO    Updating install_dir...
73521 INFO    Updating data_dir...
73522 WARNING Failed to update data_dir : [Errno 17] File exists: '/home/yunohost.app/headplane/agent'
```

## Solution

Set `force=True` in the `mkdir` command.

## PR Status

Ready?

## How to test

...
