### PR TITLE
[fix] Unredacted value due to special way to display bash comparison with set -x

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -565,6 +565,8 @@ class RedactingFormatter(Formatter):
             # (try to run "foo".replace("", "bar"))
             if data:
                 msg = msg.replace(data, "**********")
+                # bash set -x display comparison like this: [[ ohno != \o\h\n\o ]]
+                msg = msg.replace('\\' + '\\'.join(data), "**********")
         return msg
 
     def identify_data_to_redact(self, record):


### PR DESCRIPTION
## The problem

```
bash set -x display comparison like this: [[ ohno != \o\h\n\o ]]
```
So comparison are not replaced

## Solution

replace \ string too

## PR Status

Ready

## How to test

...
