### PR TITLE
[fix] Hotfix for the nginx cve about rewrite module CVE-2026-42945

### DIFF
--- a/conf/nginx/fastcgi_params_no_auth
+++ b/conf/nginx/fastcgi_params_no_auth
@@ -29,3 +29,25 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Hotfix CVE-2026-42945
+# In such a case, passing "$http_host" upstream exposes the raw client-supplied
+# Host value ("malformedhost") to the backend application, even though it does
+# not match the effective request target. Applications often use HTTP_HOST for
+# redirects, absolute URL generation, virtual host routing, or security checks;
+# forwarding the raw Host header can therefore lead to incorrect or unsafe
+# behaviour.
+#
+# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" a>
+# "$request_port", allowing HTTP_HOST to be constructed as:
+#     $host$is_request_port$request_port
+#
+# In stable/oldstable packages we use "$host" as a security workaround.
+# It avoids forwarding an untrusted raw Host header to the backend.
+#
+# Note: this changes behaviour compared to previous versions, because "$host"
+# does not preserve the client-supplied port, while "$http_host" typically
+# does. Existing deployments that rely on "$http_host" containing a port number
+# may therefore break or behave differently after this change.
+
+fastcgi_param  HTTP_HOST        $host;

--- a/conf/nginx/fastcgi_params_no_auth
+++ b/conf/nginx/fastcgi_params_no_auth
@@ -38,7 +38,7 @@ fastcgi_param  REDIRECT_STATUS    200;
 # forwarding the raw Host header can therefore lead to incorrect or unsafe
 # behaviour.
 #
-# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" a>
+# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" and
 # "$request_port", allowing HTTP_HOST to be constructed as:
 #     $host$is_request_port$request_port
 #

--- a/conf/nginx/fastcgi_params_with_auth
+++ b/conf/nginx/fastcgi_params_with_auth
@@ -29,3 +29,25 @@ fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
+
+# Hotfix CVE-2026-42945
+# In such a case, passing "$http_host" upstream exposes the raw client-supplied
+# Host value ("malformedhost") to the backend application, even though it does
+# not match the effective request target. Applications often use HTTP_HOST for
+# redirects, absolute URL generation, virtual host routing, or security checks;
+# forwarding the raw Host header can therefore lead to incorrect or unsafe
+# behaviour.
+#
+# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" a>
+# "$request_port", allowing HTTP_HOST to be constructed as:
+#     $host$is_request_port$request_port
+#
+# In stable/oldstable packages we use "$host" as a security workaround.
+# It avoids forwarding an untrusted raw Host header to the backend.
+#
+# Note: this changes behaviour compared to previous versions, because "$host"
+# does not preserve the client-supplied port, while "$http_host" typically
+# does. Existing deployments that rely on "$http_host" containing a port number
+# may therefore break or behave differently after this change.
+
+fastcgi_param  HTTP_HOST        $host;

--- a/conf/nginx/fastcgi_params_with_auth
+++ b/conf/nginx/fastcgi_params_with_auth
@@ -38,7 +38,7 @@ fastcgi_param  REDIRECT_STATUS    200;
 # forwarding the raw Host header can therefore lead to incorrect or unsafe
 # behaviour.
 #
-# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" a>
+# Newer nginx versions (since 1.30.0) introduce variables "$is_request_port" and
 # "$request_port", allowing HTTP_HOST to be constructed as:
 #     $host$is_request_port$request_port
 #

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -172,6 +172,11 @@ do_post_regen() {
     # shellcheck disable=SC2016
     sed -i 's/$remote_user;/$http_ynh_user if_not_empty;/g' /etc/nginx/fastcgi_params
 
+    # Hotfix CVE-2026-42945
+    if ! grep -qE 'fastcgi_param\s+HTTP_HOST\s+\$host;' /etc/nginx/fastcgi_params 2>/dev/null ; then
+        echo 'fastcgi_param  HTTP_HOST        $host;' >> /etc/nginx/fastcgi_params
+    fi
+
     if ls -l /etc/nginx/conf.d/*.d/*.conf; then
         chown root:root /etc/nginx/conf.d/*.d/*.conf
         chmod 644 /etc/nginx/conf.d/*.d/*.conf

--- a/hooks/conf_regen/15-nginx
+++ b/hooks/conf_regen/15-nginx
@@ -173,7 +173,9 @@ do_post_regen() {
     sed -i 's/$remote_user;/$http_ynh_user if_not_empty;/g' /etc/nginx/fastcgi_params
 
     # Hotfix CVE-2026-42945
+    # shellcheck disable=SC2016
     if ! grep -qE 'fastcgi_param\s+HTTP_HOST\s+\$host;' /etc/nginx/fastcgi_params 2>/dev/null ; then
+        # shellcheck disable=SC2016
         echo 'fastcgi_param  HTTP_HOST        $host;' >> /etc/nginx/fastcgi_params
     fi
 


### PR DESCRIPTION
## The problem
https://nvd.nist.gov/vuln/detail/CVE-2026-42945
It's fixed by debian, but we modified fastcgi_params, so file could not be fixed...

## Solution

Add the fix in our own configuration

## PR Status
Minimal test to see if the files are changed

## How to test
```
yunohost tools regen-conf nginx
```
