### PR TITLE
fix: expired influxdata repo key

### DIFF
--- a/tests/test_app_resources.py
+++ b/tests/test_app_resources.py
@@ -321,7 +321,7 @@ def test_resource_apt():
         "extras": {
             "influxdb": {
                 "repo": "deb https://repos.influxdata.com/debian stable main",
-                "key": "https://repos.influxdata.com/influxdata-archive_compat.key",
+                "key": "https://repos.influxdata.com/influxdata-archive.key",
                 "packages": "influxdb2",
             }
         },


### PR DESCRIPTION
## The problem

Failing test jobs: https://gitlab.com/YunoHost/yunohost/-/jobs/12637650168

## Solution

Follow instructions over at https://repos.influxdata.com/debian/

## PR Status

...

## How to test

...
