### PR TITLE
Make GPG key optional in apt extra repo helper

### DIFF
--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1184,7 +1184,7 @@ class AptDependenciesAppResource(AppResource):
 
     - `packages`: List of packages to be installed via `apt`
     - `packages_from_raw_bash`: A multi-line bash snippet (using triple quotes as open/close) which should echo additional packages to be installed. Meant to be used for packages to be conditionally installed depending on architecture, debian version, install questions, or other logic.
-    - `extras`: A dict of (repo, key, packages) corresponding to "extra" repositories to fetch dependencies from
+    - `extras`: A dict of (repo, key, packages) corresponding to "extra" repositories to fetch dependencies from (repo and packages are required).
 
     ### Provision/Update
 
@@ -1250,11 +1250,11 @@ class AptDependenciesAppResource(AppResource):
 
             if (
                 not isinstance(values.get("repo"), str)
-                or not isinstance(values.get("key"), str)
+                or ("key" in values and not isinstance(values.get("key"), str))
                 or not isinstance(values.get("packages"), list)
             ):
                 raise YunohostError(
-                    "In apt resource in the manifest: 'extras' repo should have the keys 'repo', 'key' defined as strings, 'packages' defined as list or 'packages_from_raw_bash' defined as string",
+                    "In apt resource in the manifest: 'extras' repo should have the keys 'repo', (optionally) 'key' defined as strings, 'packages' defined as list or 'packages_from_raw_bash' defined as string",
                     raw_msg=True,
                 )
 
@@ -1294,7 +1294,7 @@ class AptDependenciesAppResource(AppResource):
                 [
                     ynh_apt_install_dependencies_from_extra_repository,
                     f"--repo='{values['repo']}'",
-                    f"--key='{values['key']}'",
+                    f"--key='{values.get('key', "")}'",
                     f"--package='{' '.join(values['packages'])}'",
                 ]
             )

--- a/src/utils/resources.py
+++ b/src/utils/resources.py
@@ -1294,7 +1294,7 @@ class AptDependenciesAppResource(AppResource):
                 [
                     ynh_apt_install_dependencies_from_extra_repository,
                     f"--repo='{values['repo']}'",
-                    f"--key='{values.get('key', "")}'",
+                    f"--key='{values.get('key', '')}'",
                     f"--package='{' '.join(values['packages'])}'",
                 ]
             )

--- a/tests/test_app_resources.py
+++ b/tests/test_app_resources.py
@@ -323,6 +323,10 @@ def test_resource_apt():
                 "repo": "deb https://repos.influxdata.com/debian stable main",
                 "key": "https://repos.influxdata.com/influxdata-archive.key",
                 "packages": "influxdb2",
+            },
+            "non-free-firmware": {
+                "repo": "deb http://deb.debian.org/debian __YNH_DEBIAN_VERSION__ non-free-firmware",
+                "packages": "firmware-atheros",
             }
         },
     }
@@ -330,6 +334,7 @@ def test_resource_apt():
     assert os.system("dpkg --list | grep -q 'ii *nyancat '") != 0
     assert os.system("dpkg --list | grep -q 'ii *sl '") != 0
     assert os.system("dpkg --list | grep -q 'ii *influxdb2 '") != 0
+    assert os.system("dpkg --list | grep -q 'ii *firmware-atheros '") != 0
     assert os.system("dpkg --list | grep -q 'ii *lolcat '") != 0
     assert os.system("dpkg --list | grep -q 'ii *testapp-ynh-deps '") != 0
 
@@ -338,6 +343,7 @@ def test_resource_apt():
     assert os.system("dpkg --list | grep -q 'ii *nyancat '") == 0
     assert os.system("dpkg --list | grep -q 'ii *sl '") == 0
     assert os.system("dpkg --list | grep -q 'ii *influxdb2 '") == 0
+    assert os.system("dpkg --list | grep -q 'ii *firmware-atheros '") == 0
     assert (
         os.system("dpkg --list | grep -q 'ii *lolcat '") != 0
     )  # Lolcat shouldnt be installed yet
@@ -349,6 +355,7 @@ def test_resource_apt():
     assert os.system("dpkg --list | grep -q 'ii *nyancat '") == 0
     assert os.system("dpkg --list | grep -q 'ii *sl '") == 0
     assert os.system("dpkg --list | grep -q 'ii *influxdb2 '") == 0
+    assert os.system("dpkg --list | grep -q 'ii *firmware-atheros '") == 0
     assert os.system("dpkg --list | grep -q 'ii *lolcat '") == 0
     assert os.system("dpkg --list | grep -q 'ii *testapp-ynh-deps '") == 0
 
@@ -357,6 +364,7 @@ def test_resource_apt():
     assert os.system("dpkg --list | grep -q 'ii *nyancat '") != 0
     assert os.system("dpkg --list | grep -q 'ii *sl '") != 0
     assert os.system("dpkg --list | grep -q 'ii *influxdb2 '") != 0
+    assert os.system("dpkg --list | grep -q 'ii *firmware-atheros '") != 0
     assert os.system("dpkg --list | grep -q 'ii *lolcat '") != 0
     assert os.system("dpkg --list | grep -q 'ii *testapp-ynh-deps '") != 0
 


### PR DESCRIPTION
## The problem

In the hotspot app, I need to add an extra repository to provide non-free antenna from debian's non-free-firmware. However, I can't specify a GPG key for this repository, otherwise I get this error with apt:
```
Error: Conflicting values set for option Signed-By regarding source http://deb.debian.org/debian/ trixie: /usr/share/keyrings/debian-archive-keyring.pgp != /usr/share/keyrings/ynh_hotspot.gpg
```

**Related PRs:** https://github.com/YunoHost-Apps/hotspot_ynh/pull/133

## Solution

Making optionnal the GPG key solves the problem. 

## PR Status
 *Ready*

### Code TODOs

*Here are frequently forgotten tasks:*
 - [x] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [x] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [x] Run the code in cli by calling command by hand
 - [x] Test change on configuration on an instance

## How to test
*Please add here commands to install dependencies, manual change to do in ynh-dev container, commands to make some basic tests, etc.*
...
