### PR TITLE
trixie: nsswitch -> nss regen-conf should clean the /etc/yunohost/regenconf.yml file (fix #2754 & # 2748)

### DIFF
--- a/src/regenconf.py
+++ b/src/regenconf.py
@@ -478,6 +478,8 @@ def _get_regenconf_infos():
             del data["metronome"]
         if "rspamd" in data:
             del data["rspamd"]
+        if "nsswitch" in data:
+            del data["nsswitch"]
         return data
     except Exception:
         return {}


### PR DESCRIPTION
## The problem

see https://github.com/YunoHost/issues/issues/2745 (or its duplicate it seems https://github.com/YunoHost/issues/issues/2748)

## Solution

update regenconf.py to remove nsswitch data

## PR Status

- [x] test on my system
- [x] ready for review

## How to test

...
