### PR TITLE
Improve the venv migration

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -705,6 +705,7 @@
     "migration_python_venv_rebuild_disclaimer_rebuild": "Rebuilding the virtualenv will be attempted for the following apps (NB: the operation may take some time!): {rebuild_apps}",
     "migration_python_venv_rebuild_failed": "Failed to rebuild the Python virtualenv for {app}. The app may not work as long as this is not resolved. You should fix the situation by forcing the upgrade of this app using `yunohost app upgrade --force {app}`.",
     "migration_python_venv_rebuild_in_progress": "Now attempting to rebuild the Python virtualenv for `{app}`",
+    "migration_python_venv_cant_read_pyvenv": "Cannot read the previous python version in the pyvenv.cfg file for `{app}`",
     "migrations_already_ran": "Those migrations are already done: {ids}",
     "migrations_dependencies_not_satisfied": "Run these migrations: '{dependencies_id}', before migration {id}.",
     "migrations_exclusive_options": "'--auto', '--skip', and '--force-rerun' are mutually exclusive options.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -705,7 +705,6 @@
     "migration_python_venv_rebuild_disclaimer_rebuild": "Rebuilding the virtualenv will be attempted for the following apps (NB: the operation may take some time!): {rebuild_apps}",
     "migration_python_venv_rebuild_failed": "Failed to rebuild the Python virtualenv for {app}. The app may not work as long as this is not resolved. You should fix the situation by forcing the upgrade of this app using `yunohost app upgrade --force {app}`.",
     "migration_python_venv_rebuild_in_progress": "Now attempting to rebuild the Python virtualenv for `{app}`",
-    "migration_python_venv_cant_read_pyvenv": "Cannot read the previous python version in the pyvenv.cfg file for `{app}`",
     "migrations_already_ran": "Those migrations are already done: {ids}",
     "migrations_dependencies_not_satisfied": "Run these migrations: '{dependencies_id}', before migration {id}.",
     "migrations_exclusive_options": "'--auto', '--skip', and '--force-rerun' are mutually exclusive options.",

--- a/src/migrations/m0036_migrate_to_trixie.py
+++ b/src/migrations/m0036_migrate_to_trixie.py
@@ -72,52 +72,6 @@ logger = logging.getLogger("yunohost.migration")
 N_CURRENT_DEBIAN = 12
 N_CURRENT_YUNOHOST = 12
 
-VENV_REQUIREMENTS_SUFFIX = ".requirements_backup_for_trixie_upgrade.txt"
-
-
-def _get_all_venvs(dir: Path, level: int = 0, maxlevel: int = 3) -> list[Path]:
-    """
-    Returns the list of all python virtual env directories recursively
-
-    Arguments:
-        dir - the directory to scan in
-        maxlevel - the depth of the recursion
-        level - do not edit this, used as an iterator
-    """
-    if not dir.exists():
-        return []
-
-    result = []
-    # Using os functions instead of glob, because glob doesn't support hidden folders, and we need recursion with a fixed depth
-    for path in dir.iterdir():
-        if path.is_dir():
-            activatepath = path / "bin" / "activate"
-            if activatepath.is_file():
-                content = activatepath.read_text()
-                if ("VIRTUAL_ENV" in content) and ("PYTHONHOME" in content):
-                    result.append(path)
-                    continue
-            if level < maxlevel:
-                result += _get_all_venvs(path, level=level + 1)
-    return result
-
-
-def _backup_pip_freeze_for_python_app_venvs():
-    """
-    Generate a requirements file for all python virtual env located inside /opt/ and /var/www/
-    """
-    venvs = _get_all_venvs(Path("/opt/")) + _get_all_venvs(Path("/var/www/"))
-    for venv in venvs:
-        # Generate a requirements file from venv
-        # Remove pkg resources from the freeze to avoid an error during the python venv https://stackoverflow.com/a/40167445
-        pip = venv / "bin" / "pip"
-        if not pip.is_file():
-            logger.warning(f"Skipping venv {venv} because no 'pip' bin found")
-            continue
-        pip_freeze = subprocess.check_output([pip, "freeze"]).decode(encoding="utf-8")
-        pip_freeze = re.sub(r"^pkg(-|_)resources==.*$", "", pip_freeze)
-        (venv / VENV_REQUIREMENTS_SUFFIX).write_text(pip_freeze)
-
 
 def unstable_apps() -> list[str]:
     output = []
@@ -168,9 +122,6 @@ class MyMigration(Migration):
 
         # Stupid stuff because resolvconf later wants to edit /etc/resolv.conf and will miserably crash if it's immutable
         subprocess.check_call(["chattr", "-i", Path("/etc/resolv.conf").resolve()])
-
-        # Get requirements of the different venvs from python apps
-        _backup_pip_freeze_for_python_app_venvs()
 
         # Tell libc6 it's okay to restart system stuff during the upgrade
         subprocess.run(

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -24,7 +24,6 @@ from logging import getLogger
 from moulinette import m18n
 
 from ..tools import Migration, tools_migrations_state
-from ..utils.file_utils import rm
 from ..utils.process import call_async_output
 from ..utils.system import debian_version
 
@@ -63,9 +62,6 @@ class PythonMigration(Migration):
     migration_id: str
     state = None
 
-    def venv_requirements_suffix(self) -> str:
-        return f".requirements_backup_for_{debian_version()}_upgrade.txt"
-
     def extract_app_from_venv_path(self, venv_path: str) -> str:
         venv_path = venv_path.replace("/var/www/", "")
         venv_path = venv_path.replace("/opt/yunohost/", "")
@@ -90,10 +86,8 @@ class PythonMigration(Migration):
         for file in os.listdir(dir):
             path = os.path.join(dir, file)
             if os.path.isdir(path):
-                activatepath = os.path.join(path, "bin", "activate")
-                if os.path.isfile(activatepath) and os.path.isfile(
-                    path + self.venv_requirements_suffix()
-                ):
+                pyvenv_path = os.path.join(path, "pyvenv.cfg")
+                if os.path.isfile(pyvenv_path):
                     result.append(path)
                     continue
                 if level < maxlevel:
@@ -133,9 +127,6 @@ class PythonMigration(Migration):
 
         venvs = self._get_all_venvs("/opt/") + self._get_all_venvs("/var/www/")
         for venv in venvs:
-            if not os.path.isfile(venv + self.venv_requirements_suffix()):
-                continue
-
             app_corresponding_to_venv = self.extract_app_from_venv_path(venv)
 
             # Search for ignore apps
@@ -177,7 +168,6 @@ class PythonMigration(Migration):
                 app_corresponding_to_venv.startswith(app)
                 for app in self.ignored_python_apps
             ):
-                rm(venv + self.venv_requirements_suffix())
                 logger.info(
                     m18n.n(
                         "migration_python_venv_rebuild_broken_app",
@@ -201,21 +191,11 @@ class PythonMigration(Migration):
                 venv_cmd.append("--system-site-packages")
 
             # Recreate the venv
-            rm(venv, recursive=True)
             callbacks = (
                 lambda l: logger.debug("+ " + l.rstrip() + "\r"),
                 lambda l: logger.warning(l.rstrip()),
             )
-            call_async_output(venv_cmd, callbacks)
-            status = call_async_output(
-                [
-                    f"{venv}/bin/pip",
-                    "install",
-                    "-r",
-                    venv + self.venv_requirements_suffix(),
-                ],
-                callbacks,
-            )
+            status = call_async_output(["python", "-m", "venv", "--upgrade", venv], callbacks)
             if status != 0:
                 logger.error(
                     m18n.n(
@@ -223,5 +203,3 @@ class PythonMigration(Migration):
                         app=app_corresponding_to_venv,
                     )
                 )
-            else:
-                rm(venv + self.venv_requirements_suffix())

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -283,7 +283,8 @@ class PythonMigration(Migration):
                         extra_args=["--no-build-isolation"],
                     )
 
-                self._cleanup_old_python_assets(venv_path, old_python_version_major_minor)
+                if not venv_cfg.include_system_site_packages:
+                    self._cleanup_old_python_assets(venv_path, old_python_version_major_minor)
             except YunohostError as e:
                 logger.warn(e)
                 continue

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -77,7 +77,7 @@ class PythonMigration(Migration):
 
     migration_id: str
     state = None
-    pyenv_cfg_version_extractor = re.compile(
+    pyvenv_cfg_version_extractor = re.compile(
         r"version\s*=\s*(?P<version>\d+\.\d+)"  # Omit the patch number of the version
     )
 
@@ -112,8 +112,8 @@ class PythonMigration(Migration):
         for file in os.listdir(dir):
             path = os.path.join(dir, file)
             if os.path.isdir(path):
-                pyvenv_path = os.path.join(path, "pyvenv.cfg")
-                if os.path.isfile(pyvenv_path):
+                pyvenv_cfg_path = os.path.join(path, "pyvenv.cfg")
+                if os.path.isfile(pyvenv_cfg_path):
                     result.append(path)
                     continue
                 if level < maxlevel:
@@ -280,7 +280,7 @@ class PythonMigration(Migration):
                 raise e
 
     def _extract_venv_python_version(self, venv_path: Path) -> None | str:
-        py_version_match = self.pyenv_cfg_version_extractor.search(
+        py_version_match = self.pyvenv_cfg_version_extractor.search(
             read_file(venv_path / "pyvenv.cfg")
         )
         return py_version_match.group("version") if py_version_match else None

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -32,18 +32,47 @@ import re
 import tempfile
 
 from moulinette import m18n
+from configparser import ConfigParser, UNNAMED_SECTION
 
 from ..tools import Migration, tools_migrations_state
 from ..utils.error import YunohostError
-from ..utils.file_utils import read_file, rm
+from ..utils.file_utils import rm
 from ..utils.process import call_async_output, check_output
 from ..utils.system import debian_version, dpkg_compare_version
 
-type PipExecutionCallbacks = Tuple[Callable[[str], None], Callable[[str], None]]
+type ExecutionCallback = Tuple[Callable[[str], None], Callable[[str], None]]
 
 logger = getLogger("yunohost.migration")
 
-MAJOR_MINOR_PATCH_RE = r'\d+\.\d+\.\d+'
+MAJOR_MINOR_PATCH_RE = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
+
+
+class PyVenvConfig():
+    def __init__(self, venv_path: Path):
+        self.path = venv_path / "pyvenv.cfg"
+        parser = ConfigParser(allow_unnamed_section=True)
+        with open(self.path) as file:
+            parser.read_file(file)
+        self.data = parser[UNNAMED_SECTION]
+
+    @property
+    def include_system_site_packages(self) -> bool:
+        return self.data.get('include-system-site-packages', None) == 'true'
+
+    @property
+    def version(self) -> str:
+        return self.data['version']
+
+    @cached_property
+    def version_parsed(self) -> Tuple[int, int, int]:
+        match = re.match(MAJOR_MINOR_PATCH_RE, self.version)
+        if not match:
+            raise YunohostError(f"Cannot parse version stored in {self.path}: {self.version}")
+        return (
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("patch"))
+        )
 
 
 class PythonMigration(Migration):
@@ -77,10 +106,6 @@ class PythonMigration(Migration):
 
     migration_id: str
     state = None
-    pyvenv_cfg_version_extractor = re.compile(
-        r"^version\s*=\s*(?P<version>\d+\.\d+)",  # Omit the patch number of the version
-        re.MULTILINE
-    )
 
     pip_version_requirement_extractor_re = re.compile(rf"""
         ^pip\s*==\s*
@@ -225,26 +250,26 @@ class PythonMigration(Migration):
                 )
             )
 
-            old_python_version = self._extract_venv_python_version(venv_path)
-            if not old_python_version:
-                logger.warn(
-                    m18n.n(
-                        "migration_python_venv_cant_read_pyvenv",
-                        app=app_corresponding_to_venv,
-                    )
-                )
+            try:
+                venv_cfg = PyVenvConfig(venv_path)
+                (cfg_py_major, cfg_py_minor, _) = venv_cfg.version_parsed
+                # store the old python version without the patch part
+                old_python_version = f"{cfg_py_major}.{cfg_py_minor}"
+            except Exception as e:
+                logger.warn(e)
                 continue
 
-            if dpkg_compare_version(old_python_version, self.python_version) in [0, 1]:
+            if dpkg_compare_version(old_python_version, self.python_version) > -1:
                 logger.info(f"The {app_corresponding_to_venv} app looks already migrated, skipping")
                 continue
 
             # Recreate the venv
-            callbacks: PipExecutionCallbacks = (
+            callbacks: ExecutionCallback = (
                 lambda line: logger.debug("+ " + line.rstrip() + "\r"),
                 lambda line: logger.warning(line.rstrip()),
             )
-            call_async_output(["python", "-m", "venv", "--upgrade", venv], callbacks)
+
+            self._upgrade_venv(venv, venv_cfg.include_system_site_packages, callbacks)
 
             requirements = check_output(
                 [
@@ -275,16 +300,10 @@ class PythonMigration(Migration):
 
                 self._cleanup_old_python_assets(venv_path, old_python_version)
             except YunohostError as e:
-                logger.error(e)
+                logger.warn(e)
                 continue
             except Exception as e:
                 raise e
-
-    def _extract_venv_python_version(self, venv_path: Path) -> None | str:
-        py_version_match = self.pyvenv_cfg_version_extractor.search(
-            read_file(venv_path / "pyvenv.cfg")
-        )
-        return py_version_match.group("version") if py_version_match else None
 
     def _cleanup_old_python_assets(self, venv_path: Path, old_python_version: str):
         rm(venv_path / f"lib/python{old_python_version}", recursive=True, force=True)
@@ -320,11 +339,17 @@ class PythonMigration(Migration):
                 new_requirements.append(line)
         return (str.join("\n", new_requirements), str.join("\n", editables))
 
-    def _install_requirements(self, pip_path: Path, requirements: str, app: str, callbacks: PipExecutionCallbacks, extra_args: list[str] = []):
+    def _upgrade_venv(self, venv: str, include_system_site_packages: bool, callbacks: ExecutionCallback):
+        venv_cmd = ["python", "-m", "venv", "--upgrade", venv]
+        if include_system_site_packages:
+            venv_cmd.append("--system-site-packages")
+        return self._call_async_output(venv_cmd, callbacks)
+
+    def _install_requirements(self, pip_path: Path, requirements: str, app: str, callbacks: ExecutionCallback, extra_args: list[str] = []):
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(requirements.encode("utf8"))
             fp.flush()
-            status = call_async_output(
+            status = self._call_async_output(
                 [
                     pip_path,
                     "install",
@@ -341,3 +366,7 @@ class PythonMigration(Migration):
                 "migration_python_venv_rebuild_failed",
                 app=app,
             )
+
+    def _call_async_output(self, args: list[str | Path], callbacks: ExecutionCallback):
+        logger.debug(f"Running this command: {str.join(" ", [str(arg) for arg in args])}")
+        return call_async_output(args, callbacks)

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -22,6 +22,7 @@ from functools import cached_property
 from logging import getLogger
 import os
 from pathlib import Path
+import sys
 from typing import Callable, Tuple
 try:
     from pip import __version__ as PIP_VERSION
@@ -76,7 +77,7 @@ class PythonMigration(Migration):
 
     migration_id: str
     state = None
-    py_version_re = re.compile(
+    pyenv_cfg_version_extractor = re.compile(
         r"version\s*=\s*(?P<version>\d+\.\d+)"  # Omit the patch number of the version
     )
 
@@ -131,6 +132,13 @@ class PythonMigration(Migration):
         match = re.match(rf'^{MAJOR_MINOR_PATCH_RE}', PIP_VERSION)
         if not match:
             raise YunohostError(f"cannot parse pip system version: {PIP_VERSION}", raw_msg=True)
+        return match.string
+
+    @cached_property
+    def python_version(self):
+        match = re.match(rf'^{MAJOR_MINOR_PATCH_RE}', sys.version)
+        if not match:
+            raise YunohostError(f"cannot extract python version from: {sys.version}", raw_msg=True)
         return match.string
 
     @property
@@ -231,6 +239,10 @@ class PythonMigration(Migration):
                 )
                 continue
 
+            if dpkg_compare_version(old_python_version, self.python_version) in [0, 1]:
+                logger.info(f"{app_corresponding_to_venv} looks already migrated, skipping")
+                continue
+
             # Recreate the venv
             callbacks: PipExecutionCallbacks = (
                 lambda line: logger.debug("+ " + line.rstrip() + "\r"),
@@ -266,7 +278,7 @@ class PythonMigration(Migration):
             self._cleanup_old_python_assets(venv_path, old_python_version)
 
     def _extract_venv_python_version(self, venv_path: Path) -> None | str:
-        py_version_match = self.py_version_re.search(
+        py_version_match = self.pyenv_cfg_version_extractor.search(
             read_file(venv_path / "pyvenv.cfg")
         )
         return py_version_match.group("version") if py_version_match else None

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -136,10 +136,8 @@ class PythonMigration(Migration):
 
     @cached_property
     def python_version(self):
-        match = re.match(rf'^(?P<version>{MAJOR_MINOR_PATCH_RE})', sys.version)
-        if not match:
-            raise YunohostError(f"cannot extract python version from: {sys.version}", raw_msg=True)
-        return match.group("version")
+        """ Returns the python version without the patch """
+        return f"{sys.version_info.major}.{sys.version_info.minor}"
 
     @property
     def mode(self):
@@ -240,7 +238,7 @@ class PythonMigration(Migration):
                 continue
 
             if dpkg_compare_version(old_python_version, self.python_version) in [0, 1]:
-                logger.info(f"{app_corresponding_to_venv} looks already migrated, skipping")
+                logger.info(f"The {app_corresponding_to_venv} app looks already migrated, skipping")
                 continue
 
             # Recreate the venv
@@ -268,6 +266,7 @@ class PythonMigration(Migration):
                 self._install_requirements(pip_path, requirements, app_corresponding_to_venv, callbacks)
 
                 if editables_requirements:
+                    logger.debug("Installing the editables")
                     self._install_requirements(
                         pip_path,
                         editables_requirements,
@@ -277,7 +276,8 @@ class PythonMigration(Migration):
                     )
 
                 self._cleanup_old_python_assets(venv_path, old_python_version)
-            except YunohostError:
+            except YunohostError as e:
+                logger.error(e)
                 continue
             except Exception as e:
                 raise e

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -222,7 +222,14 @@ class PythonMigration(Migration):
                 fp.write(pip_freeze_output)
                 fp.flush()
                 status = call_async_output(
-                    [venv_path / "bin/pip", "install", "-r", fp.name], callbacks
+                    [
+                        venv_path / "bin/pip",
+                        "install",
+                        "--no-build-isolation",
+                        "-r",
+                        fp.name,
+                    ],
+                    callbacks,
                 )
 
             if status != 0:

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -141,9 +141,6 @@ class PythonMigration(Migration):
 
     @property
     def mode(self):
-        if not self.is_pending():
-            return "auto"
-
         if self._get_all_venvs("/opt/") + self._get_all_venvs("/var/www/"):
             return "manual"
         else:

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -18,21 +18,31 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import os
+from functools import cached_property
 from logging import getLogger
+import os
 from pathlib import Path
+from typing import Callable, Tuple
+try:
+    from pip import __version__ as PIP_VERSION
+except ImportError:
+    PIP_VERSION = ""
 import re
-import subprocess
 import tempfile
 
 from moulinette import m18n
 
 from ..tools import Migration, tools_migrations_state
+from ..utils.error import YunohostError
 from ..utils.file_utils import read_file, rm
-from ..utils.process import call_async_output
-from ..utils.system import debian_version
+from ..utils.process import call_async_output, check_output
+from ..utils.system import debian_version, dpkg_compare_version
+
+type PipExecutionCallbacks = Tuple[Callable[[str], None], Callable[[str], None]]
 
 logger = getLogger("yunohost.migration")
+
+MAJOR_MINOR_PATCH_RE = r'\d+\.\d+\.\d+'
 
 
 class PythonMigration(Migration):
@@ -67,8 +77,15 @@ class PythonMigration(Migration):
     migration_id: str
     state = None
     py_version_re = re.compile(
-        r"version\s*=\s*(?P<version>\d+\.\d+)"
-    )  # Omit the patch number of the version
+        r"version\s*=\s*(?P<version>\d+\.\d+)"  # Omit the patch number of the version
+    )
+
+    pip_version_requirement_extractor_re = re.compile(rf"""
+        ^pip\s*==\s*
+        (?P<version>{MAJOR_MINOR_PATCH_RE}) # Only get the major, minor and patch
+        (?:[^\d].*)?$ # Also grab any residual characters that follows the patch,
+                      # but don't process them, they will be removed if we skip the pip upgrade.
+    """, re.VERBOSE)
 
     def extract_app_from_venv_path(self, venv_path: str) -> str:
         venv_path = venv_path.replace("/var/www/", "")
@@ -108,6 +125,13 @@ class PythonMigration(Migration):
                 self.migration_id, "pending"
             )
         return self.state == "pending"
+
+    @cached_property
+    def pip_version_normalized(self):
+        match = re.match(rf'^{MAJOR_MINOR_PATCH_RE}', PIP_VERSION)
+        if not match:
+            raise YunohostError(f"cannot parse pip system version: {PIP_VERSION}", raw_msg=True)
+        return match.string
 
     @property
     def mode(self):
@@ -167,9 +191,14 @@ class PythonMigration(Migration):
         if self.mode == "auto":
             return
 
+        if not self.pip_version_normalized:
+            logger.info("No pip version found, skipping")
+            return
+
         venvs = self._get_all_venvs("/opt/") + self._get_all_venvs("/var/www/")
         for venv in venvs:
             venv_path = Path(venv)
+            pip_path = venv_path / "bin/pip"
             app_corresponding_to_venv = self.extract_app_from_venv_path(venv)
 
             # Search for ignore apps
@@ -203,43 +232,38 @@ class PythonMigration(Migration):
                 continue
 
             # Recreate the venv
-            callbacks = (
-                lambda l: logger.debug("+ " + l.rstrip() + "\r"),
-                lambda l: logger.warning(l.rstrip()),
+            callbacks: PipExecutionCallbacks = (
+                lambda line: logger.debug("+ " + line.rstrip() + "\r"),
+                lambda line: logger.warning(line.rstrip()),
             )
             call_async_output(["python", "-m", "venv", "--upgrade", venv], callbacks)
 
-            pip_freeze_output = subprocess.check_output(
+            requirements = check_output(
                 [
-                    venv_path / "bin/pip",
+                    pip_path,
                     "freeze",
-                    "--path",
-                    venv_path / f"lib/python{old_python_version}/site-packages",
-                ]
+                    "--all",
+                    "--path=" + str(venv_path / f"lib/python{old_python_version}/site-packages"),
+                ],
+                shell=False
             )
 
-            with tempfile.NamedTemporaryFile() as fp:
-                fp.write(pip_freeze_output)
-                fp.flush()
-                status = call_async_output(
-                    [
-                        venv_path / "bin/pip",
-                        "install",
-                        "--no-build-isolation",
-                        "-r",
-                        fp.name,
-                    ],
+            requirements = self._remove_pip_if_not_newer_than_system_version(requirements)
+
+            (requirements, editables_requirements) = self._split_editables(requirements)
+
+            self._install_requirements(pip_path, requirements, app_corresponding_to_venv, callbacks)
+
+            if editables_requirements:
+                self._install_requirements(
+                    pip_path,
+                    editables_requirements,
+                    app_corresponding_to_venv,
                     callbacks,
+                    extra_args=["--no-build-isolation"],
                 )
 
-            if status != 0:
-                logger.error(
-                    m18n.n(
-                        "migration_python_venv_rebuild_failed",
-                        app=app_corresponding_to_venv,
-                    )
-                )
-            self._cleanup(venv_path, old_python_version)
+            self._cleanup_old_python_assets(venv_path, old_python_version)
 
     def _extract_venv_python_version(self, venv_path: Path) -> None | str:
         py_version_match = self.py_version_re.search(
@@ -247,8 +271,58 @@ class PythonMigration(Migration):
         )
         return py_version_match.group("version") if py_version_match else None
 
-    def _cleanup(self, venv_path: Path, old_python_version: str):
-        rm(venv_path / f"lib/python{old_python_version}", recursive=True)
-        rm(venv_path / f"include/python{old_python_version}", recursive=True)
-        rm(venv_path / f"bin/python{old_python_version}")
-        rm(venv_path / f"bin/pip{old_python_version}")
+    def _cleanup_old_python_assets(self, venv_path: Path, old_python_version: str):
+        rm(venv_path / f"lib/python{old_python_version}", recursive=True, force=True)
+        rm(venv_path / f"include/python{old_python_version}", recursive=True, force=True)
+        rm(venv_path / f"bin/python{old_python_version}", force=True)
+        rm(venv_path / f"bin/pip{old_python_version}", force=True)
+
+    def _remove_pip_if_not_newer_than_system_version(self, requirements: str):
+        """
+        In the requirements, look for line installing pip and either:
+           - keep it if the pip version asked is newer than the one provided by the system
+           - or empty the whole line otherwise
+
+        For the sake of simplicity, we only compare the major, minor and patch.
+        """
+        def remove_if_not_newer_than_system_pip(match: re.Match[str]) -> str:
+            # HACK: yeah, we use a tool meant for debian to compare versions for pip version…
+            # We assume that such a tool does the job when comparing versions which includes only
+            # a major, minor and patch.
+            if dpkg_compare_version(match.group("version"), self.pip_version_normalized) > 0:
+                return match.string
+            return ""
+
+        return re.sub(self.pip_version_requirement_extractor_re, remove_if_not_newer_than_system_pip, requirements)
+
+    def _split_editables(self, requirements: str) -> Tuple[str, str]:
+        new_requirements = []
+        editables = []
+        for line in requirements.splitlines():
+            if line.startswith("-e"):
+                editables.append(line)
+            else:
+                new_requirements.append(line)
+        return (str.join("\n", new_requirements), str.join("\n", editables))
+
+    def _install_requirements(self, pip_path: Path, requirements: str, app: str, callbacks: PipExecutionCallbacks, extra_args: list[str] = []):
+        with tempfile.NamedTemporaryFile() as fp:
+            fp.write(requirements.encode("utf8"))
+            fp.flush()
+            status = call_async_output(
+                [
+                    pip_path,
+                    "install",
+                    "--use-pep517",  # Seems like a sane default nowadays: https://pip.pypa.io/en/stable/news/#id112
+                    *extra_args,
+                    "-r",
+                    fp.name,
+                ],
+                callbacks,
+            )
+
+        if status != 0:
+            raise YunohostError(
+                "migration_python_venv_rebuild_failed",
+                app=app,
+            )

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -20,10 +20,15 @@
 
 import os
 from logging import getLogger
+from pathlib import Path
+import re
+import subprocess
+import tempfile
 
 from moulinette import m18n
 
 from ..tools import Migration, tools_migrations_state
+from ..utils.file_utils import read_file, rm
 from ..utils.process import call_async_output
 from ..utils.system import debian_version
 
@@ -61,6 +66,9 @@ class PythonMigration(Migration):
 
     migration_id: str
     state = None
+    py_version_re = re.compile(
+        r"version\s*=\s*(?P<version>\d+\.\d+)"
+    )  # Omit the patch number of the version
 
     def extract_app_from_venv_path(self, venv_path: str) -> str:
         venv_path = venv_path.replace("/var/www/", "")
@@ -161,6 +169,7 @@ class PythonMigration(Migration):
 
         venvs = self._get_all_venvs("/opt/") + self._get_all_venvs("/var/www/")
         for venv in venvs:
+            venv_path = Path(venv)
             app_corresponding_to_venv = self.extract_app_from_venv_path(venv)
 
             # Search for ignore apps
@@ -183,19 +192,39 @@ class PythonMigration(Migration):
                 )
             )
 
-            venv_cmd = ["python", "-m", "venv", venv]
-
-            # Get venv info
-            pyvenv_cfg = open(os.path.join(venv, "pyvenv.cfg")).read()
-            if "include-system-site-packages = true" in pyvenv_cfg:
-                venv_cmd.append("--system-site-packages")
+            old_python_version = self._extract_venv_python_version(venv_path)
+            if not old_python_version:
+                logger.warn(
+                    m18n.n(
+                        "migration_python_venv_cant_read_pyvenv",
+                        app=app_corresponding_to_venv,
+                    )
+                )
+                continue
 
             # Recreate the venv
             callbacks = (
                 lambda l: logger.debug("+ " + l.rstrip() + "\r"),
                 lambda l: logger.warning(l.rstrip()),
             )
-            status = call_async_output(["python", "-m", "venv", "--upgrade", venv], callbacks)
+            call_async_output(["python", "-m", "venv", "--upgrade", venv], callbacks)
+
+            pip_freeze_output = subprocess.check_output(
+                [
+                    venv_path / "bin/pip",
+                    "freeze",
+                    "--path",
+                    venv_path / f"lib/python{old_python_version}/site-packages",
+                ]
+            )
+
+            with tempfile.NamedTemporaryFile() as fp:
+                fp.write(pip_freeze_output)
+                fp.flush()
+                status = call_async_output(
+                    [venv_path / "bin/pip", "install", "-r", fp.name], callbacks
+                )
+
             if status != 0:
                 logger.error(
                     m18n.n(
@@ -203,3 +232,16 @@ class PythonMigration(Migration):
                         app=app_corresponding_to_venv,
                     )
                 )
+            self._cleanup(venv_path, old_python_version)
+
+    def _extract_venv_python_version(self, venv_path: Path) -> None | str:
+        py_version_match = self.py_version_re.search(
+            read_file(venv_path / "pyvenv.cfg")
+        )
+        return py_version_match.group("version") if py_version_match else None
+
+    def _cleanup(self, venv_path: Path, old_python_version: str):
+        rm(venv_path / f"lib/python{old_python_version}", recursive=True)
+        rm(venv_path / f"include/python{old_python_version}", recursive=True)
+        rm(venv_path / f"bin/python{old_python_version}")
+        rm(venv_path / f"bin/pip{old_python_version}")

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -129,17 +129,17 @@ class PythonMigration(Migration):
 
     @cached_property
     def pip_version_normalized(self):
-        match = re.match(rf'^{MAJOR_MINOR_PATCH_RE}', PIP_VERSION)
+        match = re.match(rf'^(?P<version>{MAJOR_MINOR_PATCH_RE})', PIP_VERSION)
         if not match:
             raise YunohostError(f"cannot parse pip system version: {PIP_VERSION}", raw_msg=True)
-        return match.string
+        return match.group("version")
 
     @cached_property
     def python_version(self):
-        match = re.match(rf'^{MAJOR_MINOR_PATCH_RE}', sys.version)
+        match = re.match(rf'^(?P<version>{MAJOR_MINOR_PATCH_RE})', sys.version)
         if not match:
             raise YunohostError(f"cannot extract python version from: {sys.version}", raw_msg=True)
-        return match.string
+        return match.group("version")
 
     @property
     def mode(self):

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -78,7 +78,8 @@ class PythonMigration(Migration):
     migration_id: str
     state = None
     pyvenv_cfg_version_extractor = re.compile(
-        r"version\s*=\s*(?P<version>\d+\.\d+)"  # Omit the patch number of the version
+        r"^version\s*=\s*(?P<version>\d+\.\d+)",  # Omit the patch number of the version
+        re.MULTILINE
     )
 
     pip_version_requirement_extractor_re = re.compile(rf"""
@@ -86,7 +87,7 @@ class PythonMigration(Migration):
         (?P<version>{MAJOR_MINOR_PATCH_RE}) # Only get the major, minor and patch
         (?:[^\d].*)?$ # Also grab any residual characters that follows the patch,
                       # but don't process them, they will be removed if we skip the pip upgrade.
-    """, re.VERBOSE)
+    """, re.VERBOSE + re.MULTILINE)
 
     def extract_app_from_venv_path(self, venv_path: str) -> str:
         venv_path = venv_path.replace("/var/www/", "")

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -264,18 +264,23 @@ class PythonMigration(Migration):
 
             (requirements, editables_requirements) = self._split_editables(requirements)
 
-            self._install_requirements(pip_path, requirements, app_corresponding_to_venv, callbacks)
+            try:
+                self._install_requirements(pip_path, requirements, app_corresponding_to_venv, callbacks)
 
-            if editables_requirements:
-                self._install_requirements(
-                    pip_path,
-                    editables_requirements,
-                    app_corresponding_to_venv,
-                    callbacks,
-                    extra_args=["--no-build-isolation"],
-                )
+                if editables_requirements:
+                    self._install_requirements(
+                        pip_path,
+                        editables_requirements,
+                        app_corresponding_to_venv,
+                        callbacks,
+                        extra_args=["--no-build-isolation"],
+                    )
 
-            self._cleanup_old_python_assets(venv_path, old_python_version)
+                self._cleanup_old_python_assets(venv_path, old_python_version)
+            except YunohostError:
+                continue
+            except Exception as e:
+                raise e
 
     def _extract_venv_python_version(self, venv_path: Path) -> None | str:
         py_version_match = self.pyenv_cfg_version_extractor.search(

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -22,7 +22,6 @@ from functools import cached_property
 from logging import getLogger
 import os
 from pathlib import Path
-import sys
 from typing import Callable, Tuple
 try:
     from pip import __version__ as PIP_VERSION
@@ -33,12 +32,14 @@ import tempfile
 
 from moulinette import m18n
 from configparser import ConfigParser, UNNAMED_SECTION
+from packaging.version import Version, VERSION_PATTERN
+from packaging.markers import default_environment
 
 from ..tools import Migration, tools_migrations_state
 from ..utils.error import YunohostError
 from ..utils.file_utils import rm
 from ..utils.process import call_async_output, check_output
-from ..utils.system import debian_version, dpkg_compare_version
+from ..utils.system import debian_version
 
 type ExecutionCallback = Tuple[Callable[[str], None], Callable[[str], None]]
 
@@ -59,20 +60,9 @@ class PyVenvConfig():
     def include_system_site_packages(self) -> bool:
         return self.data.get('include-system-site-packages', None) == 'true'
 
-    @property
-    def version(self) -> str:
-        return self.data['version']
-
     @cached_property
-    def version_parsed(self) -> Tuple[int, int, int]:
-        match = re.match(MAJOR_MINOR_PATCH_RE, self.version)
-        if not match:
-            raise YunohostError(f"Cannot parse version stored in {self.path}: {self.version}")
-        return (
-            int(match.group("major")),
-            int(match.group("minor")),
-            int(match.group("patch"))
-        )
+    def version(self) -> Version:
+        return Version(self.data['version'])
 
 
 class PythonMigration(Migration):
@@ -107,12 +97,10 @@ class PythonMigration(Migration):
     migration_id: str
     state = None
 
-    pip_version_requirement_extractor_re = re.compile(rf"""
-        ^pip\s*==\s*
-        (?P<version>{MAJOR_MINOR_PATCH_RE}) # Only get the major, minor and patch
-        (?:[^\d].*)?$ # Also grab any residual characters that follows the patch,
-                      # but don't process them, they will be removed if we skip the pip upgrade.
-    """, re.VERBOSE + re.MULTILINE)
+    pip_version_requirement_extractor_re = re.compile(
+        rf"^pip\s*==\s*(?P<version>{VERSION_PATTERN})\s*$",
+        re.VERBOSE + re.MULTILINE  # VERBOSE is required by VERSION_PATTERN
+    )
 
     def extract_app_from_venv_path(self, venv_path: str) -> str:
         venv_path = venv_path.replace("/var/www/", "")
@@ -154,16 +142,12 @@ class PythonMigration(Migration):
         return self.state == "pending"
 
     @cached_property
-    def pip_version_normalized(self):
-        match = re.match(rf'^(?P<version>{MAJOR_MINOR_PATCH_RE})', PIP_VERSION)
-        if not match:
-            raise YunohostError(f"cannot parse pip system version: {PIP_VERSION}", raw_msg=True)
-        return match.group("version")
+    def pip_version(self):
+        return Version(PIP_VERSION) if PIP_VERSION else None
 
     @cached_property
     def python_version(self):
-        """ Returns the python version without the patch """
-        return f"{sys.version_info.major}.{sys.version_info.minor}"
+        return Version(default_environment()['python_full_version'])
 
     @property
     def mode(self):
@@ -220,7 +204,7 @@ class PythonMigration(Migration):
         if self.mode == "auto":
             return
 
-        if not self.pip_version_normalized:
+        if not PIP_VERSION:
             logger.info("No pip version found, skipping")
             return
 
@@ -252,14 +236,11 @@ class PythonMigration(Migration):
 
             try:
                 venv_cfg = PyVenvConfig(venv_path)
-                (cfg_py_major, cfg_py_minor, _) = venv_cfg.version_parsed
-                # store the old python version without the patch part
-                old_python_version = f"{cfg_py_major}.{cfg_py_minor}"
             except Exception as e:
                 logger.warn(e)
                 continue
 
-            if dpkg_compare_version(old_python_version, self.python_version) > -1:
+            if venv_cfg.version >= self.python_version:
                 logger.info(f"The {app_corresponding_to_venv} app looks already migrated, skipping")
                 continue
 
@@ -271,12 +252,16 @@ class PythonMigration(Migration):
 
             self._upgrade_venv(venv, venv_cfg.include_system_site_packages, callbacks)
 
+            # store the old python version without the patch part
+            old_python_version_major_minor = f"{venv_cfg.version.major}.{venv_cfg.version.minor}"
+
             requirements = check_output(
                 [
                     pip_path,
                     "freeze",
                     "--all",
-                    "--path=" + str(venv_path / f"lib/python{old_python_version}/site-packages"),
+                    "--path",
+                    venv_path / f"lib/python{old_python_version_major_minor}/site-packages",
                 ],
                 shell=False
             )
@@ -298,18 +283,18 @@ class PythonMigration(Migration):
                         extra_args=["--no-build-isolation"],
                     )
 
-                self._cleanup_old_python_assets(venv_path, old_python_version)
+                self._cleanup_old_python_assets(venv_path, old_python_version_major_minor)
             except YunohostError as e:
                 logger.warn(e)
                 continue
             except Exception as e:
                 raise e
 
-    def _cleanup_old_python_assets(self, venv_path: Path, old_python_version: str):
-        rm(venv_path / f"lib/python{old_python_version}", recursive=True, force=True)
-        rm(venv_path / f"include/python{old_python_version}", recursive=True, force=True)
-        rm(venv_path / f"bin/python{old_python_version}", force=True)
-        rm(venv_path / f"bin/pip{old_python_version}", force=True)
+    def _cleanup_old_python_assets(self, venv_path: Path, old_python_version_major_minor: str):
+        rm(venv_path / f"lib/python{old_python_version_major_minor}", recursive=True, force=True)
+        rm(venv_path / f"include/python{old_python_version_major_minor}", recursive=True, force=True)
+        rm(venv_path / f"bin/python{old_python_version_major_minor}", force=True)
+        rm(venv_path / f"bin/pip{old_python_version_major_minor}", force=True)
 
     def _remove_pip_if_not_newer_than_system_version(self, requirements: str):
         """
@@ -319,15 +304,13 @@ class PythonMigration(Migration):
 
         For the sake of simplicity, we only compare the major, minor and patch.
         """
-        def remove_if_not_newer_than_system_pip(match: re.Match[str]) -> str:
-            # HACK: yeah, we use a tool meant for debian to compare versions for pip version…
-            # We assume that such a tool does the job when comparing versions which includes only
-            # a major, minor and patch.
-            if dpkg_compare_version(match.group("version"), self.pip_version_normalized) > 0:
+        def maybe_empty(match: re.Match[str]) -> str:
+            assert self.pip_version
+            if Version(match.group("version")) > self.pip_version:
                 return match.string
             return ""
 
-        return re.sub(self.pip_version_requirement_extractor_re, remove_if_not_newer_than_system_pip, requirements)
+        return self.pip_version_requirement_extractor_re.sub(maybe_empty, requirements)
 
     def _split_editables(self, requirements: str) -> Tuple[str, str]:
         new_requirements = []

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -250,10 +250,11 @@ class PythonMigration(Migration):
                 lambda line: logger.warning(line.rstrip()),
             )
 
-            self._upgrade_venv(venv, venv_cfg.include_system_site_packages, callbacks)
+            self._upgrade_venv(venv_path, venv_cfg.include_system_site_packages, callbacks)
 
             # store the old python version without the patch part
             old_python_version_major_minor = f"{venv_cfg.version.major}.{venv_cfg.version.minor}"
+            old_site_packages_path = venv_path / f"lib/python{old_python_version_major_minor}/site-packages"
 
             requirements = check_output(
                 [
@@ -261,7 +262,7 @@ class PythonMigration(Migration):
                     "freeze",
                     "--all",
                     "--path",
-                    venv_path / f"lib/python{old_python_version_major_minor}/site-packages",
+                    old_site_packages_path,
                 ],
                 shell=False
             )
@@ -271,7 +272,13 @@ class PythonMigration(Migration):
             (requirements, editables_requirements) = self._split_editables(requirements)
 
             try:
-                self._install_requirements(pip_path, requirements, app_corresponding_to_venv, callbacks)
+                self._install_requirements(
+                    pip_path,
+                    requirements,
+                    app_corresponding_to_venv,
+                    callbacks,
+                    exec_as_owner_of=old_site_packages_path
+                )
 
                 if editables_requirements:
                     logger.debug("Installing the editables")
@@ -280,6 +287,7 @@ class PythonMigration(Migration):
                         editables_requirements,
                         app_corresponding_to_venv,
                         callbacks,
+                        exec_as_owner_of=old_site_packages_path,
                         extra_args=["--no-build-isolation"],
                     )
 
@@ -326,16 +334,26 @@ class PythonMigration(Migration):
                 new_requirements.append(line)
         return (str.join("\n", new_requirements), str.join("\n", editables))
 
-    def _upgrade_venv(self, venv: str, include_system_site_packages: bool, callbacks: ExecutionCallback):
+    def _call_async_output(self, args: list[str | Path], callbacks: ExecutionCallback, exec_as_owner_of: Path | None):
+        if exec_as_owner_of and exec_as_owner_of.exists():
+            args = ["sudo", "-u", "#" + str(os.stat(exec_as_owner_of).st_uid), *args]
+        logger.debug(f"Running this command: {str.join(" ", [str(arg) for arg in args])}")
+        return call_async_output(args, callbacks)
+
+    def _upgrade_venv(self, venv: Path, include_system_site_packages: bool, callbacks: ExecutionCallback):
         venv_cmd = ["python", "-m", "venv", "--upgrade", venv]
         if include_system_site_packages:
             venv_cmd.append("--system-site-packages")
-        return self._call_async_output(venv_cmd, callbacks)
+        py_venv_path = venv / "pyvenv.cfg"
+        return self._call_async_output(venv_cmd, callbacks, exec_as_owner_of=py_venv_path)
 
-    def _install_requirements(self, pip_path: Path, requirements: str, app: str, callbacks: ExecutionCallback, extra_args: list[str] = []):
+    def _install_requirements(self, pip_path: Path, requirements: str, app: str, callbacks: ExecutionCallback, exec_as_owner_of: Path, extra_args: list[str] = []):
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(requirements.encode("utf8"))
             fp.flush()
+
+            os.chown(path=fp.name, uid=os.stat(exec_as_owner_of).st_uid, gid=0)
+
             status = self._call_async_output(
                 [
                     pip_path,
@@ -346,6 +364,7 @@ class PythonMigration(Migration):
                     fp.name,
                 ],
                 callbacks,
+                exec_as_owner_of=exec_as_owner_of
             )
 
         if status != 0:
@@ -353,7 +372,3 @@ class PythonMigration(Migration):
                 "migration_python_venv_rebuild_failed",
                 app=app,
             )
-
-    def _call_async_output(self, args: list[str | Path], callbacks: ExecutionCallback):
-        logger.debug(f"Running this command: {str.join(" ", [str(arg) for arg in args])}")
-        return call_async_output(args, callbacks)

--- a/src/migrations/python.py
+++ b/src/migrations/python.py
@@ -306,8 +306,11 @@ class PythonMigration(Migration):
         """
         def maybe_empty(match: re.Match[str]) -> str:
             assert self.pip_version
-            if Version(match.group("version")) > self.pip_version:
+            frozen_version = Version(match.group("version"))
+            if frozen_version > self.pip_version:
+                logger.debug(f"pip: Will reinstall the version required by the app: {frozen_version} (more recent than the system version: {self.pip_version})")
                 return match.string
+            logger.debug(f"pip: Will upgrade version from {frozen_version} to {self.pip_version} (the system version)")
             return ""
 
         return self.pip_version_requirement_extractor_re.sub(maybe_empty, requirements)


### PR DESCRIPTION
## The problem

1. Design issue (complexity): The python migrations proceeds to a backup of pip freeze output, which makes the migration rerun impossible if the backup failed
2. Borg (client) and Borg Server aren't migrated (because they don't have the `bin/activate` file, check https://github.com/YunoHost/issues/issues/2841)
3. Searxng is installed [using an editable](https://github.com/YunoHost-Apps/searxng_ynh/blob/904e3ad096a2f17a5e0befcefeb60f299648e5f4/scripts/_common.sh#L40), which makes the migration fails
4. The pip version required by the app might be downgraded during the migration ([for example for searxng](https://github.com/YunoHost-Apps/searxng_ynh/blob/904e3ad096a2f17a5e0befcefeb60f299648e5f4/scripts/_common.sh#L37)), by default pip-freeze does not output pip in the dependencies list

Fixes https://github.com/YunoHost/issues/issues/2841
Fixes https://github.com/YunoHost/issues/issues/2861
Fixes https://github.com/YunoHost/issues/issues/2840 (not relevant anymore)

## Solution

1. Instead of backuping the `pip freeze` command output, run the command with the `--path` option, as suggested in this Stack Overflow answer: https://stackoverflow.com/a/79894112
2. Look for `pyvenv.cfg` file instead of `bin/activate`, which are generated in any case (whenever `python -m venv` has been run once without `--upgrade` or never like for borg and borgserver)
3. Make a two step installation: one for the dependencies exclusively and one for the editables for which we pass `--no-build-isolation`)
4. Search for the pip dependency in the requirements produced by `pip freeze`, compare with the pip version of the system and keep it if it is newer (otherwise the version is removed)

**AI transparency:** Local AI (gemma3:4b) used once to see how to transform a shell command into python in a general manner, possible solutions to use a pipe (without success, I chose to use `NamedTemporaryFile`). The AI has not been given the context of the code and the produced result has not been copy-pasted, used more like searching for solutions on StackOverflow.

## PR Status
*Fully tested*: With borg, grist, lasuite-meet, searxng and I hate money.

## How to test

Use ynh-dev with bookworm, then:
- install :
   - borg (choose a path for the repo to make the backups local, much simpler)
   - grist
   - searxng 
   - and ihatemoney (see https://github.com/YunoHost/yunohost/commit/f630e32da16033a17bee36916b3a1f3a3daae85e)
- start a borg backup
- from the host and in the `yunohost` folder, switch to the PR's branch
- from the container, copy the migrator to trixie's version of this PR:  `cp /ynh-dev/yunohost/src/migrations/m0036_migrate_to_trixie.py /usr/lib/python3/dist-packages/yunohost/migrations/0036_migrate_to_trixie.py`
- comment these lines to disable the automatic run of migrations following the one for trixie: https://github.com/YunoHost/yunohost/blob/83df92b76061a332aef8b05554251d5c2ee9fec8/src/migrations/0036_migrate_to_trixie.py.disabled#L343-L346
- run the migration to trixie: `yunost tools migrations run migrate_to_trixie --accept-disclaimer`
- snapshot the container if you want
- inside the container, run `./ynh-dev use-git yunohost`
- run manually the other migrations: `yunohost --debug tools migrations run --accept-disclaimer`
- check the migrations log:
  - verify that the `pip` package is upgraded for searxng
- check the services status for the the apps, that they are functional
- check the apps themselves 
  - all apps should be functional (except ihatemoney in the current state of the PR, I need help)