### PR TITLE
Fix variable expansion in dovecot config

### DIFF
--- a/conf/dovecot/dovecot.conf
+++ b/conf/dovecot/dovecot.conf
@@ -18,7 +18,7 @@ mail_gid = 8
 
 protocols = imap sieve
 
-mail_plugins = $mail_plugins quota notify push_notification
+mail_plugins = $SET:mail_plugins quota notify push_notification
 
 ###############################################################################
 # generated 2025-10-31, Mozilla Guideline v5.7, Dovecot 2.4.1, OpenSSL 3.5.1, intermediate config


### PR DESCRIPTION
## The problem

yunohost/issues#2692

## Solution

Despite [what plugins conf man page claims](https://doc.dovecot.org/2.3/configuration_manual/plugins/mail_event_logging/) [the variable expansion syntax is now ](https://doc.dovecot.org/2.4.2/core/settings/syntax.html#variable-expansion) `$SET:key_name`
 
## PR Status

Untested

## How to test

...
