### PR TITLE
[Trixie] Fix yunohost-diagnosis.service security restrictions in LXC context

### DIFF
--- a/conf/yunohost/yunohost-diagnosis.service
+++ b/conf/yunohost/yunohost-diagnosis.service
@@ -7,7 +7,7 @@ Type=simple
 User=root
 Group=root
 WorkingDirectory=/root
-ExecStart=yunohost diagnosis run --email
+ExecStart=yunohost diagnosis run --email --force
 
 # Sandboxing options to harden security
 # Depending on specificities of your service/app, you may need to tweak these
@@ -29,8 +29,9 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 LockPersonality=yes
 SystemCallArchitectures=native
-SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap @cpu-emulation
+SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @swap @cpu-emulation
 # @privileged # (not sure why this need to be removed...)
+# @setuid # (needed for ip diagnosis in LXC context)
 
 # Denying access to capabilities that should not be relevant for webapps
 # Doc: https://man7.org/linux/man-pages/man7/capabilities.7.html
@@ -41,7 +42,9 @@ CapabilityBoundingSet=~CAP_LEASE CAP_LINUX_IMMUTABLE CAP_IPC_LOCK
 CapabilityBoundingSet=~CAP_BLOCK_SUSPEND CAP_WAKE_ALARM
 CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
 CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
-CapabilityBoundingSet=~CAP_NET_ADMIN CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_NET_BROADCAST
+# CAP_NET_RAW # (needed for ip diagnosis in LXC context)
+# CAP_NET_ADMIN # (needed for nftable service diagnosis in LXC context)
 CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYSLOG
 
 [Install]


### PR DESCRIPTION


## The problem
with Trixie the yunohost cron diagnosis is replaced with a systemd timer+service.
with Yunohost 13.0.6 in a LXC context, the current service report 2 false positives alerts regarding ip (network connection) and services (nftables.service) when they are not reported when running the command directly from command line 


## Solution
Review the hardenend security:
* Update SystemCallFilter to allow  @setuid
* Update CapabilityBoundingSet to allow CAP_NET_ADMIN and CAP_NET_RAW

Addition to ensure that cache is not use in that context
* Updated ExecStart command to include --force option

**AI transparency:** *not used*

## PR Status
Fully tested

## How to test
Manually update the service, run `systemctl daemon-reload && systemctl start yunohost-diagnosis.service`
