### PR TITLE
fix(service): display timestamp 0 as unknown instead of actual date

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -463,7 +463,7 @@ def _get_and_format_service_status(service, infos):
     if "StateChangeTimestamp" in raw_status:
         output["last_state_change"] = datetime.utcfromtimestamp(
             raw_status["StateChangeTimestamp"] / 1000000
-        )
+        ) if raw_status["StateChangeTimestamp"] != 0 else "unknown"
 
     # 'test_status' is an optional field to test the status of the service using a custom command
     if "test_status" in infos:


### PR DESCRIPTION
## The problem

If the timestamp of a service's last update is reported as 0, it is processed literally as 1970-01-01 00:00:00 (UTC).
This should be processed as "unknown"

## The solution

Output "unknown" instead of the result of the calculation of the elapsed time.
It is not great UX-wise, since the text will be `<status> since Unknown`, but that's the text the webadmin is expecting: https://github.com/YunoHost/yunohost-admin/blob/19f8cf84b4ac1cb57b2f23a2887c5be971cc4e96/app/src/views/service/ServiceInfo.vue#L25

## PR Status

Ready

## How to test

...
