### PR TITLE
dns: push: Join TXT chunks split by registrars before comparing

### DIFF
--- a/src/dns.py
+++ b/src/dns.py
@@ -740,10 +740,7 @@ def domain_dns_push(
         )
 
         if record["type"] == "TXT":
-            if not record["content"].startswith('"'):
-                record["content"] = '"' + record["content"]
-            if not record["content"].endswith('"'):
-                record["content"] = record["content"] + '"'
+            record["content"] = _normalize_txt_content(record["content"])
 
         # Check if this record was previously set by YunoHost
         record["managed_by_yunohost"] = (
@@ -1028,6 +1025,23 @@ def _set_managed_dns_records_hashes(domain: str, hashes: list) -> None:
     settings = _get_domain_settings(domain)
     settings["managed_dns_records_hashes"] = hashes or []
     _set_domain_settings(domain, settings)
+
+
+def _normalize_txt_content(content: str) -> str:
+    """
+    A TXT value longer than 255 chars is stored as several chunks by registrars,
+    e.g. '"v=DKIM1; ... p=aaa" "bbb"' (typical since DKIM keys are 2048 bits).
+    Join them back so it compares equal to the single-chunk form we generate.
+    """
+
+    content = re.sub(r'"\s+"', "", content.strip())
+
+    if not content.startswith('"'):
+        content = '"' + content
+    if not content.endswith('"') or content == '"':
+        content = content + '"'
+
+    return content
 
 
 def _hash_dns_record(record: DNSRecord) -> int:

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -18,12 +18,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+import base64
+
 import pytest
 from yunohost.dns import (
     DOMAIN_REGISTRAR_LIST_PATH,
     _build_dns_conf,
     _get_dns_zone_for_domain,
     _get_registrar_config_section,
+    _normalize_txt_content,
 )
 from yunohost.domain import domain_add, domain_remove
 from yunohost.utils.file_utils import read_toml
@@ -59,6 +62,32 @@ def test_get_dns_zone_from_domain_existing():
 
     assert _get_dns_zone_for_domain("yolo.tld") == "yolo.tld"
     assert _get_dns_zone_for_domain("foo.yolo.tld") == "yolo.tld"
+
+
+def test_normalize_txt_content():
+    # A split DKIM key and its flat form must normalize the same, otherwise
+    # 'domain dns push' keeps proposing the very same record
+    key = base64.b64encode(b"x" * 1000).decode()
+    value = f"v=DKIM1; h=sha256; k=rsa; p={key}"
+    flat = f'"{value}"'
+
+    # A character-string is limited to 255 chars, so registrars cut there
+    chunks = [value[i : i + 255] for i in range(0, len(value), 255)]
+    assert len(chunks) > 1
+    split = " ".join(f'"{c}"' for c in chunks)
+
+    assert _normalize_txt_content(split) == flat
+    assert _normalize_txt_content(flat) == flat
+
+    # Shorter, non-split values are left untouched
+    assert _normalize_txt_content('"v=spf1 a mx -all"') == '"v=spf1 a mx -all"'
+    assert _normalize_txt_content('"v=DMARC1; p=none"') == '"v=DMARC1; p=none"'
+
+    # Some registrars return values without the surrounding quotes
+    assert _normalize_txt_content("v=spf1 a mx -all") == '"v=spf1 a mx -all"'
+
+    # An escaped quote is not a chunk boundary
+    assert _normalize_txt_content(r'"say \" ok"') == r'"say \" ok"'
 
 
 # Domain registrar testing


### PR DESCRIPTION
## The problem

Since DKIM keys are 2048 bits, their TXT value is too long for a single DNS character-string, so registrars split it into chunks ("aaa" "bbb"). domain dns push compared that split value to the unsplit one it generates, and kept proposing an update for a record that was already fine.

**Related issues:**
**Related PRs:**

## Solution

...

**AI transparency:** *If AI has been used, explain how. See https://doc.yunohost.org/en/dev/?persistLocale=true#%EF%B8%8F-develop*

## PR Status
*Work in progress / Untested / Tested partially / Fully tested / Wait for other PR to be merged / Ready*

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test
Tested on my server
...
