### PR TITLE
[fix] No SSH with public key after trixie migration

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -692,6 +692,7 @@
     "migration_0036_patch_yunohost_dpkg": "Applying patch on dpkg database to workaround conflict issues…",
     "migration_0036_patching_sources_list": "Patching the sources.lists file…",
     "migration_0036_problematic_apps_warning": "Please note that the following possibly problematic installed apps were detected. It looks like those were not installed from the YunoHost app catalog, or are not flagged as 'working'. Consequently, it cannot be guaranteed that they will still work after the upgrade:",
+    "migration_0036_ssh_user_home_writable_by_group": "The user '{user}' uses ssh with a public key and have its home directory writable by a group or others. New version of openssh in YunoHost 13 forbid to login with public key inside a home directory writable by another user than the owner. You probably could fix it with <code>chmod og-w /home/{user}</code>. However, you might have some apps, process or customization needing this. ",
     "migration_0036_start": "Starting migration to Trixie…",
     "migration_0036_still_on_bookworm_after_main_upgrade": "Something went wrong during the main upgrade, the system appears to still be on Debian Bookworm.",
     "migration_0036_system_not_fully_up_to_date": "Your system is not fully up-to-date. Please perform a regular upgrade before running the migration to Trixie.",

--- a/src/migrations/0036_migrate_to_trixie.py.disabled
+++ b/src/migrations/0036_migrate_to_trixie.py.disabled
@@ -42,6 +42,7 @@ incus exec migration-to-trixie -- yunohost tools migrations run 0036 --accept-di
 import jinja2
 import logging
 import re
+import stat
 import subprocess
 import textwrap
 from datetime import date
@@ -353,6 +354,9 @@ class MyMigration(Migration):
             cmd = 'at -M now >/dev/null 2>&1 <<< "sleep 10; systemctl restart nginx yunohost-api"'
             # For some reason subprocess doesn't like the redirections so we have to use bash -c explicity...
             subprocess.check_call(["bash", "-c", cmd])
+        
+        # Reload sshd due to -R unknown option
+        subprocess.check_call(["systemctl", "reload", "sshd"])
 
         if self.yunohost_major_version() != N_CURRENT_YUNOHOST + 1:
             raise YunohostError(
@@ -449,6 +453,18 @@ class MyMigration(Migration):
 
             if upgradable_system_packages - lime2_hold_packages:
                 raise YunohostError("migration_0036_system_not_fully_up_to_date")
+
+        # Check ssh users won't be unable to login with public key after migration
+        # OpenSSH_10.0p2 forbid to login with public key that are in a /home/USER
+        # with write permissions on groups cause it's possible to move .ssh even 
+        # if groups have no write permissions on thi s.ssh directory.
+        for keys_path in Path('/home').glob('.ssh/authorized_keys'):
+            ssh_user = keys_path.parts[2]
+            user_home = Path('/home') / ssh_user
+            if bool(stat.S_IWGRP & user_home.stat().st_mode) \
+               or bool(stat.S_IWOTH & user_home.stat().st_mode):
+                raise YunohostError("migration_0036_ssh_user_home_writable_by_group", user=ssh_user)
+
 
     @property
     def disclaimer(self):


### PR DESCRIPTION
## The problem

After migration ssh return `Connection reset by peer ` and new openssh forbid to log in with unsafe authorized_keys context.

**Related issues:** Fixes YunoHost/issues#2839
**Related PRs:**

## Solution

 * Reload sshd at the end of the migration
 * Cancel the migration if the server contains unsecured authorized_keys

**AI transparency:** no ai

## PR Status
Work in progress

### Code TODOs

  - [ ] Check ACL
  - [ ] Check app user (git forge? SFTP feature my_webapp ?)

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
