### PR TITLE
fix: consistent usage of --foo=bar (instead of --foo bar) when calling ynh_permission_update inside ynh_local_curl

### DIFF
--- a/helpers/helpers.v1.d/utils
+++ b/helpers/helpers.v1.d/utils
@@ -144,7 +144,7 @@ ynh_local_curl() {
     curl --silent --show-error --insecure --location --header "Host: $domain" --resolve $domain:443:127.0.0.1 $POST_data "$full_page_url" --cookie-jar $cookiefile --cookie $cookiefile
 
     if [[ $visitors_enabled == "no" ]]; then
-        ynh_permission_update --permission="main" --remove "visitors" > /dev/null
+        ynh_permission_update --permission="main" --remove="visitors" > /dev/null
     fi
 }
 


### PR DESCRIPTION
@zamentur Should not change anything, but this PR is just to avoid mixing formats following to the merge of https://github.com/YunoHost/yunohost/pull/2323