### PR TITLE
Update failregex and daemon for postfix-sasl.conf

### DIFF
--- a/conf/fail2ban/jail.conf
+++ b/conf/fail2ban/jail.conf
@@ -675,12 +675,12 @@ backend  = %(syslog_backend)s
 [postfix-sasl]
 
 filter   = postfix[mode=auth]
-port     = smtp,465,submission,imap,imaps,pop3,pop3s
-# You might consider monitoring /var/log/mail.warn instead if you are
-# running postfix since it would provide the same log lines at the
-# "warn" level but overall at the smaller filesize.
-logpath  = %(postfix_log)s
-backend  = %(postfix_backend)s
+port     = smtp,465,submission,smtps
+logpath  = /var/log/mail.log
+backend  = auto
+maxretry = 5
+findtime = 1d
+bantime  = 1w
 
 
 [perdition]

--- a/conf/fail2ban/postfix-sasl.conf
+++ b/conf/fail2ban/postfix-sasl.conf
@@ -2,5 +2,5 @@
 [INCLUDES]
 before = common.conf
 [Definition]
-_daemon = postfix/smtpd
-failregex = ^%(__prefix_line)swarning: [-._\w]+\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed(: [ A-Za-z0-9+/]*={0,2})?\s*$
+_daemon = postfix/(?:submission/)?smtpd
+failregex = ^%(__prefix_line)swarning: %(__hostname)s\[<HOST>\]: SASL (?:LOGIN|PLAIN|(?:CRAM|DIGEST)-MD5) authentication failed.*$


### PR DESCRIPTION
## The problem
Fail2ban doesn't seem to ban postfix repeated failed authentications attempts
...

**Related issues:**
https://github.com/YunoHost/issues/issues/2254

**Related PRs:**

## Solution
I'm using [this script](https://github.com/DeMiro5001/Linux-scripts/blob/main/yunohost/mail-report) placed in cron.daily and it reports between 200 to 600 (sometimes more) failed authentications attempts.
Updating the definition and hardening the jail config reduced the number to less than 25.

Here is the jail I am using : 
```
[postfix-sasl]
enabled  = true
port     = smtp,465,submission,smtps
filter   = postfix[mode=auth]
logpath  = /var/log/mail.log
backend  = auto
maxretry = 3
findtime = 1d
bantime  = 1w
```

Not sure if this fits every user

...

**AI transparency:** *Used AI because I am not good at regex and it became frustrating to see the ips trying to authenticate*

## PR Status
*Fully tested / Ready*

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [x] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
