### PR TITLE
Add support for .mount and other systemd units to yunohost service add, remove, etc.

### DIFF
--- a/helpers/helpers.v2.1.d/systemd
+++ b/helpers/helpers.v2.1.d/systemd
@@ -64,7 +64,7 @@ ynh_config_remove_systemd() {
         systemctl daemon-reload
     fi
     if [ -e "/etc/systemd/system/$service.mount" ]; then
-        ynh_systemctl --service="$service" --action=stop
+        ynh_systemctl --mount="$service" --action=stop
         systemctl disable "$service.mount" --quiet
         ynh_safe_rm "/etc/systemd/system/$service.mount"
         systemctl daemon-reload

--- a/helpers/helpers.v2.1.d/systemd
+++ b/helpers/helpers.v2.1.d/systemd
@@ -101,7 +101,7 @@ ynh_systemctl() {
     # ===========================================
 
     if [ -n "$mount" ]; then
-        if [ "$log_path$" == "/var/log/$service/$service.log" ]; then
+        if [ "$log_path" == "/var/log/$service/$service.log" ]; then
             log_path="systemd"
         fi
         service="$mount.mount"

--- a/helpers/helpers.v2.1.d/systemd
+++ b/helpers/helpers.v2.1.d/systemd
@@ -101,6 +101,9 @@ ynh_systemctl() {
     # ===========================================
 
     if [ -n "$mount" ]; then
+        if [ "$log_path$" == "/var/log/$service/$service.log" ]; then
+            log_path="systemd"
+        fi
         service="$mount.mount"
     fi
 

--- a/src/service.py
+++ b/src/service.py
@@ -57,6 +57,7 @@ def service_add(
     test_conf=None,
     needs_exposed_ports=None,
     need_lock=False,
+    unit_type=None,
 ):
     """
     Add a custom service
@@ -69,8 +70,12 @@ def service_add(
         test_conf -- Specify a custom bash command to check if the configuration of the service is valid or broken, similar to nginx -t.
         needs_exposed_ports -- A list of ports that needs to be publicly exposed for the service to work as intended.
         need_lock -- Use this option to prevent deadlocks if the service does invoke yunohost commands.
+        unit_type -- Specify that type of systemd unit to be added, e.g. mount.
     """
     services = _get_services()
+    
+    if unit_type is not None:
+        name=name+"."+unit_type
 
     services[name] = service = {}
 


### PR DESCRIPTION
## The problem

https://github.com/YunoHost/issues/issues/2763

## Solution

- `.service` is implicit in the code
- adding `.mount` explicity seems to mainly be backward compatible

## PR Status

...

## How to test

https://github.com/YunoHost-Apps/garage_ynh/pull/61
