### PR TITLE
Ensure file endline

### DIFF
--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -138,6 +138,16 @@ def _ensure_write_file_valid(file_path: str | Path) -> Path:
     return file_path
 
 
+def ensure_file_endline_terminated(file: str | Path) -> None:
+    """Ensure the file is terminated by an empty line"""
+    with Path(file).open("rb+") as stream:
+        stream.seek(-1, os.SEEK_END)
+        last_char = stream.read(1)
+        if last_char != b"\n":
+            stream.seek(0, os.SEEK_END)
+            stream.write(b"\n")
+
+
 def write_to_file(
     file_path: str | Path, data: str | bytes | list, file_mode: str = "w"
 ) -> None:

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -176,6 +176,7 @@ def write_to_file(
 
     try:
         file_path.open(file_mode).write(data)
+        ensure_file_endline_terminated(file_path)
     except IOError as e:
         raise YunohostError("cannot_write_file", file=file_path, error=str(e))
     except Exception as e:
@@ -222,6 +223,7 @@ def write_to_json(
     try:
         with file_path.open("w") as f:
             json.dump(data, f, sort_keys=sort_keys, indent=indent)
+        ensure_file_endline_terminated(file_path)
     except IOError as e:
         raise YunohostError("cannot_write_file", file=file_path, error=str(e))
     except Exception as e:
@@ -245,6 +247,7 @@ def write_to_yaml(file_path: str | Path, data: Jsonable) -> None:
     try:
         with file_path.open("w") as f:
             yaml.safe_dump(data, f, default_flow_style=False)
+        ensure_file_endline_terminated(file_path)
     except IOError as e:
         raise YunohostError("cannot_write_file", file=file_path, error=str(e))
     except Exception as e:


### PR DESCRIPTION
We should prefer files ending with an empty line: most editors do it automatically, thus adding a useless diff when manually editing / rolling back manual modifications.