### PR TITLE
migrations: Add --skip-postmigrations option

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -691,6 +691,7 @@
     "migration_0036_not_enough_free_space": "Free space is pretty low in /var/! You should have at least 1GB free to run this migration.",
     "migration_0036_patch_yunohost_dpkg": "Applying patch on dpkg database to workaround conflict issues…",
     "migration_0036_patching_sources_list": "Patching the sources.lists file…",
+    "migration_0036_post_migrations_skipped": "Post {distrib} migrations not run automatically as requested, run them when you want :)",
     "migration_0036_problematic_apps_warning": "Please note that the following possibly problematic installed apps were detected. It looks like those were not installed from the YunoHost app catalog, or are not flagged as 'working'. Consequently, it cannot be guaranteed that they will still work after the upgrade:",
     "migration_0036_start": "Starting migration to Trixie…",
     "migration_0036_still_on_bookworm_after_main_upgrade": "Something went wrong during the main upgrade, the system appears to still be on Debian Bookworm.",

--- a/share/actionsmap.yml
+++ b/share/actionsmap.yml
@@ -2083,6 +2083,9 @@ tools:
                     --accept-disclaimer:
                         help: Accept disclaimers of migrations (please read them before using this option)
                         action: store_true
+                    --skip-postmigrations:
+                        action: store_true
+                        help: Don't automatically run the following migrations if any. Especially useful to not run the migrations following a Debian version bump and run them manually instead (to be used only if you know what you are doing)
 
               ### tools_migrations_state()
               state:

--- a/src/migrations/0036_migrate_to_trixie.py.disabled
+++ b/src/migrations/0036_migrate_to_trixie.py.disabled
@@ -286,14 +286,17 @@ class MyMigration(Migration):
         # Mark this migration as completed before triggering the "new" migrations
         _write_migration_state(self.id, "done")
 
-        callbacks = (
-            lambda l: logger.debug("+ " + l.rstrip() + "\r"),
-            lambda l: logger.warning(l.rstrip()),
-        )
-        try:
-            call_async_output(["yunohost", "tools", "migrations", "run"], callbacks)
-        except Exception as e:
-            logger.error(e)
+        if not self.skip_postmigrations:
+            callbacks = (
+                lambda l: logger.debug("+ " + l.rstrip() + "\r"),
+                lambda l: logger.warning(l.rstrip()),
+            )
+            try:
+                call_async_output(["yunohost", "tools", "migrations", "run"], callbacks)
+            except Exception as e:
+                logger.error(e)
+        else:
+            logger.info(m18n.n("migration_0036_post_migrations_skipped", distrib="Trixie"))
 
         # If running from the webadmin, restart the API after a delay
         if Moulinette.interface.type == "api":

--- a/src/tools.py
+++ b/src/tools.py
@@ -801,6 +801,7 @@ def tools_migrations_run(
     auto: bool = False,
     force_rerun: bool = False,
     accept_disclaimer: bool = False,
+    skip_postmigrations: bool = False,
 ) -> None:
     """
     Perform migrations
@@ -810,6 +811,7 @@ def tools_migrations_run(
     --auto         Automatic mode, won't run manual migrations (to be used only if you know what you are doing)
     --force-rerun  Re-run already-ran migrations (to be used only if you know what you are doing)(must explicit which migrations)
     --accept-disclaimer  Accept disclaimers of migrations (please read them before using this option) (only valid for one migration)
+    --skip-postmigrations  Don't automatically run the following migrations if any. Especially useful to not run the migrations following a Debian version bump and run them manually instead (to be used only if you know what you are doing)
     """
 
     all_migrations = _get_migrations_list()
@@ -916,6 +918,8 @@ def tools_migrations_run(
         # Start register change on system
         operation_logger = OperationLogger("tools_migrations_migrate_forward")
         operation_logger.start()
+
+        migration.skip_postmigrations = skip_postmigrations
 
         if skip:
             logger.warning(m18n.n("migrations_skip_migration", id=migration.id))
@@ -1107,11 +1111,15 @@ class Migration:
 
     state: Literal["pending", "done", "skipped"] | None = None
     mode: Literal["auto", "manual"] = "auto"
+
     # List of migration ids required before running this migration
     dependencies: list[str] = []
 
     # For migrations that have @ldap_migration
     ldap_migration_started = False
+
+    # To skip the automatic run of the migrations following up the current one
+    skip_postmigrations: bool = False
 
     @property
     def disclaimer(self) -> str | None:


### PR DESCRIPTION
## The problem

As of today, testing the venv and postgresql migrations, despite being simple and fast to run, can be painful: you would have to run the whole Trixie migration, and if it fails, run it again. And again… Wait, what time is it now?

A trick is to comment lines of the Trixie migration to avoid to run those migrations, as described in this PR (section "How to test"):
https://github.com/YunoHost/yunohost/pull/2353

Quoting:
> - comment these lines to disable the automatic run of migrations following the one for trixie: https://github.com/YunoHost/yunohost/blob/83df92b76061a332aef8b05554251d5c2ee9fec8/src/migrations/0036_migrate_to_trixie.py.disabled#L343-L346

## Solution

Introduce the `--skip-postmigrations` option, to avoid the run of the `yunhost tools migrations run` command.

I am not much happy with the name, if you find a better one, I would be grateful!

**AI transparency:** not used

## PR Status
*Fully tested*

## How to test

1. Use the `ynh-dev` container
2. Switch to this PR's branch in `ynh-dev/yunohost`
3. Prepare your environment before the migration
4. Run: `./ynh-dev use-git yunohost` so the changes brought by this branch are run
5. Make a snapshot
6. Enable the Trixie migration: `mv /usr/lib/python3/dist-packages/yunohost/migrations/0036_migrate_to_trixie.py{.disabled,}`
7. And run it: `yunohost tools migrations run --accept-disclaimer --skip-postmigrations`
8. Check the migration went well and that the migrations for venv and postgresql are listed as pending: `yunohost tools migrations list`
9. ⚠️IMPORTANT: at this step, reset the `ynh-dev/yunohost` repo to the state of HEAD (changes have been brought by the migration)
10. Restore the snapshot of step 5, you may run the migration again without the `--skip-postmigrations` to validate the venv and postgresql are this time run automatically.