### PR TITLE
make upstream config usable to make loadbalancing possible on reverse_proxy

### DIFF
--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -2,10 +2,11 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
 }
-
+{%- if balancer_enable == "True" %}
 upstream {{ domain }} {
-    include /etc/nginx/conf.d/{{ domain }}.d/upstream.config;
+    include /etc/nginx/conf.d/{{ domain }}.d/upstream.conf.inc;
 }
+{%- endif %}
 
 server {
     listen 80;

--- a/conf/nginx/server.tpl.conf
+++ b/conf/nginx/server.tpl.conf
@@ -3,6 +3,10 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
+upstream {{ domain }} {
+    include /etc/nginx/conf.d/{{ domain }}.d/upstream.config;
+}
+
 server {
     listen 80;
     listen [::]:80;

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -141,6 +141,9 @@ do_pre_regen() {
         fi
 
         ynh_render_template "server.tpl.conf" "${nginx_conf_dir}/${domain}.conf"
+        # make nginx enable to use upstream config file to enable loadbalancing feature 
+        touch "${nginx_conf_dir}/${domain}.d/upstream.conf"
+        echo "server 127.0.0.1;" > "${nginx_conf_dir}/${domain}.d/upstream.conf"
         if [ $mail_enabled == "True" ]; then
             ynh_render_template "autoconfig.tpl.xml" "${mail_autoconfig_dir}/config-v1.1.xml"
         fi

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -141,9 +141,11 @@ do_pre_regen() {
         fi
 
         ynh_render_template "server.tpl.conf" "${nginx_conf_dir}/${domain}.conf"
-        # make nginx enable to use upstream config file to enable loadbalancing feature 
-        touch "${nginx_conf_dir}/${domain}.d/upstream.conf"
-        echo "server 127.0.0.1;" > "${nginx_conf_dir}/${domain}.d/upstream.conf"
+        if [ $balancer_enabled == "True" ]; then
+            # make nginx enable to use upstream config file to enable loadbalancing feature 
+            touch "${nginx_conf_dir}/${domain}.d/upstream.conf.inc"
+            echo "server 127.0.0.1;" > "${nginx_conf_dir}/${domain}.d/upstream.conf.inc"
+        fi
         if [ $mail_enabled == "True" ]; then
             ynh_render_template "autoconfig.tpl.xml" "${mail_autoconfig_dir}/config-v1.1.xml"
         fi

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -140,6 +140,12 @@ do_pre_regen() {
             export mail_enabled="False"
         fi
 
+        if tr ' ' '\n' <<< "$YNH_DOMAINS_WITH_BALANCer" | grep -q "^$domain$"; then
+            export balancer_enabled="True"
+        else
+            export balancer_enabled="False"
+        fi
+
         ynh_render_template "server.tpl.conf" "${nginx_conf_dir}/${domain}.conf"
         if [ $balancer_enabled == "True" ]; then
             # make nginx enable to use upstream config file to enable loadbalancing feature 

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -140,7 +140,7 @@ do_pre_regen() {
             export mail_enabled="False"
         fi
 
-        if tr ' ' '\n' <<< "$YNH_DOMAINS_WITH_BALANCer" | grep -q "^$domain$"; then
+        if tr ' ' '\n' <<< "$YNH_DOMAINS_WITH_BALANCER" | grep -q "^$domain$"; then
             export balancer_enabled="True"
         else
             export balancer_enabled="False"

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -19,7 +19,7 @@ i18n = "domain_config"
         default = "_none"
 
     [feature.balancer]
-        [feature.banlancer.status]
+        [feature.balancer.status]
         type = "boolean"
         default = false
 

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -19,7 +19,7 @@ i18n = "domain_config"
         default = "_none"
 
     [feature.balancer]
-        [feature.banlancer]
+        [feature.banlancer.status]
         type = "boolean"
         default = false
 

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -19,7 +19,7 @@ i18n = "domain_config"
         default = "_none"
 
     [feature.balancer]
-        [feature.app.default_app]
+        [feature.banlancer]
         type = "boolean"
         default = false
 

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -18,8 +18,8 @@ i18n = "domain_config"
         filter = "is_webapp"
         default = "_none"
 
-    [feature.balancer]
-        [feature.balancer.status]
+    [feature.proxy]
+        [feature.proxy.balancer]
         type = "boolean"
         default = false
 

--- a/share/config_domain.toml
+++ b/share/config_domain.toml
@@ -18,6 +18,11 @@ i18n = "domain_config"
         filter = "is_webapp"
         default = "_none"
 
+    [feature.balancer]
+        [feature.app.default_app]
+        type = "boolean"
+        default = false
+
     [feature.portal]
     # Only available for "topest" domains
 

--- a/src/regenconf.py
+++ b/src/regenconf.py
@@ -172,6 +172,9 @@ def regen_conf(
         env["YNH_DOMAINS_WITH_MAIL_IN_AND_OUT"] = " ".join(
             domain_list(features=["mail_in", "mail_out"])["domains"]
         )
+        env["YNH_DOMAINS_WITH_BALANCER"] = " ".join(
+            domain_list(features=["balancer"])["domains"]
+        )
 
     env["YNH_CONTEXT"] = "regenconf"
     env["YNH_HELPERS_VERSION"] = "2"


### PR DESCRIPTION
## The problem

Can not make a reverse_proxy with load balance using the redirect app 

## Solution

Include  a upstream.config file located in the domain.d directory

## PR Status

Not tested :/ please help me!

## How to test

Create a redirect app which should be modified too
