### PR TITLE
enh(apt): prevent php-litespeed installation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,6 +50,7 @@ Conflicts: iptables-persistent
  , dovecot-core (>= 1:2.4)
  , fail2ban (>= 1.1)
  , nftables (>= 1.1)
+ , php-litespeed
 Description: manageable and configured self-hosting server
  YunoHost aims to make self-hosting accessible to everyone. It configures
  an email, Web and IM server alongside a LDAP base. It also provides


### PR DESCRIPTION
## The problem

In some undetermined conditions, PHP litespeed can end up being installed on the system instead of PHP-FPM.

**Related issues:**
Closes https://github.com/YunoHost/issues/issues/2765

**Related PRs:**

## Solution

Declare a package conflict with yunohost package.
I am unsure mentioning the meta package `php-litespeed` will also prevent the installation of all the `phpX.Y-litespeed` packages.

## PR Status
Untested

### Code TODOs

*Here are frequently forgotten tasks:*
 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] Add some missing translations keys
   - [ ] Update/write unit tests
 - [ ] Update/write documentation

### Tests TODOs
*Indicate here tests you have already done, and tests you think should be done*
 - [ ] Run the code in cli by calling command by hand
 - [ ] Test change on configuration on an instance

## How to test

Not sure how to replicate the conditions of the issue.
