### PR TITLE
trixie: storage/disks API is broken (fix #2751)

### DIFF
--- a/src/utils/udisks2_interfaces.py
+++ b/src/utils/udisks2_interfaces.py
@@ -45,7 +45,7 @@ UDISKS2_DRIVE_ATA_IFC = "org.freedesktop.UDisks2.Drive.Ata"
 UDISKS2_DRIVE_NVME_IFC = "org.freedesktop.UDisks2.NVMe.Controller"
 
 
-def _get_class_from_interfaces(_1, interface_names_iter, _2):
+def _get_class_from_interfaces(_1, interface_names_iter, _2, _3):
     if UDISKS2_DRIVE_ATA_IFC in interface_names_iter:
         return AtaDisk
     if UDISKS2_DRIVE_NVME_IFC in interface_names_iter:


### PR DESCRIPTION
## The problem

see [#2751](https://github.com/YunoHost/issues/issues/2751)

## Solution

Add ``_3`` as a 4th parameter in the definition of ``_get_class_from_interfaces`` at L48 in ``udisks2_interfaces.py``


## PR Status

Ready for review

## How to test

Test with:
``sudo sed -i '48s/def _get_class_from_interfaces(_1, interface_names_iter, _2):/def _get_class_from_interfaces(_1, interface_names_iter, _2, _3):/' /usr/lib/python3/dist-packages/yunohost/utils/udisks2_interfaces.py``
