### PR TITLE
trixie: remove unecessary fields in sssd conf

### DIFF
--- a/conf/sssd/sssd.conf
+++ b/conf/sssd/sssd.conf
@@ -1,7 +1,5 @@
 [sssd]
-config_file_version = 2
 domains = LDAP
-services = nss, pam, sudo, ssh
 
 [nss]
 filter_groups = root


### PR DESCRIPTION
## The problem

...

## Solution

Fix the sssd .socket errors
Fix a warning in `/var/log/sssd/sssd.log`:
> [sssd] [sss_ini_call_validators] (0x0020): [rule/allowed_sssd_options]: Attribute 'config_file_version' is not allowed in section 'sssd'. Check for typos.

## PR Status

...

## How to test

...
