### PR TITLE
[fix] Bad regex + fullname support

### DIFF
--- a/src/user.py
+++ b/src/user.py
@@ -60,10 +60,12 @@ if TYPE_CHECKING:
 else:
     logger = getLogger("yunohost.user")
 
+
 def separate_by_comma(item: str, optional: bool = True) -> str:
     if optional:
         return fr"^({item}(,{item})*)?$"
     return fr"^({item}(,{item})*)$"
+
 
 DOMAIN_REGEX = r"([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})"
 FIELDS_FOR_IMPORT = {

--- a/src/user.py
+++ b/src/user.py
@@ -60,17 +60,21 @@ if TYPE_CHECKING:
 else:
     logger = getLogger("yunohost.user")
 
+def separate_by_comma(item: str, optional: bool = True) -> str:
+    if optional:
+        return fr"^({item}(,{item})*)?$"
+    return fr"^({item}(,{item})*)$"
 
+DOMAIN_REGEX = r"([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,})"
 FIELDS_FOR_IMPORT = {
     "username": r"^[a-z0-9][-a-z0-9_.]*$",
-    "firstname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
-    "lastname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
-    "password": r"^|(.{3,})$",
-    "mail": r"^([\w.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}))$",
-    "mail-alias": r"^|([\w.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
-    "mail-forward": r"^|([\w\+.-]+@([^\W_A-Z]+([-]*[^\W_A-Z]+)*\.)+((xn--)?[^\W_]{2,}),?)+$",
+    "fullname": r"^([^\W\d_]{1,30}[ ,.\'-]{0,3})+$",
+    "password": r"^(.{3,})?$",
+    "mail": r"^[\w.-]+@" + DOMAIN_REGEX + r"$",
+    "mail-alias": separate_by_comma(r"[\w.-]+@" + DOMAIN_REGEX),
+    "mail-forward": separate_by_comma(r"[\w\+.-]+@" + DOMAIN_REGEX),
     "mailbox-quota": r"^(\d+[bkMGT])|0|$",
-    "groups": r"^|([a-z0-9][-a-z0-9_.]*(,?[a-z0-9][-a-z0-9_.]*)*)$",
+    "groups": separate_by_comma(r"[a-z0-9][-a-z0-9_.]*")
 }
 
 ADMIN_ALIASES = ["root", "admin", "admins", "webmaster", "postmaster", "abuse"]
@@ -730,6 +734,7 @@ def user_export() -> Union[str, "HTTPResponseType"]:
         writer.writeheader()
         users = user_list(list(FIELDS_FOR_IMPORT.keys()))["users"]
         for username, user in users.items():
+            user["fullname"] = user["fullname"].strip()
             user["mail-alias"] = ",".join(user["mail-alias"])
             user["mail-forward"] = ",".join(user["mail-forward"])
             user["groups"] = ",".join(user["groups"])
@@ -764,7 +769,7 @@ def user_import(
     Import users from CSV
 
     Keyword argument:
-        csvfile -- CSV file with columns username;firstname;lastname;password;mailbox_quota;mail;alias;forward;groups
+        csvfile -- CSV file with columns username;fullname;password;mailbox_quota;mail;alias;forward;groups
 
     """
 
@@ -965,7 +970,7 @@ def user_import(
 
         user_update(
             new_infos["username"],
-            fullname=(new_infos["firstname"] + " " + new_infos["lastname"]).strip(),
+            fullname=new_infos["fullname"].strip(),
             change_password=new_infos["password"],
             mailbox_quota=new_infos["mailbox-quota"],
             mail=new_infos["mail"],
@@ -1011,7 +1016,7 @@ def user_import(
                 user["password"],
                 mailbox_quota=user["mailbox-quota"],
                 from_import=True,
-                fullname=(user["firstname"] + " " + user["lastname"]).strip(),
+                fullname=user["fullname"].strip(),
             )
             _import_update(user)
             result["created"] += 1

--- a/tests/test_user-group.py
+++ b/tests/test_user-group.py
@@ -143,8 +143,7 @@ def test_import_user():
 
     fieldnames = [
         "username",
-        "firstname",
-        "lastname",
+        "fullname",
         "password",
         "mailbox-quota",
         "mail",
@@ -158,8 +157,7 @@ def test_import_user():
         writer.writerow(
             {
                 "username": "morgan-claude.good_7",
-                "firstname": "Morgan-Claude",
-                "lastname": "Good",
+                "firstname": "Morgan-Claude Good",
                 "password": "",
                 "mailbox-quota": "1G",
                 "mail": "morgan-claude.good_7@" + maindomain,
@@ -171,8 +169,7 @@ def test_import_user():
         writer.writerow(
             {
                 "username": "sam",
-                "firstname": "Sam",
-                "lastname": "White",
+                "firstname": "Sam White",
                 "password": "",
                 "mailbox-quota": "1G",
                 "mail": "sam@" + maindomain,
@@ -184,8 +181,7 @@ def test_import_user():
         writer.writerow(
             {
                 "username": "alice",
-                "firstname": "Alice",
-                "lastname": "White",
+                "firstname": "Alice White",
                 "password": "",
                 "mailbox-quota": "1G",
                 "mail": "alice@" + maindomain,
@@ -215,10 +211,10 @@ def test_import_user():
 def test_export_user():
     result = user_export()
     should_be = (
-        "username;firstname;lastname;password;mail;mail-alias;mail-forward;mailbox-quota;groups\r\n"
-        f"alice;Alice;White;;alice@{maindomain};;;0;admins,dev\r\n"
-        f"bob;Bob;Snow;;bob@{maindomain};;;0;apps\r\n"
-        f"jack;Jack;Black;;jack@{maindomain};;;0;"
+        "username;fullname;password;mail;mail-alias;mail-forward;mailbox-quota;groups\r\n"
+        f"alice;Alice White;;alice@{maindomain};;;0;admins,dev\r\n"
+        f"bob;Bob Snow;;bob@{maindomain};;;0;apps\r\n"
+        f"jack;Jack Black;;jack@{maindomain};;;0;"
     )
     assert result == should_be
 


### PR DESCRIPTION
## The problem

-  regex use to check optional values in user_import are very very bad:  `^|(something)$` instead of `(something)?$`
-  firstname and lastname are still used... and not properly strip

**Related issues:**
**Related PRs:**

## Solution

 - Fix regex
 - Use fullname and strip it

**AI transparency:** no ai

## PR Status
Tested on cli

## Code TODOs



### Tests TODOs
 - [ ] Tests on webadmin ?

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
