### PR TITLE
ynh_local_curl helper: only print response to HTTP request

### DIFF
--- a/helpers/helpers.v1.d/utils
+++ b/helpers/helpers.v1.d/utils
@@ -136,14 +136,15 @@ ynh_local_curl() {
     # Temporarily enable visitors if needed...
     local visitors_enabled=$(ynh_permission_has_user "main" "visitors" && echo yes || echo no)
     if [[ $visitors_enabled == "no" ]]; then
-        ynh_permission_update --permission "main" --add "visitors"
+        ynh_permission_update --permission="main" --add="visitors" > /dev/null # Skip print to standard output, the caller may process the output and then expect only the HTTP response.
+                                                                               # See https://github.com/YunoHost-Apps/piwigo_ynh/issues/168#issuecomment-3694238343
     fi
 
     # Curl the URL
     curl --silent --show-error --insecure --location --header "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar $cookiefile --cookie $cookiefile
 
     if [[ $visitors_enabled == "no" ]]; then
-        ynh_permission_update --permission "main" --remove "visitors"
+        ynh_permission_update --permission "main" --remove "visitors" > /dev/null
     fi
 }
 

--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -138,7 +138,8 @@ ynh_local_curl_raw() {
     # Temporarily enable visitors if needed...
     local visitors_enabled=$(ynh_permission_has_user --permission="main" --user="visitors" && echo yes || echo no)
     if [[ $visitors_enabled == "no" ]]; then
-        ynh_permission_update --permission="main" --add="visitors"
+        ynh_permission_update --permission="main" --add="visitors" > /dev/null # Skip print to standard output, the caller may process the output and then expect only the HTTP response.
+                                                                               # See https://github.com/YunoHost-Apps/piwigo_ynh/issues/168#issuecomment-3694238343
     fi
 
     # Curl the URL
@@ -146,7 +147,7 @@ ynh_local_curl_raw() {
     curl --silent --show-error --insecure --location --header "Host: $domain" --resolve "$domain:443:127.0.0.1" "$full_page_url" --cookie-jar "$cookiefile" --cookie "$cookiefile" "$@"
 
     if [[ $visitors_enabled == "no" ]]; then
-        ynh_permission_update --permission="main" --remove="visitors"
+        ynh_permission_update --permission="main" --remove="visitors" > /dev/null
     fi
 }
 


### PR DESCRIPTION
## The problem

A package calling `ynh_local_curl` may try to process the output of the function. That's the case of Piwigo during the [installation](https://github.com/YunoHost-Apps/piwigo_ynh/blob/d68dc3b2021e1095bfe9b4a4fcba5e1115246bd7/scripts/install#L70) and the [upgrade](https://github.com/YunoHost-Apps/piwigo_ynh/blob/d68dc3b2021e1095bfe9b4a4fcba5e1115246bd7/scripts/upgrade#L84). 

But when the administrator has configured the app to not be accessible to the visitors, this leads to a problem, because the helper is temporarily changing the permissions, and by doing so adds logs to the output.

In the case of Piwigo, this leads to this issue: https://github.com/YunoHost-Apps/piwigo_ynh/issues/168

For more details, see: https://github.com/YunoHost-Apps/piwigo_ynh/issues/168#issuecomment-3694238343


## Solution

When the helper calls `ynh_permission_update`, don't print anything to stdout. But let's have stderr work.

## PR Status

Ready to be reviewed.

## How to test

Try to install Piwigo with `all_users` permissions.
