### PR TITLE
Implement `yunohost app db app` to spawn a client db prompt

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -35,6 +35,8 @@
     "app_config_unable_to_apply": "Failed to apply config panel values.",
     "app_config_unable_to_read": "Failed to read config panel values.",
     "app_corrupt_source": "YunoHost was able to download the asset '{source_id}' ({url}) for {app}, but the asset doesn't match the expected checksum. This could mean that some temporary network failure happened on your server, OR the asset was somehow changed by the upstream maintainer (or a malicious actor?) and YunoHost packagers need to investigate and perhaps update the app manifest to take this change into account.\n    Expected sha256 checksum: {expected_sha256}\n    Downloaded sha256 checksum: {computed_sha256}\n    Downloaded file size: {size}",
+    "app_db_prompt_no_app_database": "This app does not appear to have a database declared in its manifest",
+    "app_db_prompt_type_not_supported": "The command does not support this type of database: {type}",
     "app_extraction_failed": "Could not extract the installation files",
     "app_failed_to_download_asset": "Failed to download asset '{source_id}' ({url}) for {app}: {out}",
     "app_full_domain_unavailable": "Sorry, this app must be installed on a domain of its own, but other apps are already installed on the domain '{domain}'. You could use a subdomain dedicated to this app instead.",

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1085,6 +1085,8 @@ app:
             arguments:
                 app:
                     help: App ID
+                    extra:
+                        autocomplete: *apps_list
 
         ### app_register_url()
         register-url:

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -1078,6 +1078,14 @@ app:
                     extra:
                         autocomplete: *apps_list
 
+        ### app_db()
+        db:
+            action_help: Open an interactive database client prompt for the app
+            api: GET /apps/<app>/db
+            arguments:
+                app:
+                    help: App ID
+
         ### app_register_url()
         register-url:
             hide_in_help: True

--- a/src/app.py
+++ b/src/app.py
@@ -1892,6 +1892,62 @@ def app_shell(app: str) -> None:
         env=env,
     )
 
+def app_db(app):
+    """
+    Open an interactive DB pompt for the app
+
+    Keyword argument:
+        app -- App ID
+
+    """
+    import subprocess
+    import tempfile
+
+    _assert_is_installed(app)
+    local_manifest = _get_manifest_of_app(app)
+    settings = _get_app_settings(app)
+
+    db_in_manifest = local_manifest["resources"].get("database", None)
+    if not db_in_manifest:
+        raise YunohostValidationError("app_db_prompt_no_app_database")
+
+    type = db_in_manifest.get("type", None)
+    database = settings["db_name"]
+    user = settings["db_user"]
+    password = settings["db_pwd"]
+
+    if type == "postgresql":
+        password_file_content = f"localhost:5432:{database}:{user}:{password}"
+    elif type =="mysql":
+        password_file_content = f"""
+[client]
+user={user}
+password={password}
+"""
+    else:
+        raise YunohostValidationError("app_db_prompt_type_not_supported")
+
+
+    # NOTE: Postgresql (and probably mariadb too) requires the password file to
+    # be a regular one. We can't work with pipes.
+    # Let's create a temp file that is destroyed when quitting
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(password_file_content.encode())
+        fp.flush() # FIXME: should close + call NamedTemporaryFile with `delete_on_close=False`
+                   # when we can (requires 3.13 so when we deprecate bookworm)
+        env_by_type = {
+            "mysql": {},
+            "postgresql": { "PGPASSFILE": fp.name }
+        }
+        command = {
+            "mysql": ["mysql", f"--defaults-file={fp.name}", database],
+            "postgresql": ["psql", f"--user={user}"]
+        }
+        subprocess.run(
+            command[type],
+            env=env_by_type[type]
+        )
+
 
 def app_register_url(app: str, domain: str, path: str) -> None:
     """

--- a/src/app.py
+++ b/src/app.py
@@ -1892,6 +1892,7 @@ def app_shell(app: str) -> None:
         env=env,
     )
 
+
 def app_db(app):
     """
     Open an interactive DB pompt for the app
@@ -1918,26 +1919,27 @@ def app_db(app):
 
     if type == "postgresql":
         password_file_content = f"localhost:5432:{database}:{user}:{password}"
-    elif type =="mysql":
+    elif type == "mysql":
         password_file_content = f"""
 [client]
 user={user}
 password={password}
 """
     else:
-        raise YunohostValidationError("app_db_prompt_type_not_supported")
-
+        raise YunohostValidationError("app_db_prompt_type_not_supported", type=type)
 
     # NOTE: Postgresql (and probably mariadb too) requires the password file to
     # be a regular one. We can't work with pipes.
     # Let's create a temp file that is destroyed when quitting
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(password_file_content.encode())
-        fp.flush() # FIXME: should close + call NamedTemporaryFile with `delete_on_close=False`
-                   # when we can (requires 3.13 so when we deprecate bookworm)
+        # FIXME: should close + call NamedTemporaryFile with `delete_on_close=False`
+        # when we can (requires 3.13 so when we deprecate bookworm)
+        fp.flush()
+
         env_by_type = {
             "mysql": {},
-            "postgresql": { "PGPASSFILE": fp.name }
+            "postgresql": {"PGPASSFILE": fp.name}
         }
         command = {
             "mysql": ["mysql", f"--defaults-file={fp.name}", database],

--- a/src/app.py
+++ b/src/app.py
@@ -1933,8 +1933,6 @@ password={password}
     # Let's create a temp file that is destroyed when quitting
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(password_file_content.encode())
-        # FIXME: should close + call NamedTemporaryFile with `delete_on_close=False`
-        # when we can (requires 3.13 so when we deprecate bookworm)
         fp.flush()
 
         env_by_type = {


### PR DESCRIPTION
## The problem

It can be painful to remember how to open a db prompt for an app:
1. You have to identify whether the app use mysql or postgresql in the manifest
2. You have to remember the command to run (especially for postgresql with which you have to login first as `postgres`)

## Solution

Offer the `yunohost app db APP` for that.

This command also takes a different approach than the helpers: I force to connect as the app db user (rather than the admin account) for arguable reasons:
1. So the user has exactly the same rights as the app (can avoid confusions)
2. If the user does something dangerous, it is only scoped to the app.

## PR Status

Tested on both bookworm and trixie ✅

## How to test

- You may install piwigo to check it works with mysql/mariadb
- You may install lufi to check it works with postgresql
- You may run `yunohost app db lufi` or `yunohost app db piwigo` and see that you can operate on their respective DB
- You may run `yunohost app db piwigo <<< "select * from users;"` to see that we can run queries this way
- You may run `echo "select * from files limit 1;" > /tmp/lufi.sql; yunohost app db lufi < /tmp/lufi.sql` to see that we can execute sql commands this way too.