### PR TITLE
Fix migration postgresql

### DIFF
--- a/src/migrations/postgresql.py
+++ b/src/migrations/postgresql.py
@@ -58,37 +58,42 @@ class PostgreSQLMigration(Migration):
             )
 
         # Make sure there's a 15 cluster
-        try:
-            self.runcmd(f"pg_lsclusters | grep -q '^{self.previous_version} '")
-        except Exception:
+        if self.cluster_is_installed(self.previous_version):
+
+            if not space_used_by_directory(
+                f"/var/lib/postgresql/{self.previous_version}"
+            ) > free_space_in_directory("/var/lib/postgresql"):
+                raise YunohostValidationError(
+                    "migration_not_enough_space", path="/var/lib/postgresql/"
+                )
+
+            self.runcmd("systemctl stop postgresql")
+            time.sleep(3)
+            self.runcmd(
+                f"LC_ALL=C pg_dropcluster --stop {self.target_version} main || true"
+            )  # We do not trigger an exception if the command fails because that probably means cluster self.target_version doesn't exists, which is fine because it's created during the pg_upgradecluster)
+            time.sleep(3)
+            self.runcmd(
+                f"LC_ALL=C pg_upgradecluster -m upgrade {self.previous_version} main -v {self.target_version}"
+            )
+            self.runcmd(f"LC_ALL=C pg_dropcluster --stop {self.previous_version} main")
+
+            # Fix possibly borked postgresql default config when Immich is installed
+            self.runcmd(r"sed -i '/^\* \* 15 main postgres$/d' /etc/postgresql-common/user_clusters")
+
+            self.runcmd("systemctl start postgresql")
+
+            self.run_post_migration()
+
+        elif self.cluster_is_installed(self.target_version):
+            logger.info(f"Migration to version {self.target_version} looks already done, running the post-migrations steps")
+            self.run_post_migration()
+        else:
             logger.warning(
-                f"It looks like there's not active {self.previous_version} cluster, so probably don't need to run this migration"
-            )
-            return
-
-        if not space_used_by_directory(
-            f"/var/lib/postgresql/{self.previous_version}"
-        ) > free_space_in_directory("/var/lib/postgresql"):
-            raise YunohostValidationError(
-                "migration_not_enough_space", path="/var/lib/postgresql/"
+                f"It looks like there's no active cluster for postgresql-{self.previous_version}, so probably don't need to run this migration"
             )
 
-        self.runcmd("systemctl stop postgresql")
-        time.sleep(3)
-        self.runcmd(
-            f"LC_ALL=C pg_dropcluster --stop {self.target_version} main || true"
-        )  # We do not trigger an exception if the command fails because that probably means cluster self.target_version doesn't exists, which is fine because it's created during the pg_upgradecluster)
-        time.sleep(3)
-        self.runcmd(
-            f"LC_ALL=C pg_upgradecluster -m upgrade {self.previous_version} main -v {self.target_version}"
-        )
-        self.runcmd(f"LC_ALL=C pg_dropcluster --stop {self.previous_version} main")
-
-        # Fix possibly borked postgresql default config when Immich is installed
-        self.runcmd(r"sed -i '/^\* \* 15 main postgres$/d' /etc/postgresql-common/user_clusters")
-
-        self.runcmd("systemctl start postgresql")
-
+    def run_post_migration(self):
         logger.warning(m18n.n("migration_postgresql_reindexing_databases"))
 
         password = Path("/etc/yunohost/psql").read_text().strip()
@@ -106,6 +111,11 @@ class PostgreSQLMigration(Migration):
             "dpkg --list | grep '^ii ' | grep -q -w {}".format(package_name),
             raise_on_errors=False,
         )
+        return returncode == 0
+
+    def cluster_is_installed(self, version):
+        # Make sure there's a 15 cluster
+        (returncode, _, _) = self.runcmd(f"pg_lsclusters | grep -q '^{version} '", False)
         return returncode == 0
 
     def runcmd(self, cmd, raise_on_errors=True):

--- a/src/migrations/postgresql.py
+++ b/src/migrations/postgresql.py
@@ -100,7 +100,7 @@ class PostgreSQLMigration(Migration):
         sudocmd = f"LC_ALL=C sudo --login -u postgres PGUSER=postgres PGPASSWORD='{password}'"
         psqlcmd = "psql --tuples-only --no-align --dbname=postgres --command=\"SELECT datname FROM pg_database WHERE datistemplate = false OR datname = 'template1';\""
         _, out, _ = self.runcmd(f"{sudocmd} {psqlcmd}")
-        databases = [line.strip() for line in out]
+        databases = [line.strip().decode('utf8') for line in out]
         for database in databases:
             # See https://www.postgresql.org/docs/17/sql-altercollation.html#SQL-ALTERCOLLATION-NOTES
             self.runcmd(f"{sudocmd} psql --dbname='{database}' --command='REINDEX DATABASE {database};'")

--- a/src/migrations/postgresql.py
+++ b/src/migrations/postgresql.py
@@ -22,7 +22,6 @@ import os
 import subprocess
 import time
 from logging import getLogger
-from pathlib import Path
 
 from moulinette import m18n
 
@@ -96,8 +95,7 @@ class PostgreSQLMigration(Migration):
     def run_post_migration(self):
         logger.warning(m18n.n("migration_postgresql_reindexing_databases"))
 
-        password = Path("/etc/yunohost/psql").read_text().strip()
-        sudocmd = f"LC_ALL=C sudo --login -u postgres PGUSER=postgres PGPASSWORD='{password}'"
+        sudocmd = "LC_ALL=C sudo -u postgres"
         psqlcmd = "psql --tuples-only --no-align --dbname=postgres --command=\"SELECT datname FROM pg_database WHERE datistemplate = false OR datname = 'template1';\""
         _, out, _ = self.runcmd(f"{sudocmd} {psqlcmd}")
         databases = [line.strip().decode('utf8') for line in out]


### PR DESCRIPTION
## The problem

1. When the postgresql postmigration fails (but the migration to version 17 succeeds), there is no way to run again the steps (i.e. the reindexation)
2. The postmigration to version 17 fails with the error detailed in https://github.com/YunoHost/issues/issues/2851


Fixes https://github.com/YunoHost/issues/issues/2851



## Solution

1. Run the postmigrations only when the cluster in version 17 is installed (and not the one of version 15)
2. Decode the output lines as utf8 strings



## PR Status
*Tested partially*

### Code TODOs


### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test

