### PR TITLE
Content-Security-Policy modularity

### DIFF
--- a/conf/nginx/security.conf.inc.j2
+++ b/conf/nginx/security.conf.inc.j2
@@ -29,15 +29,15 @@ ssl_dhparam /usr/share/yunohost/ffdhe2048.pem;
 # https://wiki.mozilla.org/Security/Guidelines/Web_Security
 # https://observatory.mozilla.org/
 {% if experimental == "True" %}
-more_set_headers "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'; worker-src 'self' blob:;";
+more_set_headers -a "Content-Security-Policy : upgrade-insecure-requests; default-src https: data: blob: ; object-src https: data: 'unsafe-inline'; style-src https: data: 'unsafe-inline' ; script-src https: data: 'unsafe-inline' 'unsafe-eval'; worker-src 'self' blob:;";
 {% else %}
-more_set_headers "Content-Security-Policy : upgrade-insecure-requests";
+more_set_headers -a "Content-Security-Policy : upgrade-insecure-requests";
 {% endif %}
-more_set_headers "X-Content-Type-Options : nosniff";
-more_set_headers "X-XSS-Protection : 1; mode=block";
-more_set_headers "X-Download-Options : noopen";
-more_set_headers "X-Permitted-Cross-Domain-Policies : none";
-more_set_headers "X-Frame-Options : SAMEORIGIN";
+more_set_headers -a "X-Content-Type-Options : nosniff";
+more_set_headers -a "X-XSS-Protection : 1; mode=block";
+more_set_headers -a "X-Download-Options : noopen";
+more_set_headers -a "X-Permitted-Cross-Domain-Policies : none";
+more_set_headers -a "X-Frame-Options : SAMEORIGIN";
 
 # Disable the disaster privacy thing that is FLoC
 {% if experimental == "True" %}
@@ -46,7 +46,7 @@ more_set_headers "Permissions-Policy : fullscreen=(), geolocation=(), payment=()
 # Disabled because incompatible with the new cookie management system
 # proxy_cookie_path ~$ "; HTTPOnly; Secure;";
 {% else %}
-more_set_headers "Permissions-Policy : interest-cohort=()";
+more_set_headers -a "Permissions-Policy : interest-cohort=()";
 {% endif %}
 
 # Disable gzip to protect against BREACH

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Depends: python3-all (>= 3.13),
  , udisks2, udisks2-btrfs, udisks2-lvm2
  , smartmontools
  , python3-zmq
- , nginx, nginx-extras (>=1.22)
+ , nginx, nginx-extras (>=1.22), libnginx-mod-http-headers-more-filter (>=0.36)
  , apt, apt-transport-https, apt-utils, aptitude, dirmngr
  , openssh-server, nftables, fail2ban, bind9-dnsutils
  , openssl, ca-certificates, netcat-openbsd, iproute2


### PR DESCRIPTION
## The problem

Closes https://github.com/YunoHost/issues/issues/2301

**Related issues:** https://github.com/YunoHost-Apps/readeck_ynh/issues/81
**Related PRs:**

## Solution

So far, I naïvely applied what has been discussed in the issue, and added a specific requirement for `ibnginx-mod-http-headers-more-filter` that ships with the `-a` option.

**AI transparency:** unused

## PR Status
<!--*Work in progress / Untested / Tested partially / Fully tested / Wait for other PR to be merged / Ready*-->

Untested

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] ~~Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)~~
 - [ ] ~~Write data or settings migration~~
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] ~~Update/write documentation~~
 - [ ] Check affected packages, like readeck.

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...

Use ynh-dev, checkout this branch, try to install readeck.
Ping @oleole39, who might be interested