### PR TITLE
[enh] Add a test for ynh_write_var_in_file with an ending space

### DIFF
--- a/helpers/helpers.v2.1.d/templating
+++ b/helpers/helpers.v2.1.d/templating
@@ -371,13 +371,13 @@ ynh_write_var_in_file() {
         # \ and sed is quite complex you need 2 \\ to get one in a sed
         # So we need \\\\ to go through 2 sed
         value="$(echo "$value" | sed 's/"/\\\\"/g')"
-        sed -ri "${range}s$delimiter"'(^'"${var_part}"'")([^"]|\\")*("[\s;,]*)(\s*'"$comments"'.*)?$'$delimiter'\1'"${value}"'"'"${endline}${delimiter}i" "$file"
+        sed -ri "${range}s$delimiter"'(^'"${var_part}"'")([^"]|\\")*("[\s;,]*)\s*('"$comments"'.*)?$'$delimiter'\1'"${value}"'"'"${endline}${delimiter}i" "$file"
     elif [[ "$first_char" == "'" ]]; then
         # \ and sed is quite complex you need 2 \\ to get one in a sed
         # However double quotes implies to double \\ to
         # So we need \\\\\\\\ to go through 2 sed and 1 double quotes str
         value="$(echo "$value" | sed "s/'/\\\\\\\\'/g")"
-        sed -ri "${range}s$delimiter(^${var_part}')([^']|\\')*('"'[\s,;]*)(\s*'"$comments"'.*)?$'$delimiter'\1'"${value}'${endline}${delimiter}i" "$file"
+        sed -ri "${range}s$delimiter(^${var_part}')([^']|\\')*('"'[\s,;]*)\s*('"$comments"'.*)?$'$delimiter'\1'"${value}'${endline}${delimiter}i" "$file"
     else
         formated="false"
         # Boolean

--- a/tests/test_helpers.v2.1.d/ynhtest_config.sh
+++ b/tests/test_helpers.v2.1.d/ynhtest_config.sh
@@ -412,6 +412,7 @@ ynhtest_config_read_json() {
     local dummy_dir="$(mktemp -d -p "$VAR_WWW")"
     file="$dummy_dir/dummy.json"
 
+    # The space after `"url": "https://yunohost.org", ` is a test not a mistake...
     cat << EOF > "$file"
 {
      "foo": null,
@@ -420,7 +421,7 @@ ynhtest_config_read_json() {
      "theme": "colib'ris",
      "email": "root@example.com",
        "port": 1234,
-     "url": "https://yunohost.org",
+     "url": "https://yunohost.org", 
      "dict": {
          "ldap_base": "ou=users,dc=yunohost,dc=org"
      }
@@ -463,6 +464,7 @@ ynhtest_config_write_json() {
     local dummy_dir="$(mktemp -d -p "$VAR_WWW")"
     file="$dummy_dir/dummy.json"
 
+    # The space after `"url": "https://yunohost.org", ` is a test not a mistake...
     cat << EOF > "$file"
 {
      "foo": null,
@@ -471,7 +473,7 @@ ynhtest_config_write_json() {
      "theme": "colib'ris",
      "email": "root@example.com",
        "port": 1234,
-     "url": "https://yunohost.org",
+     "url": "https://yunohost.org", 
      "dict": {
          "ldap_base": "ou=users,dc=yunohost,dc=org"
      }


### PR DESCRIPTION
## The problem

I discover today that ynh_write_var_in_file fail to rewrite the value when the line end with a space ( in a json file? )

## Solution

For now i just create the test

## PR Status

...

## How to test

...
