### PR TITLE
fix(disks): unmask and start udisks2 service

### DIFF
--- a/src/service.py
+++ b/src/service.py
@@ -575,7 +575,7 @@ def service_log(name, number=50):
 
 def _run_service_command(action: str, service: str) -> bool:
     """
-    Run services management command (start, stop, enable, disable, restart, reload)
+    Run services management command (start, stop, enable, disable, restart, reload, mask, unmask)
 
     Keyword argument:
         action -- Action to perform
@@ -594,6 +594,8 @@ def _run_service_command(action: str, service: str) -> bool:
         "reload-or-restart",
         "enable",
         "disable",
+        "mask",
+        "unmask",
     ]
     if action not in possible_actions:
         raise ValueError(

--- a/src/tools.py
+++ b/src/tools.py
@@ -298,6 +298,12 @@ def tools_postinstall(
     # Enable and start YunoHost firewall at boot time
     _run_service_command("enable", "nftables")
 
+    # Enable and start udisks at boot time
+    # Somehow, it can be masked upon installation
+    _run_service_command("unmask", "udisks2")
+    _run_service_command("enable", "udisks2")
+    _run_service_command("start", "udisks2")
+
     tools_regen_conf(names=["ssh"], force=True)
 
     # Restore original ssh conf, as chosen by the


### PR DESCRIPTION
## The problem

**Related issues:**
Closes https://github.com/YunoHost/issues/issues/2845

**Related PRs:**
#2101 (ping @christophehenry, btw)

## Solution

Make sure udisks2 service is unmasked (unsure why it would masked at first, but that was the case for both bookworm and trixie ynh-dev instances), enabled, and started upon post-installation.

Since the (un-)mask actions do not exist in the service helpers, I added them.

**AI transparency:** unused

## PR Status
Untested, and we need to decide what to do with existing instances with that potential issue.

### Code TODOs

 - [ ] Discuss about this change with others contributors (on chat, contributors meeting, forum, issues or pr)
 - [ ] ~Update related repo (like yunohost-admin, yunohost-portal, package-linter, etc.)~
 - [ ] Write data or settings migration
 - [ ] Pass Continuous Integration checks
   - [ ] ~Add some missing translations keys~
   - [ ] ~Update/write unit tests~
 - [ ] ~Update/write documentation~
 - [ ] **What to do about already post-installed instances?**

### Tests TODOs

 - [ ] Test change on configuration on an instance : ynh-dev, or real instance

## How to test

Check that the Disks menu of the webadmin works correctly on a freshly post-installed server.