### PR TITLE
fix debian_version_id, return type to Literal

### DIFF
--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -59,8 +59,8 @@ def debian_version() -> Literal["bookworm", "trixie"]:
 
 
 @cache
-def debian_version_id() -> str:
-    return int(os_release()["VERSION_ID"])  # type: ignore[return-value]
+def debian_version_id() -> Literal[12, 13]:
+    return int(os_release()["VERSION_ID"].strip('"'))
 
 
 @cache


### PR DESCRIPTION
## The problem

[CI](https://gitlab.com/YunoHost/yunohost/-/jobs/12502361493)

> \>       return int(os_release()["VERSION_ID"])  # type: ignore[return-value]
E       ValueError: invalid literal for int() with base 10: '"13"'
yunohost/utils/system.py:63: ValueError

## Solution

...

## PR Status

...

## How to test

...
