### PR TITLE
Fixup kern.log parsing

### DIFF
--- a/src/diagnosers/50-systemresources.py
+++ b/src/diagnosers/50-systemresources.py
@@ -196,9 +196,9 @@ class MyDiagnoser(Diagnoser):
 
             for line in reversed(lines):
                 # Lines look like :
-                # Aug 25 18:48:21 yolo kernel: [ 9623.613667] oom_reaper: reaped process 11509 (uwsgi), now anon-rss:0kB, file-rss:0kB, shmem-rss:328kB
-                date_str = str(now.year) + " " + " ".join(line.split()[:3])
-                date = datetime.datetime.strptime(date_str, "%Y %b %d %H:%M:%S")
+                # 2025-10-15T13:58:59.799358+02:00  yolo kernel: [ 9623.613667] oom_reaper: reaped process 11509 (uwsgi), now anon-rss:0kB, file-rss:0kB, shmem-rss:328kB
+                date_str = line.split()[0]
+                date = datetime.datetime.fromisoformat(date_str)
                 diff = now - date
                 if diff.days >= 1:
                     break


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/strange-swap-problem/40633/5

Basically `cat /var/log/kern.log` yields the likes of

```
2025-10-15T13:58:59.799343+02:00 yolo kernel: [    9.192602] RAPL PMU: API unit is 2^-32 Joules, 2 fixed counters, 163840 ms ovfl timer
2025-10-15T13:58:59.799344+02:00 yolo kernel: [    9.192606] RAPL PMU: hw unit of domain pp0-core 2^-16 Joules
2025-10-15T13:58:59.799345+02:00 yolo kernel: [    9.192608] RAPL PMU: hw unit of domain package 2^-16 Joules
2025-10-15T13:58:59.799346+02:00 yolo kernel: [    9.200134] cryptd: max_cpu_qlen set to 1000
```

## Solution

Use `.fromisoformat` as the log date format is now ISO-compliant

## PR Status

`~$ python3 -c "import datetime; print(datetime.datetime.fromisoformat('2025-10-15T13:58:59.799327 yolo kernel: [    8.916139] ACPI: button: Power Button [PWRF]'.split()[0]))"` worked 🤷 

## How to test

1. Crash with OOM
2. Cry?