### PR TITLE
fix : exclude second port used by app

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1399,7 +1399,7 @@ class PortsResource(AppResource):
         # This second command is mean to cover (most) case where an app is using a port yet ain't currently using it for some reason (typically service ain't up)
         used_by_app = (
             os.system(
-                f"grep --quiet --extended-regexp \"port: '?{port}'?\" /etc/yunohost/apps/*/settings.yml"
+                f"grep --quiet --extended-regexp \"port: '?{port}'?\" --exclude=/etc/yunohost/apps/{self.app}/settings.yml /etc/yunohost/apps/*/settings.yml"
             )
             == 0
         )


### PR DESCRIPTION
## The problem

If an app have a second port, when it upgrades the apps, it will get the second port used by the app. So, it won't allow the user to upgrade application and will consider the port is "used by anpther app".

**Related issues:** : 
* fixes Yunohost/issues#2404 
* https://github.com/YunoHost-Apps/adguardhome_ynh/issues/180

## Solution

Exclude port "greped" from setting of the app itself.

**AI transparency:** *If AI has been used, explain how. See https://doc.yunohost.org/en/dev/?persistLocale=true#%EF%B8%8F-develop*

## PR Status
*Tested partially*
Tested with AdguardHome from 0.107.48~ynh2 to now.

### Code TODOs

*Here are frequently forgotten tasks:*
 - [x] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [x] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [x] Write data or settings migration
 - [x] Pass Continuous Integration checks
   - [x] Add some missing translations keys
   - [x] Update/write unit tests
 - [x] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [x] Run the code in cli by calling command by hand
 - [x] Test change on configuration on an instance

## How to test
Modify file : https://github.com/YunoHost-Apps/adguardhome_ynh/issues/180
Install adguardhome version 0.107.48~ynh2
Upgrade it.
