### PR TITLE
Helper doc: `ynh_setup_source` - The default filename is not what you may think it is

### DIFF
--- a/helpers/helpers.v2.1.d/sources
+++ b/helpers/helpers.v2.1.d/sources
@@ -54,7 +54,7 @@
 #           = false   # default if file 'format' is not set and the file is not to be extracted because it is not an archive but a script or binary or whatever asset.
 #                     #    in which case the file will only be `mv`ed to the location possibly renamed using the `rename` value
 #
-# rename    = "whatever_your_want"   # to be used for convenience when `extract` is false and the default name of the file is not practical
+# rename    = "whatever_your_want"   # to be used for convenience when `extract` is false and the default name of the file is not practical (the default filename being the value of `source_id` arg and not the upstream basename).
 # platform  = "linux/amd64"          # (defaults to "linux/$YNH_ARCH") to be used in conjonction with `format = "docker"` to specify which architecture to extract for
 # ```
 #


### PR DESCRIPTION
This PR only document a point which can seem weird at first sight. 

### Is there something more to do with the helper ?

I assume that there is a use for this behavior, although I don't get it for now. If you have an asset in the manifest which is binary for which you specify `extract = false`. When using ` ynh_setup_source`, the binary will get renamed as per `source_id` argument (i.e. `main` by default).
https://github.com/YunoHost/yunohost/blob/9161d8efe60b48c113cad24744887e1ec4126ae6/helpers/helpers.v1.d/sources#L164
https://github.com/YunoHost/yunohost/blob/9161d8efe60b48c113cad24744887e1ec4126ae6/helpers/helpers.v1.d/sources#L229-L231

Which is probably not what you want for a binary, so you have to rename it after `ynh_setup_source` with one of those ways, all of them being somehow imperfect:
- declare the resource as per upstream filename (`[resources.sources.filename]`)  but it may neither be very convenient nor very clear if you have several resources to deal with.
- use `rename = $fiename` in the manifest for the given resources. But that may look a bit strange to ask for renaming the asset with the name it already has in the resources URLs.
- use `mv` to rename the file in install/upgrade scripts. But this is one more step you might wonder what it refers to after a while as a maintainer. 

Here is a concrete case where the question arose: https://github.com/YunoHost-Apps/garage_ynh/pull/51#discussion_r2669737254