### PR TITLE
security: handle the kernel special case when checking for security issues via the security.toml index

### DIFF
--- a/src/diagnosers/00-basesystem.py
+++ b/src/diagnosers/00-basesystem.py
@@ -334,10 +334,15 @@ class MyDiagnoser(Diagnoser):  # type: ignore
             _load_security_issues_list()["system"]
         )
         for package, issues in security_issues_list_per_pkg.items():
-            if package not in installed_packages:
+            if package not in installed_packages and package != "kernel":
                 continue
 
-            current_version = dpkg_package_version(package)
+            if package != "kernel":
+                current_version = dpkg_package_version(package)
+            else:
+                # Equivalent to uname -r
+                current_version = read_file("/proc/sys/kernel/osrelease").strip()
+
             for issue in issues:
                 raw_fixed_in_version = issue["fixed_in_version"]
                 if isinstance(raw_fixed_in_version, dict):


### PR DESCRIPTION
## The problem

cf the discussion in https://github.com/YunoHost/apps/pull/3454/ about copy.fail and other security issues in the kernel, the kernel is not a regular package and it's not easy to properly list vulnerabilities in here. We need a proper `uname -r`

## Solution

Add a special case for a package named `kernel` in the security.toml check thingy in the diagnosis

## PR Status

Yolocommited

## How to test

...
