### PR TITLE
enh(dnsbl): Hostkarma yellowlist is not blocklist

### DIFF
--- a/share/dnsbl_list.yml
+++ b/share/dnsbl_list.yml
@@ -19,7 +19,7 @@
   ipv4: true
   ipv6: false
   domain: false
-  non_blocklisted_return_code: ['127.0.0.1', '127.0.0.5', '127.0.1.1']
+  non_blocklisted_return_code: ['127.0.0.1', '127.0.0.3', '127.0.0.5', '127.0.1.1']
 - name: ImproWare IP based spamlist
   dns_server: spamrbl.imp.ch
   website: https://antispam.imp.ch/


### PR DESCRIPTION
## The problem

Our own infra server is yellowlisted by Hostkarma.
From their own words, 

> yellow listing indicates a mixed source of good email and spam. Sources like Hotmail, Yahoo, and Gmail are yellow sources. Yellow means that the IP address or host name contains no information about if it is good or bad and no reason to check white or black lists.

**Related issues:**
**Related PRs:** #2245

## Solution

Add the code `127.0.0.3` for yellowlist to the acceptable return codes.

**AI transparency:** *If AI has been used, explain how. See https://doc.yunohost.org/en/dev/?persistLocale=true#%EF%B8%8F-develop* nope

## PR Status
Ready

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

None needed, IMHO.

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test

It should be straightforward.