### PR TITLE
Add comment for ynh_del_swap for proper doc generation

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -554,12 +554,15 @@ ynh_add_swap() {
     fi
 }
 
+# Delete swap
+#
+# usage: ynh_del_swap 
 ynh_del_swap() {
     # If there a swap at this place
     if [ -e "/swap_$app" ]; then
         # Clean the fstab
         sed -i "/#Swap added by $app/d" /etc/fstab
-        # Desactive the swap file
+        # Deactive the swap file
         swapoff "/swap_$app"
         # And remove it
         rm "/swap_$app"


### PR DESCRIPTION
## The problem
Noticed that `ynh_del_swap` is not documented here https://doc.yunohost.org/en/dev/packaging/scripts/helpers_v2.1/ although it exists in the repo.
...

## Solution
Add comment to `ynh_del_swap` function for proper doc generation. Also fixed a typo.
...

## PR Status
Ready.
...

## How to test
Nothing to test as this PR just adds / edits comments.
...
