### PR TITLE
disable proxy_set_header Authorization in proxy_params_no_auth

### DIFF
--- a/conf/nginx/proxy_params_no_auth
+++ b/conf/nginx/proxy_params_no_auth
@@ -14,7 +14,9 @@ proxy_set_header   Upgrade              $http_upgrade;
 proxy_set_header   Connection           $connection_upgrade;
 
 # Clean auth headers to ensure that the client can't inject any header for authentication
-proxy_set_header   Authorization        "";
+# If following line is uncommented, it forces the Authorization header to be empty even in cases where the app has other auth mechanism than just the YunoHost SSO
+# The login to the app would then fail.
+# proxy_set_header   Authorization        "";
 proxy_set_header   Ynh-User             "";
 proxy_set_header   Ynh-User-Email       "";
 proxy_set_header   Ynh-User-Fullname    "";

--- a/conf/nginx/proxy_params_no_auth
+++ b/conf/nginx/proxy_params_no_auth
@@ -14,8 +14,7 @@ proxy_set_header   Upgrade              $http_upgrade;
 proxy_set_header   Connection           $connection_upgrade;
 
 # Clean auth headers to ensure that the client can't inject any header for authentication
-# If following line is uncommented, it forces the Authorization header to be empty even in cases where the app has other auth mechanism than just the YunoHost SSO
-# The login to the app would then fail.
+# The Authorization header cannot be force-cleared here, because some apps do have auth mechanism that depend on other things than the YunoHost SSO (cf other basic-auth based stuff like Webdav(?) or "Bearer"-type auth
 # proxy_set_header   Authorization        "";
 proxy_set_header   Ynh-User             "";
 proxy_set_header   Ynh-User-Email       "";


### PR DESCRIPTION
As discussed in https://github.com/YunoHost/package_linter/pull/182

## The problem

https://github.com/YunoHost/package_linter/pull/182

## Solution

I’ve commented the line instead of removing it to still have the same structure as for `proxy_params_with_auth` and explain why we disable it for `proxy_params_no_auth`


## PR Status

...

## How to test

...
