### PR TITLE
[enh] Add dash in username and force first char to be alphanum

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -753,7 +753,7 @@
     "pattern_password": "Must be at least 3 characters long",
     "pattern_password_app": "Sorry, passwords can not contain the following characters: {forbidden_chars}",
     "pattern_port_or_range": "Must be a valid port number (i.e. 0-65535) or range of ports (e.g. 100:200)",
-    "pattern_username": "Must be lower-case alphanumeric and underscore characters only",
+    "pattern_username": "Must be lower-case alphanumeric, dot, dash and underscore characters only",
     "permission_already_allowed": "Group '{group}' already has permission '{permission}' enabled",
     "permission_already_disallowed": "Group '{group}' already has permission '{permission}' disabled",
     "permission_cannot_remove_main": "Removing a main permission is not allowed",

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -73,7 +73,7 @@ user:
                     help: The unique username to create
                     extra:
                         pattern: &pattern_username
-                            - !!str ^[a-z0-9_\.]+$
+                            - !!str ^[a-z][-a-z0-9_\.]*$
                             - "pattern_username"
                 -F:
                     full: --fullname
@@ -265,7 +265,7 @@ user:
                             help: Name of the group to be created
                             extra:
                                 pattern: &pattern_groupname
-                                    - !!str ^[a-z0-9_]+$
+                                    - !!str ^[a-z][-a-z0-9_\.]*$
                                     - "pattern_groupname"
 
                 ### user_group_delete()

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -73,7 +73,7 @@ user:
                     help: The unique username to create
                     extra:
                         pattern: &pattern_username
-                            - !!str ^[a-z][-a-z0-9_\.]*$
+                            - !!str ^[a-z0-9][-a-z0-9_\.]*$
                             - "pattern_username"
                 -F:
                     full: --fullname

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -265,7 +265,7 @@ user:
                             help: Name of the group to be created
                             extra:
                                 pattern: &pattern_groupname
-                                    - !!str ^[a-z][-a-z0-9_\.]*$
+                                    - !!str ^[a-z0-9][-a-z0-9_\.]*$
                                     - "pattern_groupname"
 
                 ### user_group_delete()

--- a/src/user.py
+++ b/src/user.py
@@ -62,7 +62,7 @@ else:
 
 
 FIELDS_FOR_IMPORT = {
-    "username": r"^[a-z0-9_.]+$",
+    "username": r"^[a-z][-a-z0-9_.]*$",
     "firstname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
     "lastname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
     "password": r"^|(.{3,})$",
@@ -70,7 +70,7 @@ FIELDS_FOR_IMPORT = {
     "mail-alias": r"^|([\w.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
     "mail-forward": r"^|([\w\+.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
     "mailbox-quota": r"^(\d+[bkMGT])|0|$",
-    "groups": r"^|([a-z0-9_]+(,?[a-z0-9_]+)*)$",
+    "groups": r"^|([a-z][-a-z0-9_.]*(,?[a-z][-a-z0-9_.]*)*)$",
 }
 
 ADMIN_ALIASES = ["root", "admin", "admins", "webmaster", "postmaster", "abuse"]

--- a/src/user.py
+++ b/src/user.py
@@ -62,7 +62,7 @@ else:
 
 
 FIELDS_FOR_IMPORT = {
-    "username": r"^[a-z][-a-z0-9_.]*$",
+    "username": r"^[a-z0-9][-a-z0-9_.]*$",
     "firstname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
     "lastname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
     "password": r"^|(.{3,})$",
@@ -70,7 +70,7 @@ FIELDS_FOR_IMPORT = {
     "mail-alias": r"^|([\w.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
     "mail-forward": r"^|([\w\+.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
     "mailbox-quota": r"^(\d+[bkMGT])|0|$",
-    "groups": r"^|([a-z][-a-z0-9_.]*(,?[a-z][-a-z0-9_.]*)*)$",
+    "groups": r"^|([a-z0-9][-a-z0-9_.]*(,?[a-z0-9][-a-z0-9_.]*)*)$",
 }
 
 ADMIN_ALIASES = ["root", "admin", "admins", "webmaster", "postmaster", "abuse"]

--- a/tests/test_user-group.py
+++ b/tests/test_user-group.py
@@ -219,7 +219,7 @@ def test_export_user():
 
 
 def test_create_group():
-    with message("group_created", group="adminsys"):
+    with message("group_created", group="volunteer-stand.2026_02"):
         user_group_create("volunteer-stand.2026_02")
 
     group_res = user_group_list()["groups"]

--- a/tests/test_user-group.py
+++ b/tests/test_user-group.py
@@ -113,13 +113,13 @@ def test_list_groups():
 
 def test_create_user():
     with message("user_created"):
-        user_create("albert", maindomain, "test123Ynh", fullname="Albert Good")
+        user_create("morgan-claude.good_7", maindomain, "test123Ynh", fullname="Morgan-Claude Good")
 
     group_res = user_group_list()["groups"]
-    assert "albert" in user_list()["users"]
-    assert "albert" in group_res
-    assert "albert" in group_res["albert"]["members"]
-    assert "albert" in group_res["all_users"]["members"]
+    assert "morgan-claude.good_7" in user_list()["users"]
+    assert "morgan-claude.good_7" in group_res
+    assert "morgan-claude.good_7" in group_res["morgan-claude.good_7"]["members"]
+    assert "morgan-claude.good_7" in group_res["all_users"]["members"]
 
 
 def test_del_user():
@@ -152,14 +152,14 @@ def test_import_user():
         writer.writeheader()
         writer.writerow(
             {
-                "username": "albert",
-                "firstname": "Albert",
+                "username": "morgan-claude.good_7",
+                "firstname": "Morgan-Claude",
                 "lastname": "Good",
                 "password": "",
                 "mailbox-quota": "1G",
-                "mail": "albert@" + maindomain,
-                "mail-alias": "albert2@" + maindomain,
-                "mail-forward": "albert@example.com",
+                "mail": "morgan-claude.good_7@" + maindomain,
+                "mail-alias": "morgan-claude.good_72@" + maindomain,
+                "mail-forward": "morgan-claude.good_7@example.com",
                 "groups": "dev",
             }
         )
@@ -195,12 +195,12 @@ def test_import_user():
 
     group_res = user_group_list()["groups"]
     user_res = user_list(list(FIELDS_FOR_IMPORT.keys()))["users"]
-    assert "albert" in user_res
+    assert "morgan-claude.good_7" in user_res
     assert "sam" in user_res
     assert "alice" in user_res
     assert "bob" not in user_res
     assert len(user_res["sam"]["mail-alias"]) == 2
-    assert "albert" in group_res["dev"]["members"]
+    assert "morgan-claude.good_7" in group_res["dev"]["members"]
     assert "sam" in group_res["apps"]["members"]
     assert "sam" not in group_res["dev"]["members"]
     assert "alice" in group_res["admins"]["members"]
@@ -220,12 +220,12 @@ def test_export_user():
 
 def test_create_group():
     with message("group_created", group="adminsys"):
-        user_group_create("adminsys")
+        user_group_create("volunteer-stand.2026_02")
 
     group_res = user_group_list()["groups"]
-    assert "adminsys" in group_res
-    assert "members" in group_res["adminsys"].keys()
-    assert group_res["adminsys"]["members"] == []
+    assert "volunteer-stand.2026_02" in group_res
+    assert "members" in group_res["volunteer-stand.2026_02"].keys()
+    assert group_res["volunteer-stand.2026_02"]["members"] == []
 
 
 def test_del_group():


### PR DESCRIPTION
## The problem

In /etc/adduser.conf a default REGEX for user and group name exists:

```
# Non-system user- and groupnames are checked against this regular
# expression.
# Default: NAME_REGEX="^[a-z][-a-z0-9_]*\$?$"
#NAME_REGEX="^[a-z][-a-z0-9_]*\$?$"
```

We currently don't accept dash chars, but we probably should as we accept dot (that is not in default REGEX_NAME...).
## Solution

Use the default regex, with dot in more and without the $ at the end. We also tolerate usernames starting with a number in order to avoid some user to be banned from their server :/
```python3
r"^[a-z0-9][-a-z0-9_.]*$"
```

Note: some yunohost app could not support this kind of names (with dot, dash or even underscore) however, i think the high risk is for the dot char... [And we already decided to accept it](https://github.com/YunoHost/issues/issues/2287)
Note2: if we want to ease the way to autoconfigure email, we need username to be the first part of the email, so allowing dash is necessary cause lot of people want this kind of address ex: `jean-michel.smith@domain.tld`

## PR Status
Tested manually: user create, user import, user list
Waiting for auto test 

## How to test

...
