### PR TITLE
fix(postgres): prevent login shells

### DIFF
--- a/helpers/helpers.v1.d/postgresql
+++ b/helpers/helpers.v1.d/postgresql
@@ -44,7 +44,7 @@ ynh_psql_connect_as() {
     ynh_handle_getopts_args "$@"
     database="${database:-}"
 
-    sudo --login --user=postgres PGUSER="$user" PGPASSWORD="$password" psql "$database"
+    sudo --user=postgres PGUSER="$user" PGPASSWORD="$password" psql "$database"
 }
 
 # Execute a command as root user
@@ -138,7 +138,7 @@ ynh_psql_drop_db() {
     # https://stackoverflow.com/questions/17449420/postgresql-unable-to-drop-database-because-of-some-auto-connections-to-db
     ynh_psql_execute_as_root --sql="REVOKE CONNECT ON DATABASE $db FROM public;" --database="$db"
     ynh_psql_execute_as_root --sql="SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db' AND pid <> pg_backend_pid();" --database="$db"
-    sudo --login --user=postgres dropdb $db
+    sudo --user=postgres dropdb $db
 }
 
 # Dump a database
@@ -158,7 +158,7 @@ ynh_psql_dump_db() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    sudo --login --user=postgres pg_dump "$database"
+    sudo --user=postgres pg_dump "$database"
 }
 
 # Create a user
@@ -193,7 +193,7 @@ ynh_psql_user_exists() {
     # Manage arguments with getopts
     ynh_handle_getopts_args "$@"
 
-    if ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user"; then
+    if ! sudo --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user"; then
         return 1
     else
         return 0
@@ -220,7 +220,7 @@ ynh_psql_database_exists() {
     if ! command -v psql; then
         ynh_print_err -m "PostgreSQL is not installed, impossible to check for db existence."
         return 1
-    elif ! sudo --login --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"; then
+    elif ! sudo --user=postgres PGUSER="postgres" PGPASSWORD="$(cat $PSQL_ROOT_PWD_FILE)" psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"; then
         return 1
     else
         return 0

--- a/helpers/helpers.v2.1.d/postgresql
+++ b/helpers/helpers.v2.1.d/postgresql
@@ -33,7 +33,7 @@ PSQL_VERSION=15
 #
 ynh_psql_db_shell() {
     local database="${1:-$db_name}"
-    sudo --login --user=postgres psql "$database"
+    sudo --user=postgres psql "$database"
 }
 
 # Create a database and grant optionnaly privilegies to a user
@@ -56,7 +56,7 @@ ynh_psql_create_db() {
         sql+="GRANT ALL PRIVILEGES ON DATABASE ${db} TO ${user} WITH GRANT OPTION;"
     fi
 
-    sudo --login --user=postgres psql <<< "$sql"
+    sudo --user=postgres psql <<< "$sql"
 }
 
 # Drop a database
@@ -73,9 +73,9 @@ ynh_psql_drop_db() {
     local db=$1
     # First, force disconnection of all clients connected to the database
     # https://stackoverflow.com/questions/17449420/postgresql-unable-to-drop-database-because-of-some-auto-connections-to-db
-    sudo --login --user=postgres psql "$db" <<< "REVOKE CONNECT ON DATABASE $db FROM public;"
-    sudo --login --user=postgres psql "$db" <<< "SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db' AND pid <> pg_backend_pid();"
-    sudo --login --user=postgres dropdb "$db"
+    sudo --user=postgres psql "$db" <<< "REVOKE CONNECT ON DATABASE $db FROM public;"
+    sudo --user=postgres psql "$db" <<< "SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = '$db' AND pid <> pg_backend_pid();"
+    sudo --user=postgres dropdb "$db"
 }
 
 # Dump a database
@@ -88,7 +88,7 @@ ynh_psql_drop_db() {
 #
 ynh_psql_dump_db() {
     local database="${1:-$db_name}"
-    sudo --login --user=postgres pg_dump "$database"
+    sudo --user=postgres pg_dump "$database"
 }
 
 # Create a user
@@ -102,7 +102,7 @@ ynh_psql_dump_db() {
 ynh_psql_create_user() {
     local user=$1
     local pwd=$2
-    sudo --login --user=postgres psql <<< "CREATE USER $user WITH ENCRYPTED PASSWORD '$pwd'"
+    sudo --user=postgres psql <<< "CREATE USER $user WITH ENCRYPTED PASSWORD '$pwd'"
 }
 
 # Check if a psql user exists
@@ -115,7 +115,7 @@ ynh_psql_create_user() {
 #
 ynh_psql_user_exists() {
     local user=$1
-    sudo --login --user=postgres psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user"
+    sudo --user=postgres psql -tAc "SELECT rolname FROM pg_roles WHERE rolname='$user';" | grep --quiet "$user"
 }
 
 # Check if a psql database exists
@@ -128,7 +128,7 @@ ynh_psql_user_exists() {
 #
 ynh_psql_database_exists() {
     local database=$1
-    sudo --login --user=postgres psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"
+    sudo --user=postgres psql -tAc "SELECT datname FROM pg_database WHERE datname='$database';" | grep --quiet "$database"
 }
 
 # Drop a user
@@ -139,5 +139,5 @@ ynh_psql_database_exists() {
 # | arg: user - the user name to drop
 #
 ynh_psql_drop_user() {
-    sudo --login --user=postgres psql <<< "DROP USER ${1};"
+    sudo --user=postgres psql <<< "DROP USER ${1};"
 }

--- a/hooks/conf_regen/35-postgresql
+++ b/hooks/conf_regen/35-postgresql
@@ -61,7 +61,7 @@ do_post_regen() {
     chown root:postgres "$PSQL_ROOT_PWD_FILE"
     chmod 440 "$PSQL_ROOT_PWD_FILE"
 
-    sudo --login --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$(cat "$PSQL_ROOT_PWD_FILE")'" postgres
+    sudo --user=postgres psql -c"ALTER user postgres WITH PASSWORD '$(cat "$PSQL_ROOT_PWD_FILE")'" postgres
 
     # force all user to connect to local databases using hashed passwords
     # https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html#EXAMPLE-PG-HBA.CONF


### PR DESCRIPTION
## The problem

Custom login scripts, for example in `/etc/profile.d` might add text like MOTD in the command outputs of `psql` commands, breaking havoc in apps.

Example with ***third-party*** Proxmox VE script:
- https://community-scripts.org/scripts/yunohost
- This custom installation of YunoHost adds a script in `/etc/profile.d` intended to display a MOTD upon SSH login: https://github.com/community-scripts/ProxmoxVE/blob/fcd77d9332e434d0e75f141e18de47c9cba2d47d/misc/install.func#L453
- This MOTD nicely ends up injected in the output parsing of YunoHost's postgresql helpers: https://paste.yunohost.org/efumocuvey.http (look around `2026-05-21 22:56:58,439` and `2026-05-21 22:56:58,831` to see a very unintendedly edgy database name).

> [!CAUTION]
> Note that this might also happen for other helpers, namely ruby and go.

## Solution

No `--login` when calling `postgres`

## PR Status

To be tested.

## How to test

...
