### PR TITLE
postgresql.py: fix syntax error (solves #2838)

### DIFF
--- a/src/migrations/postgresql.py
+++ b/src/migrations/postgresql.py
@@ -93,7 +93,7 @@ class PostgreSQLMigration(Migration):
 
         password = Path("/etc/yunohost/psql").read_text().strip()
         sudocmd = f"LC_ALL=C sudo --login -u postgres PGUSER=postgres PGPASSWORD='{password}'"
-        psqlcmd = "psql --tuples-only --no-align --dbname=postgres --command='SELECT datname FROM pg_database WHERE datistemplate = false OR datname = 'template1';'"
+        psqlcmd = "psql --tuples-only --no-align --dbname=postgres --command=\"SELECT datname FROM pg_database WHERE datistemplate = false OR datname = 'template1';\""
         _, out, _ = self.runcmd(f"{sudocmd} {psqlcmd}")
         databases = [line.strip() for line in out]
         for database in databases:


### PR DESCRIPTION
## The problem

**Related issues:** #2838

Fixes https://github.com/YunoHost/issues/issues/2838

## Solution

Replace single quotes by escaped double  quotes for the command, so the single quotes are used for strings in the SQL query.

## PR Status
- ready
- tested on my machine, the fix has been then backported in this development branch.

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
