### PR TITLE
Update sshd KexAlgorithms to address OpenSSH client warning

### DIFF
--- a/conf/ssh/sshd_config
+++ b/conf/ssh/sshd_config
@@ -15,6 +15,10 @@ HostKey {{ key }}{% endfor %}
 # ##############################################
 # Stuff recommended by Mozilla "modern" compat'
 # https://infosec.mozilla.org/guidelines/openssh
+# Plus sntrup761x25519-sha512@openssh.com as 
+# first KexAlgorithm  as recommended by OpenSSH 
+# for post quantum security:
+# https://www.openssh.org/pq.html
 # ##############################################
 
 {% if compatibility == "intermediate" %}
@@ -24,7 +28,7 @@ HostKey {{ key }}{% endfor %}
 {% else %}
   # By default use "modern" Mozilla configuration
   # Keys, ciphers and MACS
-  KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+  KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
   Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
   MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 {% endif %}


### PR DESCRIPTION
Add sntrup761x25519-sha512@openssh.com to KexAlgorithms for post-quantum security. See https://github.com/yunohost/issues/issues/2738

## The problem

See also https://github.com/yunohost/issues/issues/2738

"OpenSSH 10.1 started warning users when connections use cryptography that is not safe against quantum computers." as stated on https://www.openssh.org/pq.html

The warning is as follows 
```
** WARNING: connection is not using a post-quantum key exchange algorithm.
** This session may be vulnerable to "store now, decrypt later" attacks.
** The server may need to be upgraded. See https://openssh.com/pq.html
```

## Solution

Add `sntrup761x25519-sha512` as first KexAlgorithm proposed by sshd (in the "modern" setting).

## PR Status

...

## How to test

...
