### PR TITLE
Delay rebinding Ruby version until after the new version is installed

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1801,7 +1801,6 @@ class RubyAppResource(AppResource):
             f"{self.rbenv} latest --print '{self.version}'",
             env={"RBENV_ROOT": self.RBENV_ROOT},
         )
-        self.set_setting("ruby_version", ruby_version)
         logger.info(f"Building Ruby {ruby_version}, this may take some time...")
         self._run_script(
             "provision_or_update",
@@ -1816,9 +1815,12 @@ class RubyAppResource(AppResource):
             if {self.rbenv} alias --list | grep --quiet '{self.app} '; then
                 {self.rbenv} alias {self.app} --remove
             fi
-            {self.rbenv} alias {self.app} '{ruby_version}'
         """,
         )
+        os.system(f"RBENV_ROOT= {self.RBENV_ROOT} {self.rbenv} alias {self.app} '{ruby_version}'")
+
+        self.set_setting("ruby_version", ruby_version)
+
         self.garbage_collect_unused_versions()
 
     def deprovision(self, context: Dict = {}):


### PR DESCRIPTION
## The problem

Discourse that switches version from 3.3.x to 3.4.x fails upgrade tests

Log (unhelpful):
```
2026-08-03 22:51:41,327: DEBUG - Executing command '['sh', '-c', '/bin/bash -x "./provision_or_update_ruby"  7>&1']'
2026-08-03 22:51:41,333: DEBUG - + source /usr/share/yunohost/helpers
2026-08-03 22:51:41,334: DEBUG - ++++ dirname -- /usr/share/yunohost/helpers
2026-08-03 22:51:41,335: DEBUG - +++ cd -- /usr/share/yunohost
2026-08-03 22:51:41,336: DEBUG - +++ pwd
2026-08-03 22:51:41,336: DEBUG - ++ SCRIPT_DIR=/usr/share/yunohost
2026-08-03 22:51:41,336: DEBUG - ++ YNH_HELPERS_VERSION=2.1
2026-08-03 22:51:41,340: DEBUG - ++ readonly 'XTRACE_ENABLE=set -o xtrace'
2026-08-03 22:51:41,340: DEBUG - ++ XTRACE_ENABLE='set -o xtrace'
2026-08-03 22:51:41,505: DEBUG - /var/www/discourse /var/cache/yunohost/app_tmp_work_dirs/app_51poj92v
2026-08-03 22:51:41,525: WARNING - rbenv: version `3.4.10' not installed
2026-08-03 22:51:42,128: ERROR - provision_or_update failed for ruby : An error occured inside the script snippet
```

TBH seems like 'installing version' step was a no-op as it completed instantly, hence the subsequent binding problem.

See 'upgrade from 2026.1.0' step in https://ci-apps-dev.yunohost.org/ci/job/23352

```

41507 INFO    Updating ruby...
43860 INFO    Building Ruby 3.4.10, this may take some time...
44009 WARNING rbenv: version `3.4.10' not installed
44511 ERROR   provision_or_update failed for ruby : An error occured inside the script snippet
44512 INFO    The operation 'Upgrade the 'discourse' app' could not be completed. Please share the full log of this operation using the command 'yunohost log share 20260804-115114-app_upgrade-discourse' to get help
44526 WARNING Here's an extract of the logs before the crash. It might help debugging the error:
44526 INFO    DEBUG - HEAD is now at c4a73d2 Clone with HTTP instead of SSH
44526 INFO    DEBUG - + popd
44526 INFO    DEBUG - /var/cache/yunohost/app_tmp_work_dirs/app_kiffyyzd/app_folder
44527 INFO    DEBUG - + _ynh_git_clone https://github.com/momo-lab/xxenv-latest /opt/rbenv/plugins/xxenv-latest
44527 INFO    DEBUG - + local url=https://github.com/momo-lab/xxenv-latest
44527 INFO    DEBUG - + local dest_dir=/opt/rbenv/plugins/xxenv-latest
44527 INFO    DEBUG - + local branch=master
44527 INFO    DEBUG - + mkdir -p /opt/rbenv/plugins/xxenv-latest
44527 INFO    DEBUG - + pushd /opt/rbenv/plugins/xxenv-latest
44527 INFO    DEBUG - /opt/rbenv/plugins/xxenv-latest /var/cache/yunohost/app_tmp_work_dirs/app_kiffyyzd/app_folder
44527 INFO    DEBUG - + '[' -d /opt/rbenv/plugins/xxenv-latest/.git ']'
44527 INFO    DEBUG - + git remote set-url origin https://github.com/momo-lab/xxenv-latest
44527 INFO    DEBUG - + git fetch -q --tags --prune origin master
44528 INFO    DEBUG - + git reset --hard origin/master
44528 INFO    DEBUG - HEAD is now at fe8fb00 Merge pull request #24 from jmcantrell/master
44528 INFO    DEBUG - + popd
44528 INFO    DEBUG - /var/cache/yunohost/app_tmp_work_dirs/app_kiffyyzd/app_folder
44528 INFO    DEBUG - + mkdir -p /opt/rbenv/cache
44528 INFO    DEBUG - + mkdir -p /opt/rbenv/shims
44528 INFO    DEBUG - + ynh_exit_properly
44528 WARNING Failed to update ruby : The operation 'Upgrade the 'discourse' app' could not be completed. Please share the full log of this operation using the command 'yunohost log share 20260804-115114-app_upgrade-discourse' to get help
```

note that subsequent resource reverts fail because `ruby_version` points to a version that was not installed correctly.

...

**Related issues:**
**Related PRs:**

## Solution
- only rebind `ruby_version` after the version installs
- move aliasing to separate script to have some better visibility into what's happening

...

**AI transparency:** *If AI has been used, explain how. See https://doc.yunohost.org/en/dev/?persistLocale=true#%EF%B8%8F-develop*

## PR Status
Tested partially - manually applied on my instance, now I'm able to upgrade Discourse

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
