### PR TITLE
fix(form): allow empty domain when optional

### DIFF
--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1701,10 +1701,9 @@ class DomainOption(BaseChoicesOption):
 
     @validator("default", pre=True, always=True)
     def inject_default(cls, value: str | None, values: Values) -> str | None:
-        # If the option is optional and no default was explicitly set,
-        # don't force the main domain as default
-        if values.get("optional") and value in (None, ""):
-            return None
+        # If the option is optional, don't force the main domain as default
+        if values.get("optional"):
+            return ""
 
         # TODO remove calls to resources in validators (pydantic V2 should adress this)
         from ..domain import _get_maindomain

--- a/src/utils/form.py
+++ b/src/utils/form.py
@@ -1701,6 +1701,11 @@ class DomainOption(BaseChoicesOption):
 
     @validator("default", pre=True, always=True)
     def inject_default(cls, value: str | None, values: Values) -> str | None:
+        # If the option is optional and no default was explicitly set,
+        # don't force the main domain as default
+        if values.get("optional") and value in (None, ""):
+            return None
+
         # TODO remove calls to resources in validators (pydantic V2 should adress this)
         from ..domain import _get_maindomain
 


### PR DESCRIPTION
## The problem

I have an optional domain parameter (so it's empty by default), but during the initialization his value is set do the default domain: https://ci-apps-dev.yunohost.org/ci/job/17058

## Solution

If optional is True, return empty string

## PR Status

Done

## How to test

...
