### PR TITLE
Helper doc: escape capture group parentheses for back-references to work in `ynh_replace`

### DIFF
--- a/helpers/helpers.v2.1.d/string
+++ b/helpers/helpers.v2.1.d/string
@@ -47,7 +47,9 @@ ynh_string_random() {
 # | arg: --file=     - File in which the string will be replaced.
 #
 # As this helper is based on sed command, regular expressions and references to
-# sub-expressions can be used (see sed manual page for more information)
+# sub-expressions can be used (see sed manual page for more information). In particular
+# for back-references, as in sed without specific options, you will need to escape
+# the parentheses of the capture group.
 ynh_replace() {
     # ============ Argument parsing =============
     local -A args_array=([m]=match= [r]=replace= [f]=file=)


### PR DESCRIPTION
e.g. : 
```sh
ynh_replace --match="^\(\s*const SERVER_LONG_DESCRIPTION = \).*;$" --replace="\1$content;"  --file="$config_file"
```
