### PR TITLE
fix : Ipv6 pref sending if available

### DIFF
--- a/conf/postfix/main.cf
+++ b/conf/postfix/main.cf
@@ -91,6 +91,7 @@ mailbox_command = procmail -a "$EXTENSION"
 mailbox_size_limit = 0
 recipient_delimiter = +
 inet_interfaces = all
+smtp_address_preference = ipv6
 
 #### Fit to the maximum message size to 25mb, more than allowed by GMail or Yahoo ####
 # /!\ This size is the size of the attachment in base64.

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -109,6 +109,9 @@ do_pre_regen() {
         sed -i \
             's/inet_interfaces = all/&\ninet_protocols = ipv4/' \
             "${postfix_dir}/main.cf"
+        sed -i \
+            's/smtp_address_preferences = ipv4/&\nsmtp_address_preferences = ipv6/' \
+            "${postfix_dir}/main.cf"
     fi
 }
 

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -110,7 +110,7 @@ do_pre_regen() {
             's/inet_interfaces = all/&\ninet_protocols = ipv4/' \
             "${postfix_dir}/main.cf"
         sed -i \
-            's/smtp_address_preferences = ipv6/&\nsmtp_address_preferences = ipv4/' \
+            's/smtp_address_preference = ipv6/smtp_address_preference = ipv4/' \
             "${postfix_dir}/main.cf"
     fi
 }

--- a/hooks/conf_regen/19-postfix
+++ b/hooks/conf_regen/19-postfix
@@ -110,7 +110,7 @@ do_pre_regen() {
             's/inet_interfaces = all/&\ninet_protocols = ipv4/' \
             "${postfix_dir}/main.cf"
         sed -i \
-            's/smtp_address_preferences = ipv4/&\nsmtp_address_preferences = ipv6/' \
+            's/smtp_address_preferences = ipv6/&\nsmtp_address_preferences = ipv4/' \
             "${postfix_dir}/main.cf"
     fi
 }

--- a/src/dns.py
+++ b/src/dns.py
@@ -212,10 +212,10 @@ def _build_dns_conf(
             spf4 = ""
             spf6 = ""
             if ipv4:
-                spf4 = ' ip4:' + ipv6
+                spf4 = ' ip4:' + ipv4
             if ipv6: 
                 spf6 = ' ip6:' + ipv6
-            mail.append((basename, ttl, "TXT", '"v=spf1 a mx',spf4, spf6, ' -all"'))
+            mail.append((basename, ttl, "TXT", f'"v=spf1 a mx{spf4}{spf6} -all"'))
 
             # DKIM/DMARC record
             dkim_host, dkim_publickey = _get_DKIM(domain)

--- a/src/dns.py
+++ b/src/dns.py
@@ -208,12 +208,13 @@ def _build_dns_conf(
             mail.append((basename, ttl, "MX", f"10 {domain}."))
 
         if settings["mail_out"]:
-            # Tentative de mitigation en cas où le serveur du domaine d'envoi du mail est différent du serveur du domaine (site externalisé) Issue: #2465
+            # Tentative de mitigation en cas où le serveur du domaine d'envoi du mail est différent
+            # du serveur du domaine (site externalisé) Issue: #2465
             spf4 = ""
             spf6 = ""
             if ipv4:
                 spf4 = ' ip4:' + ipv4
-            if ipv6: 
+            if ipv6:
                 spf6 = ' ip6:' + ipv6
             mail.append((basename, ttl, "TXT", f'"v=spf1 a mx{spf4}{spf6} -all"'))
 

--- a/src/dns.py
+++ b/src/dns.py
@@ -209,11 +209,13 @@ def _build_dns_conf(
 
         if settings["mail_out"]:
             # Tentative de mitigation en cas où le serveur du domaine d'envoi du mail est différent du serveur du domaine (site externalisé) Issue: #2465
-            if ip4:
-                spf4 = 'ip4:' + ipv6
-            if ip6: 
-                spf6 = 'ip6:' + ipv6
-            mail.append((basename, ttl, "TXT", '"v=spf1 a mx ',spf4, ' ', spf6, ' -all"'))
+            spf4 = ""
+            spf6 = ""
+            if ipv4:
+                spf4 = ' ip4:' + ipv6
+            if ipv6: 
+                spf6 = ' ip6:' + ipv6
+            mail.append((basename, ttl, "TXT", '"v=spf1 a mx',spf4, spf6, ' -all"'))
 
             # DKIM/DMARC record
             dkim_host, dkim_publickey = _get_DKIM(domain)

--- a/src/dns.py
+++ b/src/dns.py
@@ -208,7 +208,12 @@ def _build_dns_conf(
             mail.append((basename, ttl, "MX", f"10 {domain}."))
 
         if settings["mail_out"]:
-            mail.append((basename, ttl, "TXT", '"v=spf1 a mx -all"'))
+            # Tentative de mitigation en cas où le serveur du domaine d'envoi du mail est différent du serveur du domaine (site externalisé) Issue: #2465
+            if ip4:
+                spf4 = 'ip4:' + ipv6
+            if ip6: 
+                spf6 = 'ip6:' + ipv6
+            mail.append((basename, ttl, "TXT", '"v=spf1 a mx ',spf4, ' ', spf6, ' -all"'))
 
             # DKIM/DMARC record
             dkim_host, dkim_publickey = _get_DKIM(domain)


### PR DESCRIPTION
AW: I just added the solution provided by @jershon 

## The problem

For SPF record : 
As I understood, it could be problem if main domain (exemple for a website) has different ipv4 than actual mail server.

For ipv6 : 
Some email provider communicate only in ipv6. Apparently following issue this can be a solution of not receiving mail on some email hosting providers.

**Related issues:** : fixes Yunohost/Issues#2465
**Related PRs:**

## Solution

- add preference to ipv6 if avilable
- Correct SPF record. Allow domain to be handle by server IP even if main site is no handle by server.

**AI transparency:** Understand difference between record (I didn't fully remember what was the good way to handle such case).

## PR Status
*Tested partially*

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [x] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [x] Write data or settings migration
 - [x] Pass Continuous Integration checks
   - [x] Add some missing translations keys
   - [x] Update/write unit tests
 - [x] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [x] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
