### PR TITLE
[enh] Antibot with proof of work

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,6 +11,7 @@
     "antibot_challenge_doesnt_exist_or_expired": "This 'prove you are human' challenge does not exist or has expired. Please try again.",
     "antibot_challenge_wrong_answer": "The 'prove you are human' challenge did not receive the expected answer. Please try again.",
     "antibot_challenge_too_quick": "The 'prove you are human' challenge fails cause you answered too quickly to the form. Please try again.",
+    "antibot_challenge_no_proof_of_work": "The 'prove you are human' challenge fails for some reasons. Please try again or contact an administrator.",
     "app_action_broke_system": "This action seems to have broken these important services: {services}",
     "app_action_cannot_be_ran_because_required_services_down": "These required services should be running to run this action: {services}. Try restarting them to continue (and possibly investigate why they are down).",
     "app_action_failed": "Failed to run action {action} for app {app}",

--- a/share/actionsmap-portal.yml
+++ b/share/actionsmap-portal.yml
@@ -161,6 +161,10 @@ portal:
                     help: The anti-bot challenge answer
                     extra:
                         required: True
+                --proof-of-work:
+                    help: The anti-bot proof of work
+                    extra:
+                        required: True
 
         ### portal_registration_confirm()
         registration_confirm:

--- a/src/portal.py
+++ b/src/portal.py
@@ -463,7 +463,7 @@ def portal_invitation_consume(token, username, fullname, password, external_emai
 
 # FIXME : this is probably not a proper global state shared between all the gevent/bottle threads
 # Though for now it looks like we have a single thread anyway so it may be OK ?
-CHALLENGES: dict[str, tuple[int, int, list[str]]] = dict()
+CHALLENGES: dict[str, tuple[int, int, str]] = dict()
 
 
 def _generate_antibot_challenge() -> tuple[str, str, str]:

--- a/src/portal.py
+++ b/src/portal.py
@@ -463,13 +463,15 @@ def portal_invitation_consume(token, username, fullname, password, external_emai
 
 # FIXME : this is probably not a proper global state shared between all the gevent/bottle threads
 # Though for now it looks like we have a single thread anyway so it may be OK ?
-CHALLENGES: dict[str, tuple[int, int]] = dict()
+CHALLENGES: dict[str, tuple[int, int, list[str]]] = dict()
 
 
-def _generate_antibot_challenge() -> tuple[str, str]:
+def _generate_antibot_challenge() -> tuple[str, str, str]:
 
-    from random import randint, choice
+    from secrets import randbelow, choice
     from .utils.misc import random_ascii
+    from hashlib import sha256
+
     token = random_ascii(64)
 
     CALCULATIONS = {
@@ -478,8 +480,8 @@ def _generate_antibot_challenge() -> tuple[str, str]:
         "-": lambda a, b: a - b,
     }
 
-    x = randint(0, 10)
-    y = randint(0, 10)
+    x = randbelow(10)
+    y = randbelow(10)
     operator = choice(list(CALCULATIONS.keys()))
 
     # avoid negative results for subtraction
@@ -488,13 +490,23 @@ def _generate_antibot_challenge() -> tuple[str, str]:
 
     answer = CALCULATIONS[operator](x, y)
 
+    # Create a Proof of Work challenge
+    # Force bots to bruteforce 10 hashes
+    pow_answers = [str(randbelow(100000)) for i in range(10)]
+    def createHash(value: str):
+        m = sha256()
+        m.update(value.encode())
+        return m.hexdigest()
+    pow_challenges = [createHash(token + pow_answer)
+                      for pow_answer in pow_answers]
+    pow_challenge = '|'.join(pow_challenges)
+
     generated_time = int(time.time())
     calculation = f"{x} {operator} {y}"
-    CHALLENGES[token] = (generated_time, answer)
-
+    CHALLENGES[token] = (generated_time, answer, '|'.join(pow_answers))
     _cleanup_expired_antibot_challenges()
 
-    return token, calculation
+    return token, calculation, pow_challenge
 
 
 def _cleanup_expired_antibot_challenges() -> None:
@@ -514,16 +526,19 @@ def _cleanup_expired_antibot_challenges() -> None:
         del CHALLENGES[token]
 
 
-def _verify_antibot_challenge(token: str, answer: str) -> None:
+def _verify_antibot_challenge(token: str, answer: str, pow_answers: str) -> None:
 
     _cleanup_expired_antibot_challenges()
 
-    generated_time, expected_answer = CHALLENGES.pop(token, (0, None))
+    generated_time, expected_answer, pow_expected_answers = CHALLENGES.pop(token, (0, None, None))
     if expected_answer is None:
         raise YunohostValidationError("antibot_challenge_doesnt_exist_or_expired")
 
     if not isinstance(answer, str) or not answer.strip().isdigit() or int(answer.strip()) != expected_answer:
         raise YunohostValidationError("antibot_challenge_wrong_answer")
+
+    if not isinstance(pow_answers, str) or pow_answers != pow_expected_answers:
+        raise YunohostValidationError("antibot_challenge_no_proof_of_work")
 
     if int(time.time()) < generated_time + ANTIBOT_CHALLENGE_MIN_DURATION:
         raise YunohostValidationError("antibot_challenge_too_quick")
@@ -547,11 +562,11 @@ def portal_registration_challenge() -> dict[str, str]:
     domain = request.get_header("host")
     _assert_registration_enabled_for_domain(domain)
 
-    token, calculation = _generate_antibot_challenge()
-    return {"token": token, "calculation": calculation}
+    token, calculation, pow_challenge = _generate_antibot_challenge()
+    return {"token": token, "calculation": calculation, "pow": pow_challenge}
 
 
-def portal_registration_queue(username, fullname, password, external_email=None, notes=None, accept_tos=False, challenge_token="", challenge_answer="") -> None:
+def portal_registration_queue(username, fullname, password, external_email=None, notes=None, accept_tos=False, challenge_token="", challenge_answer="", proof_of_work="") -> None:
 
     try:
         Auth().get_session_cookie()
@@ -563,7 +578,7 @@ def portal_registration_queue(username, fullname, password, external_email=None,
     from bottle import request
     domain = request.get_header("host")
     _assert_registration_enabled_for_domain(domain)
-    _verify_antibot_challenge(challenge_token, challenge_answer)
+    _verify_antibot_challenge(challenge_token, challenge_answer, proof_of_work)
 
     _call_socket_api("user_registration_queue", {
         "username": username,


### PR DESCRIPTION
## The problem
In the user self registration PR, the antibot math and time mechanism seems too simple for 2026 (and 2006 too).

**Related issues:** 
**Related PRs:** https://github.com/YunoHost/yunohost-portal/pull/44

## The solution
Here i suggest to integrate a basic proof of work mechanism without adding another extra dependencies (i have firstly search for self-hosted captcha and if there was a standard API...).

So, for an attacker it means:
 - automate the attack with a browser automation (be slow and pay for energy)
 - or succeed to craft a countermeasure with an other language (like go)

This new mechanism run when people are filling the form, and if needed finish the computation before to send the registration request.

It asks for webclient to bruteforce 10 sha256 hashes specially crafted. Currently, each hash is made from a range of 100 000 combination (salted with the challenge token), so client has to generate about 500 000 hash to find the 10 hashes...

On the portal, it uses 5 workers to speed the computation. On my core i5 it takes ~12s to solve the 10 hash (and 36s with a mono thread approach), but it should be tested on smartphone or older cpu. Some self hosted captcha solution use a wasm to speed the operation (it could be a future improvement). I guess we can optimize by varying those params (number of hashes, hash complexity, number of workers).

If the user finish to fill and save before the end of the computation, the save button display the load indicator until the computation is finished and the form sent.

An improvement could be to increase difficulty if there are a lot of requests (on a per IP basis ?), a lot pending requests, or a lot of challenge pending.

About energy, i consider registration form of yunohost should not be use so often and for me the energy cost should not be so high in normal context. Of course, if an attacker decide to try to spam and compute the hash, it consume energy on attacker side.


**AI transparency:** no use but i took some idea from https://github.com/a-ve/wicketkeeper/blob/develop/client/src/solvers/fast.js

## PR Status
*Tested partially*

### Code TODOs
 - [ ] use `navigator.hardwareConcurrency || 1` to deduce the good number of worker
 - [ ] Add some comments
 - [ ] Increase hash complexity based on some stress indicators
 - [x] Update related repo yunohost-portal
 - ~~[ ] Write data or settings migration~~
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Write unit tests
 - ~~[ ] Update/write documentation~~

### Tests TODOs
 - [x] Run the code from a yunohost protal run with docker compose (it's important cause the URL in http should be localhost
 - [ ] Check that hash compute ir rerun with new challenge if the first sumition failed due to challenge. Indeed the old challenge has been invalidating.
 - [ ] Test change on configuration on an instance

## How to test
Run the code with a yunohost portal from docker and localhost url. In http you have to run it with `localhost` or `127.0.0.1`
