### PR TITLE
Use pybuild to build the Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ tests/apps
 # Tmp/local doc stuff
 doc/bash-completion.sh
 doc/bash_completion.d
+doc/zsh_completion.d
+doc/*.gz
 doc/openapi.js
 doc/openapi.json
 doc/swagger

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,15 @@ src/locales
 # Test
 tests/apps
 
+# debhelper
+/debian/.debhelper/
+/debian/yunohost/
+/debian/debhelper-build-stamp
+/debian/files
+/debian/install
+/debian/yunohost.*
+/.pybuild
+
 # Tmp/local doc stuff
 doc/bash-completion.sh
 doc/bash_completion.d

--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,20 @@ Source: yunohost
 Section: utils
 Priority: extra
 Maintainer: YunoHost Contributors <contrib@yunohost.org>
-Build-Depends: debhelper (>=9), debhelper-compat (= 13), dh-python, python3-all (>= 3.13), python3-yaml, python3-jinja2 (>= 3.0)
+Build-Depends: debhelper-compat (= 13),
+               dh-sequence-python3,
+               pybuild-plugin-pyproject,
+               python3-all (>= 3.13),
+               python3-yaml,
+               python3-jinja2 (>= 3.0)
 Standards-Version: 3.9.6
 Homepage: https://yunohost.org/
 
 Package: yunohost
 Essential: yes
 Architecture: all
-Depends: python3-all (>= 3.13),
+Depends: ${misc:Depends},
+ , ${python3:Depends}
  , moulinette (>= 12.1), ssowat (>= 12.0),
  , python3-psutil, python3-requests, python3-dnspython
  , python3-miniupnpc, python3-dbus, python3-jinja2 (>= 3.0)

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,2 @@
+zmq python3-zmq
+moulinette_ moulinette

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,12 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
+
+export PYBUILD_NAME=yunohost
 
 %:
-	dh ${@} --with python3
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_auto_build:
+	dh_auto_build
 	# Generate bash completion file
 	mkdir -p doc/bash_completion.d
 	python3 doc/generate_bash_completion.py -o doc/bash_completion.d/yunohost
@@ -13,3 +15,7 @@ override_dh_auto_build:
 	python3 doc/generate_zsh_completion.py -o doc/zsh_completion.d/_yunohost
 	# Generate man pages
 	python3 doc/generate_manpages.py --gzip --output doc/yunohost.8.gz
+
+override_dh_auto_test:
+	# Do not run tests with debhelper
+	true

--- a/maintenance/version.py
+++ b/maintenance/version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+This file is used by Setuptools to fetch the version from the changelog.
+"""
+
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).parent.parent.resolve()
+DEBIAN_CHANGELOG = PROJECT_DIR / "debian" / "changelog"
+
+
+def get_version() -> str:
+    firstline = DEBIAN_CHANGELOG.read_text().splitlines()[0]
+    return firstline.split()[1].strip("()")
+
+
+version = get_version()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ tests = [
     "mock",
 ]
 
+[tool.setuptools.dynamic]
+version = {attr = "maintenance.version.version"}
+
+[tool.setuptools.package-dir]
+"yunohost" = "src"
+
 [tool.mypy]
 follow_imports = "skip"
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ omit = [
 env_list = ["py313-lint", "py313-invalidcode", "py313-black-check", "py313-black-run"]
 
 [tool.tox.env_run_base]
-skip_install = true
+use_develop = true
 allowlist_externals = ["black"]
 
 [tool.tox.env.py313-lint]
@@ -150,6 +150,7 @@ commands = [[
 
 [tool.tox.env.py313-mypy]
 skip_install = false
+skipsdist = true
 deps = ["mypy>=1.17"]
 dependency_groups = ["tests"]
 commands = [["mypy", "--install-types", "--non-interactive", "src/",]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
 [project]
-name = "yunohost"
+name = "YunoHost"
 description = "An operating system aiming to simplify as much as possible the administration of a server"
-readme = "README.md"
 dynamic = ["version"]
+readme = "README.md"
+license = "AGPL-3.0"
 authors = [
     { name = "YunoHost", email = "yunohost@yunohost.org" }
 ]
+urls.Repository = "https://github.com/YunoHost/yunohost"
+urls.Homepage = "https://yunohost.org"
 
 requires-python = ">=3.13"
 


### PR DESCRIPTION
## The problem

The debian package is not built as a python package, particularly it is missing
`/usr/lib/python3/dist-packages/yunohost-13.0.5.dist-info`.

Also it is ensuring the debian package follows Debian guidelines of a python based program.

## Solution

* Fix pyproject setuptools build (implement dynamic version, based on the content of the changelog)
* Use pybuild

## PR Status

Partially tested: used debdiff to check that the deb package file listing only differs by the dist-info files.

### Tests TODOs
 - [x] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance
