### PR TITLE
migrations: trixie: migrate deb822 Suites properly

### DIFF
--- a/src/migrations/0036_migrate_to_trixie.py.disabled
+++ b/src/migrations/0036_migrate_to_trixie.py.disabled
@@ -556,7 +556,7 @@ sideway (typically by SSHing from the local network, or through rescue access on
             new_file_pars = []
             paragraphs = Deb822.iter_paragraphs(file.read_text())
             for paragraph in paragraphs:
-                paragraph["Suites"] = "trixie"
+                paragraph["Suites"] = paragraph["Suites"].replace("bookworm", "trixie")
 
                 if re.match(
                     r"^https?://(repo|forge)\.yunohost\.org.*", paragraph["URIs"]


### PR DESCRIPTION
Replace bookworm with trixie, but do not set the value Suites to only 'trixie'.

## The problem

Some repos have `./` as Suite, like CollaboraOnline. 

We already have applied this logic to legacy .lists files.