### PR TITLE
[enh] Prefer to use email address as default identifier

### DIFF
--- a/conf/dovecot/dovecot-ldap.conf
+++ b/conf/dovecot/dovecot-ldap.conf
@@ -3,7 +3,7 @@ auth_bind = yes
 ldap_version = 3
 base = ou=users,dc=yunohost,dc=org
 user_attrs = uidNumber=500,gidNumber=8,mailuserquota=quota_rule=*:bytes=%$
-user_filter = (&(objectClass=inetOrgPerson)(uid=%n)(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
-pass_filter = (&(objectClass=inetOrgPerson)(uid=%n)(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
+user_filter = (&(objectClass=inetOrgPerson)(|(uid=%n)(mail=%n@%d))(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
+pass_filter = (&(objectClass=inetOrgPerson)(|(uid=%n)(mail=%n@%d))(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
 default_pass_scheme = SSHA
 

--- a/conf/nginx/autoconfig.tpl.xml
+++ b/conf/nginx/autoconfig.tpl.xml
@@ -6,14 +6,14 @@
       <port>993</port>
       <socketType>SSL</socketType>
       <authentication>password-cleartext</authentication>
-      <username>%EMAILLOCALPART%</username>
+      <username>%EMAILADDRESS%</username>
     </incomingServer>
     <outgoingServer type="smtp">
       <hostname>{{ domain }}</hostname>
       <port>587</port>
       <socketType>STARTTLS</socketType>
       <authentication>password-cleartext</authentication>
-      <username>%EMAILLOCALPART%</username>
+      <username>%EMAILADDRESS%</username>
     </outgoingServer>
   </emailProvider>
 </clientConfig>


### PR DESCRIPTION
## The problem

Imagine you self-host 2 non profit organizations on the same server (multitenant usecase), you want each non profit org to have a contact@ email address with their own domain, BUT you can't create 2 username `contact`... 

SO, currently, you have to configure things like this:
```
username: nonprofita
mail: contact@nonprofitA.tld
```
```
username: nonprofitb
mail: contact@nonprofitB.tld
```

However, **with this configuration, autoconfig is broken**, cause it uses EMAILLOCALPART, so the mail client will try to log in with `contact` instead of the good username...


## Solution

In the past we have decided to encourage local part to be the same as username in order to fix autoconfig issues, but it doesn't work for the usecase above. Since this decision, it seems postfix and dovecot config has been reviewed to allowed authentication with the full email... 

However after some tests, it seems it doesn't really support email, it just remove the @domain.tld part, but it probably should be possible to make it working by review ldap request and some params.



## PR Status
TODO:
 - [x] Find a way to configure postfix and dovecot to be able to login with all mail alias.
 - [ ]  Check everything works even for mailman etc https://github.com/YunoHost/yunohost/blob/dc028b1defce71fdce72d93a977a7835c84c3779/conf/postfix/plain/master.cf#L123


## How to test

...
