### PR TITLE
Fixup date arithmetic in system diagnoser

### DIFF
--- a/src/diagnosers/50-systemresources.py
+++ b/src/diagnosers/50-systemresources.py
@@ -192,7 +192,7 @@ class MyDiagnoser(Diagnoser):
             out = check_output(cmd)
             lines = out.split("\n") if out else []
 
-            now = datetime.datetime.now()
+            now = datetime.datetime.now(datetime.timezone.utc)
 
             for line in reversed(lines):
                 # Lines look like :


### PR DESCRIPTION
## The problem

https://forum.yunohost.org/t/strange-traceback-in-diagnosis/41347/4

```
Diagnosis failed for category 'systemresources':
Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/yunohost/diagnosis.py", line 193, in diagnosis_run
code, report = diagnoser.diagnose(force=force)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/yunohost/diagnosis.py", line 443, in diagnose
items = list(self.run())
^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/yunohost/diagnosers/50-systemresources.py", line 173, in run
kills_count = self.recent_kills_by_oom_reaper()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/yunohost/diagnosers/50-systemresources.py", line 208, in recent_kills_by_oom_reaper
processes = list(analyzed_kern_log())
^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3/dist-packages/yunohost/diagnosers/50-systemresources.py", line 202, in analyzed_kern_log
diff = now - date
~~~~^~~~~~
TypeError: can't subtract offset-naive and offset-aware datetimes
```

## Solution

https://stackoverflow.com/questions/796008/cant-subtract-offset-naive-and-offset-aware-datetimes/25662061#25662061

Extract `now()` in TZ-aware format.

## PR Status

```
>>> import datetime
>>> now = datetime.datetime.now(datetime.timezone.utc)
>>> date = datetime.datetime.fromisoformat('2026-01-21T13:58:59.799358+02:00')
>>> print(now)
2026-01-21 14:17:50.425599+00:00
>>> print(date)
2026-01-21 13:58:59.799358+02:00
>>> print(now - date)
2:18:50.626241
```

YOLOworks 🤷 

## How to test

1. Have a process killed by oomreaper recently
2. Run diagnostics
