### PR TITLE
[fix] Make `mail_user` property of `[resources.system_user]` work in all expected contexts

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -703,6 +703,10 @@ def app_change_url(
 
             service_reload_or_restart("nginx")
 
+            # Regenerate postfix maps for app system users who need to send emails,
+            # taking into account the latest apps settings
+            regen_mail_app_user_config_for_dovecot_and_postfix()
+
             logger.success(
                 m18n.n("app_change_url_success", app=app, domain=domain, path=path)
             )
@@ -1100,6 +1104,9 @@ def app_upgrade(
                             f"{app_setting_path}/{file_to_copy}",
                             recursive=True,
                         )
+
+                # Regenerate postfix maps for app system users who need to send emails, taking into account the latest apps settings
+                regen_mail_app_user_config_for_dovecot_and_postfix()
 
                 # Clean and set permissions
                 rmtree(workdir)
@@ -1657,6 +1664,9 @@ def app_install(
     if "hooks" in os.listdir(extracted_app_folder):
         for file in os.listdir(extracted_app_folder + "/hooks"):
             hook_add(app_instance_name, extracted_app_folder + "/hooks/" + file)
+
+    # Regenerate postfix maps for app system users who need to send emails, taking into account the latest apps settings
+    regen_mail_app_user_config_for_dovecot_and_postfix()
 
     # Clean and set permissions
     rmtree(extracted_app_folder)

--- a/src/backup.py
+++ b/src/backup.py
@@ -1447,6 +1447,7 @@ class RestoreManager:
             )
         finally:
             if not restore_failed:
+                from .app import regen_mail_app_user_config_for_dovecot_and_postfix
                 self.targets.set_result("apps", app_instance_name, "Success")
                 operation_logger.success()
 
@@ -1461,6 +1462,10 @@ class RestoreManager:
 
                 # Cleaning temporary scripts directory
                 shutil.rmtree(tmp_workdir_for_app, ignore_errors=True)
+
+                # Regenerate postfix maps for app system users who need to send emails,
+                # taking into account the latest apps settings
+                regen_mail_app_user_config_for_dovecot_and_postfix()
 
                 # Call post_app_restore hook
                 env_dict = _make_environment_for_app_script(app_instance_name)


### PR DESCRIPTION
### Reminder on the `mail_user` feature

The YNH documentation [describes a `mail_user` property](https://doc.yunohost.org/en/dev/packaging/resources/#:~:text=mail_user) that allows changing the username of an email address associated to a system user in the FROM header. 

One typical use case of this feature relates to apps sending notifications email and which requires access to SMTP server. SMTP login and password thus remains the ones of the system user, but instead of seeing `$app@$domain` (which when installed on a subdomain would result in `$app@$app.$main_domain`, i.e. looking complicated) when enabling this option, the user receiving a notification email could see sender address as `no-reply@$domain` for instance, which is a more common and straightforward practice.

### Problem

However as of now (tested on YNH 12.1.39), this feature only works in two cases:
- When installing the app
- When running `regen-conf` command

This is because `mail_user` is added to `app_senders_map` (a [virtual map dedicated to app system users](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/conf/postfix/main.cf#L113) who need to send emails. More info in [postfix documentation](https://www.postfix.org/postconf.5.html#:~:text=smtpd_sender_login_maps)) within [function `regen_mail_app_user_config_for_dovecot_and_postfix()`](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/src/app.py#L2609) in `app.py` and that this function is only triggered when [provisioning a system user](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/src/utils/resources.py#L881) with `allow_email = true` (i.e. at app initial install), or when regenerating the global configuration via [dovecot](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/hooks/conf_regen/25-dovecot#L80) and [postfix](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/hooks/conf_regen/19-postfix#L133) hooks.

That leaves a number of cases where it won't be taken into account and eventually fail:
- When adding this feature via an app upgrade (i.e. which wasn't installed initially with this feature)
- When restoring a backup of the app 
- When changing URL (the $domain portion of the email address won't be updated).
- It can't be tweaked within the package's scripts in general and in config script and associated config panel in particular (i.e. for instance to allow admin changing the email address shown in FROM header in the config panel). 

### Examples of apps requiring this feature 
- https://github.com/YunoHost-Apps/indico_ynh
- https://github.com/YunoHost-Apps/docmost_ynh/tree/testing
- https://github.com/oleole39/comentario_ynh


### Solution
This PR originates from a Matrix discussion with @otm33GH and @DeMiro5001 and aims at triggering the `regen_mail_app_user_config_for_dovecot_and_postfix()` function in each of the forgotten contexts listed above.



### TODO:
- [x] Fix install script context  
- [x] Fix upgrade script context
- [x] Fix change_url script context  
- [x] Fix restore script context
- [ ] Fix config script context (help appreciated)
  - I can't figure out where the core knows (if it ever does?) that an app config has just been sucessfully saved and applied (be it via Web UI config panel or SSH). 
    - Could it be somewhere in `app.py`, like [there](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/src/app.py#L2263) maybe (I don't really get how `.set()` works there) or [just below within](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/src/app.py#L2292) an `else` statement when there is no validation error ? 
    - Or if the core doesn't know about it, could the python function somehow be triggered within the [bash config helpers](https://github.com/YunoHost/yunohost/blob/c936c0b6017199bc812be7c5e899f98c6b8cb48e/helpers/helpers.v2.1.d/config#L73)
- [ ] Test (help appreciated)