### PR TITLE
enh(postfix): allow auth with email

### DIFF
--- a/conf/postfix/plain/ldap-accounts.cf
+++ b/conf/postfix/plain/ldap-accounts.cf
@@ -1,5 +1,5 @@
 server_host = localhost
 server_port = 389
 search_base = dc=yunohost,dc=org
-query_filter = (&(objectClass=mailAccount)(mail=%s)(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
-result_attribute = uid
+query_filter = (&(objectClass=mailAccount)(|(mail=%s)(uid=%s))(permission=cn=mail.main,ou=permission,dc=yunohost,dc=org))
+result_attribute = mail, uid


### PR DESCRIPTION
## The problem

Fixes https://github.com/YunoHost/issues/issues/2722

## Solution

Include `uid` and `mail` in the search query, and let output them both in the `result_attribute`s.
I think it only works on the main email address.

## PR Status
Ready

### Code TODOs

*Here are frequently forgotten tasks:*
 - [x] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr): PRLanta 2026-08-05
 - [ ] ~~Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)~~
 - [ ] ~~Write data or settings migration~~
 - [ ] ~~Pass Continuous Integration checks~~
   - [ ] ~~Add some missing translations keys~~
   - [ ] Update/write unit tests: ?
 - [ ] Update/write documentation: https://doc.yunohost.org/en/admin/email/clients

### Tests TODOs

Tested on YNH v13.0.5
Untested on YNH 12

## How to test

Apply patch, restart postfix, try logging in with either username or email address.
