### PR TITLE
fix(auth): handle users with email aliases

### DIFF
--- a/src/authenticators/ldap_ynhuser.py
+++ b/src/authenticators/ldap_ynhuser.py
@@ -124,21 +124,15 @@ def user_is_allowed_on_domain(user: str, domain: str) -> bool:
             )
             return False
 
+        # Check all the user's email aliases: if one matches the domain, they can access it.
         user_mail_list = user_result[0]["mail"]
-        if len(user_mail_list) != 1:
-            logger.error(
-                f"User {user} found, but has the wrong number of email addresses: {user_mail_list}"
-            )
-            return False
-
-        user_mail = user_mail_list[0]
-        if "@" not in user_mail:
-            logger.error(f"Invalid email address for {user}: {user_mail}")
-            return False
-
-        if user_mail.split("@")[1] == domain:
-            # A user from that domain is welcome
-            return True
+        for user_mail in user_mail_list:
+            if "@" not in user_mail:
+                logger.error(f"Invalid email address for {user}: {user_mail}")
+                continue
+            if user_mail.split("@")[1] == domain:
+                # A user from that domain is welcome
+                return True
 
         # Users from other domains don't belong here
         return False


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/2850
Small ping @selfhoster1312, FYI, since you wrote the initial code. :)

## Solution

...

**AI transparency:** unused

## PR Status
Untested

### Code TODOs

*Here are frequently forgotten tasks:*
 - [x] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr): live at YunoCamp 2026
 - [ ] ~~Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)~~
 - [ ] ~~Write data or settings migration~~
 - [ ] Pass Continuous Integration checks
   - [ ] ~~Add some missing translations keys~~
   - [ ] ~~Update/write unit tests~~
 - [ ] ~~Update/write documentation~~

### Tests TODOs

 - [x] Test change on configuration on an instance:
 - [x] Create a user with an alias, remove all their app permissions, and try to log in
 - [x] Check that users with no alias can still log in.