### PR TITLE
fix: update vendored docker-image-extract to support OCI multi-registry (ghcr.io, quay.io, etc.)

### DIFF
--- a/helpers/vendor/docker-image-extract/docker-image-extract
+++ b/helpers/vendor/docker-image-extract/docker-image-extract
@@ -1,8 +1,9 @@
-#!/usr/bin/env bash
-
-# This script pulls and extracts all files from an image in Docker Hub.
+#!/bin/sh
 #
-# Copyright (c) 2020-2023, Jeremy Lin
+# This script pulls and extracts all files from an image in Docker Hub or any
+# OCI-compliant registry (ghcr.io, quay.io, registry.gitlab.com, etc.).
+#
+# Copyright (c) 2020-2024, Jeremy Lin
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,12 +28,13 @@ PLATFORM="${PLATFORM_DEFAULT}"
 OUT_DIR="./output"
 
 usage() {
-    echo "This script pulls and extracts all files from an image in Docker Hub."
+    echo "This script pulls and extracts all files from an image in Docker Hub or any OCI registry."
     echo
     echo "$0 [OPTIONS...] IMAGE[:REF]"
     echo
-    echo "IMAGE can be a community user image (like 'some-user/some-image') or a"
-    echo "Docker official image (like 'hello-world', which contains no '/')."
+    echo "IMAGE can be:"
+    echo "  - A Docker Hub image: 'hello-world', 'some-user/some-image'"
+    echo "  - An OCI registry image: 'ghcr.io/user/image', 'quay.io/user/image'"
     echo
     echo "REF is either a tag name or a full SHA-256 image digest (with a 'sha256:' prefix)."
     echo "The default ref is the 'latest' tag."
@@ -40,8 +42,6 @@ usage() {
     echo "Options:"
     echo
     echo "  -p PLATFORM  Pull image for the specified platform (default: ${PLATFORM})"
-    echo "               For a given image on Docker Hub, the 'Tags' tab lists the"
-    echo "               platforms supported for that image."
     echo "  -o OUT_DIR   Extract image to the specified output dir (default: ${OUT_DIR})"
     echo "  -h           Show help with usage examples"
 }
@@ -51,14 +51,14 @@ usage_detailed() {
     echo
     echo "Examples:"
     echo
-    echo "# Pull and extract all files in the 'hello-world' image tagged 'latest'."
+    echo "# Pull from Docker Hub."
     echo "\$ $0 hello-world:latest"
     echo
-    echo "# Same as above; ref defaults to the 'latest' tag."
-    echo "\$ $0 hello-world"
+    echo "# Pull from GitHub Container Registry."
+    echo "\$ $0 ghcr.io/user/image:latest"
     echo
-    echo "# Pull the 'hello-world' image for the 'linux/arm64/v8' platform."
-    echo "\$ $0 -p linux/arm64/v8 hello-world"
+    echo "# Pull for a specific platform."
+    echo "\$ $0 -p linux/arm64/v8 ghcr.io/user/image"
     echo
     echo "# Pull an image by digest."
     echo "\$ $0 hello-world:sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042"
@@ -127,35 +127,11 @@ if ! have_curl && ! have_wget; then
     exit 1
 fi
 
-image_spec="$1"
-image="${image_spec%%:*}"
-if [ "${image#*/}" = "${image}" ]; then
-    # Docker official images are in the 'library' namespace.
-    image="library/${image}"
-fi
-ref="${image_spec#*:}"
-if [ "${ref}" = "${image_spec}" ]; then
-    echo "Defaulting ref to tag 'latest'..."
-    ref=latest
-fi
-
-# Split platform (OS/arch/variant) into separate variables.
-# A platform specifier doesn't always include the `variant` component.
-OLD_IFS="${IFS}"
-IFS=/ read -r OS ARCH VARIANT <<EOF
-${PLATFORM}
-EOF
-IFS="${OLD_IFS}"
-
 # Given a JSON input on stdin, extract the string value associated with the
 # specified key. This avoids an extra dependency on a tool like `jq`.
 extract() {
     local key="$1"
-    # Extract "<key>":"<val>" (assumes key/val won't contain double quotes).
-    # The colon may have whitespace on either side.
     grep -o "\"${key}\"[[:space:]]*:[[:space:]]*\"[^\"]\+\"" |
-    # Extract just <val> by deleting the last '"', and then greedily deleting
-    # everything up to '"'.
     sed -e 's/"$//' -e 's/.*"//'
 }
 
@@ -181,108 +157,277 @@ fetch() {
     fi
 }
 
-# https://docs.docker.com/docker-hub/api/latest/#tag/repositories
-manifest_list_url="https://hub.docker.com/v2/repositories/${image}/tags/${ref}"
-
-# If the ref is already a SHA-256 image digest, then we don't need to look up anything.
-if [ -z "${ref##sha256:*}" ]; then
-    digest="${ref}"
-else
-    echo "Getting multi-arch manifest list..."
-    NL='
-'
-    digest=$(fetch "${manifest_list_url}" |
-        # Break up the single-line JSON output into separate lines by adding
-        # newlines before and after the chars '[', ']', '{', and '}'.
-        # This uses the \${NL} syntax because some BSD variants of sed don't
-        # support \n syntax in the replacement string, but instead require
-        # a literal newline preceded by a backslash.
-        sed -e 's/\([][{}]\)/\'"${NL}"'\1\'"${NL}"'/g' |
-        # Extract the "images":[...] list.
-        sed -n '/"images":/,/]/ p' |
-        # Each image's details are now on a separate line, e.g.
-        # "architecture":"arm64","features":"","variant":"v8","digest":"sha256:054c85801c4cb41511b176eb0bf13a2c4bbd41611ddd70594ec3315e88813524","os":"linux","os_features":"","os_version":null,"size":828724,"status":"active","last_pulled":"2022-09-02T22:46:48.240632Z","last_pushed":"2022-09-02T00:42:45.69226Z"
-        # The image details are interspersed with lines of stray punctuation,
-        # so grep for an arbitrary string that must be in these lines.
-        grep architecture |
-        # Search for an image that matches the platform.
-        while read -r image; do
-            # Arch is probably most likely to be unique, so check that first.
-            arch="$(echo ${image} | extract 'architecture')"
-            if [ "${arch}" != "${ARCH}" ]; then continue; fi
-
-            os="$(echo ${image} | extract 'os')"
-            if [ "${os}" != "${OS}" ]; then continue; fi
-
-            variant="$(echo ${image} | extract 'variant')"
-            if [ "${variant}" = "${VARIANT}" ]; then
-                echo ${image} | extract 'digest'
-                break
-            fi
-        done)
-
-    if [ -n "${digest}" ]; then
-        echo "Platform ${PLATFORM} resolved to '${digest}'..."
+# Fetch only the response headers for a URL (GET request, body discarded).
+# HEAD (-I) is avoided because some registries (e.g., ghcr.io) return 405 on HEAD.
+fetch_headers() {
+    local url="$1"
+    if have_curl; then
+        curl -sSL -D - -o /dev/null "${url}" 2>/dev/null
     else
-        echo "No image digest found. Verify that the image, ref, and platform are valid."
-        exit 1
+        wget -qS -O /dev/null "${url}" 2>&1
+    fi
+}
+
+# ============================================================
+# REGISTRY DETECTION
+# ============================================================
+#
+# A registry prefix is detected when the first path component of the image
+# spec contains a dot (e.g., ghcr.io, quay.io, registry.gitlab.com).
+# Docker Hub shorthand images (hello-world, user/image) have no dot.
+
+image_spec="$1"
+_first_component="${image_spec%%/*}"
+_first_no_port="${_first_component%%:*}"
+
+if [ "${_first_component}" != "${image_spec}" ] && echo "${_first_no_port}" | grep -q '\.'; then
+    # Non-Docker Hub OCI registry (e.g., ghcr.io/user/image:tag)
+    registry="${_first_no_port}"
+    _rest="${image_spec#*/}"        # "user/image:tag"
+    image="${_rest%%:*}"            # "user/image"
+    _ref_candidate="${_rest#*:}"
+    if [ "${_ref_candidate}" = "${_rest}" ]; then
+        echo "Defaulting ref to tag 'latest'..."
+        ref="latest"
+    else
+        ref="${_ref_candidate}"
+    fi
+else
+    # Docker Hub
+    registry=""
+    image="${image_spec%%:*}"
+    if [ "${image#*/}" = "${image}" ]; then
+        # Docker official images are in the 'library' namespace.
+        image="library/${image}"
+    fi
+    ref="${image_spec#*:}"
+    if [ "${ref}" = "${image_spec}" ]; then
+        echo "Defaulting ref to tag 'latest'..."
+        ref=latest
     fi
 fi
 
-# https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate
-api_token_url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:$image:pull"
+# Split platform (OS/arch/variant) into separate variables.
+OLD_IFS="${IFS}"
+IFS=/ read -r OS ARCH VARIANT <<EOF
+${PLATFORM}
+EOF
+IFS="${OLD_IFS}"
 
-# https://github.com/docker/distribution/blob/master/docs/spec/api.md#pulling-an-image-manifest
-manifest_url="https://registry-1.docker.io/v2/${image}/manifests/${digest}"
+# ============================================================
+# SHARED: DOWNLOAD AND EXTRACT LAYERS
+# ============================================================
 
-# https://github.com/docker/distribution/blob/master/docs/spec/api.md#pulling-a-layer
-blobs_base_url="https://registry-1.docker.io/v2/${image}/blobs"
+extract_layers() {
+    local blobs_url="$1"
+    local auth_hdr="$2"
+    local layers="$3"
 
-echo "Getting API token..."
-token=$(fetch "${api_token_url}" | extract 'token')
-auth_header="Authorization: Bearer $token"
+    mkdir -p "${OUT_DIR}"
 
-# https://github.com/distribution/distribution/blob/main/docs/spec/manifest-v2-2.md
-docker_manifest_v2="application/vnd.docker.distribution.manifest.v2+json"
-
-# https://github.com/opencontainers/image-spec/blob/main/manifest.md
-oci_manifest_v1="application/vnd.oci.image.manifest.v1+json"
-
-# Docker Hub can return either type of manifest format. Most images seem to
-# use the Docker format for now, but the OCI format will likely become more
-# common as features that require that format become enabled by default
-# (e.g., https://github.com/docker/build-push-action/releases/tag/v3.3.0).
-accept_header="Accept: ${docker_manifest_v2},${oci_manifest_v1}"
-
-echo "Getting image manifest for $image:$ref..."
-layers=$(fetch "${manifest_url}" "${auth_header}" "${accept_header}" |
-             # Extract `digest` values only after the `layers` section appears.
-             sed -n '/"layers":/,$ p' |
-             extract 'digest')
-
-if [ -z "${layers}" ]; then
-    echo "No layers returned. Verify that the image and ref are valid."
-    exit 1
-fi
-
-mkdir -p "${OUT_DIR}"
-
-for layer in $layers; do
-    hash="${layer#sha256:}"
-    echo "Fetching and extracting layer ${hash}..."
-    fetch "${blobs_base_url}/${layer}" "${auth_header}" | gzip -d | tar -C "${OUT_DIR}" -xf -
-    # Ref: https://github.com/moby/moby/blob/master/image/spec/v1.2.md#creating-an-image-filesystem-changeset
-    #      https://github.com/moby/moby/blob/master/pkg/archive/whiteouts.go
-    # Search for "whiteout" files to indicate files deleted in this layer.
-    OLD_IFS="${IFS}"
-    find "${OUT_DIR}" -name '.wh.*' | while IFS= read -r f; do
-        dir="${f%/*}"
-        wh_file="${f##*/}"
-        file="${wh_file#.wh.}"
-        # Delete both the whiteout file and the whited-out file.
-        rm -rf "${dir}/${wh_file}" "${dir}/${file}"
+    for layer in ${layers}; do
+        local hash="${layer#sha256:}"
+        echo "Fetching and extracting layer ${hash}..."
+        if [ -n "${auth_hdr}" ]; then
+            fetch "${blobs_url}/${layer}" "${auth_hdr}"
+        else
+            fetch "${blobs_url}/${layer}"
+        fi | gzip -d | tar -C "${OUT_DIR}" -xf -
+        # Handle "whiteout" files (deletions in this layer).
+        # Ref: https://github.com/moby/moby/blob/master/image/spec/v1.2.md#creating-an-image-filesystem-changeset
+        OLD_IFS="${IFS}"
+        find "${OUT_DIR}" -name '.wh.*' | while IFS= read -r f; do
+            dir="${f%/*}"
+            wh_file="${f##*/}"
+            file="${wh_file#.wh.}"
+            rm -rf "${dir}/${wh_file}" "${dir}/${file}"
+        done
+        IFS="${OLD_IFS}"
     done
-    IFS="${OLD_IFS}"
-done
 
-echo "Image contents extracted into ${OUT_DIR}."
+    echo "Image contents extracted into ${OUT_DIR}."
+}
+
+# ============================================================
+# DOCKER HUB FLOW (original logic, unchanged)
+# ============================================================
+
+if [ -z "${registry}" ]; then
+
+    manifest_list_url="https://hub.docker.com/v2/repositories/${image}/tags/${ref}"
+
+    if [ -z "${ref##sha256:*}" ]; then
+        digest="${ref}"
+    else
+        echo "Getting multi-arch manifest list..."
+        NL='
+'
+        digest=$(fetch "${manifest_list_url}" |
+            sed -e 's/\([][{}]\)/\'"${NL}"'\1\'"${NL}"'/g' |
+            sed -n '/"images":/,/]/ p' |
+            grep architecture |
+            while read -r image_entry; do
+                arch="$(echo ${image_entry} | extract 'architecture')"
+                if [ "${arch}" != "${ARCH}" ]; then continue; fi
+
+                os="$(echo ${image_entry} | extract 'os')"
+                if [ "${os}" != "${OS}" ]; then continue; fi
+
+                variant="$(echo ${image_entry} | extract 'variant')"
+                if [ "${variant}" = "${VARIANT}" ]; then
+                    echo ${image_entry} | extract 'digest'
+                    break
+                fi
+            done)
+
+        if [ -n "${digest}" ]; then
+            echo "Platform ${PLATFORM} resolved to '${digest}'..."
+        else
+            echo "No image digest found. Verify that the image, ref, and platform are valid."
+            exit 1
+        fi
+    fi
+
+    api_token_url="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${image}:pull"
+    manifest_url="https://registry-1.docker.io/v2/${image}/manifests/${digest}"
+    blobs_base_url="https://registry-1.docker.io/v2/${image}/blobs"
+
+    echo "Getting API token..."
+    token=$(fetch "${api_token_url}" | extract 'token')
+    auth_header="Authorization: Bearer ${token}"
+
+    docker_manifest_v2="application/vnd.docker.distribution.manifest.v2+json"
+    oci_manifest_v1="application/vnd.oci.image.manifest.v1+json"
+    accept_header="Accept: ${docker_manifest_v2},${oci_manifest_v1}"
+
+    echo "Getting image manifest for ${image}:${ref}..."
+    layers=$(fetch "${manifest_url}" "${auth_header}" "${accept_header}" |
+                 sed -n '/"layers":/,$ p' |
+                 extract 'digest')
+
+    if [ -z "${layers}" ]; then
+        echo "No layers returned. Verify that the image and ref are valid."
+        exit 1
+    fi
+
+    extract_layers "${blobs_base_url}" "${auth_header}" "${layers}"
+
+# ============================================================
+# OCI REGISTRY FLOW (dynamic auth via WWW-Authenticate)
+# ============================================================
+
+else
+
+    # 1. Discover auth endpoint from the WWW-Authenticate header on /v2/
+    echo "Probing registry ${registry} for auth endpoint..."
+    www_auth=$(fetch_headers "https://${registry}/v2/" | grep -i "www-authenticate" | head -1)
+
+    auth_realm=$(echo "${www_auth}" | grep -o 'realm="[^"]*"' | sed 's/realm="//;s/"$//')
+    auth_service=$(echo "${www_auth}" | grep -o 'service="[^"]*"' | sed 's/service="//;s/"$//')
+
+    # 2. Acquire token (or proceed without auth if the registry is fully public)
+    auth_header=""
+    if [ -z "${auth_realm}" ]; then
+        echo "Registry ${registry} returned no WWW-Authenticate — proceeding without auth."
+    else
+        echo "Auth endpoint: ${auth_realm} (service: ${auth_service})"
+        echo "Getting API token..."
+        token_url="${auth_realm}?service=${auth_service}&scope=repository:${image}:pull"
+        token=$(fetch "${token_url}" | extract 'token')
+
+        # Some registries use "access_token" instead of "token" (RFC 6749 naming)
+        if [ -z "${token}" ]; then
+            token=$(fetch "${token_url}" | extract 'access_token')
+        fi
+
+        if [ -z "${token}" ]; then
+            echo "ERROR: Could not acquire auth token from ${auth_realm}."
+            exit 1
+        fi
+
+        auth_header="Authorization: Bearer ${token}"
+    fi
+
+    # 3. Fetch manifest — accept both index (multi-arch) and single manifest formats
+    oci_index="application/vnd.oci.image.index.v1+json"
+    docker_list="application/vnd.docker.distribution.manifest.list.v2+json"
+    oci_manifest="application/vnd.oci.image.manifest.v1+json"
+    docker_manifest_v2="application/vnd.docker.distribution.manifest.v2+json"
+    accept_all="Accept: ${oci_index},${docker_list},${oci_manifest},${docker_manifest_v2}"
+
+    manifests_base_url="https://${registry}/v2/${image}/manifests"
+    blobs_base_url="https://${registry}/v2/${image}/blobs"
+
+    echo "Getting manifest for ${image}:${ref}..."
+    if [ -n "${auth_header}" ]; then
+        manifest_response=$(fetch "${manifests_base_url}/${ref}" "${auth_header}" "${accept_all}")
+    else
+        manifest_response=$(fetch "${manifests_base_url}/${ref}" "${accept_all}")
+    fi
+
+    media_type=$(echo "${manifest_response}" | extract 'mediaType' | head -1)
+
+    # 4. If manifest list/index: resolve to platform-specific digest
+    if [ "${media_type}" = "application/vnd.oci.image.index.v1+json" ] || \
+       [ "${media_type}" = "application/vnd.docker.distribution.manifest.list.v2+json" ]; then
+
+        echo "Manifest is a multi-arch index. Resolving platform ${PLATFORM}..."
+
+        # Strategy: split compact JSON array on "},{"  to get one manifest entry per line,
+        # then match architecture + os (+ optional variant) to find the right digest.
+        digest=$(echo "${manifest_response}" |
+            tr -d '[:space:]' |
+            grep -o '"manifests":\[.*\]' |
+            sed 's/"manifests":\[//' | sed 's/\]$//' |
+            sed 's/},{/\n{/g' |
+            while IFS= read -r entry; do
+                arch=$(echo "${entry}" | extract 'architecture')
+                [ "${arch}" = "${ARCH}" ] || continue
+
+                os_val=$(echo "${entry}" | extract 'os')
+                [ "${os_val}" = "${OS}" ] || continue
+
+                if [ -n "${VARIANT}" ]; then
+                    variant_val=$(echo "${entry}" | extract 'variant')
+                    [ "${variant_val}" = "${VARIANT}" ] || continue
+                fi
+
+                echo "${entry}" | extract 'digest'
+                break
+            done)
+
+        if [ -z "${digest}" ]; then
+            echo "ERROR: No manifest found for platform ${PLATFORM} in the index."
+            echo "       Check that the image supports this platform."
+            exit 1
+        fi
+
+        echo "Platform ${PLATFORM} resolved to '${digest}'..."
+
+        # 5. Fetch the platform-specific single manifest
+        echo "Getting image manifest for ${image}@${digest}..."
+        accept_single="Accept: ${oci_manifest},${docker_manifest_v2}"
+        if [ -n "${auth_header}" ]; then
+            layers=$(fetch "${manifests_base_url}/${digest}" "${auth_header}" "${accept_single}" |
+                sed -n '/"layers":/,$ p' | extract 'digest')
+        else
+            layers=$(fetch "${manifests_base_url}/${digest}" "${accept_single}" |
+                sed -n '/"layers":/,$ p' | extract 'digest')
+        fi
+
+    else
+        # Single-arch manifest — extract layers directly
+        echo "Manifest is a single-arch image."
+        layers=$(echo "${manifest_response}" |
+            sed -n '/"layers":/,$ p' |
+            extract 'digest')
+    fi
+
+    if [ -z "${layers}" ]; then
+        echo "ERROR: No layers returned. Verify that the image and ref are valid."
+        exit 1
+    fi
+
+    extract_layers "${blobs_base_url}" "${auth_header}" "${layers}"
+
+fi


### PR DESCRIPTION
## Problem

The vendored `docker-image-extract` script is hardcoded for Docker Hub only. Packaging apps that pull images from other OCI registries (e.g. `ghcr.io` for [AFFiNE](https://github.com/YunoHost-Apps/affine_ynh)) fails because the script always uses `auth.docker.io` and `registry-1.docker.io` regardless of the image source.

## Solution

Dynamically discover the auth endpoint by probing `GET /v2/` and parsing the `WWW-Authenticate: Bearer realm="...",service="..."` header returned on a 401 (OCI Distribution Spec standard). The Docker Hub flow is fully preserved for backward compatibility.

## Changes

- **Registry detection**: hostname containing a dot in the first path component is treated as a registry (e.g. `ghcr.io/user/image`)
- **Dynamic auth discovery**: `GET /v2/` → parse `WWW-Authenticate` → build token URL from `realm` + `service`
- **No-auth registries**: `mcr.microsoft.com` returns 200 on `/v2/` with no `WWW-Authenticate` — handled gracefully
- **Multi-arch index**: support both `application/vnd.oci.image.index.v1+json` and `application/vnd.docker.distribution.manifest.list.v2+json`
- **Docker Hub**: original flow unchanged

## Test results

| Registry | Image | Result |
|---|---|---|
| docker.io | `hello-world`, `alpine:3.18` | PASS |
| ghcr.io | `toeverything/affine:stable` | PASS |
| quay.io | `prometheus/prometheus` | PASS |
| registry.gitlab.com | `gitlab-org/gitlab-runner` | PASS |
| mcr.microsoft.com | `hello-world` | PASS |

Validated with `package_check` on the AFFiNE YunoHost package (install + remove green).

Upstream PR submitted to `jjlin/docker-image-extract`: https://github.com/jjlin/docker-image-extract/pull/7
