### PR TITLE
[fix] Update time regularly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends: python3-all (>= 3.11),
  , git, curl, wget, cron, unzip, jq, bc, at, procps, j2cli
  , lsb-release, haveged, fake-hwclock, lsof, whois
  , xz-utils, zstd
+ , chrony
 Recommends: yunohost-admin (>= 12.1), yunohost-portal (>= 12.1)
  , ntp, inetutils-ping | iputils-ping
  , bash-completion, rsyslog


### PR DESCRIPTION
## The problem
gaut from ARN has this problem on a VPS (datacenter melbicom, Lagos)
```
Err:3 https://packages.sury.org/php bookworm InRelease                                                              
  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses not yet valid certificate.  Could not handshake: Error in the certificate verification. [IP: 2a04:4e42:6a::820 443]
Reading package lists... Done                                                                                       
E: Release file for http://security.debian.org/debian-security/dists/bookworm-security/InRelease is not valid yet (invalid for another 2d 16h 51min 11s). Updates for this repository will not be applied.
E: Release file for http://deb.debian.org/debian/dists/bookworm-updates/InRelease is not valid yet (invalid for another 2d 16h 7min 32s). Updates for this repository will not be applied.
```

The time was not correct, so it triggers this cert error

## Solution
Proxmox has added `chrony` by default since pve7 and we probably should do the same. It replace `systemd-timesyncd` which seems to run only at boot (source proxmox doc).

## PR Status

 - [ ] Check chrony is available on arm
 - [ ] Check if we can just update systemd-timesyncd config to run it regularly.

## How to test

...
