### PR TITLE
Add interactive terminal check for backup confirmation prompt

### DIFF
--- a/src/backup.py
+++ b/src/backup.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time
@@ -1743,7 +1744,10 @@ class BackupMethod:
 
         # Ask confirmation for copying
         if size > MB_ALLOWED_TO_ORGANIZE:
-            try:
+            # Check if we're in an interactive terminal
+            is_interactive = sys.stdout.isatty() if hasattr(sys.stdout, 'isatty') else False
+
+            if is_interactive:
                 i = Moulinette.prompt(
                     m18n.n(
                         "backup_ask_for_copying_if_needed",
@@ -1751,11 +1755,11 @@ class BackupMethod:
                         size=str(size),
                     )
                 )
-            except NotImplementedError:
-                raise YunohostError("backup_unable_to_organize_files")
-            else:
                 if i != "y" and i != "Y":
                     raise YunohostError("backup_unable_to_organize_files")
+            else:
+                # In non-interactive mode, accept automatically with a warning
+                logger.warning(f"Copying {size:.1f} MB without confirmation (non-interactive mode)")
 
         # Copy unbinded path
         logger.debug(m18n.n("backup_copying_to_organize_the_archive", size=str(size)))


### PR DESCRIPTION
## The problem

Backups fail in non-interactive mode (cron, CLI without terminal) because the confirmation prompt for copying files > 10 MB raises a NotImplementedError.

## Solution

Detect interactive mode using sys.stdout.isatty(). In non-interactive mode, automatically accept the copy with a warning in the logs.

## PR Status

...

## How to test

...
