### PR TITLE
Link to a changelog from relevant tag

### DIFF
--- a/.github/workflows/releases_from_tags.yaml
+++ b/.github/workflows/releases_from_tags.yaml
@@ -32,4 +32,4 @@ jobs:
           release_name: YunoHost ${{ steps.patch-tag-name.outputs.version }}
           tag_name: ${{ github.ref }}
           body: |
-            Refer to [the debian changelog](${{ github.server_url }}/${{ github.repository }}/blob/dev/debian/changelog) for details.
+            Refer to [the debian changelog](${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref }}/debian/changelog) for details.


### PR DESCRIPTION
## The problem

Trixie changelog points to `dev` which is for 12.xx

## Solution

Link to changelog from related release tag.

## PR Status

[Should work](https://static.wikia.nocookie.net/starcraft/images/b/bf/TerranDukeSiegeTankYes02SC1.ogg/revision/latest?cb=20170514112920)🤷 

## How to test

...
