### PR TITLE
_ynh_apply_default_permissions: Fixup `/var/log` permissions

### DIFF
--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -287,7 +287,7 @@ _ynh_apply_default_permissions() {
             chmod -R u=rwX,g=rX,o=--- "$target"
             chown -R "$app:$group" "$target"
             return
-        elif [ "$target" == "${data_dir:-}" || "$target" == "/var/log/$app" ]; then
+        elif [ "$target" == "${data_dir:-}" ] || [ "$target" == "/var/log/$app" ]; then
             # Read the group from the data manifest resource
             local group="$(ynh_read_manifest 'resources.data_dir.group' | sed 's/null//g' | sed "s/__APP__/$app/g" | cut -f1 -d:)"
             chmod 750 "$target"

--- a/helpers/helpers.v2.1.d/0-utils
+++ b/helpers/helpers.v2.1.d/0-utils
@@ -287,7 +287,7 @@ _ynh_apply_default_permissions() {
             chmod -R u=rwX,g=rX,o=--- "$target"
             chown -R "$app:$group" "$target"
             return
-        elif [ "$target" == "${data_dir:-}" ]; then
+        elif [ "$target" == "${data_dir:-}" || "$target" == "/var/log/$app" ]; then
             # Read the group from the data manifest resource
             local group="$(ynh_read_manifest 'resources.data_dir.group' | sed 's/null//g' | sed "s/__APP__/$app/g" | cut -f1 -d:)"
             chmod 750 "$target"


### PR DESCRIPTION
## The problem

Inconsistent permissions on `/var/log/$app` between when provisioned via `ynh_add_logrotate` vs `ynh_restore`

## Solution

Fixup permissions as seen via `_ynh_apply_default_permissions`

## PR Status

Followup would be to make `ynh_add_logrotate` use `_ynh_apply_default_permissions`

## How to test

Restore an app that does not create parents for `/var/log/$app` explicitly
