### PR TITLE
enh(dnsbl): Hostkarma

### DIFF
--- a/share/dnsbl_list.yml
+++ b/share/dnsbl_list.yml
@@ -19,7 +19,7 @@
   ipv4: true
   ipv6: false
   domain: false
-  non_blocklisted_return_code: ['127.0.0.1', '127.0.0.5']
+  non_blocklisted_return_code: ['127.0.0.1', '127.0.0.5', '127.0.1.1']
 - name: ImproWare IP based spamlist
   dns_server: spamrbl.imp.ch
   website: https://antispam.imp.ch/

--- a/share/dnsbl_list.yml
+++ b/share/dnsbl_list.yml
@@ -34,21 +34,21 @@
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: Backscatterer.org 
-  dns_server: ips.backscatterer.org 
-  website: http://www.backscatterer.org/ 
+- name: Backscatterer.org
+  dns_server: ips.backscatterer.org
+  website: http://www.backscatterer.org/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
 - name: inps.de
   dns_server: dnsbl.inps.de
-  website: http://dnsbl.inps.de/ 
+  website: http://dnsbl.inps.de/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: LASHBACK 
+- name: LASHBACK
   dns_server: ubl.unsubscore.com
   website: https://blacklist.lashback.com/
   ipv4: true
@@ -56,57 +56,57 @@
   domain: false
   non_blocklisted_return_code: []
 - name: Mailspike.org
-  dns_server: bl.mailspike.net 
+  dns_server: bl.mailspike.net
   website: http://www.mailspike.net/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: NiX Spam 
+- name: NiX Spam
   dns_server: ix.dnsbl.manitu.net
-  website: http://www.dnsbl.manitu.net/ 
+  website: http://www.dnsbl.manitu.net/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: REDHAWK 
+- name: REDHAWK
   dns_server: access.redhawk.org
-  website: https://www.redhawk.org/SpamHawk/query.php 
+  website: https://www.redhawk.org/SpamHawk/query.php
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: SORBS Open SMTP relays 
+- name: SORBS Open SMTP relays
   dns_server: smtp.dnsbl.sorbs.net
-  website: http://www.sorbs.net/ 
-  ipv4: true
-  ipv6: false
-  domain: false
-  non_blocklisted_return_code: []
-- name: SORBS Spamhost (last 28 days) 
-  dns_server: recent.spam.dnsbl.sorbs.net
-  website: http://www.sorbs.net/ 
-  ipv4: true
-  ipv6: false
-  domain: false
-  non_blocklisted_return_code: []
-- name: SORBS Spamhost (last 48 hours) 
-  dns_server: new.spam.dnsbl.sorbs.net 
   website: http://www.sorbs.net/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: SpamCop Blocking List 
-  dns_server: bl.spamcop.net 
-  website: https://www.spamcop.net/bl.shtml 
+- name: SORBS Spamhost (last 28 days)
+  dns_server: recent.spam.dnsbl.sorbs.net
+  website: http://www.sorbs.net/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: Spam Eating Monkey SEM-BACKSCATTER 
+- name: SORBS Spamhost (last 48 hours)
+  dns_server: new.spam.dnsbl.sorbs.net
+  website: http://www.sorbs.net/
+  ipv4: true
+  ipv6: false
+  domain: false
+  non_blocklisted_return_code: []
+- name: SpamCop Blocking List
+  dns_server: bl.spamcop.net
+  website: https://www.spamcop.net/bl.shtml
+  ipv4: true
+  ipv6: false
+  domain: false
+  non_blocklisted_return_code: []
+- name: Spam Eating Monkey SEM-BACKSCATTER
   dns_server: backscatter.spameatingmonkey.net
-  website: https://spameatingmonkey.com/services 
+  website: https://spameatingmonkey.com/services
   ipv4: true
   ipv6: false
   domain: false
@@ -118,30 +118,30 @@
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: Spam Eating Monkey SEM-IPV6BL 
-  dns_server: bl.ipv6.spameatingmonkey.net 
-  website: https://spameatingmonkey.com/services 
+- name: Spam Eating Monkey SEM-IPV6BL
+  dns_server: bl.ipv6.spameatingmonkey.net
+  website: https://spameatingmonkey.com/services
   ipv4: false
   ipv6: true
   domain: false
   non_blocklisted_return_code: []
-- name: SpamRATS! all 
-  dns_server: all.spamrats.com 
-  website: http://www.spamrats.com/ 
+- name: SpamRATS! all
+  dns_server: all.spamrats.com
+  website: http://www.spamrats.com/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: PSBL (Passive Spam Block List) 
+- name: PSBL (Passive Spam Block List)
   dns_server: psbl.surriel.com
   website: http://psbl.surriel.com/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: SWINOG 
+- name: SWINOG
   dns_server: dnsrbl.swinog.ch
-  website: https://antispam.imp.ch/ 
+  website: https://antispam.imp.ch/
   ipv4: true
   ipv6: false
   domain: false
@@ -153,30 +153,30 @@
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
-- name: Weighted Private Block List 
-  dns_server: db.wpbl.info 
-  website: http://www.wpbl.info/ 
+- name: Weighted Private Block List
+  dns_server: db.wpbl.info
+  website: http://www.wpbl.info/
   ipv4: true
   ipv6: false
   domain: false
   non_blocklisted_return_code: []
 - name: AntiCaptcha.NET IPv6
   dns_server: dnsbl6.anticaptcha.net
-  website: http://anticaptcha.net/ 
+  website: http://anticaptcha.net/
   ipv4: false
   ipv6: true
   domain: false
   non_blocklisted_return_code: []
-- name: Suomispam Blacklist 
-  dns_server: bl.suomispam.net 
-  website: http://suomispam.net/ 
+- name: Suomispam Blacklist
+  dns_server: bl.suomispam.net
+  website: http://suomispam.net/
   ipv4: true
   ipv6: true
   domain: false
   non_blocklisted_return_code: []
-- name: NordSpam 
+- name: NordSpam
   dns_server: bl.nordspam.com
-  website: https://www.nordspam.com/ 
+  website: https://www.nordspam.com/
   ipv4: true
   ipv6: true
   domain: false


### PR DESCRIPTION
## The problem

Hostkarma returns a code on our infra that is only informative and not a blocking status.

## Solution

Add `127.0.1.1` to the codes to ignore.
cf. https://wiki.junkemailfilter.com/index.php/Spam_DNS_Lists if we want to add more.

## PR Status

...

## How to test

...
