### PR TITLE
Normalize casing of `--force` shorthand in `app` cli

### DIFF
--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1004,10 +1004,10 @@ app:
                 -u:
                     full: --url
                     help: Git url to fetch for upgrade
-                -f:
+                -F:
                     full: --file
                     help: Folder or tarball for upgrade
-                -F:
+                -f:
                     full: --force
                     help: Force the update, even though the app is up to date
                     action: store_true


### PR DESCRIPTION
## The problem

`yunohost app upgrade` and `yunohost app install` use different shorthand for `--force` (`-F` vs `-f` respectively)

## Solution

Bite the bullet and use `-f` in both cases.

## PR Status

YOLO

## How to test

Invoke from cli 🤷 
