### PR TITLE
Switch to list-based subprocess call for group removal

### DIFF
--- a/src/user.py
+++ b/src/user.py
@@ -1124,7 +1124,7 @@ def user_group_create(
                 m18n.n("group_already_exist_on_system_but_removing_it", group=groupname)
             )
             subprocess.check_call(
-                f"sed --in-place '/^{groupname}:/d' /etc/group", shell=True
+                ["sed", "--in-place", f"/^{groupname}:/d", "/etc/group"]
             )
         else:
             raise YunohostValidationError(


### PR DESCRIPTION
Improving the robustness of system-level operations is a key part of maintaining project correctness. I've updated the group removal logic in `src/user.py` to use a list-based subprocess call instead of a shell-based one. 

Avoiding `shell=True` when executing commands like `sed` ensures that the parameters are passed directly to the executable, removing the unnecessary shell overhead and making the operation more predictable when handling system identifiers. This is a straightforward refinement that aligns with established best practices for secure and reliable system automation.