### PR TITLE
[fix] Improve password redact accuracy

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -558,7 +558,7 @@ class RedactingFormatter(Formatter):
 
     def format(self, record):
         msg = super(RedactingFormatter, self).format(record)
-        self.identify_data_to_redact(msg)
+        self.identify_data_to_redact(record.msg)
         for data in self.data_to_redact:
             # we check that data is not empty string,
             # otherwise this may lead to super epic stuff
@@ -570,26 +570,109 @@ class RedactingFormatter(Formatter):
         return msg
 
     def identify_data_to_redact(self, record):
+        print(record)
+        # This matches stuff like db_pwd=the_secret or admin_password=other_secret
+        # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
+        # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
+        secret_keys = 'pass|secret|token|salt'
+        secret_keys = f"{secret_keys}|{secret_keys.upper()}|pwd"
+        # Avoid to match some non relevant var compound with 'key'
+        secret_keys_regex = f"\w*({secret_keys})\w*|local key_?| key\w*|\w+key\w*|\w*KEY\w+|\w+KEY"
+        operator_regex = r'(\s+\-\-value)?='
+        value_regex = r"'([^']|'\''){5,}'|-----BEGIN.*-----END|\S{5,}"
+        redact_regex = fr"({secret_keys_regex}){operator_regex}({value_regex})",
+        exclude_keys = [
+            "manifest_key",
+            "bind_key_",
+            "local key",
+            "local key_",
+            "version_key",
+            "version_key_",
+            "cache_key",
+            "foreign_key",
+            "primary_key",
+            "keys_zone",
+            "meta_keywords",
+            "csrf_token",
+            "jsonwebtoken",
+            "MYSQL_ROOT_PWD_FILE",
+            "SALTCORN_BIN",
+            "tls_passthrough_module",
+        ]
+        exclude_keys_suffixes = (
+            '_uri', '_url', '_path', '_key_expires', '_key_expires_date', '_enabled'
+        )
+        exclude_values = (
+            "true",
+            "false",
+            "value",
+            "value1",
+            "value2",
+            "value3",
+            "version",
+            "db_pwd",
+            "disabled",
+            "enabled",
+            "lambda",
+            "by_order",
+            '\K\w+',
+            "(generate_random_password)",
+        )
         # Wrapping this in a try/except because we don't want this to
         # break everything in case it fails miserably for some reason :s
         try:
-            # This matches stuff like db_pwd=the_secret or admin_password=other_secret
-            # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
-            # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
-            match = re.search(
-                r"(pwd|pass|passwd|password|passphrase|secret\w*|\w+key|token|PASSPHRASE)=(\S{3,})$",
-                record.strip(),
-            )
-            if (
-                match
-                and match.group(2) not in self.data_to_redact
-                and match.group(1) not in ["key", "manifest_key"]
-            ):
-                self.data_to_redact.append(match.group(2))
-        except Exception as e:
+            match = re.search(redact_regex, record.strip())
+        except re.error as e:
             logger.warning(
                 "Failed to parse line to try to identify data to redact ... : %s" % e
             )
+            match = None
+        if match:
+            key = match.group(1).strip()
+            to_redact = match.group(4)
+            if (
+                to_redact
+                # Some keys are false positive and should not be redacted
+                and key not in exclude_keys
+                # Keys that end ups by uri, url or path are just path and not secret
+                and not key.lower().endswith(exclude_keys_suffixes)
+                # Python venv build could display some false positive library
+                # like passlib or tokenizer
+                # example: 'Collecting tokenizers==0.19.1'
+                and not record.strip().startswith(("Created serverSetting through seed key",))
+                # Some values are clearly vars or function call
+                and to_redact.strip("'{}\"$,") not in exclude_values + (key.lower(), key.upper())
+            ):
+                # key='https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D'
+                # key=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+                # key=https://download.docker.com/linux/debian/gpg
+                if (
+                    (key == "key" and to_redact.split("'").startswith(("https://", "--key=https://")))
+                    or (key == 'pwd_output' and to_redact.startswith("/var/cache/yunohost/"))
+                    or (key == 'ynh_key' and to_redact.startswith("/etc/yunohost/certs"))
+                    or (key == "ssh_keys" and "/etc/ssh/ssh_host_" in to_redact)
+                    or (key == "public_key" and to_redact.startswith("ssh-"))
+                    or (key == "AUTH_KEYS" and to_redact == "/root/.ssh/authorized_keys")
+                ):
+                    to_redact = None
+                elif record.strip(' +').startswith(('POST_data=', 'curl --silent')):
+                    to_redact = to_redact.split("&")[0]
+
+                # Python venv build could display some false positive library
+                # like passlib or tokenizer
+                # example: 'Collecting tokenizers==0.19.1'
+                elif to_redact.startswith("=") and record.strip().startswith(("Collecting ", "Requirement already satisfied")):
+                    to_redact = None
+
+                # Synapse displayed strings like this difficult to catch properly
+                # macaroon_secret_key_param='macaroon_secret_key: "*******"'
+                elif key == "macaroon_secret_key_param":
+                    to_replace = "macaroon_secret_key_param='macaroon_secret_key: "
+                    to_redact = to_redact.replace(to_replace, '').strip('"')
+
+                # Avoid to readd same secrets
+                if to_redact and to_redact not in self.data_to_redact:
+                    self.data_to_redact.append(to_redact.removeprefix("base64:"))
 
 
 class OperationLogger:

--- a/src/log.py
+++ b/src/log.py
@@ -570,7 +570,6 @@ class RedactingFormatter(Formatter):
         return msg
 
     def identify_data_to_redact(self, record):
-        print(record)
         # This matches stuff like db_pwd=the_secret or admin_password=other_secret
         # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
         # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
@@ -580,7 +579,7 @@ class RedactingFormatter(Formatter):
         secret_keys_regex = f"\w*({secret_keys})\w*|local key_?| key\w*|\w+key\w*|\w*KEY\w+|\w+KEY"
         operator_regex = r'(\s+\-\-value)?='
         value_regex = r"'([^']|'\''){5,}'|-----BEGIN.*-----END|\S{5,}"
-        redact_regex = fr"({secret_keys_regex}){operator_regex}({value_regex})",
+        redact_regex = re.compile(f"({secret_keys_regex}){operator_regex}({value_regex})")
         exclude_keys = [
             "manifest_key",
             "bind_key_",

--- a/src/log.py
+++ b/src/log.py
@@ -37,6 +37,7 @@ from .utils.error import YunohostError, YunohostValidationError
 from .utils.file_utils import read_file, read_yaml
 from .utils.logging import SUCCESS
 from .utils.system import get_ynh_package_version
+from .utils.password import redact_secrets
 
 logger = getLogger("yunohost.log")
 
@@ -558,120 +559,7 @@ class RedactingFormatter(Formatter):
 
     def format(self, record):
         msg = super(RedactingFormatter, self).format(record)
-        self.identify_data_to_redact(record.msg)
-        for data in self.data_to_redact:
-            # we check that data is not empty string,
-            # otherwise this may lead to super epic stuff
-            # (try to run "foo".replace("", "bar"))
-            if data:
-                msg = msg.replace(data, "**********")
-                # bash set -x display comparison like this: [[ ohno != \o\h\n\o ]]
-                msg = msg.replace("\\" + "\\".join(data), "**********")
-        return msg
-
-    def identify_data_to_redact(self, record):
-        # This matches stuff like db_pwd=the_secret or admin_password=other_secret
-        # (the secret part being at least 3 chars to avoid catching some lines like just "db_pwd=")
-        # Some names like "key" or "manifest_key" are ignored, used in helpers like ynh_app_setting_set or ynh_read_manifest
-        secret_keys = 'pass|secret|token|salt'
-        secret_keys = f"{secret_keys}|{secret_keys.upper()}|pwd"
-        # Avoid to match some non relevant var compound with 'key'
-        secret_keys_regex = f"\w*({secret_keys})\w*|local key_?| key\w*|\w+key\w*|\w*KEY\w+|\w+KEY"
-        operator_regex = r'(\s+\-\-value)?='
-        value_regex = r"'([^']|'\''){5,}'|-----BEGIN.*-----END|\S{5,}"
-        redact_regex = re.compile(f"({secret_keys_regex}){operator_regex}({value_regex})")
-        exclude_keys = [
-            "manifest_key",
-            "bind_key_",
-            "local key",
-            "local key_",
-            "version_key",
-            "version_key_",
-            "cache_key",
-            "foreign_key",
-            "primary_key",
-            "keys_zone",
-            "meta_keywords",
-            "csrf_token",
-            "jsonwebtoken",
-            "MYSQL_ROOT_PWD_FILE",
-            "SALTCORN_BIN",
-            "tls_passthrough_module",
-        ]
-        exclude_keys_suffixes = (
-            '_uri', '_url', '_path', '_key_expires', '_key_expires_date', '_enabled'
-        )
-        exclude_values = (
-            "true",
-            "false",
-            "value",
-            "value1",
-            "value2",
-            "value3",
-            "version",
-            "db_pwd",
-            "disabled",
-            "enabled",
-            "lambda",
-            "by_order",
-            '\K\w+',
-            "(generate_random_password)",
-        )
-        # Wrapping this in a try/except because we don't want this to
-        # break everything in case it fails miserably for some reason :s
-        try:
-            match = re.search(redact_regex, record.strip())
-        except re.error as e:
-            logger.warning(
-                "Failed to parse line to try to identify data to redact ... : %s" % e
-            )
-            match = None
-        if match:
-            key = match.group(1).strip()
-            to_redact = match.group(4)
-            if (
-                to_redact
-                # Some keys are false positive and should not be redacted
-                and key not in exclude_keys
-                # Keys that end ups by uri, url or path are just path and not secret
-                and not key.lower().endswith(exclude_keys_suffixes)
-                # Python venv build could display some false positive library
-                # like passlib or tokenizer
-                # example: 'Collecting tokenizers==0.19.1'
-                and not record.strip().startswith(("Created serverSetting through seed key",))
-                # Some values are clearly vars or function call
-                and to_redact.strip("'{}\"$,") not in exclude_values + (key.lower(), key.upper())
-            ):
-                # key='https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0C54D189F4BA284D'
-                # key=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-                # key=https://download.docker.com/linux/debian/gpg
-                if (
-                    (key == "key" and to_redact.split("'").startswith(("https://", "--key=https://")))
-                    or (key == 'pwd_output' and to_redact.startswith("/var/cache/yunohost/"))
-                    or (key == 'ynh_key' and to_redact.startswith("/etc/yunohost/certs"))
-                    or (key == "ssh_keys" and "/etc/ssh/ssh_host_" in to_redact)
-                    or (key == "public_key" and to_redact.startswith("ssh-"))
-                    or (key == "AUTH_KEYS" and to_redact == "/root/.ssh/authorized_keys")
-                ):
-                    to_redact = None
-                elif record.strip(' +').startswith(('POST_data=', 'curl --silent')):
-                    to_redact = to_redact.split("&")[0]
-
-                # Python venv build could display some false positive library
-                # like passlib or tokenizer
-                # example: 'Collecting tokenizers==0.19.1'
-                elif to_redact.startswith("=") and record.strip().startswith(("Collecting ", "Requirement already satisfied")):
-                    to_redact = None
-
-                # Synapse displayed strings like this difficult to catch properly
-                # macaroon_secret_key_param='macaroon_secret_key: "*******"'
-                elif key == "macaroon_secret_key_param":
-                    to_replace = "macaroon_secret_key_param='macaroon_secret_key: "
-                    to_redact = to_redact.replace(to_replace, '').strip('"')
-
-                # Avoid to readd same secrets
-                if to_redact and to_redact not in self.data_to_redact:
-                    self.data_to_redact.append(to_redact.removeprefix("base64:"))
+        return redact_secrets(msg, self.data_to_redact)
 
 
 class OperationLogger:

--- a/src/utils/password.py
+++ b/src/utils/password.py
@@ -19,6 +19,7 @@
 #
 
 import os
+import re
 import string
 import subprocess
 
@@ -217,3 +218,123 @@ class PasswordValidator:
         p = subprocess.Popen(command.split(), stdin=subprocess.PIPE)
         p.communicate(input=password.encode("utf-8"))
         return not bool(p.returncode)
+
+
+SECRET_KEYS = 'pass|secret|token|salt'
+SECRET_KEYS = f"{SECRET_KEYS}|{SECRET_KEYS.upper()}|pwd"
+# Avoid to match some non relevant var compound with 'key'
+SECRET_KEYS_REGEX = f"(?:\w|-)*(?:{SECRET_KEYS})\w*|local key_?| key\w*|\w(?:\w|-)*key\w*|\w*KEY\w+|\w+KEY"
+OPERATOR_REGEX = '(?:\s+\-\-value)?[\'"]?\s*(?:=|:|=>)\s*'
+VALUE_REGEX = r"'(?:[^']|'\''){5,}'|\S{5,}"
+REDACT_REGEX_STR = f"({SECRET_KEYS_REGEX}){OPERATOR_REGEX}(?:'?-----BEGIN [A-Z]+(?: '?KEY)?-----)?({VALUE_REGEX})(?:'?-----END'? [A-Z ]+-----'?)?"
+REDACT_REGEX = re.compile(REDACT_REGEX_STR)
+EXCLUDE_KEYS = [
+    "manifest_key",
+    "bind_key_",
+    "local key",
+    "local key_",
+    "version_key",
+    "version_key_",
+    "cache_key",
+    "foreign_key",
+    "primary_key",
+    "keys_zone",
+    "meta_keywords",
+    "csrf_token",
+    "jsonwebtoken",
+    "MYSQL_ROOT_PWD_FILE",
+    "SALTCORN_BIN",
+    "tls_passthrough_module",
+    "translation_key",
+    "tokenizer",
+    "teampass",
+    "misskey"
+    "calckey"
+    "libxcb-keysyms1"
+]
+EXCLUDE_KEYS_SUFFIXES = (
+    '_uri', '_url', '_path', '_key_expires', '_key_expires_date', '_enabled', '_algorithm', '_class', 'file'
+)
+EXCLUDE_VALUES = (
+    "**********",
+    "true",
+    "false",
+    "value",
+    "value1",
+    "value2",
+    "value3",
+    "version",
+    "unbound variable",
+    "db_pwd",
+    "disabled",
+    "enabled",
+    "lambda",
+    "by_order",
+    '\k\w+',
+    "(generate_random_password)",
+)
+
+def find_secrets(data: str, known_secrets: list = []) -> list:
+    for line in data.splitlines():
+        # Remove datetime and level if present
+        line = re.sub(r"^\d+-\d+-\d+ \d+:\d+:\d+,\d+: (DEBUG|ERROR|WARN(ING)?|INFO) - +", '', line)
+
+        # Large regex to find potential secrets
+        for match in re.finditer(REDACT_REGEX, line):
+            key = match.group(1).strip().removeprefix('--')
+            to_redact = match.group(2)
+            # print(key + " " + to_redact + "               " + line,
+            #      file=sys.stderr)
+
+            # Filter false positive
+            if (
+                not to_redact
+                # Some keys are false positive and should not be redacted
+                or key in EXCLUDE_KEYS
+                # Keys that end ups by uri, url or path are just path and not secret
+                or key.lower().endswith(EXCLUDE_KEYS_SUFFIXES)
+                # Python venv build could display some false positive library
+                # like passlib or tokenizer
+                # example: 'Collecting tokenizers==0.19.1'
+                or line.strip(' +').startswith(("Created serverSetting through seed key", "getent passwd "))
+            ):
+                continue
+
+            if line.strip(' +').startswith(('POST_data=', 'curl --silent')) or " --args '" in line:
+                to_redact = to_redact.split("&")[0]
+            to_redact = to_redact.strip("\"',;").removeprefix("base64:")
+
+            if (
+                # Some values are clearly vars or function call
+                to_redact.lower().strip("{}$") in EXCLUDE_VALUES + (key.lower(), key.upper())
+                or (key == "key" and to_redact.startswith(("https://", "--key=https://", "http://", "--key=http://")))
+                or (key == 'pwd_output' and to_redact.startswith("/var/cache/yunohost/"))
+                or (key == 'ynh_key' and to_redact.startswith("/etc/yunohost/certs"))
+                or (key == "ssh_keys" and "/etc/ssh/ssh_host_" in to_redact)
+                or (key == "public_key" and to_redact.startswith("ssh-"))
+                or (key == "AUTH_KEYS" and to_redact == "/root/.ssh/authorized_keys")
+                or (key == "password" and "--password= --database=" in line)
+                # Python venv build could display some false positive library
+                # like passlib or tokenizer
+                # example: 'Collecting tokenizers==0.19.1'
+                or (to_redact.startswith("=") and line.strip().startswith(("Collecting ", "Requirement already satisfied")))
+            ):
+                continue
+
+            # Avoid to readd same secrets
+            if to_redact and to_redact not in known_secrets:
+                known_secrets.append(to_redact)
+    return known_secrets
+
+def redact_secrets(msg: str, secrets_to_redact: list = []) -> str:
+    find_secrets(msg, secrets_to_redact)
+    for secret in secrets_to_redact:
+        # we check that data is not empty string,
+        # otherwise this may lead to super epic stuff
+        # (try to run "foo".replace("", "bar"))
+        if secret:
+            msg = msg.replace(secret, "**********")
+            # bash set -x display comparison like this: [[ ohno != \o\h\n\o ]]
+            msg = msg.replace("\\" + "\\".join(secret), "**********")
+    return msg
+

--- a/src/utils/password.py
+++ b/src/utils/password.py
@@ -293,9 +293,6 @@ def find_secrets(data: str, known_secrets: list = []) -> list:
                 or key in EXCLUDE_KEYS
                 # Keys that end ups by uri, url or path are just path and not secret
                 or key.lower().endswith(EXCLUDE_KEYS_SUFFIXES)
-                # Python venv build could display some false positive library
-                # like passlib or tokenizer
-                # example: 'Collecting tokenizers==0.19.1'
                 or line.strip(' +').startswith(("Created serverSetting through seed key", "getent passwd "))
             ):
                 continue

--- a/src/utils/yunopaste.py
+++ b/src/utils/yunopaste.py
@@ -27,6 +27,7 @@ import requests
 from ..domain import _get_maindomain, domain_list
 from ..utils.error import YunohostError
 from ..utils.network import get_public_ip
+from ..utils.password import redact_secrets
 
 logger = logging.getLogger("yunohost.utils.yunopaste")
 
@@ -111,4 +112,6 @@ def anonymize(data: str) -> str:
     if ipv6:
         data = data.replace(str(ipv6), "xx:xx:xx:xx:xx:xx")
 
+    # Try to find and remove secrets like password, token, keys...
+    data = redact_secrets(data)
     return data


### PR DESCRIPTION
## The problem

The current regex to filter password don't match all password in logs.

## Solution

Make the regex doing some false positive and remove this false positive with some whitelist mechanism.

## PR Status

Not really tested

This case is not managed:
```
mail_pwd=r'\'''\'''\''xxxxxxxxxxxxxxxxxxxxxxxxxx-'\'''\'''\''[:-1]
jwt_private_key_notification_server=r'\'''\'''\''xxxxxxxxxxxxxxxxxxxxxxxxxx-'\'''\'''\''[:-1]
```
## TODO
 - [ ] Write some unit test with those info
 - [ ] ~~Add `hash` and `HASH`~~
 - [x] Add `: ` as assignment operator
 - [ ] Anonymize public key in yunopaste anonymize function
### False positive (rejected by post-logic)
```
dex_token_uri=https://dex.maindomain2.tld/example/token
dex_keys_uri
api_key_expires=1835787894
api_key_expires_date=2028-03-04
eval 'jwt_private_key_notification_server=$value'
eval 'apikey_link=$value'
asttokens==3.0.0
tokenizers==0.21.1
DB_LIST_FOREIGN_KEYS=false
# ENABLE_TOKEN_AUTH=true
-- add_reference(:users, :invite, {:null=>true, :default=>nil, :foreign_key=>{:on_delete=>:nullify}, :index=>false})
    +  proxy_cache_path proxy_cache keys_zone=gitlab:10m max_size=1g levels=1:2;
ssh_keys='/etc/ssh/ssh_host_ecdsa_key
AUTH_KEYS=/root/.ssh/authorized_keys
gpg_key_url=https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey
gpg_keyring_path=/usr/share/keyrings/gitlab_gitlab-ee-archive-keyring.gpg
Created serverSetting through seed key=analytics
Created serverSetting through seed key=crawlingAndIndexing
Created serverSetting through seed key=appearance
Created serverSetting through seed key=culture
Created serverSetting through seed key=search
key=version
LIBRETIME_POSTGRESQL_PASSWORD=$(generate_random_password)
LIBRETIME_RABBITMQ_PASSWORD=$(generate_random_password)
LIBRETIME_ICECAST_ADMIN_PASSWORD=$(generate_random_password)
LIBRETIME_ICECAST_SOURCE_PASSWORD=$(generate_random_password)
LIBRETIME_ICECAST_RELAY_PASSWORD=$(generate_random_password)
pwd_output=/var/cache/yunohost/app_tmp_work_dirs/app_2zf5hjd8/scripts
ynh_key=/etc/yunohost/certs/yunohost.org/key.pem
tls_private_key_path=tls_private_key_path,
    archives = sorted(archives, key=lambda x: os.path.getctime(x))
           for ep in sorted(loaded, key=by_order):
YNH_APP_ARG_BOTTOKEN=disabled
match_string='MAIL_PASSWORD=[^\\n]*'
jsonwebtoken=/var/www/vaultwarden/build/target/release/deps/libjsonwebtoken-5990e6f82686c340.rlib
export 'public_key=ssh-ed25519 AAAAC3NXXXXXXXXX root@domain.tld'
yunohost app install https://github.com/YunoHost-Apps/borgserver_ynh -a "ssh_user=&public_key=ssh-ed25519 AAAAC3XXXXXXXXXX root@maindomain.tld"
```
### False postive not rejected
```
key=${key:-};
MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
VITE_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
export TOOLJET_DB_PASS=_tooljet_db_pwd
 689  nov. 25 22:09:06 maindomain.tld python[1381]: 2023-11-25 22:09:06,102 - synapse.federation.transport.server._base - 312 - WARNING - PUT-253- authenticate_request failed: 401: Failed to find any key to satisfy: _FetchKeyRequest(server_name='domain.tld', minimum_valid_until_ts=1700946532911, key_ids=['ed25519:a_hRTL'])
     return self.execute_command("GET", name, keys=[name])
 							<input id="id_pwd" name="pwd" type="password" onkeyup="pwdStrength(this.id, ['Very weak password', 'Weak password', 'Good password', 'Strong password'])" size="20" maxlength="255"/>
```

### Was not matched, and now it's matched
```
SIGNING_SALT=xxxxxxxxx
ynh_app_setting_set --app=APP --key=password --value=xxxxxxxxxxxxxxxxx
macaroon_secret_key_param='macaroon_secret_key: "xxxxxxxxxxxxxxxxxxxxxxx"'

ynh_app_setting_set --app=monica --key=private_key --value=-----BEGIN PRIVATE 'KEY-----\nMIIJQwIBADANBXXXXXsryygQ0A=\n-----END' PRIVATE KEY-----

POST_data='&weblog_title=YunoBlog&user_name=py&admin_password=xxxxxxxxxxx&admin_password2=xxxxxxxxxxx
POST_data='--data exec=install&etape=2&chmod=750&adresse_db=localhost&login_db=spip_hypersupers&pass_db=xxxxxxxxxxx&server_db=mysql'
curl --silent --show-error --insecure --location --header 'Host: maindomain.tld' --resolve maindomain.tld:443:127.0.0.1 --data 'exec=install&etape=2&chmod=750&adresse_db=localhost&login_db=spip_hypersupers&pass_db=xxxxxxxxxxxxxxxx&server_db=mysql' 'https://localhost/dfgfdsgfdg/ecrire/?suivant' --cookie-jar /tmp/ynh-spip_hypersupers-cookie.txt --cookie /tmp/ynh-spip_hypersupers-cookie.txt
About to run the command '['sh', '-c', 'YNH_APP_ARG_REGISTRATION=0 YNH_CWD=/var/cache/yunohost/from_file/pleroma_ynh-41da3ffe97d821659b6ad3a81b8ce7b977467681/scripts YNH_APP_ARG_SIZE=5g YNH_APP_INSTANCE_NAME=pleroma YNH_STDINFO=/tmp/tmpoRD0VW/stdinfo YNH_APP_INSTANCE_NUMBER=1 YNH_APP_ARG_PASSWORD=\'\xc3\x88~R\xc3xxxxxxxxxxxxxxxxxxxx' YNH_APP_ARG_IS_PUBLIC=1 YNH_APP_ARG_ADMIN=admin YNH_APP_ARG_NAME=\'xxxxxxxxxx\' YNH_APP_ID=pleroma YNH_APP_ARG_CACHE=1 YNH_APP_ARG_DOMAIN=domain.tld BASH_XTRACEFD=7 /bin/bash -x "./install" domain.tld amgine 1 \'\xc3\x88~R\xc3xxxxxxxxxxxxxxxxxxxx' \'xxxxxxxxxxx' 0 1 5g pleroma 7>&1']'
```

And more...

### Still not matched
```
mail_pwd=r'\'''\'''\''xxxxxxxxxxxxxxxxxxxxxxxxxx-'\'''\'''\''[:-1]
jwt_private_key_notification_server=r'\'''\'''\''xxxxxxxxxxxxxxxxxxxxxxxxxx-'\'''\'''\''[:-1]
./b296f6ad2ec8fc7b0ea75e741aa7b010:2873:2024-04-17 03:24:12,457: DEBUG -     key=${key:-};
ynh_app_setting_set --app=mautrix_telegram --key=apihash --value=xxxxxxxxxxxxxxxxx
```

## How to test

...
