### PR TITLE
sse: Improve heartbeat handling and error logging in sse_stream

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -82,13 +82,13 @@ BORING_LOG_LINES = [
 ]
 
 
-def _update_log_cache_symlinks():
-    one_year_ago = time.time() - 365 * 24 * 3600
+def _update_log_cache_symlinks(since_days_ago=365):
+    cutoff_time = time.time() - since_days_ago * 24 * 3600
 
     logs = glob.iglob(OPERATIONS_PATH + "*.yml")
     for log_md in logs:
-        if os.path.getmtime(log_md) < one_year_ago:
-            # Let's ignore files older than one year because hmpf reading a shitload of yml is not free
+        if os.path.getmtime(log_md) < cutoff_time:
+            # Let's ignore old files because hmpf reading a shitload of yml is not free
             continue
 
         name = log_md.split("/")[-1][: -len(".yml")]
@@ -137,7 +137,7 @@ log_list_cache: dict[str, dict[str, Any]] = {}
 
 
 def log_list(
-    limit=None, with_details=False, with_suboperations=False, since_days_ago=365
+    limit=None, with_details=False, with_suboperations=False, since_days_ago=30
 ):
     """
     List available logs
@@ -154,7 +154,7 @@ def log_list(
 
     operations = {}
 
-    _update_log_cache_symlinks()
+    _update_log_cache_symlinks(since_days_ago)
 
     since = time.time() - since_days_ago * 24 * 3600
     logs = [

--- a/src/utils/sse.py
+++ b/src/utils/sse.py
@@ -307,8 +307,8 @@ def sse_stream() -> Generator[str, None, None]:
         else:
             entries = [entry.strip() for entry in log_stream_cache.readlines()]
             for payload in entries:
-                type, payload = payload.split(":", 1)
-                yield f"event: {type}\n"
+                event_type, payload = payload.split(":", 1)
+                yield f"event: {event_type}\n"
                 yield f"data: {payload}\n\n"
         finally:
             if log_stream_cache:
@@ -319,23 +319,39 @@ def sse_stream() -> Generator[str, None, None]:
 
     try:
         while True:
-            if time.time() - last_heartbeat > SSE_HEARTBEAT_PERIOD:
-                _, current_operation_id, cmdline, started_by = get_current_operation()
-                event: SSEEventHeartbeat = {
-                    "current_operation": current_operation_id,
-                    "cmdline": cmdline,
-                    "timestamp": time.time(),
-                    "started_by": started_by,
-                }
-                payload = json.dumps(event)
-                yield "event: heartbeat\n"
-                yield f"data: {payload}\n\n"
-                last_heartbeat = time.time()
-            if sub.poll(10, zmq.POLLIN):
-                _, payload = sub.recv_multipart()
-                type, payload = payload.decode().split(":", 1)
-                yield f"event: {type}\n"
-                yield f"data: {payload}\n\n"
+            # Calculate remaining time until next heartbeat
+            time_until_heartbeat = SSE_HEARTBEAT_PERIOD - (time.time() - last_heartbeat)
+
+            if time_until_heartbeat <= 0:
+                # Time to send heartbeat
+                try:
+                    _, current_operation_id, cmdline, started_by = get_current_operation()
+                    event: SSEEventHeartbeat = {
+                        "current_operation": current_operation_id,
+                        "cmdline": cmdline,
+                        "timestamp": time.time(),
+                        "started_by": started_by,
+                    }
+                    payload = json.dumps(event)
+                    yield "event: heartbeat\n"
+                    yield f"data: {payload}\n\n"
+                    last_heartbeat = time.time()
+                except Exception as e:
+                    logging.warning(f"Failed to send heartbeat: {e}")
+                    last_heartbeat = time.time()  # Reset to avoid spamming errors
+
+            # Poll for messages with a timeout that aligns with heartbeat timing
+            # Use the time until next heartbeat (in ms) or 1 second max to keep responsive
+            poll_timeout = min(int(time_until_heartbeat * 1000), 1000) if time_until_heartbeat > 0 else 1000
+
+            if sub.poll(poll_timeout, zmq.POLLIN):
+                try:
+                    _, message_payload = sub.recv_multipart()
+                    event_type, event_data = message_payload.decode().split(":", 1)
+                    yield f"event: {event_type}\n"
+                    yield f"data: {event_data}\n\n"
+                except Exception as e:
+                    logging.warning(f"Failed to process message: {e}")
     finally:
         sub.close()
         ctx.term()


### PR DESCRIPTION
## The problem

Polling every 10 ms consumes resources unnecessarily
On my server, I have a lot of operations (is there never any cleanup O.O)
> sudo ls /var/log/yunohost/operations/ -la | wc -l
108035

`log_list` (called in the sse_stream function) takes ages to complete, `_update_log_cache_symlinks` takes 14s

## Solution

- Change 10 ms to time until the next heartbeat
- forward `since_days_ago` of `log_list` to  `_update_log_cache_symlinks`
- change `since_days_ago` default value to 30 (yunohost-admin takes only [25 entries](https://github.com/YunoHost/yunohost-admin/blob/440f254972c7c7d96ca080a4bd09f0ebaea99c63/app/src/views/tool/ToolLogs.vue#L9) anyway)

## PR Status

Tested in prod LUL

## How to test

...
