### PR TITLE
trixie: configure sssd_ldap to use ldap:// on localhost without any TLS

### DIFF
--- a/conf/sssd/sssd.conf
+++ b/conf/sssd/sssd.conf
@@ -17,11 +17,9 @@ auth_provider = ldap
 chpass_provider = ldap
 sudo_provider = ldap
 
-ldap_uri = ldaps://localhost:636
+ldap_uri = ldap://localhost:389
 ldap_search_base = dc=yunohost,dc=org
 
-ldap_tls_reqcert = allow
-ldap_tls_cacert = /etc/yunohost/certs/yunohost.org/crt.pem
-ldap_tls_key = /etc/yunohost/certs/yunohost.org/key.pem
+ldap_tls_reqcert = never
 
 cache_credentials = True


### PR DESCRIPTION
## The problem

sssd_ldap use a ldaps:// on localhost what adds no security ( since localhost ) and does consume cpu and create delays.

## Solution

remove anything about tls, switch from ldaps:// to ldap://

## Additionnal informations

to get it working correctly in tls if later on an external ldap server would be in use :

a real certificate with a trusted ca should be used ldap_tls_reqcert = demand should be used with ldaps://<domain.tld>:636 url

still some extra info about removed fields that were not relevant anyway :

remove ldap_tls_cacert
/etc/yunohost/certs/yunohost.org/crt.pem is a self signed certificate it is for yunohost.org that won't match
it is not a CA ( CA:FALSE )
found information indicating self-signed certificates can't be verified with ssdd anyway see ( https://docs.pagure.org/sssd.sssd/users/faq.html )

remove ldap_tls_key
this would not be required even with tls
it is for client authentication and we don't provide ldap_tls_cert afaik ynh ldap server is not configured to accept client certificates

## PR Status

It did work in my yunohost dev environment ...

## How to test

restart sssd 

create an new user
login to system with it
getent passwd <new_user>
