### PR TITLE
[enh] Generate random ascii between a-zA-Z0-9 instead of a-f0-9

### DIFF
--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -19,6 +19,7 @@
 import string
 import secrets
 
+
 def random_ascii(length: int = 40) -> str:
     """Return a random ascii a-zA-Z0-9 string"""
     return ''.join(secrets.choice(string.ascii_letters + string.digits)

--- a/src/utils/misc.py
+++ b/src/utils/misc.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-import binascii
-import os
-
+import string
+import secrets
 
 def random_ascii(length: int = 40) -> str:
-    """Return a random ascii string"""
-    return binascii.hexlify(os.urandom(length)).decode("ascii")[:length]
+    """Return a random ascii a-zA-Z0-9 string"""
+    return ''.join(secrets.choice(string.ascii_letters + string.digits)
+                   for _ in range(length))


### PR DESCRIPTION
## The problem

`random_ascii` function generate hexadecimal chars instead of all alphabet (or ASCII) chars. 
`0123456789abcdef`

It could create future mistakes cause for example writing `random_ascii(12)` means the same entropy as a 8 chars `a-zA-Z0-9` secrets...

I searched for potential bad usage of this old function that could create security hole in production code, and i didn't found critical code.

**Related issues:** -
**Related PRs:** -

## Solution
I suggest here that `random_ascii` generate string on `a-zA-Z0-9` range with the `secrets` cryptographic module instead of directly calling `/dev/urandom`.
`0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`

Alternatively we could generate on all ascii printable chars, but this breaks some config and create various issues:
`0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c`

**AI transparency:** no use
## PR Status
Tested manually

### Code TODOs

### Tests TODOs

## How to test
