### PR TITLE
misc: When calling apt update, use --error-on=any to have a valid returncode

### DIFF
--- a/helpers/helpers.v1.d/apt
+++ b/helpers/helpers.v1.d/apt
@@ -126,7 +126,7 @@ ynh_apt() {
 #
 # Requires YunoHost version 2.2.4 or higher.
 ynh_package_update() {
-    ynh_apt update
+    ynh_apt update --error-on=any
 }
 
 # Install package(s)

--- a/helpers/helpers.v2.1.d/apt
+++ b/helpers/helpers.v2.1.d/apt
@@ -127,7 +127,7 @@ Description: Fake package for ${app} (YunoHost app) dependencies
  This meta-package is only responsible of installing its dependencies.
 EOF
 
-    _ynh_apt update
+    _ynh_apt update --error-on=any
 
     _ynh_wait_dpkg_free
 
@@ -269,7 +269,7 @@ EOF
     # ynh_apt_install_dependencies will also call an ynh_apt update on its own
     # and it's good to limit unecessary requests ...  Here we mainly want to
     # validate that the url+key is correct before going further
-    _ynh_apt update -o Dir::Etc::sourcelist="/etc/apt/sources.list.d/$app.list"
+    _ynh_apt update --error-on=any -o Dir::Etc::sourcelist="/etc/apt/sources.list.d/$app.list"
 
     # Force the cache to be reupdated on the next "apt update" (in
     # ynh_apt_install_dependencies) because the previous command with
@@ -296,7 +296,7 @@ EOF
     ynh_safe_rm "/etc/apt/sources.list.d/$app.list"
     ynh_safe_rm "/etc/apt/preferences.d/$app"
     ynh_safe_rm "/etc/apt/trusted.gpg.d/$app.gpg"
-    _ynh_apt update
+    _ynh_apt update --error-on=any
 }
 
 # #####################

--- a/src/tools.py
+++ b/src/tools.py
@@ -383,7 +383,7 @@ def tools_update(
         # Update APT cache
         # LC_ALL=C is here to make sure the results are in english
         command = (
-            "LC_ALL=C apt-get update -o Acquire::Retries=3 --allow-releaseinfo-change"
+            "LC_ALL=C apt-get update --error-on=any -o Acquire::Retries=3 --allow-releaseinfo-change --error-on=any"
         )
 
         # Filter boring message about "apt not having a stable CLI interface"


### PR DESCRIPTION
```
# apt-get update
Hit:1 http://deb.debian.org/debian bookworm InRelease
…
Err:5 https://dl.yarnpkg.com/debian stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
Reading package lists... Done
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
W: Failed to fetch https://dl.yarnpkg.com/debian/dists/stable/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 62D54FD4003F6525
W: Some index files failed to download. They have been ignored, or old ones used instead.
# echo $?
0
```

Real-life bug here: https://github.com/YunoHost/issues/issues/2762